### PR TITLE
feat(reports): add DREN statistics dashboard with charts and exports

### DIFF
--- a/app/(admin)/admin/reports/dren/error.tsx
+++ b/app/(admin)/admin/reports/dren/error.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function DrenError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+        <AlertTriangle className="h-8 w-8 text-destructive" />
+      </div>
+      <div className="text-center space-y-1">
+        <h2 className="text-lg font-semibold">Une erreur est survenue</h2>
+        <p className="text-sm text-muted-foreground max-w-md">
+          {error.message || "Impossible de charger les statistiques. Veuillez réessayer."}
+        </p>
+      </div>
+      <Button onClick={reset} variant="outline">
+        Réessayer
+      </Button>
+    </div>
+  )
+}

--- a/app/(admin)/admin/reports/dren/loading.tsx
+++ b/app/(admin)/admin/reports/dren/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function DrenLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <Skeleton className="h-7 w-56" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-lg" />
+        ))}
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Skeleton className="h-80 rounded-lg" />
+        <Skeleton className="h-80 rounded-lg" />
+      </div>
+      <Skeleton className="h-64 rounded-lg" />
+    </div>
+  )
+}

--- a/app/(admin)/admin/reports/dren/page.tsx
+++ b/app/(admin)/admin/reports/dren/page.tsx
@@ -1,0 +1,7 @@
+import { DrenPageClient } from "@/components/admin/reports/dren/DrenPageClient"
+
+export const metadata = { title: "Statistiques DREN | KLASSCI" }
+
+export default function DrenPage() {
+  return <DrenPageClient />
+}

