### PR TITLE
chore(skills): add create-issue + full workflow chain to plan-and-confirm

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -2,7 +2,6 @@
 name: code-review
 description: Review frontend Next.js/TypeScript code for bugs, accessibility, performance, and KLASSCI conventions. Use when asked to review code or before creating a PR.
 disable-model-invocation: true
-allowed-tools: Bash(git *), Read, Grep, Glob
 ---
 
 Perform a thorough code review of the KLASSCI frontend changes.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -2,7 +2,6 @@
 name: commit
 description: Create a conventional commit for the frontend. Use when the user asks to commit changes.
 disable-model-invocation: true
-allowed-tools: Bash(git *)
 ---
 
 Create a conventional commit for the KLASSCI frontend following these steps:

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: create-issue
+description: Créer une issue GitHub structurée après approbation du plan. Propose l'assignation à un développeur ou au dev actuel.
+---
+
+# Créer une Issue GitHub — KLASSCI Frontend
+
+Ce skill est invoqué automatiquement après le **OKAY** du `/plan-and-confirm`.
+Il crée l'issue GitHub correspondant au plan approuvé, puis propose la suite du workflow.
+
+---
+
+## Étape 1 — Détecter le repo actuel
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+---
+
+## Étape 2 — Construire et créer l'issue
+
+À partir du plan approuvé, extraire :
+- **Titre** : `type(scope): description courte` (ex: `feat(auth): NextAuth.js v5 login multi-tenant`)
+- **Labels** : selon le type (`feat` → `enhancement`, `fix` → `bug`, `chore` → `chore`)
+- **Body** structuré :
+
+```bash
+gh issue create \
+  --repo <REPO> \
+  --title "<type>(<scope>): <description>" \
+  --label "<label>" \
+  --body "$(cat <<'EOF'
+## Contexte
+
+<!-- Pourquoi cette issue existe -->
+
+## Ce qui sera fait
+
+<!-- Résumé du plan approuvé -->
+
+## Fichiers impactés
+
+<!-- Liste des fichiers à créer/modifier -->
+
+## Critères de succès
+
+- [ ] <!-- critère 1 -->
+- [ ] <!-- critère 2 -->
+
+## Notes techniques
+
+<!-- Points d'attention identifiés lors du plan -->
+EOF
+)"
+```
+
+Après création, afficher :
+```
+✅ Issue créée : #<N> — <titre>
+   URL : <url>
+```
+
+---
+
+## Étape 3 — Assignation
+
+Demander à l'utilisateur :
+
+> **Cette issue sera-t-elle traitée par toi ou par un autre développeur ?**
+> 1. **Moi-même** → je continue directement avec `/worktree-start`
+> 2. **Un autre développeur** → entre son GitHub login pour l'assigner
+
+Si assignation à quelqu'un d'autre :
+```bash
+gh issue edit <N> --repo <REPO> --add-assignee <github-login>
+```
+
+Afficher :
+```
+✅ Issue #<N> assignée à @<login>
+   Le développeur peut démarrer avec : /worktree-start <N>
+```
+
+---
+
+## Étape 4 — Lancer le worktree (si "Moi-même")
+
+Si l'utilisateur prend l'issue lui-même, enchaîner directement :
+
+> Issue #<N> créée. Je lance `/worktree-start <N>` pour démarrer le travail.
+
+Invoquer `/worktree-start` avec le numéro d'issue.
+
+---
+
+## Règles
+
+- Toujours créer l'issue AVANT de toucher au code
+- Le titre de l'issue = le titre de la future branche et PR
+- Ne jamais créer une issue sans body structuré
+
+$ARGUMENTS

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -2,7 +2,6 @@
 name: create-pr
 description: Create a pull request for the frontend. Use when the user asks to create a PR.
 disable-model-invocation: true
-allowed-tools: Bash(git *), Bash(gh *)
 ---
 
 Create a pull request for the KLASSCI frontend targeting `develop`.

