### PR TITLE
fix(build): promote typedRoutes top-level, add login route stub

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,5 @@
+// TODO issue #2 — feat(auth): NextAuth.js v5 setup
+// Stub pour satisfaire typedRoutes — à implémenter
+export default function LoginPage() {
+  return null;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  experimental: {
-    typedRoutes: true,
-  },
+  typedRoutes: true,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Fixes

- **next.config.ts** : `typedRoutes` déplacé de `experimental` vers top-level (Next.js 15.5+ l'a promu — warning CI)
- **app/(auth)/login/page.tsx** : stub vide pour satisfaire `RouteImpl<"/login">` avec `typedRoutes` actif

`typedRoutes` reste activé — pas question de le désactiver. Le stub sera remplacé par l'implémentation complète dans l'issue #2 (feat(auth): NextAuth.js v5).