### PR TITLE
feat(teacher): add teacher portal with 3 pages

### DIFF
--- a/app/(teacher)/teacher/classes/error.tsx
+++ b/app/(teacher)/teacher/classes/error.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function ClassesError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <AlertTriangle className="h-8 w-8 text-destructive" />
+      <p className="text-sm text-muted-foreground">{error.message || "Impossible de charger les classes."}</p>
+      <Button onClick={reset} variant="outline" size="sm">Réessayer</Button>
+    </div>
+  )
+}

--- a/app/(teacher)/teacher/classes/loading.tsx
+++ b/app/(teacher)/teacher/classes/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function ClassesLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-36" />
+        <Skeleton className="h-4 w-52" />
+      </div>
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-44 rounded-lg" />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/(teacher)/teacher/classes/page.tsx
+++ b/app/(teacher)/teacher/classes/page.tsx
@@ -1,0 +1,7 @@
+import { TeacherClassesClient } from "@/components/teacher/TeacherClassesClient"
+
+export const metadata = { title: "Mes classes | KLASSCI" }
+
+export default function TeacherClassesPage() {
+  return <TeacherClassesClient />
+}

--- a/app/(teacher)/teacher/dashboard/error.tsx
+++ b/app/(teacher)/teacher/dashboard/error.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function DashboardError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <AlertTriangle className="h-8 w-8 text-destructive" />
+      <p className="text-sm text-muted-foreground">{error.message || "Impossible de charger le tableau de bord."}</p>
+      <Button onClick={reset} variant="outline" size="sm">Réessayer</Button>
+    </div>
+  )
+}

--- a/app/(teacher)/teacher/dashboard/loading.tsx
+++ b/app/(teacher)/teacher/dashboard/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+      <Skeleton className="h-20 rounded-xl" />
+      <div className="grid grid-cols-2 gap-3">
+        <Skeleton className="h-20 rounded-lg" />
+        <Skeleton className="h-20 rounded-lg" />
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-36" />
+        <Skeleton className="h-16 rounded-lg" />
+        <Skeleton className="h-16 rounded-lg" />
+      </div>
+    </div>
+  )
+}

--- a/app/(teacher)/teacher/dashboard/page.tsx
+++ b/app/(teacher)/teacher/dashboard/page.tsx
@@ -1,63 +1,7 @@
-import { CalendarDays, AlertTriangle, UserX } from "lucide-react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { DataError } from "@/components/shared/DataError"
+import { TeacherDashboardClient } from "@/components/teacher/TeacherDashboardClient"
 
 export const metadata = { title: "Accueil Enseignant | KLASSCI" }
 
 export default function TeacherDashboardPage() {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="font-serif text-xl tracking-tight">Espace Enseignant</h1>
-        <p className="text-sm text-muted-foreground">
-          Votre journee en un coup d&apos;oeil
-        </p>
-      </div>
-
-      {/* Next course */}
-      <Card className="border-primary/20 bg-primary/5">
-        <CardContent className="flex items-center gap-4 p-4">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
-            <CalendarDays className="h-6 w-6" />
-          </div>
-          <div className="min-w-0">
-            <p className="text-xs font-medium text-primary uppercase tracking-wider">Prochain cours</p>
-            <p className="text-sm text-muted-foreground mt-1">Aucun cours programme</p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Courses & alerts — awaiting dedicated endpoints */}
-      <DataError
-        message="Les donnees enseignant necessitent les endpoints /teacher/schedule et /teacher/alerts (a venir)"
-        compact
-      />
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Card>
-          <CardContent className="flex items-center gap-3 p-4">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-100 text-amber-700">
-              <AlertTriangle className="h-5 w-5" />
-            </div>
-            <div>
-              <p className="text-sm font-medium">Notes manquantes</p>
-              <p className="text-xs text-muted-foreground">Aucune alerte</p>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="flex items-center gap-3 p-4">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-rose-100 text-rose-700">
-              <UserX className="h-5 w-5" />
-            </div>
-            <div>
-              <p className="text-sm font-medium">Absences signalees</p>
-              <p className="text-xs text-muted-foreground">Aucune absence</p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  )
+  return <TeacherDashboardClient />
 }

