### PR TITLE
feat(reports): add bulletin scolaire page with preview and generation

### DIFF
--- a/app/(admin)/admin/reports/error.tsx
+++ b/app/(admin)/admin/reports/error.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function ReportsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+        <AlertTriangle className="h-8 w-8 text-destructive" />
+      </div>
+      <div className="text-center space-y-1">
+        <h2 className="text-lg font-semibold">Une erreur est survenue</h2>
+        <p className="text-sm text-muted-foreground max-w-md">
+          {error.message || "Impossible de charger les bulletins. Veuillez réessayer."}
+        </p>
+      </div>
+      <Button onClick={reset} variant="outline">
+        Réessayer
+      </Button>
+    </div>
+  )
+}

--- a/app/(admin)/admin/reports/loading.tsx
+++ b/app/(admin)/admin/reports/loading.tsx
@@ -1,0 +1,15 @@
+import { BulletinListSkeleton } from "@/components/admin/reports/BulletinListSkeleton"
+
+export default function ReportsLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <div className="h-7 w-48 animate-pulse rounded bg-muted" />
+          <div className="h-4 w-64 animate-pulse rounded bg-muted" />
+        </div>
+      </div>
+      <BulletinListSkeleton />
+    </div>
+  )
+}

--- a/app/(admin)/admin/reports/page.tsx
+++ b/app/(admin)/admin/reports/page.tsx
@@ -1,0 +1,7 @@
+import { ReportsPageClient } from "@/components/admin/reports/ReportsPageClient"
+
+export const metadata = { title: "Bulletins scolaires | KLASSCI" }
+
+export default function ReportsPage() {
+  return <ReportsPageClient />
+}

--- a/components/admin/reports/BulletinGenerateButton.tsx
+++ b/components/admin/reports/BulletinGenerateButton.tsx
@@ -11,7 +11,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog"
 import { useGenerateBulletins } from "@/lib/hooks/useBulletins"
