### PR TITLE
feat(notifications): add notification system with bell, dropdown, and admin page

### DIFF
--- a/app/(admin)/admin/notifications/error.tsx
+++ b/app/(admin)/admin/notifications/error.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function NotificationsError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <AlertTriangle className="h-8 w-8 text-destructive" />
+      <p className="text-sm text-muted-foreground">{error.message || "Impossible de charger les notifications."}</p>
+      <Button onClick={reset} variant="outline" size="sm">Réessayer</Button>
+    </div>
+  )
+}

--- a/app/(admin)/admin/notifications/loading.tsx
+++ b/app/(admin)/admin/notifications/loading.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function NotificationsLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-40" />
+          <Skeleton className="h-4 w-56" />
+        </div>
+        <Skeleton className="h-9 w-48" />
+      </div>
+      <div className="flex gap-3">
+        <Skeleton className="h-10 w-[180px]" />
+        <Skeleton className="h-10 w-[160px]" />
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 rounded-lg" />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/(admin)/admin/notifications/page.tsx
+++ b/app/(admin)/admin/notifications/page.tsx
@@ -1,0 +1,7 @@
+import { NotificationsPageClient } from "@/components/admin/notifications/NotificationsPageClient"
+
+export const metadata = { title: "Notifications | KLASSCI" }
+
+export default function NotificationsPage() {
+  return <NotificationsPageClient />
+}