--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -2,7 +2,6 @@
 name: new-component
 description: Scaffold a new React component following KLASSCI conventions (Server/Client decision, Skeleton, Modal pattern). Use when asked to create a new component.
 argument-hint: "[ComponentName] [type: page-section|modal|table|card|form]"
-allowed-tools: Read, Glob, Write
 ---
 
 Scaffold a new component: $ARGUMENTS

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -2,7 +2,6 @@
 name: new-page
 description: Scaffold a new Next.js App Router page with layout, loading, error boundaries, and proper portal routing. Use when asked to add a new page.
 argument-hint: "[portal/path] e.g. admin/enrollments"
-allowed-tools: Read, Glob, Write, Bash(ls *)
 ---
 
 Scaffold a new Next.js App Router page: $ARGUMENTS

--- a/.claude/skills/plan-and-confirm/SKILL.md
+++ b/.claude/skills/plan-and-confirm/SKILL.md
@@ -1,83 +1,134 @@
 ---
 name: plan-and-confirm
 description: Explore the codebase, present a clear implementation plan, and wait for explicit user approval before writing any code. Use for any non-trivial change (new feature, bug fix, refactor). Rule #1 — never code without OKAY.
-allowed-tools: Read, Glob, Grep, Bash(git *)
 ---
 
 # Plan & Confirm — KLASSCI Frontend
 
-## Phase 1 — Explore (read only, no modifications)
+## Phase 1 — Explorer (lecture seule, zéro modification)
 
-Before writing any plan, explore the relevant files:
+Avant d'écrire quoi que ce soit, explorer les fichiers concernés :
 
-1. Read all files directly related to the task (pages, components, hooks, stores, validators, API clients, tests)
-2. Search for usages of the affected symbols: `Grep` for component names, hook names, API function names
-3. Identify Zod schema constraints, TanStack Query keys, Zustand store slices, and Next.js layout boundaries
-4. Check whether the change affects a Server Component or a Client Component (`"use client"` directive)
-5. Check if a corresponding backend endpoint exists or needs to be created first
+1. Lire tous les fichiers liés à la tâche (pages, composants, hooks, actions serveur, types, schémas Zod)
+2. Chercher les usages des symboles affectés : `Grep` sur noms de composants, hooks, fonctions API
+3. Identifier : directives `"use client"`, contraintes Zod, dépendances backend (endpoint existant ?)
+4. Vérifier si des tests existent pour les fichiers impactés
 
-**Rule: zero file modifications in this phase.**
+**Règle : zéro modification de fichier dans cette phase.**
 
 ---
 
-## Phase 2 — Present the plan
+## Phase 2 — Présenter le plan
 
-Structure your response exactly as follows:
+Structurer la réponse exactement ainsi :
 
 ### Ce que j'ai compris
-- Describe the request with precise file:line references
-- Flag any ambiguous or non-obvious points
-- List all possible interpretations if more than one exists
+- Décrire la demande avec des références précises `fichier:ligne`
+- Signaler tout point ambigu ou non évident
+- Lister toutes les interprétations possibles s'il y en a plusieurs
 
 ### Ce que je vais faire
-- List every file to modify or create, with the reasoning for each change
-- State explicitly what will NOT be changed and why
-- Specify: Server Component vs Client Component for each new file
-- Specify: new Zod schema / new query key / new store slice if needed
+- Lister chaque fichier à modifier ou créer, avec la justification
+- Préciser : Server Component vs Client Component pour chaque nouveau fichier
+- Indiquer explicitement ce qui NE sera PAS modifié et pourquoi
 
 ### Points d'attention
-- Any component that could break elsewhere (shared layout, shared store)
-- Any assumption made (and why)
-- Any API contract dependency on the backend
+- Tout composant qui pourrait casser ailleurs (layout partagé, store)
+- Toute hypothèse faite (et pourquoi)
+- Toute dépendance sur un endpoint backend
 
 ---
 
-## Phase 3 — Wait for approval
+## Phase 3 — Attendre l'approbation
 
-**⛔ STOP. Do not touch any file.**
+**⛔ STOP. Ne toucher à aucun fichier.**
 