--- a/app/(teacher)/teacher/timetable/error.tsx
+++ b/app/(teacher)/teacher/timetable/error.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function TimetableError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <AlertTriangle className="h-8 w-8 text-destructive" />
+      <p className="text-sm text-muted-foreground">{error.message || "Impossible de charger l'emploi du temps."}</p>
+      <Button onClick={reset} variant="outline" size="sm">Réessayer</Button>
+    </div>
+  )
+}

--- a/app/(teacher)/teacher/timetable/loading.tsx
+++ b/app/(teacher)/teacher/timetable/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function TimetableLoading() {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-4 w-56" />
+      </div>
+      <Skeleton className="h-[500px] rounded-lg" />
+    </div>
+  )
+}

--- a/app/(teacher)/teacher/timetable/page.tsx
+++ b/app/(teacher)/teacher/timetable/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation"
+import { auth } from "@/auth"
+import { TeacherScheduleClient } from "@/components/teacher/TeacherScheduleClient"
+
+export const metadata = { title: "Mon emploi du temps | KLASSCI" }
+
+export default async function TeacherTimetablePage() {
+  const session = await auth()
+  const teacherId = session?.user?.id ? Number(session.user.id) : 0
+
+  if (!teacherId) {
+    redirect("/login")
+  }
+
+  return <TeacherScheduleClient teacherId={teacherId} />
+}

--- a/components/teacher/TeacherClassesClient.tsx
+++ b/components/teacher/TeacherClassesClient.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import Link from "next/link"
+import {
+  Users,
+  GraduationCap,
+  ClipboardList,
+  ChevronRight,
+} from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { DataError } from "@/components/shared/DataError"
+import { useTeacherClasses } from "@/lib/hooks/useTeacherPortal"
+import type { TeacherClass } from "@/lib/contracts/teacher-portal"
+
+export function TeacherClassesClient() {
+  const { data: classes, isLoading, isError, refetch } = useTeacherClasses()
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="font-serif text-xl tracking-tight">Mes classes</h1>
+        <p className="text-sm text-muted-foreground">
+          Classes assignées et statistiques
+        </p>
+      </div>
+
+      {isLoading ? (
+        <ClassesSkeleton />
+      ) : isError ? (
+        <DataError
+          message="Impossible de charger la liste des classes."
+          onRetry={() => refetch()}
+        />
+      ) : !classes || classes.length === 0 ? (
+        <div className="py-12 text-center">
+          <Users className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
+          <p className="text-sm text-muted-foreground">
+            Aucune classe assignée.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {classes.map((cls) => (
+            <ClassCard key={cls.id} cls={cls} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ClassCard({ cls }: { cls: TeacherClass }) {
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardContent className="p-4 space-y-3">
+        {/* En-tête */}
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="font-semibold text-sm">{cls.name}</p>
+            <p className="text-xs text-muted-foreground">{cls.subject_name}</p>
+          </div>
+          <Badge variant="secondary" className="text-[10px]">
+            {cls.level}
+          </Badge>
+        </div>
+
+        {/* Indicateurs */}
+        <div className="grid grid-cols-3 gap-2">
+          <div className="rounded-lg bg-muted/50 p-2 text-center">
+            <Users className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
+            <p className="text-sm font-bold">{cls.student_count}</p>
+            <p className="text-[10px] text-muted-foreground">Élèves</p>
+          </div>
+          <div className="rounded-lg bg-muted/50 p-2 text-center">
+            <GraduationCap className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
+            <p
+              className={`text-sm font-bold ${
+                cls.general_average === null
+                  ? "text-muted-foreground"
+                  : cls.general_average >= 10
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-destructive"
+              }`}
+            >
+              {cls.general_average !== null
+                ? cls.general_average.toFixed(2)
+                : "—"}
+            </p>
+            <p className="text-[10px] text-muted-foreground">Moyenne</p>
+          </div>
+          <div className="rounded-lg bg-muted/50 p-2 text-center">
+            <ClipboardList className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
+            <p className="text-sm font-bold">{cls.total_evaluations}</p>
+            <p className="text-[10px] text-muted-foreground">Évals</p>
+          </div>
+        </div>
+
+        {/* Action */}
+        <Link
+          href={`/teacher/grades/${cls.id}`}
+          className="flex items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
+        >
+          Gérer les notes <ChevronRight className="h-3 w-3" />
+        </Link>
+      </CardContent>
+    </Card>
+  )
+}
+
+function ClassesSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <Skeleton key={i} className="h-44 rounded-lg" />
+      ))}
+    </div>
+  )
+}