-import type { Trimester } from "@/lib/contracts/bulletin"
+import { BulletinGenerateSchema, type Trimester } from "@/lib/contracts/bulletin"
 
 interface BulletinGenerateButtonProps {
   classId: number | undefined
@@ -38,11 +38,13 @@ export function BulletinGenerateButton({
   const disabled = !classId || !trimester || !academicYearId
 
   function handleGenerate() {
-    if (!classId || !trimester || !academicYearId) return
-    mutate(
-      { class_id: classId, trimester, academic_year_id: academicYearId },
-      { onSuccess: () => setConfirmOpen(false) },
-    )
+    const result = BulletinGenerateSchema.safeParse({
+      class_id: classId,
+      trimester,
+      academic_year_id: academicYearId,
+    })
+    if (!result.success) return
+    mutate(result.data, { onSuccess: () => setConfirmOpen(false) })
   }
 
   return (

--- a/components/admin/reports/BulletinGenerateButton.tsx
+++ b/components/admin/reports/BulletinGenerateButton.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { useState } from "react"
+import { FileText } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { useGenerateBulletins } from "@/lib/hooks/useBulletins"
+import type { Trimester } from "@/lib/contracts/bulletin"
+
+interface BulletinGenerateButtonProps {
+  classId: number | undefined
+  trimester: Trimester | undefined
+  academicYearId: number | undefined
+  className?: string
+}
+
+const trimesterLabels: Record<string, string> = {
+  "1": "1er trimestre",
+  "2": "2ème trimestre",
+  "3": "3ème trimestre",
+}
+
+export function BulletinGenerateButton({
+  classId,
+  trimester,
+  academicYearId,
+  className,
+}: BulletinGenerateButtonProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const { mutate, isPending } = useGenerateBulletins()
+
+  const disabled = !classId || !trimester || !academicYearId
+
+  function handleGenerate() {
+    if (!classId || !trimester || !academicYearId) return
+    mutate(
+      { class_id: classId, trimester, academic_year_id: academicYearId },
+      { onSuccess: () => setConfirmOpen(false) },
+    )
+  }
+
+  return (
+    <>
+      <Button
+        onClick={() => setConfirmOpen(true)}
+        disabled={disabled}
+        className={className}
+      >
+        <FileText className="mr-2 h-4 w-4" />
+        Générer les bulletins
+      </Button>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Générer les bulletins</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Cette action va générer les bulletins pour le{" "}
+            <strong>{trimester ? trimesterLabels[trimester] : ""}</strong>.
+            Les bulletins existants en brouillon seront recalculés.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Annuler
+            </Button>
+            <Button onClick={handleGenerate} disabled={isPending}>
+              {isPending ? "Génération..." : "Confirmer"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/components/admin/reports/BulletinList.tsx
+++ b/components/admin/reports/BulletinList.tsx
@@ -17,7 +17,7 @@ import { BulletinPreviewModal } from "./BulletinPreviewModal"
 import { BulletinListSkeleton } from "./BulletinListSkeleton"
 import { useBulletins, usePublishBulletins } from "@/lib/hooks/useBulletins"
 import { bulletinsApi } from "@/lib/api/bulletins"
-import { getMentionColor } from "@/lib/utils"
+import { getMentionColor, downloadBlob } from "@/lib/utils"
 import type { BulletinListParams, Bulletin } from "@/lib/contracts/bulletin"
 
 interface BulletinListProps {
@@ -35,12 +35,7 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
     setDownloadingId(bulletin.id)
     try {
       const blob = await bulletinsApi.downloadPdf(bulletin.id)
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = `bulletin-${bulletin.student_name}.pdf`
-      a.click()
-      URL.revokeObjectURL(url)
+      downloadBlob(blob, `bulletin-${bulletin.student_name}.pdf`)
     } catch (err) {
       toast.error("Erreur lors du téléchargement", {
         description: err instanceof Error ? err.message : "Erreur inconnue",

--- a/components/admin/reports/BulletinList.tsx
+++ b/components/admin/reports/BulletinList.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useState, useMemo } from "react"
-import { Eye, Download, Send } from "lucide-react"
+import { useState, useMemo, useCallback } from "react"
+import { Eye, Download, Send, ChevronLeft, ChevronRight } from "lucide-react"
+import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
   Table,
@@ -15,32 +16,39 @@ import { BulletinStatusBadge } from "./BulletinStatusBadge"
 import { BulletinPreviewModal } from "./BulletinPreviewModal"
 import { BulletinListSkeleton } from "./BulletinListSkeleton"
 import { useBulletins, usePublishBulletins } from "@/lib/hooks/useBulletins"
+import { bulletinsApi } from "@/lib/api/bulletins"
+import { getMentionColor } from "@/lib/utils"
 import type { BulletinListParams, Bulletin } from "@/lib/contracts/bulletin"
-
-function getMentionColor(mention: string | null): string {
-  if (!mention) return ""
-  switch (mention) {
-    case "Très Bien":
-      return "text-emerald-600 dark:text-emerald-400"
-    case "Bien":
-      return "text-primary"
-    case "Assez Bien":
-      return "text-accent"
-    case "Passable":
-      return "text-amber-600 dark:text-amber-400"
-    default:
-      return ""
-  }
-}
 
 interface BulletinListProps {
   params: BulletinListParams
+  onPageChange?: (page: number) => void
 }
 
-export function BulletinList({ params }: BulletinListProps) {
+export function BulletinList({ params, onPageChange }: BulletinListProps) {
   const { data, isLoading, isError } = useBulletins(params)
   const { mutate: publish, isPending: isPublishing } = usePublishBulletins()
   const [previewId, setPreviewId] = useState<number | null>(null)
+  const [downloadingId, setDownloadingId] = useState<number | null>(null)
+
+  const handleDownloadPdf = useCallback(async (bulletin: Bulletin) => {
+    setDownloadingId(bulletin.id)
+    try {
+      const blob = await bulletinsApi.downloadPdf(bulletin.id)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `bulletin-${bulletin.student_name}.pdf`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.error("Erreur lors du téléchargement", {
+        description: err instanceof Error ? err.message : "Erreur inconnue",
+      })
+    } finally {
+      setDownloadingId(null)
+    }
+  }, [])
 
   const bulletins = useMemo(() => data?.data ?? [], [data])
   const hasDrafts = useMemo(
@@ -137,15 +145,14 @@ export function BulletinList({ params }: BulletinListProps) {
                       <Eye className="h-4 w-4" />
                       <span className="sr-only">Voir le bulletin de {bulletin.student_name}</span>
                     </Button>
-                    <Button size="icon" variant="ghost" asChild>
-                      <a
-                        href={`${process.env.NEXT_PUBLIC_API_URL}/bulletins/${bulletin.id}/pdf`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <Download className="h-4 w-4" />
-                        <span className="sr-only">Télécharger le bulletin de {bulletin.student_name}</span>
-                      </a>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => handleDownloadPdf(bulletin)}
+                      disabled={downloadingId === bulletin.id}
+                    >
+                      <Download className="h-4 w-4" />
+                      <span className="sr-only">Télécharger le bulletin de {bulletin.student_name}</span>
                     </Button>
                   </div>
                 </TableCell>
@@ -155,8 +162,31 @@ export function BulletinList({ params }: BulletinListProps) {
         </Table>
       </div>
 
-      <div className="text-xs text-muted-foreground text-right">
-        {data?.total ?? 0} bulletin(s) — Page {data?.page ?? 1}/{data?.total_pages ?? 1}
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>{data?.total ?? 0} bulletin(s)</span>
+        <div className="flex items-center gap-2">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            disabled={!data || data.page <= 1}
+            onClick={() => onPageChange?.(Math.max(1, (data?.page ?? 1) - 1))}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            <span className="sr-only">Page précédente</span>
+          </Button>
+          <span>Page {data?.page ?? 1}/{data?.total_pages ?? 1}</span>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            disabled={!data || data.page >= data.total_pages}
+            onClick={() => onPageChange?.((data?.page ?? 1) + 1)}
+          >
+            <ChevronRight className="h-4 w-4" />
+            <span className="sr-only">Page suivante</span>
+          </Button>
+        </div>
       </div>
 
       <BulletinPreviewModal

--- a/components/admin/reports/BulletinList.tsx
+++ b/components/admin/reports/BulletinList.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { useState, useMemo } from "react"
+import { Eye, Download, Send } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { BulletinStatusBadge } from "./BulletinStatusBadge"
+import { BulletinPreviewModal } from "./BulletinPreviewModal"
+import { BulletinListSkeleton } from "./BulletinListSkeleton"
+import { useBulletins, usePublishBulletins } from "@/lib/hooks/useBulletins"
+import type { BulletinListParams, Bulletin } from "@/lib/contracts/bulletin"
+
+function getMentionColor(mention: string | null): string {
+  if (!mention) return ""
+  switch (mention) {
+    case "Très Bien":
+      return "text-emerald-600 dark:text-emerald-400"
+    case "Bien":
+      return "text-primary"
+    case "Assez Bien":
+      return "text-accent"
+    case "Passable":
+      return "text-amber-600 dark:text-amber-400"
+    default:
+      return ""
+  }
+}
+
+interface BulletinListProps {
+  params: BulletinListParams
+}
+
+export function BulletinList({ params }: BulletinListProps) {
+  const { data, isLoading, isError } = useBulletins(params)
+  const { mutate: publish, isPending: isPublishing } = usePublishBulletins()
+  const [previewId, setPreviewId] = useState<number | null>(null)
+
+  const bulletins = useMemo(() => data?.data ?? [], [data])
+  const hasDrafts = useMemo(
+    () => bulletins.some((b) => b.status === "brouillon"),
+    [bulletins],
+  )
+
+  if (isLoading) return <BulletinListSkeleton />
+
+  if (isError) {
+    return (
+      <div className="py-12 text-center text-sm text-muted-foreground">
+        Impossible de charger les bulletins.
+      </div>
+    )
+  }
+
+  if (bulletins.length === 0) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-sm text-muted-foreground">
+          Aucun bulletin trouvé pour les critères sélectionnés.
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Utilisez le bouton &quot;Générer les bulletins&quot; pour créer les bulletins.
+        </p>
+      </div>
+    )
+  }
+
+  function handlePublish() {
+    if (!params.class_id || !params.trimester) return
+    publish({ classId: params.class_id, trimester: params.trimester })
+  }
+
+  return (
+    <div className="space-y-4">
+      {hasDrafts && params.class_id && params.trimester && (
+        <div className="flex items-center justify-between rounded-lg border border-accent/30 bg-accent/5 p-3">
+          <p className="text-sm">
+            Des bulletins sont en <strong>brouillon</strong>. Publiez-les pour les rendre visibles aux parents.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handlePublish}
+            disabled={isPublishing}
+          >
+            <Send className="mr-2 h-3 w-3" />
+            {isPublishing ? "Publication..." : "Publier tout"}
+          </Button>
+        </div>
+      )}
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Élève</TableHead>
+              <TableHead>Classe</TableHead>
+              <TableHead className="text-center">Moyenne</TableHead>
+              <TableHead className="text-center">Rang</TableHead>
+              <TableHead>Mention</TableHead>
+              <TableHead>Statut</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bulletins.map((bulletin: Bulletin) => (
+              <TableRow key={bulletin.id}>
+                <TableCell className="font-medium">{bulletin.student_name}</TableCell>
+                <TableCell>{bulletin.class_name}</TableCell>
+                <TableCell className="text-center font-semibold">
+                  {bulletin.average !== null ? bulletin.average.toFixed(2) : "—"}
+                </TableCell>
+                <TableCell className="text-center">
+                  {bulletin.rank ?? "—"}/{bulletin.total_students}
+                </TableCell>
+                <TableCell>
+                  <span className={`font-medium ${getMentionColor(bulletin.mention)}`}>
+                    {bulletin.mention ?? "—"}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <BulletinStatusBadge status={bulletin.status} />
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => setPreviewId(bulletin.id)}
+                    >
+                      <Eye className="h-4 w-4" />
+                      <span className="sr-only">Voir le bulletin de {bulletin.student_name}</span>
+                    </Button>
+                    <Button size="icon" variant="ghost" asChild>
+                      <a
+                        href={`${process.env.NEXT_PUBLIC_API_URL}/bulletins/${bulletin.id}/pdf`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Download className="h-4 w-4" />
+                        <span className="sr-only">Télécharger le bulletin de {bulletin.student_name}</span>
+                      </a>
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="text-xs text-muted-foreground text-right">
+        {data?.total ?? 0} bulletin(s) — Page {data?.page ?? 1}/{data?.total_pages ?? 1}
+      </div>
+
+      <BulletinPreviewModal
+        bulletinId={previewId}
+        onClose={() => setPreviewId(null)}
+      />
+    </div>
+  )
+}

--- a/components/admin/reports/BulletinListSkeleton.tsx
+++ b/components/admin/reports/BulletinListSkeleton.tsx
@@ -1,0 +1,31 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function BulletinListSkeleton() {
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-3">
+        <Skeleton className="h-10 w-48" />
+        <Skeleton className="h-10 w-36" />
+        <Skeleton className="h-10 w-36" />
+      </div>
+      <div className="rounded-lg border">
+        <div className="border-b p-4">
+          <div className="grid grid-cols-6 gap-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-4" />
+            ))}
+          </div>
+        </div>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="border-b p-4 last:border-0">
+            <div className="grid grid-cols-6 gap-4">
+              {Array.from({ length: 6 }).map((_, j) => (
+                <Skeleton key={j} className="h-4" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/admin/reports/BulletinPreviewModal.tsx
+++ b/components/admin/reports/BulletinPreviewModal.tsx
@@ -5,6 +5,7 @@ import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { BulletinStatusBadge } from "./BulletinStatusBadge"
 import { useBulletin } from "@/lib/hooks/useBulletins"
+import { getMentionColor } from "@/lib/utils"
 import {
   Table,
   TableBody,
@@ -14,29 +15,19 @@ import {
   TableRow,
 } from "@/components/ui/table"
 
+const COUNCIL_DECISION_LABELS: Record<string, string> = {
+  admis: "Admis(e)",
+  redouble: "Redouble",
+  exclu: "Exclu(e)",
+}
+
 interface BulletinPreviewModalProps {
   bulletinId: number | null
   onClose: () => void
 }
 
-function getMentionColor(mention: string | null): string {
-  if (!mention) return "text-muted-foreground"
-  switch (mention) {
-    case "Très Bien":
-      return "text-emerald-600 dark:text-emerald-400"
-    case "Bien":
-      return "text-primary"
-    case "Assez Bien":
-      return "text-accent"
-    case "Passable":
-      return "text-amber-600 dark:text-amber-400"
-    default:
-      return "text-muted-foreground"
-  }
-}
-
 export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewModalProps) {
-  const { data: bulletin, isLoading } = useBulletin(bulletinId ?? 0)
+  const { data: bulletin, isLoading } = useBulletin(bulletinId)
 
   return (
     <Dialog open={bulletinId !== null} onOpenChange={onClose}>
@@ -98,29 +89,38 @@ export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewMod
                 <TableRow>
                   <TableHead>Matière</TableHead>
                   <TableHead className="text-center">Coeff.</TableHead>
-                  <TableHead className="text-center">Moyenne</TableHead>
+                  <TableHead className="text-center">Note/20</TableHead>
+                  <TableHead className="text-center">Coef × Note</TableHead>
                   <TableHead className="text-center">Moy. classe</TableHead>
                   <TableHead>Enseignant</TableHead>
                   <TableHead>Appréciation</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {bulletin.subject_grades.map((sg) => (
-                  <TableRow key={sg.subject_name}>
-                    <TableCell className="font-medium">{sg.subject_name}</TableCell>
-                    <TableCell className="text-center">{sg.coefficient}</TableCell>
-                    <TableCell className="text-center font-semibold">
-                      {sg.average !== null ? sg.average.toFixed(2) : "—"}
-                    </TableCell>
-                    <TableCell className="text-center text-muted-foreground">
-                      {sg.class_average !== null ? sg.class_average.toFixed(2) : "—"}
-                    </TableCell>
-                    <TableCell className="text-sm">{sg.teacher_name}</TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {sg.appreciation ?? "—"}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {bulletin.subject_grades.map((sg) => {
+                  // Calcul du total coef × note (fourni par l'API ou calculé)
+                  const coefXNote = sg.coef_x_note
+                    ?? (sg.average !== null ? sg.coefficient * sg.average : null)
+                  return (
+                    <TableRow key={sg.subject_name}>
+                      <TableCell className="font-medium">{sg.subject_name}</TableCell>
+                      <TableCell className="text-center">{sg.coefficient}</TableCell>
+                      <TableCell className="text-center font-semibold">
+                        {sg.average !== null ? sg.average.toFixed(2) : "—"}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        {coefXNote !== null ? coefXNote.toFixed(2) : "—"}
+                      </TableCell>
+                      <TableCell className="text-center text-muted-foreground">
+                        {sg.class_average !== null ? sg.class_average.toFixed(2) : "—"}
+                      </TableCell>
+                      <TableCell className="text-sm">{sg.teacher_name}</TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {sg.appreciation ?? "—"}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
               </TableBody>
             </Table>
 
@@ -143,13 +143,21 @@ export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewMod
               </div>
             </div>
 
-            {/* Appréciation du conseil de classe */}
-            {bulletin.class_council_appreciation && (
-              <div className="rounded-lg border p-4 space-y-1">
-                <p className="text-sm font-medium">Appréciation du conseil de classe</p>
-                <p className="text-sm text-muted-foreground">
-                  {bulletin.class_council_appreciation}
-                </p>
+            {/* Conseil de classe : décision + appréciation */}
+            {(bulletin.council_decision || bulletin.class_council_appreciation) && (
+              <div className="rounded-lg border p-4 space-y-2">
+                <p className="text-sm font-medium">Conseil de classe</p>
+                {bulletin.council_decision && (
+                  <p className="text-sm">
+                    <span className="text-muted-foreground">Décision :</span>{" "}
+                    <strong>{COUNCIL_DECISION_LABELS[bulletin.council_decision] ?? bulletin.council_decision}</strong>
+                  </p>
+                )}
+                {bulletin.class_council_appreciation && (
+                  <p className="text-sm text-muted-foreground">
+                    {bulletin.class_council_appreciation}
+                  </p>
+                )}
               </div>
             )}
           </div>

--- a/components/admin/reports/BulletinPreviewModal.tsx
+++ b/components/admin/reports/BulletinPreviewModal.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { BulletinStatusBadge } from "./BulletinStatusBadge"
 import { useBulletin } from "@/lib/hooks/useBulletins"
 import { getMentionColor } from "@/lib/utils"
+import type { CouncilDecision } from "@/lib/contracts/bulletin"
 import {
   Table,
   TableBody,
@@ -15,7 +16,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 
-const COUNCIL_DECISION_LABELS: Record<string, string> = {
+const COUNCIL_DECISION_LABELS: Record<CouncilDecision, string> = {
   admis: "Admis(e)",
   redouble: "Redouble",
   exclu: "Exclu(e)",

--- a/components/admin/reports/BulletinPreviewModal.tsx
+++ b/components/admin/reports/BulletinPreviewModal.tsx
@@ -1,0 +1,179 @@
+"use client"
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import { BulletinStatusBadge } from "./BulletinStatusBadge"
+import { useBulletin } from "@/lib/hooks/useBulletins"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+interface BulletinPreviewModalProps {
+  bulletinId: number | null
+  onClose: () => void
+}
+
+function getMentionColor(mention: string | null): string {
+  if (!mention) return "text-muted-foreground"
+  switch (mention) {
+    case "Très Bien":
+      return "text-emerald-600 dark:text-emerald-400"
+    case "Bien":
+      return "text-primary"
+    case "Assez Bien":
+      return "text-accent"
+    case "Passable":
+      return "text-amber-600 dark:text-amber-400"
+    default:
+      return "text-muted-foreground"
+  }
+}
+
+export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewModalProps) {
+  const { data: bulletin, isLoading } = useBulletin(bulletinId ?? 0)
+
+  return (
+    <Dialog open={bulletinId !== null} onOpenChange={onClose}>
+      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Bulletin scolaire</DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <BulletinPreviewSkeleton />
+        ) : bulletin ? (
+          <div className="space-y-6">
+            {/* En-tête école */}
+            <div className="text-center space-y-1 border-b pb-4">
+              <p className="text-xs text-muted-foreground uppercase tracking-wider">
+                République de Côte d&apos;Ivoire
+              </p>
+              <h2 className="font-serif text-lg font-semibold">
+                Bulletin de notes — {bulletin.academic_year_label}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {bulletin.trimester === "1" && "Premier trimestre"}
+                {bulletin.trimester === "2" && "Deuxième trimestre"}
+                {bulletin.trimester === "3" && "Troisième trimestre"}
+              </p>
+            </div>
+
+            {/* Infos élève */}
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div className="space-y-1">
+                <p>
+                  <span className="text-muted-foreground">Élève :</span>{" "}
+                  <strong>{bulletin.student_name}</strong>
+                </p>
+                <p>
+                  <span className="text-muted-foreground">Classe :</span>{" "}
+                  {bulletin.class_name}
+                </p>
+              </div>
+              <div className="space-y-1 text-right">
+                <p>
+                  <span className="text-muted-foreground">Rang :</span>{" "}
+                  <strong>
+                    {bulletin.rank ?? "—"}/{bulletin.total_students}
+                  </strong>
+                </p>
+                <p>
+                  <span className="text-muted-foreground">Statut :</span>{" "}
+                  <BulletinStatusBadge status={bulletin.status} />
+                </p>
+              </div>
+            </div>
+
+            <Separator />
+
+            {/* Tableau des notes */}
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Matière</TableHead>
+                  <TableHead className="text-center">Coeff.</TableHead>
+                  <TableHead className="text-center">Moyenne</TableHead>
+                  <TableHead className="text-center">Moy. classe</TableHead>
+                  <TableHead>Enseignant</TableHead>
+                  <TableHead>Appréciation</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {bulletin.subject_grades.map((sg) => (
+                  <TableRow key={sg.subject_name}>
+                    <TableCell className="font-medium">{sg.subject_name}</TableCell>
+                    <TableCell className="text-center">{sg.coefficient}</TableCell>
+                    <TableCell className="text-center font-semibold">
+                      {sg.average !== null ? sg.average.toFixed(2) : "—"}
+                    </TableCell>
+                    <TableCell className="text-center text-muted-foreground">
+                      {sg.class_average !== null ? sg.class_average.toFixed(2) : "—"}
+                    </TableCell>
+                    <TableCell className="text-sm">{sg.teacher_name}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {sg.appreciation ?? "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+
+            <Separator />
+
+            {/* Résumé */}
+            <div className="flex items-center justify-between rounded-lg bg-muted/50 p-4">
+              <div className="space-y-1">
+                <p className="text-sm text-muted-foreground">Moyenne générale</p>
+                <p className="text-2xl font-bold">
+                  {bulletin.average !== null ? bulletin.average.toFixed(2) : "—"}
+                  <span className="text-sm font-normal text-muted-foreground">/20</span>
+                </p>
+              </div>
+              <div className="text-right space-y-1">
+                <p className="text-sm text-muted-foreground">Mention</p>
+                <p className={`text-lg font-semibold ${getMentionColor(bulletin.mention)}`}>
+                  {bulletin.mention ?? "Aucune"}
+                </p>
+              </div>
+            </div>
+
+            {/* Appréciation du conseil de classe */}
+            {bulletin.class_council_appreciation && (
+              <div className="rounded-lg border p-4 space-y-1">
+                <p className="text-sm font-medium">Appréciation du conseil de classe</p>
+                <p className="text-sm text-muted-foreground">
+                  {bulletin.class_council_appreciation}
+                </p>
+              </div>
+            )}
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function BulletinPreviewSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-2">
+        <Skeleton className="mx-auto h-4 w-48" />
+        <Skeleton className="mx-auto h-6 w-72" />
+        <Skeleton className="mx-auto h-4 w-36" />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+      </div>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Skeleton key={i} className="h-8 w-full" />
+      ))}
+    </div>
+  )
+}

--- a/components/admin/reports/BulletinStatusBadge.tsx
+++ b/components/admin/reports/BulletinStatusBadge.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { Badge } from "@/components/ui/badge"
 import type { BulletinStatus } from "@/lib/contracts/bulletin"
 

--- a/components/admin/reports/BulletinStatusBadge.tsx
+++ b/components/admin/reports/BulletinStatusBadge.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import type { BulletinStatus } from "@/lib/contracts/bulletin"
+
+const statusConfig: Record<BulletinStatus, { label: string; variant: "default" | "secondary" }> = {
+  brouillon: { label: "Brouillon", variant: "secondary" },
+  publie: { label: "Publié", variant: "default" },
+}
+
+export function BulletinStatusBadge({ status }: { status: BulletinStatus }) {
+  const config = statusConfig[status]
+  return <Badge variant={config.variant}>{config.label}</Badge>
+}

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -8,41 +8,40 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
 import { BulletinList } from "./BulletinList"
 import { BulletinGenerateButton } from "./BulletinGenerateButton"
+import { useClasses, useAcademicYears } from "@/lib/hooks/useReferenceData"
 import type { BulletinListParams, Trimester, BulletinStatus } from "@/lib/contracts/bulletin"
-
-// Données de démo — sera remplacé par l'API /classes et /academic-years
-const DEMO_CLASSES = [
-  { id: 1, name: "6ème A" },
-  { id: 2, name: "6ème B" },
-  { id: 3, name: "5ème A" },
-  { id: 4, name: "5ème B" },
-  { id: 5, name: "4ème A" },
-  { id: 6, name: "3ème A" },
-]
-
-const DEMO_ACADEMIC_YEARS = [
-  { id: 1, label: "2025-2026" },
-  { id: 2, label: "2024-2025" },
-]
 
 export function ReportsPageClient() {
   const [classId, setClassId] = useState<number | undefined>(undefined)
   const [trimester, setTrimester] = useState<Trimester | undefined>(undefined)
-  const [academicYearId, setAcademicYearId] = useState<number | undefined>(
-    DEMO_ACADEMIC_YEARS[0].id,
-  )
+  const [academicYearId, setAcademicYearId] = useState<number | undefined>(undefined)
   const [status, setStatus] = useState<BulletinStatus | undefined>(undefined)
+  const [page, setPage] = useState(1)
+
+  const { data: classes, isLoading: classesLoading } = useClasses()
+  const { data: academicYears, isLoading: yearsLoading } = useAcademicYears()
+
+  // Pré-sélectionner la première année académique quand les données arrivent
+  if (!academicYearId && academicYears && academicYears.length > 0) {
+    setAcademicYearId(academicYears[0].id)
+  }
 
   const params: BulletinListParams = {
     ...(classId && { class_id: classId }),
     ...(trimester && { trimester }),
     ...(academicYearId && { academic_year_id: academicYearId }),
     ...(status && { status }),
+    page,
   }
 
   const filtersReady = !!classId && !!trimester
+
+  function handlePageChange(newPage: number) {
+    setPage(newPage)
+  }
 
   return (
     <div className="space-y-6">
@@ -62,41 +61,49 @@ export function ReportsPageClient() {
 
       {/* Filtres */}
       <div className="flex flex-wrap items-center gap-3">
-        <Select
-          value={academicYearId?.toString() ?? ""}
-          onValueChange={(v) => setAcademicYearId(Number(v))}
-        >
-          <SelectTrigger className="w-40">
-            <SelectValue placeholder="Année" />
-          </SelectTrigger>
-          <SelectContent>
-            {DEMO_ACADEMIC_YEARS.map((y) => (
-              <SelectItem key={y.id} value={y.id.toString()}>
-                {y.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {yearsLoading ? (
+          <Skeleton className="h-10 w-40" />
+        ) : (
+          <Select
+            value={academicYearId?.toString() ?? ""}
+            onValueChange={(v) => { setAcademicYearId(Number(v)); setPage(1) }}
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Année" />
+            </SelectTrigger>
+            <SelectContent>
+              {academicYears?.map((y) => (
+                <SelectItem key={y.id} value={y.id.toString()}>
+                  {y.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
 
-        <Select
-          value={classId?.toString() ?? ""}
-          onValueChange={(v) => setClassId(Number(v))}
-        >
-          <SelectTrigger className="w-40">
-            <SelectValue placeholder="Classe" />
-          </SelectTrigger>
-          <SelectContent>
-            {DEMO_CLASSES.map((c) => (
-              <SelectItem key={c.id} value={c.id.toString()}>
-                {c.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {classesLoading ? (
+          <Skeleton className="h-10 w-40" />
+        ) : (
+          <Select
+            value={classId?.toString() ?? ""}
+            onValueChange={(v) => { setClassId(Number(v)); setPage(1) }}
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Classe" />
+            </SelectTrigger>
+            <SelectContent>
+              {classes?.map((c) => (
+                <SelectItem key={c.id} value={c.id.toString()}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
 
         <Select
           value={trimester ?? ""}
-          onValueChange={(v) => setTrimester(v as Trimester)}
+          onValueChange={(v) => { setTrimester(v as Trimester); setPage(1) }}
         >
           <SelectTrigger className="w-44">
             <SelectValue placeholder="Trimestre" />
@@ -110,7 +117,7 @@ export function ReportsPageClient() {
 
         <Select
           value={status ?? "all"}
-          onValueChange={(v) => setStatus(v === "all" ? undefined : (v as BulletinStatus))}
+          onValueChange={(v) => { setStatus(v === "all" ? undefined : (v as BulletinStatus)); setPage(1) }}
         >
           <SelectTrigger className="w-36">
             <SelectValue placeholder="Statut" />
@@ -125,7 +132,7 @@ export function ReportsPageClient() {
 
       {/* Liste ou message */}
       {filtersReady ? (
-        <BulletinList params={params} />
+        <BulletinList params={params} onPageChange={handlePageChange} />
       ) : (
         <div className="py-16 text-center">
           <p className="text-sm text-muted-foreground">

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import {
   Select,
   SelectContent,
@@ -25,9 +25,11 @@ export function ReportsPageClient() {
   const { data: academicYears, isLoading: yearsLoading } = useAcademicYears()
 
   // Pré-sélectionner la première année académique quand les données arrivent
-  if (!academicYearId && academicYears && academicYears.length > 0) {
-    setAcademicYearId(academicYears[0].id)
-  }
+  useEffect(() => {
+    if (!academicYearId && academicYears && academicYears.length > 0) {
+      setAcademicYearId(academicYears[0].id)
+    }
+  }, [academicYearId, academicYears])
 
   const params: BulletinListParams = {
     ...(classId && { class_id: classId }),

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { BulletinList } from "./BulletinList"
+import { BulletinGenerateButton } from "./BulletinGenerateButton"
+import type { BulletinListParams, Trimester, BulletinStatus } from "@/lib/contracts/bulletin"
+
+// Données de démo — sera remplacé par l'API /classes et /academic-years
+const DEMO_CLASSES = [
+  { id: 1, name: "6ème A" },
+  { id: 2, name: "6ème B" },
+  { id: 3, name: "5ème A" },
+  { id: 4, name: "5ème B" },
+  { id: 5, name: "4ème A" },
+  { id: 6, name: "3ème A" },
+]
+
+const DEMO_ACADEMIC_YEARS = [
+  { id: 1, label: "2025-2026" },
+  { id: 2, label: "2024-2025" },
+]
+
+export function ReportsPageClient() {
+  const [classId, setClassId] = useState<number | undefined>(undefined)
+  const [trimester, setTrimester] = useState<Trimester | undefined>(undefined)
+  const [academicYearId, setAcademicYearId] = useState<number | undefined>(
+    DEMO_ACADEMIC_YEARS[0].id,
+  )
+  const [status, setStatus] = useState<BulletinStatus | undefined>(undefined)
+
+  const params: BulletinListParams = {
+    ...(classId && { class_id: classId }),
+    ...(trimester && { trimester }),
+    ...(academicYearId && { academic_year_id: academicYearId }),
+    ...(status && { status }),
+  }
+
+  const filtersReady = !!classId && !!trimester
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-serif text-2xl tracking-tight">Bulletins scolaires</h1>
+          <p className="text-sm text-muted-foreground">
+            Génération et consultation des bulletins par classe et trimestre
+          </p>
+        </div>
+        <BulletinGenerateButton
+          classId={classId}
+          trimester={trimester}
+          academicYearId={academicYearId}
+        />
+      </div>
+
+      {/* Filtres */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Select
+          value={academicYearId?.toString() ?? ""}
+          onValueChange={(v) => setAcademicYearId(Number(v))}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Année" />
+          </SelectTrigger>
+          <SelectContent>
+            {DEMO_ACADEMIC_YEARS.map((y) => (
+              <SelectItem key={y.id} value={y.id.toString()}>
+                {y.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={classId?.toString() ?? ""}
+          onValueChange={(v) => setClassId(Number(v))}
+        >
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Classe" />
+          </SelectTrigger>
+          <SelectContent>
+            {DEMO_CLASSES.map((c) => (
+              <SelectItem key={c.id} value={c.id.toString()}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={trimester ?? ""}
+          onValueChange={(v) => setTrimester(v as Trimester)}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue placeholder="Trimestre" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="1">1er trimestre</SelectItem>
+            <SelectItem value="2">2ème trimestre</SelectItem>
+            <SelectItem value="3">3ème trimestre</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={status ?? "all"}
+          onValueChange={(v) => setStatus(v === "all" ? undefined : (v as BulletinStatus))}
+        >
+          <SelectTrigger className="w-36">
+            <SelectValue placeholder="Statut" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Tous</SelectItem>
+            <SelectItem value="brouillon">Brouillon</SelectItem>
+            <SelectItem value="publie">Publié</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Liste ou message */}
+      {filtersReady ? (
+        <BulletinList params={params} />
+      ) : (
+        <div className="py-16 text-center">
+          <p className="text-sm text-muted-foreground">
+            Sélectionnez une classe et un trimestre pour afficher les bulletins.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/api/bulletins.ts
+++ b/lib/api/bulletins.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { getSession } from "next-auth/react"
 import { apiFetch, safeValidate } from "./client"
 import {
   BulletinSchema,
@@ -51,7 +52,13 @@ export const bulletinsApi = {
   downloadPdf: async (id: number): Promise<Blob> => {
     const baseUrl = process.env.NEXT_PUBLIC_API_URL
     if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
-    const res = await fetch(`${baseUrl}/bulletins/${id}/pdf`)
+    const session = await getSession()
+    if (!session?.accessToken) throw new Error("Non authentifié")
+    const res = await fetch(`${baseUrl}/bulletins/${id}/pdf`, {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+    })
     if (!res.ok) throw new Error("Impossible de télécharger le bulletin")
     return res.blob()
   },

--- a/lib/api/bulletins.ts
+++ b/lib/api/bulletins.ts
@@ -1,0 +1,58 @@
+import { z } from "zod"
+import { apiFetch, safeValidate } from "./client"
+import {
+  BulletinSchema,
+  type Bulletin,
+  type BulletinListParams,
+  type BulletinGenerate,
+} from "@/lib/contracts/bulletin"
+import { PaginatedResponseSchema, type PaginatedResponse } from "@/lib/contracts"
+
+const PaginatedBulletinSchema = PaginatedResponseSchema(BulletinSchema)
+const BulletinArraySchema = z.array(BulletinSchema)
+
+export const bulletinsApi = {
+  list: async (params: BulletinListParams = {}): Promise<PaginatedResponse<Bulletin>> => {
+    const query = new URLSearchParams(
+      Object.entries(params)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => [k, String(v)]),
+    ).toString()
+    const json = await apiFetch<PaginatedResponse<Bulletin> | Bulletin[]>(
+      `/bulletins${query ? `?${query}` : ""}`,
+    )
+    if (Array.isArray(json)) {
+      const arr = safeValidate(BulletinArraySchema, json, "GET /bulletins")
+      return { data: arr, total: arr.length, page: 1, per_page: arr.length, total_pages: 1 }
+    }
+    return safeValidate(PaginatedBulletinSchema, json, "GET /bulletins")
+  },
+
+  getById: async (id: number): Promise<Bulletin> => {
+    const json = await apiFetch<{ data?: Bulletin } | Bulletin>(`/bulletins/${id}`)
+    const bulletin = (json as { data?: Bulletin }).data ?? (json as Bulletin)
+    return safeValidate(BulletinSchema, bulletin, `GET /bulletins/${id}`)
+  },
+
+  generate: async (data: BulletinGenerate): Promise<{ message: string; count: number }> => {
+    return apiFetch("/bulletins/generate", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+  },
+
+  publish: async (classId: number, trimester: string): Promise<{ message: string; count: number }> => {
+    return apiFetch("/bulletins/publish", {
+      method: "POST",
+      body: JSON.stringify({ class_id: classId, trimester }),
+    })
+  },
+
+  downloadPdf: async (id: number): Promise<Blob> => {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL
+    if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
+    const res = await fetch(`${baseUrl}/bulletins/${id}/pdf`)
+    if (!res.ok) throw new Error("Impossible de télécharger le bulletin")
+    return res.blob()
+  },
+}

--- a/lib/api/bulletins.ts
+++ b/lib/api/bulletins.ts
@@ -1,6 +1,5 @@
 import { z } from "zod"
-import { getSession } from "next-auth/react"
-import { apiFetch, safeValidate } from "./client"
+import { apiFetch, apiFetchBlob, safeValidate } from "./client"
 import {
   BulletinSchema,
   type Bulletin,
@@ -50,16 +49,6 @@ export const bulletinsApi = {
   },
 
   downloadPdf: async (id: number): Promise<Blob> => {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL
-    if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
-    const session = await getSession()
-    if (!session?.accessToken) throw new Error("Non authentifié")
-    const res = await fetch(`${baseUrl}/bulletins/${id}/pdf`, {
-      headers: {
-        Authorization: `Bearer ${session.accessToken}`,
-      },
-    })
-    if (!res.ok) throw new Error("Impossible de télécharger le bulletin")
-    return res.blob()
+    return apiFetchBlob(`/bulletins/${id}/pdf`)
   },
 }

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -30,6 +30,15 @@ async function authHeaders(): Promise<Record<string, string>> {
   return headers
 }
 
+/** Fetch authentifié retournant un Blob (pour téléchargement PDF, Excel, etc.) */
+export async function apiFetchBlob(path: string): Promise<Blob> {
+  const headers = await authHeaders()
+  delete headers["Content-Type"]
+  const res = await fetch(`${getBaseUrl()}${path}`, { headers })
+  if (!res.ok) throw new Error(`Erreur ${res.status} lors du téléchargement`)
+  return res.blob()
+}
+
 export async function apiFetch<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { schema, ...fetchOptions } = options
   const headers = { ...(await authHeaders()), ...fetchOptions.headers }

--- a/lib/contracts/bulletin.ts
+++ b/lib/contracts/bulletin.ts
@@ -6,10 +6,15 @@ export const BulletinStatusSchema = z.enum(["brouillon", "publie"])
 
 export const TrimesterSchema = z.enum(["1", "2", "3"])
 
+export const MentionSchema = z.enum(["Très Bien", "Bien", "Assez Bien", "Passable"])
+
+export const CouncilDecisionSchema = z.enum(["admis", "redouble", "exclu"])
+
 export const SubjectGradeSchema = z.object({
   subject_name: z.string(),
   coefficient: z.number(),
   average: z.number().nullable(),
+  coef_x_note: z.number().nullable().optional(),
   class_average: z.number().nullable(),
   teacher_name: z.string(),
   appreciation: z.string().nullable(),
@@ -28,8 +33,9 @@ export const BulletinSchema = z.object({
   average: z.number().nullable(),
   rank: z.number().nullable(),
   total_students: z.number(),
-  mention: z.string().nullable(),
+  mention: MentionSchema.nullable(),
   subject_grades: z.array(SubjectGradeSchema),
+  council_decision: CouncilDecisionSchema.nullable().optional(),
   class_council_appreciation: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
@@ -53,6 +59,8 @@ export const BulletinGenerateSchema = z.object({
 
 export type BulletinStatus = z.infer<typeof BulletinStatusSchema>
 export type Trimester = z.infer<typeof TrimesterSchema>
+export type Mention = z.infer<typeof MentionSchema>
+export type CouncilDecision = z.infer<typeof CouncilDecisionSchema>
 export type SubjectGrade = z.infer<typeof SubjectGradeSchema>
 export type Bulletin = z.infer<typeof BulletinSchema>
 export type BulletinListParams = z.infer<typeof BulletinListParamsSchema>

--- a/lib/contracts/bulletin.ts
+++ b/lib/contracts/bulletin.ts
@@ -1,0 +1,59 @@
+import { z } from "zod"
+
+// Miroir de app/schemas/bulletin.py (backend)
+
+export const BulletinStatusSchema = z.enum(["brouillon", "publie"])
+
+export const TrimesterSchema = z.enum(["1", "2", "3"])
+
+export const SubjectGradeSchema = z.object({
+  subject_name: z.string(),
+  coefficient: z.number(),
+  average: z.number().nullable(),
+  class_average: z.number().nullable(),
+  teacher_name: z.string(),
+  appreciation: z.string().nullable(),
+})
+
+export const BulletinSchema = z.object({
+  id: z.number(),
+  student_id: z.number(),
+  student_name: z.string(),
+  class_id: z.number(),
+  class_name: z.string(),
+  trimester: TrimesterSchema,
+  academic_year_id: z.number(),
+  academic_year_label: z.string(),
+  status: BulletinStatusSchema,
+  average: z.number().nullable(),
+  rank: z.number().nullable(),
+  total_students: z.number(),
+  mention: z.string().nullable(),
+  subject_grades: z.array(SubjectGradeSchema),
+  class_council_appreciation: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const BulletinListParamsSchema = z.object({
+  class_id: z.number().optional(),
+  trimester: TrimesterSchema.optional(),
+  academic_year_id: z.number().optional(),
+  status: BulletinStatusSchema.optional(),
+  page: z.number().optional(),
+  per_page: z.number().optional(),
+  search: z.string().optional(),
+})
+
+export const BulletinGenerateSchema = z.object({
+  class_id: z.number({ required_error: "La classe est requise" }).positive(),
+  trimester: TrimesterSchema,
+  academic_year_id: z.number({ required_error: "L'année académique est requise" }).positive(),
+})
+
+export type BulletinStatus = z.infer<typeof BulletinStatusSchema>
+export type Trimester = z.infer<typeof TrimesterSchema>
+export type SubjectGrade = z.infer<typeof SubjectGradeSchema>
+export type Bulletin = z.infer<typeof BulletinSchema>
+export type BulletinListParams = z.infer<typeof BulletinListParamsSchema>
+export type BulletinGenerate = z.infer<typeof BulletinGenerateSchema>

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -2,6 +2,7 @@ export * from "./auth"
 export * from "./enrollment"
 export * from "./timetable"
 export * from "./grade"
+export * from "./bulletin"
 
 // Shared pagination contract
 import { z } from "zod"

--- a/lib/hooks/useBulletins.ts
+++ b/lib/hooks/useBulletins.ts
@@ -1,0 +1,57 @@
+"use client"
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { bulletinsApi } from "@/lib/api/bulletins"
+import type { BulletinListParams, BulletinGenerate } from "@/lib/contracts/bulletin"
+
+export const bulletinKeys = {
+  all: ["bulletins"] as const,
+  list: (params: BulletinListParams) => ["bulletins", "list", params] as const,
+  detail: (id: number) => ["bulletins", id] as const,
+}
+
+export function useBulletins(params: BulletinListParams = {}) {
+  return useQuery({
+    queryKey: bulletinKeys.list(params),
+    queryFn: () => bulletinsApi.list(params),
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useBulletin(id: number) {
+  return useQuery({
+    queryKey: bulletinKeys.detail(id),
+    queryFn: () => bulletinsApi.getById(id),
+    enabled: !!id,
+  })
+}
+
+export function useGenerateBulletins() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: BulletinGenerate) => bulletinsApi.generate(data),
+    onSuccess: (result) => {
+      toast.success(`${result.count} bulletin(s) généré(s) avec succès`)
+      queryClient.invalidateQueries({ queryKey: bulletinKeys.all })
+    },
+    onError: (err) => {
+      toast.error("Erreur", { description: err.message })
+    },
+  })
+}
+
+export function usePublishBulletins() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ classId, trimester }: { classId: number; trimester: string }) =>
+      bulletinsApi.publish(classId, trimester),
+    onSuccess: (result) => {
+      toast.success(`${result.count} bulletin(s) publié(s)`)
+      queryClient.invalidateQueries({ queryKey: bulletinKeys.all })
+    },
+    onError: (err) => {
+      toast.error("Erreur", { description: err.message })
+    },
+  })
+}

--- a/lib/hooks/useBulletins.ts
+++ b/lib/hooks/useBulletins.ts
@@ -21,7 +21,7 @@ export function useBulletins(params: BulletinListParams = {}) {
 
 export function useBulletin(id: number | null) {
   return useQuery({
-    queryKey: bulletinKeys.detail(id ?? 0),
+    queryKey: bulletinKeys.detail(id!),
     queryFn: () => bulletinsApi.getById(id!),
     enabled: id !== null && id > 0,
   })

--- a/lib/hooks/useBulletins.ts
+++ b/lib/hooks/useBulletins.ts
@@ -19,11 +19,11 @@ export function useBulletins(params: BulletinListParams = {}) {
   })
 }
 
-export function useBulletin(id: number) {
+export function useBulletin(id: number | null) {
   return useQuery({
-    queryKey: bulletinKeys.detail(id),
-    queryFn: () => bulletinsApi.getById(id),
-    enabled: !!id,
+    queryKey: bulletinKeys.detail(id ?? 0),
+    queryFn: () => bulletinsApi.getById(id!),
+    enabled: id !== null && id > 0,
   })
 }
 

--- a/lib/hooks/useReferenceData.ts
+++ b/lib/hooks/useReferenceData.ts
@@ -1,0 +1,42 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { apiFetch } from "@/lib/api/client"
+
+// Types simples pour les données de référence (classes, années académiques)
+interface ClassItem {
+  id: number
+  name: string
+}
+
+interface AcademicYear {
+  id: number
+  label: string
+}
+
+export const referenceKeys = {
+  classes: ["classes"] as const,
+  academicYears: ["academic-years"] as const,
+}
+
+export function useClasses() {
+  return useQuery({
+    queryKey: referenceKeys.classes,
+    queryFn: async () => {
+      const json = await apiFetch<{ data?: ClassItem[] } | ClassItem[]>("/classes")
+      return Array.isArray(json) ? json : (json.data ?? [])
+    },
+    staleTime: 1000 * 60 * 10,
+  })
+}
+
+export function useAcademicYears() {
+  return useQuery({
+    queryKey: referenceKeys.academicYears,
+    queryFn: async () => {
+      const json = await apiFetch<{ data?: AcademicYear[] } | AcademicYear[]>("/academic-years")
+      return Array.isArray(json) ? json : (json.data ?? [])
+    },
+    staleTime: 1000 * 60 * 10,
+  })
+}

--- a/lib/hooks/useReferenceData.ts
+++ b/lib/hooks/useReferenceData.ts
@@ -1,18 +1,17 @@
 "use client"
 
+import { z } from "zod"
 import { useQuery } from "@tanstack/react-query"
-import { apiFetch } from "@/lib/api/client"
+import { apiFetch, safeValidate } from "@/lib/api/client"
 
-// Types simples pour les données de référence (classes, années académiques)
-interface ClassItem {
-  id: number
-  name: string
-}
+// Schemas Zod pour les données de référence
+const ClassItemSchema = z.object({ id: z.number(), name: z.string() })
+const AcademicYearSchema = z.object({ id: z.number(), label: z.string() })
+const ClassItemArraySchema = z.array(ClassItemSchema)
+const AcademicYearArraySchema = z.array(AcademicYearSchema)
 
-interface AcademicYear {
-  id: number
-  label: string
-}
+export type ClassItem = z.infer<typeof ClassItemSchema>
+export type AcademicYear = z.infer<typeof AcademicYearSchema>
 
 export const referenceKeys = {
   classes: ["classes"] as const,
@@ -24,7 +23,8 @@ export function useClasses() {
     queryKey: referenceKeys.classes,
     queryFn: async () => {
       const json = await apiFetch<{ data?: ClassItem[] } | ClassItem[]>("/classes")
-      return Array.isArray(json) ? json : (json.data ?? [])
+      const arr = Array.isArray(json) ? json : (json.data ?? [])
+      return safeValidate(ClassItemArraySchema, arr, "GET /classes")
     },
     staleTime: 1000 * 60 * 10,
   })
@@ -35,7 +35,8 @@ export function useAcademicYears() {
     queryKey: referenceKeys.academicYears,
     queryFn: async () => {
       const json = await apiFetch<{ data?: AcademicYear[] } | AcademicYear[]>("/academic-years")
-      return Array.isArray(json) ? json : (json.data ?? [])
+      const arr = Array.isArray(json) ? json : (json.data ?? [])
+      return safeValidate(AcademicYearArraySchema, arr, "GET /academic-years")
     },
     staleTime: 1000 * 60 * 10,
   })

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,20 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Couleur Tailwind pour la mention du bulletin (format ivoirien) */
+export function getMentionColor(mention: string | null): string {
+  if (!mention) return "text-muted-foreground"
+  switch (mention) {
+    case "Très Bien":
+      return "text-emerald-600 dark:text-emerald-400"
+    case "Bien":
+      return "text-primary"
+    case "Assez Bien":
+      return "text-accent"
+    case "Passable":
+      return "text-amber-600 dark:text-amber-400"
+    default:
+      return "text-muted-foreground"
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,6 +5,18 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/** Déclenche le téléchargement d'un Blob côté navigateur */
+export function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
 /** Couleur Tailwind pour la mention du bulletin (format ivoirien) */
 export function getMentionColor(mention: string | null): string {
   if (!mention) return "text-muted-foreground"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "next": "15.5.12",
         "next-auth": "^5.0.0-beta.25",
         "next-intl": "^3.26.3",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.71.2",
@@ -8724,6 +8725,16 @@
       "peerDependencies": {
         "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {


### PR DESCRIPTION
## Summary
- Add `/admin/reports` page for managing school bulletins (report cards)
- Filters by class, trimester, academic year, and status (brouillon/publié)
- Preview modal with full Ivorian school bulletin template (notes, averages, rank, mention, council appreciation)
- Generate button with confirmation dialog
- Publish workflow (brouillon → publié) with banner notification
- PDF download link per bulletin

## Changes
- `lib/contracts/bulletin.ts` — Zod schemas (Bulletin, SubjectGrade, BulletinStatus, Trimester)
- `lib/api/bulletins.ts` — API client (list, getById, generate, publish, downloadPdf)
- `lib/hooks/useBulletins.ts` — TanStack Query hooks with toast notifications
- `app/(admin)/admin/reports/` — page, loading skeleton, error boundary
- `components/admin/reports/` — ReportsPageClient, BulletinList, BulletinPreviewModal, BulletinGenerateButton, BulletinStatusBadge, BulletinListSkeleton

## Closes

Closes #28

## Testing
- [x] No TypeScript errors `npx tsc --noEmit`
- [x] Build OK `npm run build`
- [x] Skeleton loaders in place
- [x] Modal pattern followed for preview
- [x] sr-only accessibility on action buttons

## Checklist
- [x] No `any` TypeScript types
- [x] No `dangerouslySetInnerHTML`
- [x] No sensitive data in localStorage
- [x] TanStack Query invalidation is targeted
- [x] Zod schemas as source of truth