-Output literally:
+Afficher littéralement :
 
 > Merci de confirmer avec **OKAY** si la compréhension et le plan sont corrects.
 > Sinon, dites-moi ce qui est inexact et je vais ajuster avant de coder.
 
-**Absolute rule:** If the user does not say OKAY (or equivalent: "oui", "c'est bon", "go", "lance"), stay in Phase 3. Do not proceed.
+**Règle absolue :** Si l'utilisateur ne dit pas OKAY (ou équivalent : "oui", "c'est bon", "go", "lance"), rester en Phase 3.
 
 ---
 
-## Phase 4 — Implement (only after OKAY)
+## Phase 4 — Implémenter (seulement après OKAY)
 
-Once OKAY is received:
+Une fois OKAY reçu :
 
-1. Implement exactly as described in the approved plan — no additions, no improvements beyond scope
-2. If something discovered during implementation changes the plan → **stop and re-present** before continuing
-3. After implementation, verify:
+1. Implémenter exactement comme décrit dans le plan approuvé — sans ajouts ni améliorations hors périmètre
+2. Si une découverte change le plan → **stopper et re-présenter** avant de continuer
+3. Après chaque fichier modifié, vérifier :
    ```bash
-   npm run type-check
-   npm run lint
-   npm test
+   npx tsc --noEmit 2>&1 | head -20
+   npm run lint 2>&1 | head -20
    ```
-4. Summarize changes with file:line references
+4. Résumer les changements avec des références `fichier:ligne`
 
-**Never commit** unless the user explicitly asks.
+**Ne jamais committer** sauf demande explicite.
 
 ---
 
-## Rules
+## Phase 5 — Créer l'issue GitHub
 
-- **Never code without OKAY** — this is rule #1
-- Base all analysis on files actually read — no guessing
-- If the plan is rejected, re-explore if needed then present a revised plan
-- A "trivial change" (typo, single string edit) does not require this workflow
+Une fois le travail implémenté et validé localement, invoquer `/create-issue` :
+
+> Je crée maintenant l'issue GitHub correspondant au plan approuvé.
+
+`/create-issue` va :
+- Créer l'issue sur `African-DC/klassci-college-frontend` avec body structuré
+- Demander : **toi-même** ou **assigner à un autre développeur** ?
+- Si toi-même → enchaîner sur Phase 6
+
+---
+
+## Phase 6 — Worktree + Serveur de développement
+
+Une fois l'issue créée, invoquer `/worktree-start <N>` :
+
+Le worktree sera créé dans `../worktree-front-<N>-<slug>` (relatif à ce repo).
+
+Ensuite proposer :
+
+> Veux-tu que je lance le serveur de développement dans le worktree ?
+> ```bash
+> cd ../worktree-front-<N>-<slug>
+> npm install   # si node_modules absent
+> npm run dev   # démarre sur http://localhost:3000
+> ```
+> Ou tu le lances toi-même ?
+
+Attendre la validation visuelle dans le navigateur avant de passer à la PR.
+
+---
+
+## Phase 7 — Pull Request
+
+Quand tests et validation visuelle sont OK, invoquer `/worktree-finish` :
+- Commit des changements
+- Push de la branche
+- PR vers `develop` avec `Closes #<N>` dans le body
+- Retourner l'URL de la PR
+
+---
+
+## Phase 8 — Nettoyage
+
+Après merge de la PR confirmé :
+
+> La PR est mergée. Veux-tu nettoyer le worktree ?
+> ```bash
+> git worktree remove ../worktree-front-<N>-<slug>
+> git worktree prune
+> ```
+
+---
+
+## Règles
+
+- **Jamais de code sans OKAY** — c'est la règle #1
+- Baser toute analyse sur les fichiers réellement lus — jamais de suppositions
+- Si le plan est rejeté, re-explorer puis présenter un plan révisé
+- Un changement trivial (typo, chaîne de caractères) ne nécessite pas ce workflow
 
 $ARGUMENTS

--- a/.claude/skills/worktree-finish/SKILL.md
+++ b/.claude/skills/worktree-finish/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: worktree-finish
 description: Finish work on a worktree — push branch, create PR to develop, clean up. Use when the feature/fix is complete.