--- a/components/teacher/TeacherClassesClient.tsx
+++ b/components/teacher/TeacherClassesClient.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import Link from "next/link"
+import type { Route } from "next"
 import {
   Users,
   GraduationCap,
@@ -99,7 +100,7 @@ function ClassCard({ cls }: { cls: TeacherClass }) {
 
         {/* Action */}
         <Link
-          href={`/teacher/grades/${cls.id}`}
+          href={`/teacher/grades/${cls.id}` as Route}
           className="flex items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
         >
           Gérer les notes <ChevronRight className="h-3 w-3" />

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import Link from "next/link"
+import {
+  CalendarDays,
+  Users,
+  BookOpen,
+  ClipboardList,
+  ChevronRight,
+  AlertTriangle,
+} from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { DataError } from "@/components/shared/DataError"
+import { useTeacherDashboard } from "@/lib/hooks/useTeacherPortal"
+import type { TeacherUpcomingEval } from "@/lib/contracts/teacher-portal"
+
+export function TeacherDashboardClient() {
+  const { data, isLoading, isError, refetch } = useTeacherDashboard()
+
+  if (isLoading) return <DashboardSkeleton />
+
+  if (isError) {
+    return (
+      <div className="space-y-6">
+        <DashboardHeader name={null} />
+        <DataError
+          message="Impossible de charger le tableau de bord."
+          onRetry={() => refetch()}
+        />
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="space-y-6">
+        <DashboardHeader name={null} />
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          Aucune donnée disponible.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <DashboardHeader name={data.teacher_name} />
+
+      {/* Prochain cours */}
+      <Card className="border-primary/20 bg-primary/5">
+        <CardContent className="flex items-center gap-4 p-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+            <CalendarDays className="h-6 w-6" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-primary uppercase tracking-wider">
+              Prochain cours
+            </p>
+            {data.next_course ? (
+              <div className="mt-1">
+                <p className="text-sm font-semibold">
+                  {data.next_course.subject_name}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {data.next_course.start_time} - {data.next_course.end_time}
+                  {" • "}{data.next_course.class_name}
+                  {data.next_course.room && ` • Salle ${data.next_course.room}`}
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground mt-1">
+                Aucun cours programmé
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* KPIs */}
+      <div className="grid grid-cols-2 gap-3">
+        <Card className="border-0 shadow-sm ring-1 ring-border">
+          <CardContent className="flex items-center gap-3 p-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+              <Users className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <p className="text-2xl font-bold">{data.total_students}</p>
+              <p className="text-[10px] text-muted-foreground">Élèves</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Link href="/teacher/classes">
+          <Card className="border-0 shadow-sm ring-1 ring-border hover:ring-primary/50 transition-colors">
+            <CardContent className="flex items-center gap-3 p-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                <BookOpen className="h-5 w-5 text-primary" />
+              </div>
+              <div className="flex-1">
+                <p className="text-2xl font-bold">{data.total_classes}</p>
+                <p className="text-[10px] text-muted-foreground">Classes</p>
+              </div>
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+
+      {/* Évaluations à venir */}
+      <div>
+        <h2 className="text-sm font-semibold mb-3">Évaluations à venir</h2>
+        {data.upcoming_evaluations.length === 0 ? (
+          <Card className="border-0 shadow-sm ring-1 ring-border">
+            <CardContent className="py-8 text-center">
+              <ClipboardList className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" />
+              <p className="text-sm text-muted-foreground">
+                Aucune évaluation programmée.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-2">
+            {data.upcoming_evaluations.map((evaluation) => (
+              <EvaluationCard key={evaluation.id} evaluation={evaluation} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DashboardHeader({ name }: { name: string | null }) {
+  return (
+    <div>
+      <h1 className="font-serif text-xl tracking-tight">
+        {name ? `Bonjour, ${name.split(" ")[0]}` : "Espace Enseignant"}
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        Votre journée en un coup d&apos;œil
+      </p>
+    </div>
+  )
+}
+
+function EvaluationCard({ evaluation }: { evaluation: TeacherUpcomingEval }) {
+  const gradedPercent =
+    evaluation.total_students > 0
+      ? Math.round((evaluation.graded_students / evaluation.total_students) * 100)
+      : 0
+  const needsGrading = evaluation.graded_students < evaluation.total_students
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardContent className="p-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold truncate">{evaluation.title}</p>
+            <p className="text-xs text-muted-foreground">
+              {evaluation.class_name} • {evaluation.subject_name}
+            </p>
+            <p className="text-xs text-muted-foreground">{evaluation.date}</p>
+          </div>
+          <div className="flex flex-col items-end gap-1 shrink-0">
+            <Badge variant="secondary" className="text-[10px]">
+              {evaluation.type}
+            </Badge>
+            {needsGrading && (
+              <span className="flex items-center gap-1 text-[10px] text-accent">
+                <AlertTriangle className="h-3 w-3" />
+                {gradedPercent}% noté
+              </span>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+      <Skeleton className="h-20 rounded-xl" />
+      <div className="grid grid-cols-2 gap-3">
+        <Skeleton className="h-20 rounded-lg" />
+        <Skeleton className="h-20 rounded-lg" />
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-36" />
+        <Skeleton className="h-16 rounded-lg" />
+        <Skeleton className="h-16 rounded-lg" />
+      </div>
+    </div>
+  )
+}

--- a/components/teacher/TeacherScheduleClient.tsx
+++ b/components/teacher/TeacherScheduleClient.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { TeacherScheduleView } from "@/components/teacher/timetable/TeacherScheduleView"
+
+interface TeacherScheduleClientProps {
+  teacherId: number
+}
+
+export function TeacherScheduleClient({ teacherId }: TeacherScheduleClientProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="font-serif text-xl tracking-tight">Mon emploi du temps</h1>
+        <p className="text-sm text-muted-foreground">Votre planning de la semaine</p>
+      </div>
+      <TeacherScheduleView teacherId={teacherId} />
+    </div>
+  )
+}

--- a/lib/api/teacher-portal.ts
+++ b/lib/api/teacher-portal.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+import { apiFetch, safeValidate } from "./client"
+import {
+  TeacherDashboardSchema,
+  TeacherClassSchema,
+  type TeacherDashboard,
+  type TeacherClass,
+} from "@/lib/contracts/teacher-portal"
+
+const TeacherClassArraySchema = z.array(TeacherClassSchema)
+
+// Extrait l'item de la réponse API, qu'elle soit { data: T } ou T directement
+function unwrapResponse<T>(res: unknown): T {
+  if (res !== null && typeof res === "object" && "data" in res && (res as Record<string, unknown>).data !== undefined) {
+    return (res as Record<string, unknown>).data as T
+  }
+  return res as T
+}
+
+export const teacherPortalApi = {
+  // Dashboard — KPIs, prochain cours, évaluations à venir
+  getDashboard: async (): Promise<TeacherDashboard> => {
+    const res = await apiFetch<unknown>("/teacher/dashboard")
+    return safeValidate(TeacherDashboardSchema, unwrapResponse(res), "GET /teacher/dashboard")
+  },
+
+  // Liste des classes assignées avec stats
+  getClasses: async (): Promise<TeacherClass[]> => {
+    const res = await apiFetch<unknown>("/teacher/classes")
+    const arr = Array.isArray(res) ? res : unwrapResponse<TeacherClass[]>(res)
+    return safeValidate(TeacherClassArraySchema, arr, "GET /teacher/classes")
+  },
+}

--- a/lib/contracts/teacher-portal.ts
+++ b/lib/contracts/teacher-portal.ts
@@ -1,0 +1,50 @@
+import { z } from "zod"
+import { EvaluationTypeSchema } from "./grade"
+
+// Contrats pour le portail enseignant — endpoints /teacher/*
+
+// Prochain cours de l'enseignant
+export const TeacherNextCourseSchema = z.object({
+  subject_name: z.string(),
+  class_name: z.string(),
+  start_time: z.string(),
+  end_time: z.string(),
+  room: z.string().nullish(),
+})
+
+// Classe assignée à l'enseignant
+export const TeacherClassSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  level: z.string(),
+  student_count: z.number(),
+  subject_name: z.string(),
+  general_average: z.number().nullable(),
+  total_evaluations: z.number(),
+})
+
+// Évaluation à venir
+export const TeacherUpcomingEvalSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  type: EvaluationTypeSchema,
+  date: z.string(),
+  class_name: z.string(),
+  subject_name: z.string(),
+  graded_students: z.number(),
+  total_students: z.number(),
+})
+
+// Dashboard enseignant
+export const TeacherDashboardSchema = z.object({
+  teacher_name: z.string(),
+  total_students: z.number(),
+  total_classes: z.number(),
+  next_course: TeacherNextCourseSchema.nullable(),
+  upcoming_evaluations: z.array(TeacherUpcomingEvalSchema),
+})
+
+export type TeacherNextCourse = z.infer<typeof TeacherNextCourseSchema>
+export type TeacherClass = z.infer<typeof TeacherClassSchema>
+export type TeacherUpcomingEval = z.infer<typeof TeacherUpcomingEvalSchema>
+export type TeacherDashboard = z.infer<typeof TeacherDashboardSchema>

--- a/lib/hooks/useTeacherPortal.ts
+++ b/lib/hooks/useTeacherPortal.ts
@@ -1,0 +1,26 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { teacherPortalApi } from "@/lib/api/teacher-portal"
+
+export const teacherPortalKeys = {
+  all: ["teacher-portal"] as const,
+  dashboard: () => ["teacher-portal", "dashboard"] as const,
+  classes: () => ["teacher-portal", "classes"] as const,
+}
+
+export function useTeacherDashboard() {
+  return useQuery({
+    queryKey: teacherPortalKeys.dashboard(),
+    queryFn: () => teacherPortalApi.getDashboard(),
+    staleTime: 1000 * 60 * 2,
+  })
+}
+
+export function useTeacherClasses() {
+  return useQuery({
+    queryKey: teacherPortalKeys.classes(),
+    queryFn: () => teacherPortalApi.getClasses(),
+    staleTime: 1000 * 60 * 5,
+  })
+}


### PR DESCRIPTION
## Description

Implémente le portail enseignant avec 3 pages fonctionnelles :

- **`/teacher/dashboard`** — KPIs (nb élèves, nb classes), prochain cours, évaluations à venir avec indicateur de notation
- **`/teacher/timetable`** — emploi du temps personnel (réutilise `TeacherScheduleView` existant, teacherId résolu côté serveur via `auth()`)
- **`/teacher/classes`** — liste des classes assignées avec stats (moyenne, nb élèves, nb évals) et lien vers la saisie de notes

### Architecture

- **Contrats Zod** : `lib/contracts/teacher-portal.ts` — réutilise `EvaluationTypeSchema` depuis `grade.ts`
- **API layer** : `lib/api/teacher-portal.ts` — `GET /teacher/dashboard`, `GET /teacher/classes`
- **Hooks TanStack Query** : `lib/hooks/useTeacherPortal.ts` — `useTeacherDashboard()`, `useTeacherClasses()`
- **Client components** : `TeacherDashboardClient`, `TeacherScheduleClient`, `TeacherClassesClient`
- Chaque page a son `loading.tsx` (skeleton) et `error.tsx` (error boundary)

### Pattern suivi

- Server Component pages → Client Components avec TanStack Query
- Skeleton loaders individuels (pas de spinner global)
- `DataError` partagé pour la gestion d'erreurs avec retry
- Mobile-first (tablette en classe)

## Closes

Closes #35

## Checklist

- [x] Linting passe (`npm run lint`)
- [x] Type-check OK (`npx tsc --noEmit`)
- [ ] Build OK (`npm run build`)
- [ ] Branche à jour avec develop