--- a/components/admin/notifications/NotificationsPageClient.tsx
+++ b/components/admin/notifications/NotificationsPageClient.tsx
@@ -1,0 +1,258 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Bell,
+  UserPlus,
+  ClipboardList,
+  Wallet,
+  AlertCircle,
+  Settings,
+  Check,
+  CheckCheck,
+  Filter,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { DataError } from "@/components/shared/DataError"
+import {
+  useNotifications,
+  useNotificationCount,
+  useMarkAsRead,
+  useMarkAllAsRead,
+} from "@/lib/hooks/useNotifications"
+import type { Notification, NotificationType } from "@/lib/contracts/notification"
+import { cn } from "@/lib/utils"
+
+/** Icône par type de notification */
+const TYPE_ICONS: Record<NotificationType, React.ComponentType<{ className?: string }>> = {
+  inscription: UserPlus,
+  note: ClipboardList,
+  paiement: Wallet,
+  absence: AlertCircle,
+  systeme: Settings,
+}
+
+/** Couleur de fond par type */
+const TYPE_COLORS: Record<NotificationType, string> = {
+  inscription: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  note: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+  paiement: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  absence: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400",
+  systeme: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
+}
+
+/** Labels pour les types */
+const TYPE_LABELS: Record<NotificationType, string> = {
+  inscription: "Inscription",
+  note: "Note",
+  paiement: "Paiement",
+  absence: "Absence",
+  systeme: "Système",
+}
+
+/** Formater une date relative */
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return "À l'instant"
+  if (minutes < 60) return `Il y a ${minutes}min`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `Il y a ${hours}h`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `Il y a ${days}j`
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  })
+}
+
+const NOTIFICATION_TYPES: NotificationType[] = [
+  "inscription",
+  "note",
+  "paiement",
+  "absence",
+  "systeme",
+]
+
+export function NotificationsPageClient() {
+  const [typeFilter, setTypeFilter] = useState<NotificationType | "all">("all")
+  const [readFilter, setReadFilter] = useState<"all" | "unread" | "read">("all")
+
+  const params = {
+    ...(typeFilter !== "all" && { type: typeFilter }),
+    ...(readFilter === "unread" && { is_read: false }),
+    ...(readFilter === "read" && { is_read: true }),
+  }
+
+  const { data: notifications, isLoading, isError, refetch } = useNotifications(params)
+  const { data: countData } = useNotificationCount()
+  const markAsRead = useMarkAsRead()
+  const markAllAsRead = useMarkAllAsRead()
+
+  const unreadCount = countData?.unread_count ?? 0
+
+  return (
+    <div className="space-y-6">
+      {/* En-tête */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Notifications</h1>
+          <p className="text-sm text-muted-foreground">
+            {unreadCount > 0
+              ? `${unreadCount} notification${unreadCount > 1 ? "s" : ""} non lue${unreadCount > 1 ? "s" : ""}`
+              : "Toutes les notifications sont lues"}
+          </p>
+        </div>
+        {unreadCount > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => markAllAsRead.mutate()}
+            disabled={markAllAsRead.isPending}
+          >
+            <CheckCheck className="mr-2 h-4 w-4" />
+            Tout marquer comme lu
+          </Button>
+        )}
+      </div>
+
+      {/* Filtres */}
+      <div className="flex gap-3">
+        <Select
+          value={typeFilter}
+          onValueChange={(v) => setTypeFilter(v as NotificationType | "all")}
+        >
+          <SelectTrigger className="w-[180px]">
+            <Filter className="mr-2 h-4 w-4" />
+            <SelectValue placeholder="Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Tous les types</SelectItem>
+            {NOTIFICATION_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {TYPE_LABELS[type]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={readFilter}
+          onValueChange={(v) => setReadFilter(v as "all" | "unread" | "read")}
+        >
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder="Statut" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Toutes</SelectItem>
+            <SelectItem value="unread">Non lues</SelectItem>
+            <SelectItem value="read">Lues</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Liste */}
+      {isLoading ? (
+        <NotificationsSkeleton />
+      ) : isError ? (
+        <DataError
+          message="Impossible de charger les notifications."
+          onRetry={() => refetch()}
+        />
+      ) : !notifications || notifications.length === 0 ? (
+        <div className="py-16 text-center">
+          <Bell className="mx-auto mb-3 h-10 w-10 text-muted-foreground/40" />
+          <p className="text-sm text-muted-foreground">Aucune notification.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {notifications.map((notification) => (
+            <NotificationRow
+              key={notification.id}
+              notification={notification}
+              onMarkAsRead={() => markAsRead.mutate(notification.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function NotificationRow({
+  notification,
+  onMarkAsRead,
+}: {
+  notification: Notification
+  onMarkAsRead: () => void
+}) {
+  const Icon = TYPE_ICONS[notification.type]
+
+  return (
+    <Card
+      className={cn(
+        "border-0 shadow-sm ring-1 ring-border transition-colors",
+        !notification.is_read && "ring-primary/30 bg-primary/[0.02]",
+      )}
+    >
+      <CardContent className="flex items-start gap-4 p-4">
+        <div
+          className={cn(
+            "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg",
+            TYPE_COLORS[notification.type],
+          )}
+        >
+          <Icon className="h-5 w-5" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <p className={cn("text-sm", !notification.is_read && "font-semibold")}>
+              {notification.title}
+            </p>
+            <Badge variant="secondary" className="text-[10px]">
+              {TYPE_LABELS[notification.type]}
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground mt-0.5">{notification.message}</p>
+          <p className="text-xs text-muted-foreground/70 mt-1">
+            {timeAgo(notification.created_at)}
+          </p>
+        </div>
+
+        {!notification.is_read && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="shrink-0"
+            onClick={onMarkAsRead}
+          >
+            <Check className="mr-1 h-3 w-3" />
+            Lire
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function NotificationsSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Skeleton key={i} className="h-20 rounded-lg" />
+      ))}
+    </div>
+  )
+}

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import { signOut, useSession } from "next-auth/react"
 import { useTheme } from "next-themes"
-import { Bell, Menu, LogOut, User, ChevronDown, Sun, Moon } from "lucide-react"
+import { Menu, LogOut, User, ChevronDown, Sun, Moon } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Separator } from "@/components/ui/separator"
@@ -14,6 +14,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { NotificationBell } from "@/components/shared/NotificationBell"
 
 interface NavbarProps {
   onMenuClick: () => void
@@ -56,10 +57,7 @@ export function Navbar({ onMenuClick }: NavbarProps) {
         </Button>
 
         {/* Notifications */}
-        {/* TODO: remplacer par un hook useNotificationCount() */}
-        <Button variant="ghost" size="icon" className="relative">
-          <Bell className="h-5 w-5 text-muted-foreground" />
-        </Button>
+        <NotificationBell />
 
         <Separator orientation="vertical" className="h-8 mx-1" />
 

--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import Link from "next/link"
+import {
+  Bell,
+  UserPlus,
+  ClipboardList,
+  Wallet,
+  AlertCircle,
+  Settings,
+  Check,
+  CheckCheck,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useNotificationCount, useNotifications, useMarkAsRead, useMarkAllAsRead } from "@/lib/hooks/useNotifications"
+import type { Notification, NotificationType } from "@/lib/contracts/notification"
+import { cn } from "@/lib/utils"
+
+/** Icône par type de notification */
+const TYPE_ICONS: Record<NotificationType, React.ComponentType<{ className?: string }>> = {
+  inscription: UserPlus,
+  note: ClipboardList,
+  paiement: Wallet,
+  absence: AlertCircle,
+  systeme: Settings,
+}
+
+/** Couleur de fond par type */
+const TYPE_COLORS: Record<NotificationType, string> = {
+  inscription: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  note: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+  paiement: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  absence: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400",
+  systeme: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
+}
+
+/** Formater une date relative simple */
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return "À l'instant"
+  if (minutes < 60) return `Il y a ${minutes}min`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `Il y a ${hours}h`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `Il y a ${days}j`
+  return new Date(dateStr).toLocaleDateString("fr-FR", { day: "numeric", month: "short" })
+}
+
+export function NotificationBell() {
+  const { data: countData } = useNotificationCount()
+  const { data: recent } = useNotifications({ per_page: 5 })
+  const markAsRead = useMarkAsRead()
+  const markAllAsRead = useMarkAllAsRead()
+
+  const unreadCount = countData?.unread_count ?? 0
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative">
+          <Bell className="h-5 w-5 text-muted-foreground" />
+          {unreadCount > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-bold text-destructive-foreground">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80">
+        <div className="flex items-center justify-between px-2">
+          <DropdownMenuLabel>Notifications</DropdownMenuLabel>
+          {unreadCount > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-auto py-1 px-2 text-xs text-muted-foreground"
+              onClick={() => markAllAsRead.mutate()}
+              disabled={markAllAsRead.isPending}
+            >
+              <CheckCheck className="mr-1 h-3 w-3" />
+              Tout lire
+            </Button>
+          )}
+        </div>
+        <DropdownMenuSeparator />
+
+        {!recent || recent.length === 0 ? (
+          <div className="py-6 text-center">
+            <Bell className="mx-auto mb-2 h-6 w-6 text-muted-foreground/50" />
+            <p className="text-xs text-muted-foreground">Aucune notification</p>
+          </div>
+        ) : (
+          <div className="max-h-[300px] overflow-y-auto">
+            {recent.map((notification) => (
+              <NotificationItem
+                key={notification.id}
+                notification={notification}
+                onMarkAsRead={() => markAsRead.mutate(notification.id)}
+              />
+            ))}
+          </div>
+        )}
+
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link
+            href="/admin/notifications"
+            className="flex items-center justify-center text-xs text-primary font-medium"
+          >
+            Voir toutes les notifications
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function NotificationItem({
+  notification,
+  onMarkAsRead,
+}: {
+  notification: Notification
+  onMarkAsRead: () => void
+}) {
+  const Icon = TYPE_ICONS[notification.type]
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-3 px-3 py-2.5 hover:bg-muted/50 transition-colors",
+        !notification.is_read && "bg-primary/5",
+      )}
+    >
+      <div
+        className={cn(
+          "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+          TYPE_COLORS[notification.type],
+        )}
+      >
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className={cn("text-xs leading-snug", !notification.is_read && "font-semibold")}>
+          {notification.title}
+        </p>
+        <p className="text-[10px] text-muted-foreground mt-0.5 truncate">
+          {notification.message}
+        </p>
+        <p className="text-[10px] text-muted-foreground/70 mt-0.5">
+          {timeAgo(notification.created_at)}
+        </p>
+      </div>
+      {!notification.is_read && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 shrink-0"
+          onClick={(e) => {
+            e.stopPropagation()
+            onMarkAsRead()
+          }}
+        >
+          <Check className="h-3 w-3 text-muted-foreground" />
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/lib/api/notifications.ts
+++ b/lib/api/notifications.ts
@@ -1,0 +1,54 @@
+import { z } from "zod"
+import { apiFetch, safeValidate } from "./client"
+import {
+  NotificationSchema,
+  NotificationCountSchema,
+  type Notification,
+  type NotificationCount,
+  type NotificationType,
+} from "@/lib/contracts/notification"
+
+const NotificationArraySchema = z.array(NotificationSchema)
+
+export interface NotificationListParams {
+  type?: NotificationType
+  is_read?: boolean
+  page?: number
+  per_page?: number
+}
+
+export const notificationsApi = {
+  // Liste des notifications avec filtres
+  list: async (params: NotificationListParams = {}): Promise<Notification[]> => {
+    const query = new URLSearchParams()
+    if (params.type) query.set("type", params.type)
+    if (params.is_read !== undefined) query.set("is_read", String(params.is_read))
+    if (params.page) query.set("page", String(params.page))
+    if (params.per_page) query.set("per_page", String(params.per_page))
+
+    const qs = query.toString()
+    const res = await apiFetch<unknown>(`/notifications${qs ? `?${qs}` : ""}`)
+    const arr = Array.isArray(res)
+      ? res
+      : (res as Record<string, unknown>).data !== undefined
+        ? (res as Record<string, unknown>).data
+        : res
+    return safeValidate(NotificationArraySchema, arr, "GET /notifications")
+  },
+
+  // Compteur de notifications non lues
+  getUnreadCount: async (): Promise<NotificationCount> => {
+    const res = await apiFetch<unknown>("/notifications/count")
+    return safeValidate(NotificationCountSchema, res, "GET /notifications/count")
+  },
+
+  // Marquer une notification comme lue
+  markAsRead: async (id: number): Promise<void> => {
+    await apiFetch<void>(`/notifications/${id}/read`, { method: "PATCH" })
+  },
+
+  // Marquer toutes les notifications comme lues
+  markAllAsRead: async (): Promise<void> => {
+    await apiFetch<void>("/notifications/read-all", { method: "PATCH" })
+  },
+}

--- a/lib/contracts/notification.ts
+++ b/lib/contracts/notification.ts
@@ -1,0 +1,29 @@
+import { z } from "zod"
+
+// Contrats pour les notifications — endpoints /notifications/*
+
+export const NotificationTypeSchema = z.enum([
+  "inscription",
+  "note",
+  "paiement",
+  "absence",
+  "systeme",
+])
+
+export const NotificationSchema = z.object({
+  id: z.number(),
+  type: NotificationTypeSchema,
+  title: z.string(),
+  message: z.string(),
+  is_read: z.boolean(),
+  link: z.string().nullish(),
+  created_at: z.string(),
+})
+
+export const NotificationCountSchema = z.object({
+  unread_count: z.number(),
+})
+
+export type NotificationType = z.infer<typeof NotificationTypeSchema>
+export type Notification = z.infer<typeof NotificationSchema>
+export type NotificationCount = z.infer<typeof NotificationCountSchema>

--- a/lib/hooks/useNotifications.ts
+++ b/lib/hooks/useNotifications.ts
@@ -1,0 +1,116 @@
+"use client"
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { notificationsApi, type NotificationListParams } from "@/lib/api/notifications"
+import type { Notification } from "@/lib/contracts/notification"
+
+export const notificationKeys = {
+  all: ["notifications"] as const,
+  list: (params: NotificationListParams) => ["notifications", "list", params] as const,
+  count: () => ["notifications", "count"] as const,
+}
+
+export function useNotifications(params: NotificationListParams = {}) {
+  return useQuery({
+    queryKey: notificationKeys.list(params),
+    queryFn: () => notificationsApi.list(params),
+    staleTime: 1000 * 60 * 2,
+  })
+}
+
+export function useNotificationCount() {
+  return useQuery({
+    queryKey: notificationKeys.count(),
+    queryFn: () => notificationsApi.getUnreadCount(),
+    staleTime: 1000 * 30,
+    refetchInterval: 1000 * 30,
+  })
+}
+
+export function useMarkAsRead() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => notificationsApi.markAsRead(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: notificationKeys.all })
+      // Mise à jour optimiste du compteur
+      const prevCount = queryClient.getQueryData<{ unread_count: number }>(notificationKeys.count())
+      if (prevCount && prevCount.unread_count > 0) {
+        queryClient.setQueryData(notificationKeys.count(), {
+          unread_count: prevCount.unread_count - 1,
+        })
+      }
+      // Mise à jour optimiste de la liste
+      const queries = queryClient.getQueriesData<Notification[]>({
+        queryKey: ["notifications", "list"],
+      })
+      for (const [key, data] of queries) {
+        if (data) {
+          queryClient.setQueryData(
+            key,
+            data.map((n) => (n.id === id ? { ...n, is_read: true } : n)),
+          )
+        }
+      }
+      return { prevCount, queries }
+    },
+    onError: (_err, _id, context) => {
+      if (context?.prevCount) {
+        queryClient.setQueryData(notificationKeys.count(), context.prevCount)
+      }
+      if (context?.queries) {
+        for (const [key, data] of context.queries) {
+          queryClient.setQueryData(key, data)
+        }
+      }
+      toast.error("Erreur", { description: "Impossible de marquer comme lu." })
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: notificationKeys.all })
+    },
+  })
+}
+
+export function useMarkAllAsRead() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => notificationsApi.markAllAsRead(),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: notificationKeys.all })
+      // Compteur à zéro
+      const prevCount = queryClient.getQueryData<{ unread_count: number }>(notificationKeys.count())
+      queryClient.setQueryData(notificationKeys.count(), { unread_count: 0 })
+      // Toutes les notifications marquées comme lues
+      const queries = queryClient.getQueriesData<Notification[]>({
+        queryKey: ["notifications", "list"],
+      })
+      for (const [key, data] of queries) {
+        if (data) {
+          queryClient.setQueryData(
+            key,
+            data.map((n) => ({ ...n, is_read: true })),
+          )
+        }
+      }
+      return { prevCount, queries }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prevCount) {
+        queryClient.setQueryData(notificationKeys.count(), context.prevCount)
+      }
+      if (context?.queries) {
+        for (const [key, data] of context.queries) {
+          queryClient.setQueryData(key, data)
+        }
+      }
+      toast.error("Erreur", { description: "Impossible de tout marquer comme lu." })
+    },
+    onSuccess: () => {
+      toast.success("Toutes les notifications marquées comme lues")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: notificationKeys.all })
+    },
+  })
+}