-allowed-tools: Bash(git *), Bash(gh *)
 ---
 
 # Clôture worktree — KLASSCI Frontend
@@ -79,9 +78,18 @@ git worktree prune
    Issue   : #<issue-number>
 
 ⏳ En attente de review.
-   Une fois mergée, tu peux nettoyer avec :
-   git worktree remove ../worktree-front-<issue>-<slug>
 ```
+
+### Étape 7 — Nettoyage (après merge uniquement)
+
+Une fois la PR mergée, proposer :
+
+> La PR est mergée. Veux-tu nettoyer le worktree ?
+> ```bash
+> # Depuis klassci-frontend/ (pas depuis le worktree)
+> git worktree remove ../worktree-front-<issue>-<slug>
+> git worktree prune
+> ```
 
 ### Règles importantes
 
@@ -89,5 +97,6 @@ git worktree prune
 - Le titre du PR doit suivre : `type(scope): description`
 - `Closes #N` dans le body ferme l'issue automatiquement au merge
 - Ne pas squash les commits (merge commit pour conserver l'historique)
+- Toujours nettoyer le worktree **depuis le repo principal**, jamais depuis l'intérieur du worktree
 
 $ARGUMENTS

--- a/.claude/skills/worktree-start/SKILL.md
+++ b/.claude/skills/worktree-start/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: worktree-start
 description: Start work on a GitHub issue using a git worktree. Use when starting a new feature or fix from an issue number.
-allowed-tools: Bash(git *), Bash(gh *)
 ---
 
 # Démarrage worktree — KLASSCI Frontend
@@ -54,6 +53,20 @@ Ouvre ce dossier dans ton éditeur ou navigue avec :
   cd ../worktree-front-<issue>-<slug>
 ```
 
+### Étape 5 — Proposer le serveur de développement
+
+Après création du worktree, proposer :
+
+> Veux-tu que je lance le serveur de développement dans le worktree ?
+> ```bash
+> cd ../worktree-front-<issue>-<slug>
+> npm install   # si node_modules absent
+> npm run dev   # démarre sur http://localhost:3000
+> ```
+> Ou tu le lances toi-même ?
+
+Attendre que l'utilisateur valide visuellement dans le navigateur avant de passer à la PR.
+
 ### Règles importantes
 
 - **Jamais travailler directement sur `develop` ou `main`**
@@ -61,5 +74,6 @@ Ouvre ce dossier dans ton éditeur ou navigue avec :
 - Toujours partir de `origin/develop` (pas du local)
 - Branche naming : `feature/N-desc`, `fix/N-desc`, `hotfix/N-desc`, `chore/desc`
 - Dans le worktree, lancer `npm install` si `node_modules` absent
+- Une fois le travail terminé dans le worktree, invoquer `/worktree-finish`
 
 $ARGUMENTS


### PR DESCRIPTION
## Description

Enrichit le workflow de développement en chaînant automatiquement les skills existants.

## Changements

- `.claude/skills/create-issue/` — **nouveau skill** : crée l'issue GitHub après approbation du plan, propose self-assignation ou assignation à un autre dev
- `.claude/skills/plan-and-confirm/SKILL.md` — ajout des phases 5-8 : create-issue → worktree-start → serveur dev (`npm run dev`) → create-pr → worktree-finish
- `.claude/skills/worktree-start/SKILL.md` — ajout étape 5 : proposer `npm run dev` après création du worktree
- `.claude/skills/worktree-finish/SKILL.md` — ajout étape 7 : proposer le nettoyage après merge de la PR
- Tous les skills — suppression de l'attribut `allowed-tools` non supporté dans les skill files

## Workflow complet résultant

```
/plan-and-confirm → OKAY → /create-issue → (assigner ?) → /worktree-start → npm run dev → /worktree-finish
```

## Type of change
- [x] chore — maintenance

## Checklist
- [x] Aucun code applicatif modifié
- [x] Aucun secret committed
- [x] Attribut allowed-tools retiré de tous les skill files