--- a/components/admin/reports/dren/DrenPageClient.tsx
+++ b/components/admin/reports/dren/DrenPageClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState } from "react"
-import { Download, FileSpreadsheet, Users, UserCheck, TrendingUp, BarChart3 } from "lucide-react"
+import { useState, useCallback } from "react"
+import { Download, FileSpreadsheet, Loader2, Users, UserCheck, TrendingUp, BarChart3 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -12,10 +12,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { toast } from "sonner"
 import { EnrollmentByLevelChart } from "./EnrollmentByLevelChart"
 import { SuccessRateChart } from "./SuccessRateChart"
 import { LevelStatsTable } from "./LevelStatsTable"
 import { useDrenStats } from "@/lib/hooks/useDrenStats"
+import { drenApi } from "@/lib/api/dren"
 
 // Données de démo — sera remplacé par l'API /academic-years
 const DEMO_ACADEMIC_YEARS = [
@@ -26,8 +28,28 @@ const DEMO_ACADEMIC_YEARS = [
 export function DrenPageClient() {
   const [academicYearId, setAcademicYearId] = useState<number>(DEMO_ACADEMIC_YEARS[0].id)
   const { data: stats, isLoading, isError } = useDrenStats(academicYearId)
+  const [downloading, setDownloading] = useState<"excel" | "pdf" | null>(null)
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL
+  // Téléchargement authentifié via blob
+  const handleDownload = useCallback(async (type: "excel" | "pdf") => {
+    setDownloading(type)
+    try {
+      const blob = type === "excel"
+        ? await drenApi.downloadExcel(academicYearId)
+        : await drenApi.downloadPdf(academicYearId)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `stats-dren-${academicYearId}.${type === "excel" ? "xlsx" : "pdf"}`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      console.error(`[DREN] ${type} download failed:`, err)
+      toast.error(err instanceof Error ? err.message : `Impossible de télécharger le fichier ${type.toUpperCase()}`)
+    } finally {
+      setDownloading(null)
+    }
+  }, [academicYearId])
 
   return (
     <div className="space-y-6">
@@ -40,25 +62,13 @@ export function DrenPageClient() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" asChild>
-            <a
-              href={`${baseUrl}/reports/dren/excel?academic_year_id=${academicYearId}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <FileSpreadsheet className="mr-2 h-4 w-4" />
-              Excel
-            </a>
+          <Button variant="outline" size="sm" onClick={() => handleDownload("excel")} disabled={downloading === "excel"}>
+            {downloading === "excel" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <FileSpreadsheet className="mr-2 h-4 w-4" />}
+            Excel
           </Button>
-          <Button variant="outline" size="sm" asChild>
-            <a
-              href={`${baseUrl}/reports/dren/pdf?academic_year_id=${academicYearId}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Download className="mr-2 h-4 w-4" />
-              PDF
-            </a>
+          <Button variant="outline" size="sm" onClick={() => handleDownload("pdf")} disabled={downloading === "pdf"}>
+            {downloading === "pdf" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Download className="mr-2 h-4 w-4" />}
+            PDF
           </Button>
         </div>
       </div>

--- a/components/admin/reports/dren/DrenPageClient.tsx
+++ b/components/admin/reports/dren/DrenPageClient.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import { useState } from "react"
+import { Download, FileSpreadsheet, Users, UserCheck, TrendingUp, BarChart3 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { EnrollmentByLevelChart } from "./EnrollmentByLevelChart"
+import { SuccessRateChart } from "./SuccessRateChart"
+import { LevelStatsTable } from "./LevelStatsTable"
+import { useDrenStats } from "@/lib/hooks/useDrenStats"
+
+// Données de démo — sera remplacé par l'API /academic-years
+const DEMO_ACADEMIC_YEARS = [
+  { id: 1, label: "2025-2026" },
+  { id: 2, label: "2024-2025" },
+]
+
+export function DrenPageClient() {
+  const [academicYearId, setAcademicYearId] = useState<number>(DEMO_ACADEMIC_YEARS[0].id)
+  const { data: stats, isLoading, isError } = useDrenStats(academicYearId)
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL
+
+  return (
+    <div className="space-y-6">
+      {/* En-tête */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-serif text-2xl tracking-tight">Statistiques DREN</h1>
+          <p className="text-sm text-muted-foreground">
+            Tableau de bord des indicateurs pour la Direction Régionale
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <a
+              href={`${baseUrl}/reports/dren/excel?academic_year_id=${academicYearId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <FileSpreadsheet className="mr-2 h-4 w-4" />
+              Excel
+            </a>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <a
+              href={`${baseUrl}/reports/dren/pdf?academic_year_id=${academicYearId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Download className="mr-2 h-4 w-4" />
+              PDF
+            </a>
+          </Button>
+        </div>
+      </div>
+
+      {/* Filtre année */}
+      <Select
+        value={academicYearId.toString()}
+        onValueChange={(v) => setAcademicYearId(Number(v))}
+      >
+        <SelectTrigger className="w-44">
+          <SelectValue placeholder="Année académique" />
+        </SelectTrigger>
+        <SelectContent>
+          {DEMO_ACADEMIC_YEARS.map((y) => (
+            <SelectItem key={y.id} value={y.id.toString()}>
+              {y.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Contenu */}
+      {isLoading ? (
+        <DrenSkeleton />
+      ) : isError ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          Impossible de charger les statistiques.
+        </div>
+      ) : stats ? (
+        <>
+          {/* KPIs */}
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <KpiCard
+              icon={Users}
+              label="Effectif total"
+              value={stats.total_students.toLocaleString("fr-FR")}
+            />
+            <KpiCard
+              icon={UserCheck}
+              label="Taux de réussite"
+              value={`${stats.overall_success_rate.toFixed(1)}%`}
+              className={stats.overall_success_rate >= 60 ? "text-emerald-600" : "text-accent"}
+            />
+            <KpiCard
+              icon={BarChart3}
+              label="Garçons / Filles"
+              value={`${stats.total_male} / ${stats.total_female}`}
+            />
+            <KpiCard
+              icon={TrendingUp}
+              label="Moyenne générale"
+              value={stats.overall_average !== null ? stats.overall_average.toFixed(2) : "—"}
+            />
+          </div>
+
+          {/* Graphiques */}
+          <div className="grid gap-6 lg:grid-cols-2">
+            <EnrollmentByLevelChart data={stats.gender_distribution} />
+            <SuccessRateChart data={stats.success_rates} />
+          </div>
+
+          {/* Tableau détaillé */}
+          <LevelStatsTable data={stats.levels} />
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+// Carte KPI
+function KpiCard({
+  icon: Icon,
+  label,
+  value,
+  className,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: string
+  className?: string
+}) {
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+          <Icon className="h-5 w-5 text-primary" />
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">{label}</p>
+          <p className={`text-lg font-bold ${className ?? ""}`}>{value}</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// Skeleton de chargement
+function DrenSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-lg" />
+        ))}
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Skeleton className="h-80 rounded-lg" />
+        <Skeleton className="h-80 rounded-lg" />
+      </div>
+      <Skeleton className="h-64 rounded-lg" />
+    </div>
+  )
+}

--- a/components/admin/reports/dren/EnrollmentByLevelChart.tsx
+++ b/components/admin/reports/dren/EnrollmentByLevelChart.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { GenderDistribution } from "@/lib/contracts/dren"
+
+interface EnrollmentByLevelChartProps {
+  data: GenderDistribution[]
+}
+
+export function EnrollmentByLevelChart({ data }: EnrollmentByLevelChartProps) {
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardHeader>
+        <CardTitle className="text-base font-medium">Effectifs par niveau</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+            <XAxis dataKey="level" className="text-xs" />
+            <YAxis className="text-xs" />
+            <Tooltip
+              contentStyle={{
+                borderRadius: "8px",
+                border: "1px solid hsl(var(--border))",
+                backgroundColor: "hsl(var(--card))",
+              }}
+            />
+            <Legend />
+            <Bar
+              dataKey="male"
+              name="Garçons"
+              fill="hsl(216, 80%, 30%)"
+              radius={[4, 4, 0, 0]}
+            />
+            <Bar
+              dataKey="female"
+              name="Filles"
+              fill="hsl(28, 91%, 54%)"
+              radius={[4, 4, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/reports/dren/LevelStatsTable.tsx
+++ b/components/admin/reports/dren/LevelStatsTable.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { LevelStats } from "@/lib/contracts/dren"
+
+interface LevelStatsTableProps {
+  data: LevelStats[]
+}
+
+export function LevelStatsTable({ data }: LevelStatsTableProps) {
+  // Totaux
+  const totals = data.reduce(
+    (acc, level) => ({
+      total_students: acc.total_students + level.total_students,
+      male_count: acc.male_count + level.male_count,
+      female_count: acc.female_count + level.female_count,
+      success_count: acc.success_count + level.success_count,
+      fail_count: acc.fail_count + level.fail_count,
+    }),
+    { total_students: 0, male_count: 0, female_count: 0, success_count: 0, fail_count: 0 },
+  )
+
+  const totalRate =
+    totals.total_students > 0
+      ? ((totals.success_count / totals.total_students) * 100).toFixed(1)
+      : "—"
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardHeader>
+        <CardTitle className="text-base font-medium">Détail par niveau</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Niveau</TableHead>
+              <TableHead className="text-center">Effectif</TableHead>
+              <TableHead className="text-center">Garçons</TableHead>
+              <TableHead className="text-center">Filles</TableHead>
+              <TableHead className="text-center">Admis</TableHead>
+              <TableHead className="text-center">Recalés</TableHead>
+              <TableHead className="text-center">Taux de réussite</TableHead>
+              <TableHead className="text-center">Moyenne</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.map((level) => (
+              <TableRow key={level.level}>
+                <TableCell className="font-medium">{level.level}</TableCell>
+                <TableCell className="text-center">{level.total_students}</TableCell>
+                <TableCell className="text-center">{level.male_count}</TableCell>
+                <TableCell className="text-center">{level.female_count}</TableCell>
+                <TableCell className="text-center text-emerald-600">
+                  {level.success_count}
+                </TableCell>
+                <TableCell className="text-center text-rose-600">
+                  {level.fail_count}
+                </TableCell>
+                <TableCell className="text-center font-semibold">
+                  {level.success_rate.toFixed(1)}%
+                </TableCell>
+                <TableCell className="text-center">
+                  {level.average !== null ? level.average.toFixed(2) : "—"}
+                </TableCell>
+              </TableRow>
+            ))}
+            {/* Ligne total */}
+            <TableRow className="bg-muted/50 font-semibold">
+              <TableCell>Total</TableCell>
+              <TableCell className="text-center">{totals.total_students}</TableCell>
+              <TableCell className="text-center">{totals.male_count}</TableCell>
+              <TableCell className="text-center">{totals.female_count}</TableCell>
+              <TableCell className="text-center text-emerald-600">
+                {totals.success_count}
+              </TableCell>
+              <TableCell className="text-center text-rose-600">
+                {totals.fail_count}
+              </TableCell>
+              <TableCell className="text-center">{totalRate}%</TableCell>
+              <TableCell className="text-center">—</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/reports/dren/SuccessRateChart.tsx
+++ b/components/admin/reports/dren/SuccessRateChart.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { SuccessRateByLevel } from "@/lib/contracts/dren"
+
+interface SuccessRateChartProps {
+  data: SuccessRateByLevel[]
+}
+
+// Couleur selon le taux de réussite
+function getRateColor(rate: number): string {
+  if (rate >= 80) return "hsl(142, 71%, 45%)" // emerald
+  if (rate >= 60) return "hsl(216, 80%, 30%)" // primary
+  if (rate >= 40) return "hsl(28, 91%, 54%)" // accent
+  return "hsl(0, 84%, 60%)" // rose
+}
+
+export function SuccessRateChart({ data }: SuccessRateChartProps) {
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardHeader>
+        <CardTitle className="text-base font-medium">Taux de réussite par niveau</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+            <XAxis dataKey="level" className="text-xs" />
+            <YAxis domain={[0, 100]} unit="%" className="text-xs" />
+            <Tooltip
+              formatter={(value: number) => [`${value.toFixed(1)}%`, "Taux de réussite"]}
+              contentStyle={{
+                borderRadius: "8px",
+                border: "1px solid hsl(var(--border))",
+                backgroundColor: "hsl(var(--card))",
+              }}
+            />
+            <Bar dataKey="rate" name="Taux" radius={[4, 4, 0, 0]}>
+              {data.map((entry, index) => (
+                <Cell key={index} fill={getRateColor(entry.rate)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/api/dren.ts
+++ b/lib/api/dren.ts
@@ -1,3 +1,4 @@
+import { getSession } from "next-auth/react"
 import { apiFetch, safeValidate } from "./client"
 import { DrenStatsSchema, type DrenStats } from "@/lib/contracts/dren"
 
@@ -11,20 +12,28 @@ export const drenApi = {
     return safeValidate(DrenStatsSchema, stats, "GET /reports/dren")
   },
 
-  // Télécharger l'export Excel
+  // Télécharger l'export Excel (authentifié)
   downloadExcel: async (academicYearId: number): Promise<Blob> => {
     const baseUrl = process.env.NEXT_PUBLIC_API_URL
     if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
-    const res = await fetch(`${baseUrl}/reports/dren/excel?academic_year_id=${academicYearId}`)
+    const session = await getSession()
+    if (!session?.accessToken) throw new Error("Session expirée — reconnectez-vous")
+    const res = await fetch(`${baseUrl}/reports/dren/excel?academic_year_id=${academicYearId}`, {
+      headers: { Authorization: `Bearer ${session.accessToken}` },
+    })
     if (!res.ok) throw new Error("Impossible de télécharger le fichier Excel")
     return res.blob()
   },
 
-  // Télécharger l'export PDF
+  // Télécharger l'export PDF (authentifié)
   downloadPdf: async (academicYearId: number): Promise<Blob> => {
     const baseUrl = process.env.NEXT_PUBLIC_API_URL
     if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
-    const res = await fetch(`${baseUrl}/reports/dren/pdf?academic_year_id=${academicYearId}`)
+    const session = await getSession()
+    if (!session?.accessToken) throw new Error("Session expirée — reconnectez-vous")
+    const res = await fetch(`${baseUrl}/reports/dren/pdf?academic_year_id=${academicYearId}`, {
+      headers: { Authorization: `Bearer ${session.accessToken}` },
+    })
     if (!res.ok) throw new Error("Impossible de télécharger le fichier PDF")
     return res.blob()
   },

--- a/lib/api/dren.ts
+++ b/lib/api/dren.ts
@@ -1,0 +1,31 @@
+import { apiFetch, safeValidate } from "./client"
+import { DrenStatsSchema, type DrenStats } from "@/lib/contracts/dren"
+
+export const drenApi = {
+  // Récupérer les statistiques agrégées pour une année académique
+  getStats: async (academicYearId: number): Promise<DrenStats> => {
+    const json = await apiFetch<{ data?: DrenStats } | DrenStats>(
+      `/reports/dren?academic_year_id=${academicYearId}`,
+    )
+    const stats = (json as { data?: DrenStats }).data ?? (json as DrenStats)
+    return safeValidate(DrenStatsSchema, stats, "GET /reports/dren")
+  },
+
+  // Télécharger l'export Excel
+  downloadExcel: async (academicYearId: number): Promise<Blob> => {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL
+    if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
+    const res = await fetch(`${baseUrl}/reports/dren/excel?academic_year_id=${academicYearId}`)
+    if (!res.ok) throw new Error("Impossible de télécharger le fichier Excel")
+    return res.blob()
+  },
+
+  // Télécharger l'export PDF
+  downloadPdf: async (academicYearId: number): Promise<Blob> => {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL
+    if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
+    const res = await fetch(`${baseUrl}/reports/dren/pdf?academic_year_id=${academicYearId}`)
+    if (!res.ok) throw new Error("Impossible de télécharger le fichier PDF")
+    return res.blob()
+  },
+}

--- a/lib/contracts/dren.ts
+++ b/lib/contracts/dren.ts
@@ -1,0 +1,44 @@
+import { z } from "zod"
+
+// Miroir de app/schemas/dren.py (backend)
+// Statistiques agrégées pour la Direction Régionale de l'Éducation Nationale
+
+export const LevelStatsSchema = z.object({
+  level: z.string(),
+  total_students: z.number(),
+  male_count: z.number(),
+  female_count: z.number(),
+  success_count: z.number(),
+  fail_count: z.number(),
+  success_rate: z.number(),
+  average: z.number().nullable(),
+})
+
+export const GenderDistributionSchema = z.object({
+  level: z.string(),
+  male: z.number(),
+  female: z.number(),
+})
+
+export const SuccessRateByLevelSchema = z.object({
+  level: z.string(),
+  rate: z.number(),
+})
+
+export const DrenStatsSchema = z.object({
+  academic_year_id: z.number(),
+  academic_year_label: z.string(),
+  total_students: z.number(),
+  total_male: z.number(),
+  total_female: z.number(),
+  overall_success_rate: z.number(),
+  overall_average: z.number().nullable(),
+  levels: z.array(LevelStatsSchema),
+  gender_distribution: z.array(GenderDistributionSchema),
+  success_rates: z.array(SuccessRateByLevelSchema),
+})
+
+export type LevelStats = z.infer<typeof LevelStatsSchema>
+export type GenderDistribution = z.infer<typeof GenderDistributionSchema>
+export type SuccessRateByLevel = z.infer<typeof SuccessRateByLevelSchema>
+export type DrenStats = z.infer<typeof DrenStatsSchema>

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -2,6 +2,7 @@ export * from "./auth"
 export * from "./enrollment"
 export * from "./timetable"
 export * from "./grade"
+export * from "./dren"
 
 // Shared pagination contract
 import { z } from "zod"

--- a/lib/hooks/useDrenStats.ts
+++ b/lib/hooks/useDrenStats.ts
@@ -1,0 +1,19 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { drenApi } from "@/lib/api/dren"
+
+export const drenKeys = {
+  all: ["dren"] as const,
+  stats: (academicYearId: number) => ["dren", "stats", academicYearId] as const,
+}
+
+// Récupérer les statistiques DREN pour une année académique
+export function useDrenStats(academicYearId: number | undefined) {
+  return useQuery({
+    queryKey: drenKeys.stats(academicYearId ?? 0),
+    queryFn: () => drenApi.getStats(academicYearId!),
+    enabled: !!academicYearId,
+    staleTime: 1000 * 60 * 10, // 10 minutes — données stables
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "next": "15.5.12",
         "next-auth": "^5.0.0-beta.25",
         "next-intl": "^3.26.3",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.71.2",
@@ -8724,6 +8725,16 @@
       "peerDependencies": {
         "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {


### PR DESCRIPTION
## Summary
- Ajout de la page `/admin/reports/dren` — tableau de bord statistiques pour la DREN
- 4 KPIs : effectif total, taux de réussite, répartition garçons/filles, moyenne générale
- Graphique effectifs par niveau avec répartition F/H (Recharts BarChart)
- Graphique taux de réussite par niveau avec couleurs sémantiques
- Tableau détaillé par niveau avec ligne totaux
- Export Excel et PDF via liens directs backend
- Filtre par année académique

## Changes
- `lib/contracts/dren.ts` — Schémas Zod (DrenStats, LevelStats, GenderDistribution, SuccessRateByLevel)
- `lib/api/dren.ts` — Client API (getStats, downloadExcel, downloadPdf)
- `lib/hooks/useDrenStats.ts` — Hook TanStack Query
- `app/(admin)/admin/reports/dren/` — page, loading skeleton, error boundary
- `components/admin/reports/dren/` — DrenPageClient, EnrollmentByLevelChart, SuccessRateChart, LevelStatsTable

## Closes

Closes #30

## Testing
- [x] No TypeScript errors `npx tsc --noEmit`
- [x] Build OK `npm run build`
- [x] Skeleton loaders in place
- [x] Commentaires en français

## Checklist
- [x] No `any` TypeScript types
- [x] No `dangerouslySetInnerHTML`
- [x] No sensitive data in localStorage
- [x] TanStack Query invalidation is targeted
- [x] Zod schemas as source of truth
- [x] Recharts pour les graphiques (conformément au stack)