### PR TITLE
chore(theme): add next-themes dependency for dark/light mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "next": "15.5.12",
         "next-auth": "^5.0.0-beta.25",
         "next-intl": "^3.26.3",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.71.2",
@@ -8724,6 +8725,16 @@
       "peerDependencies": {
         "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {


### PR DESCRIPTION
## Description
Ajoute la dépendance `next-themes` manquante. Le reste de l'implémentation (ThemeProvider, toggle Sun/Moon dans Navbar, variables CSS dark, suppressHydrationWarning) était déjà en place.

## Closes
Closes #26

## Checklist
- [x] Type-check OK (`npx tsc --noEmit`)
- [x] ThemeProvider wrappé dans Providers.tsx
- [x] Toggle Sun/Moon dans Navbar.tsx
- [x] Variables CSS `.dark` dans globals.css
- [x] `darkMode: ['class']` dans tailwind.config.ts
- [x] `suppressHydrationWarning` sur `<html>`