### PR DESCRIPTION
## Description

Implémente le système de notifications complet :

- **NotificationBell** dans la Navbar admin — badge compteur non-lus, dropdown avec les 5 dernières notifications, actions marquer comme lu (unitaire + bulk)
- **Page `/admin/notifications`** ��� liste complète avec filtres par type (inscription, note, paiement, absence, système) et statut (lues/non-lues), bouton "Tout marquer comme lu"
- **5 types de notifications** avec icônes et couleurs distinctes : inscription (bleu), note (vert), paiement (ambre), absence (rose), système (gris)

### Architecture

- **Contrat Zod** : `lib/contracts/notification.ts` — NotificationSchema, NotificationCountSchema, NotificationTypeSchema
- **API layer** : `lib/api/notifications.ts` — `GET /notifications`, `GET /notifications/count`, `PATCH /notifications/{id}/read`, `PATCH /notifications/read-all`
- **Hooks TanStack Query** : `lib/hooks/useNotifications.ts` — `useNotifications()`, `useNotificationCount()` (polling 30s), `useMarkAsRead()`, `useMarkAllAsRead()` avec mises à jour optimistes
- **Navbar.tsx** : remplacement du placeholder Bell par `<NotificationBell />`

### Patterns suivis

- Mises à jour optimistes avec rollback on error pour le marquage
- Polling `refetchInterval: 30s` pour le compteur (WebSocket viendra plus tard)
- Skeleton loaders + error boundaries
- Filtres via `useState` + query params TanStack Query

## Closes

Closes #37

## Checklist

- [x] Linting passe (`npm run lint`)
- [x] Type-check OK (`npx tsc --noEmit`)
- [ ] Build OK (`npm run build`)
- [ ] Branche à jour avec develop