### PR TITLE
feat(roles): add roles & permissions CRUD page

### DIFF
--- a/app/(admin)/admin/roles/error.tsx
+++ b/app/(admin)/admin/roles/error.tsx
@@ -1,0 +1,3 @@
+"use client"
+
+export { default } from "@/components/shared/AdminError"

--- a/app/(admin)/admin/roles/loading.tsx
+++ b/app/(admin)/admin/roles/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function RolesLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-10 w-40" />
+      </div>
+      <div className="rounded-lg border">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 border-b p-4 last:border-0">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-6 w-8" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/(admin)/admin/roles/page.tsx
+++ b/app/(admin)/admin/roles/page.tsx
@@ -1,0 +1,7 @@
+import { RolesPageClient } from "@/components/admin/roles/RolesPageClient"
+
+export const metadata = { title: "Rôles & Permissions | KLASSCI" }
+
+export default function RolesPage() {
+  return <RolesPageClient />
+}

--- a/components/admin/roles/PermissionMatrix.tsx
+++ b/components/admin/roles/PermissionMatrix.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useMemo } from "react"
+import { Checkbox } from "@/components/ui/checkbox"
+import type { Permission, PermissionModule } from "@/lib/contracts/role"
+import { cn } from "@/lib/utils"
+
+/** Labels lisibles pour chaque module */
+const MODULE_LABELS: Record<PermissionModule, string> = {
+  inscriptions: "Inscriptions",
+  notes: "Notes & Évaluations",
+  paiements: "Paiements",
+  presences: "Présences",
+  emploi_du_temps: "Emploi du temps",
+  utilisateurs: "Utilisateurs",
+  parametres: "Paramètres",
+  notifications: "Notifications",
+}
+
+interface PermissionMatrixProps {
+  permissions: Permission[]
+  selectedIds: number[]
+  onChange: (ids: number[]) => void
+}
+
+export function PermissionMatrix({ permissions, selectedIds, onChange }: PermissionMatrixProps) {
+  /** Groupe les permissions par module */
+  const grouped = useMemo(() => {
+    const map = new Map<PermissionModule, Permission[]>()
+    for (const perm of permissions) {
+      const list = map.get(perm.module) ?? []
+      list.push(perm)
+      map.set(perm.module, list)
+    }
+    return map
+  }, [permissions])
+
+  /** Set pour des lookups O(1) */
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds])
+
+  function togglePermission(id: number) {
+    if (selectedSet.has(id)) {
+      onChange(selectedIds.filter((pid) => pid !== id))
+    } else {
+      onChange([...selectedIds, id])
+    }
+  }
+
+  function toggleModule(module: PermissionModule) {
+    const modulePermIds = grouped.get(module)?.map((p) => p.id) ?? []
+    const allSelected = modulePermIds.every((id) => selectedSet.has(id))
+
+    if (allSelected) {
+      const removeSet = new Set(modulePermIds)
+      onChange(selectedIds.filter((id) => !removeSet.has(id)))
+    } else {
+      const merged = new Set([...selectedIds, ...modulePermIds])
+      onChange(Array.from(merged))
+    }
+  }
+
+  if (permissions.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4 text-center">
+        Aucune permission disponible.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      {Array.from(grouped.entries()).map(([module, perms]) => {
+        const modulePermIds = perms.map((p) => p.id)
+        const allChecked = modulePermIds.every((id) => selectedSet.has(id))
+        const someChecked = !allChecked && modulePermIds.some((id) => selectedSet.has(id))
+
+        return (
+          <div key={module} className="space-y-2">
+            {/* En-tête du module */}
+            <div className="flex items-center gap-2">
+              <Checkbox
+                checked={allChecked ? true : someChecked ? "indeterminate" : false}
+                onCheckedChange={() => toggleModule(module)}
+              />
+              <span className="text-sm font-semibold">
+                {MODULE_LABELS[module] ?? module}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                ({modulePermIds.filter((id) => selectedSet.has(id)).length}/{perms.length})
+              </span>
+            </div>
+
+            {/* Permissions du module */}
+            <div className="ml-6 grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {perms.map((perm) => {
+                const isChecked = selectedSet.has(perm.id)
+                return (
+                  <label
+                    key={perm.id}
+                    className={cn(
+                      "flex items-start gap-2 rounded-md border px-3 py-2 cursor-pointer transition-colors",
+                      isChecked
+                        ? "border-primary/30 bg-primary/[0.03]"
+                        : "border-transparent hover:bg-muted/50",
+                    )}
+                  >
+                    <Checkbox
+                      checked={isChecked}
+                      onCheckedChange={() => togglePermission(perm.id)}
+                      className="mt-0.5"
+                    />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium leading-tight">{perm.name}</p>
+                      {perm.description && (
+                        <p className="text-xs text-muted-foreground mt-0.5">{perm.description}</p>
+                      )}
+                    </div>
+                  </label>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/admin/roles/RoleCreateModal.tsx
+++ b/components/admin/roles/RoleCreateModal.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { RoleForm } from "@/components/forms/RoleForm"
+
+interface RoleCreateModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function RoleCreateModal({ open, onClose }: RoleCreateModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Nouveau rôle</DialogTitle>
+        </DialogHeader>
+        <RoleForm onSuccess={onClose} />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/roles/RoleEditModal.tsx
+++ b/components/admin/roles/RoleEditModal.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { RoleUpdateSchema, type RoleUpdate } from "@/lib/contracts/role"
+import { useRole, useUpdateRole, usePermissions } from "@/lib/hooks/useRoles"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { PermissionMatrix } from "./PermissionMatrix"
+
+function EditFormSkeleton() {
+  return (
+    <div className="space-y-5">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-11 w-full" />
+        </div>
+      ))}
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-11 w-full" />
+    </div>
+  )
+}
+
+function EditForm({ roleId, onClose }: { roleId: number; onClose: () => void }) {
+  const { data: roleData, isLoading } = useRole(roleId)
+  const { mutate, isPending, error } = useUpdateRole(roleId)
+  const { data: allPermissions } = usePermissions()
+
+  const form = useForm<RoleUpdate>({
+    resolver: zodResolver(RoleUpdateSchema),
+    values: roleData
+      ? {
+          name: roleData.name,
+          description: roleData.description ?? undefined,
+          permission_ids: roleData.permissions?.map((p) => p.id) ?? [],
+        }
+      : undefined,
+  })
+
+  if (isLoading || !roleData) return <EditFormSkeleton />
+
+  function onSubmit(data: RoleUpdate) {
+    mutate(data, { onSuccess: onClose })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nom du rôle</FormLabel>
+              <FormControl>
+                <Input className="h-11" {...field} value={field.value ?? ""} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Textarea
+                  className="min-h-[80px] resize-none"
+                  placeholder="Description du rôle..."
+                  {...field}
+                  value={field.value ?? ""}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="permission_ids"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Permissions</FormLabel>
+              <PermissionMatrix
+                permissions={allPermissions ?? []}
+                selectedIds={field.value ?? []}
+                onChange={field.onChange}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {error && (
+          <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
+            <p className="text-sm text-destructive">{error.message}</p>
+          </div>
+        )}
+
+        <Button type="submit" size="lg" className="w-full h-11 font-semibold" disabled={isPending}>
+          {isPending ? "Enregistrement..." : "Mettre à jour"}
+        </Button>
+      </form>
+    </Form>
+  )
+}
+
+interface RoleEditModalProps {
+  roleId: number | null
+  open: boolean
+  onClose: () => void
+}
+
+export function RoleEditModal({ roleId, open, onClose }: RoleEditModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Modifier le rôle</DialogTitle>
+        </DialogHeader>
+        {roleId && <EditForm roleId={roleId} onClose={onClose} />}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/roles/RolesPageClient.tsx
+++ b/components/admin/roles/RolesPageClient.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useState } from "react"
+import { Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { RolesTable } from "./RolesTable"
+import { RoleCreateModal } from "./RoleCreateModal"
+
+export function RolesPageClient() {
+  const [createOpen, setCreateOpen] = useState(false)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-serif text-2xl tracking-tight">Rôles & Permissions</h1>
+          <p className="text-sm text-muted-foreground">Gérez les rôles et leurs permissions d&apos;accès</p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Nouveau rôle
+        </Button>
+      </div>
+
+      <RolesTable />
+
+      <RoleCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
+    </div>
+  )
+}

--- a/components/admin/roles/RolesTable.tsx
+++ b/components/admin/roles/RolesTable.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import type { ColumnDef } from "@tanstack/react-table"
+import { ShieldCheck } from "lucide-react"
+import { useRoles, useDeleteRole } from "@/lib/hooks/useRoles"
+import type { Role } from "@/lib/contracts/role"
+import { Badge } from "@/components/ui/badge"
+import { CrudTable } from "@/components/shared/CrudTable"
+import { RoleEditModal } from "./RoleEditModal"
+
+export function RolesTable() {
+  const [page, setPage] = useState(1)
+  const { data, isLoading, isError, error, refetch } = useRoles({ page })
+  const deleteMutation = useDeleteRole()
+
+  const columns: ColumnDef<Role>[] = useMemo(() => [
+    {
+      accessorKey: "name",
+      header: "Nom",
+      cell: ({ row }) => (
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4 text-primary" />
+          <span className="font-medium">{row.original.name}</span>
+          {row.original.is_system && (
+            <Badge variant="outline" className="text-[10px]">Système</Badge>
+          )}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "description",
+      header: "Description",
+      cell: ({ row }) => (
+        <span className="text-sm text-muted-foreground">
+          {row.original.description ?? "—"}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "permissions",
+      header: "Permissions",
+      cell: ({ row }) => {
+        const count = row.original.permissions?.length ?? 0
+        return (
+          <Badge variant="secondary" className="font-mono">
+            {count}
+          </Badge>
+        )
+      },
+    },
+  ], [])
+
+  return (
+    <CrudTable<Role>
+      data={data}
+      columns={columns}
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+      refetch={refetch}
+      deleteMutation={deleteMutation}
+      renderEditModal={({ itemId, open, onClose }) => (
+        <RoleEditModal roleId={itemId} open={open} onClose={onClose} />
+      )}
+      getItemLabel={(r) => r.name}
+      emptyMessage="Aucun rôle trouvé"
+      errorMessage="Impossible de charger les rôles"
+      deleteDescription="Cette action est irréversible. Le rôle sera définitivement supprimé."
+      page={page}
+      onPageChange={setPage}
+    />
+  )
+}

--- a/components/forms/RoleForm.tsx
+++ b/components/forms/RoleForm.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { RoleCreateSchema, type RoleCreate } from "@/lib/contracts/role"
+import { useCreateRole, usePermissions } from "@/lib/hooks/useRoles"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { PermissionMatrix } from "@/components/admin/roles/PermissionMatrix"
+
+interface RoleFormProps {
+  onSuccess: () => void
+}
+
+export function RoleForm({ onSuccess }: RoleFormProps) {
+  const form = useForm<RoleCreate>({
+    resolver: zodResolver(RoleCreateSchema),
+    defaultValues: {
+      name: "",
+      description: "",
+      permission_ids: [],
+    },
+  })
+
+  const { data: allPermissions } = usePermissions()
+  const { mutate, isPending, error } = useCreateRole()
+
+  function onSubmit(data: RoleCreate) {
+    mutate(data, {
+      onSuccess: () => {
+        form.reset()
+        onSuccess()
+      },
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nom du rôle *</FormLabel>
+              <FormControl>
+                <Input placeholder="Ex : Directeur des études" className="h-11" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Textarea
+                  className="min-h-[80px] resize-none"
+                  placeholder="Décrivez les responsabilités de ce rôle..."
+                  {...field}
+                  value={field.value ?? ""}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="permission_ids"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Permissions</FormLabel>
+              <PermissionMatrix
+                permissions={allPermissions ?? []}
+                selectedIds={field.value ?? []}
+                onChange={field.onChange}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {error && (
+          <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
+            <p className="text-sm text-destructive">{error.message}</p>
+          </div>
+        )}
+
+        <Button type="submit" size="lg" className="w-full h-11 font-semibold" disabled={isPending}>
+          {isPending ? "Enregistrement..." : "Créer le rôle"}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ComponentRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/lib/api/roles.ts
+++ b/lib/api/roles.ts
@@ -1,0 +1,20 @@
+import { z } from "zod"
+import { RoleSchema, PermissionSchema } from "@/lib/contracts/role"
+import type { Role, RoleCreate, RoleUpdate, Permission } from "@/lib/contracts/role"
+import { createCrudApi } from "./createCrudApi"
+import { apiFetch, safeValidate } from "./client"
+
+export const rolesApi = createCrudApi<Role, RoleCreate, RoleUpdate>(
+  "/roles",
+  RoleSchema,
+)
+
+const PermissionsArraySchema = z.array(PermissionSchema)
+
+/** Récupère toutes les permissions disponibles */
+export async function getPermissions(): Promise<Permission[]> {
+  const res = await apiFetch<unknown>("/permissions")
+  // Gère les deux formats de réponse : Permission[] ou { data: Permission[] }
+  const raw = Array.isArray(res) ? res : (res as { data?: unknown }).data ?? res
+  return safeValidate(PermissionsArraySchema, raw, "/permissions")
+}

--- a/lib/contracts/role.ts
+++ b/lib/contracts/role.ts
@@ -1,0 +1,51 @@
+import { z } from "zod"
+
+/** Module fonctionnel auquel appartient une permission */
+export const PermissionModuleSchema = z.enum([
+  "inscriptions",
+  "notes",
+  "paiements",
+  "presences",
+  "emploi_du_temps",
+  "utilisateurs",
+  "parametres",
+  "notifications",
+])
+
+export const PermissionSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  description: z.string().nullish(),
+  module: PermissionModuleSchema,
+})
+
+export const RoleSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  description: z.string().nullish(),
+  is_system: z.boolean().optional(),
+  permissions: z.array(PermissionSchema).optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+})
+
+export const RoleCreateSchema = z.object({
+  name: z.string({ required_error: "Le nom est requis" }).min(1, "Le nom est requis"),
+  description: z.string().optional(),
+  permission_ids: z.array(z.number()).optional(),
+})
+
+export const RoleUpdateSchema = RoleCreateSchema.partial()
+
+export const RoleListParamsSchema = z.object({
+  page: z.number().optional(),
+  per_page: z.number().optional(),
+  search: z.string().optional(),
+})
+
+export type Permission = z.infer<typeof PermissionSchema>
+export type PermissionModule = z.infer<typeof PermissionModuleSchema>
+export type Role = z.infer<typeof RoleSchema>
+export type RoleCreate = z.infer<typeof RoleCreateSchema>
+export type RoleUpdate = z.infer<typeof RoleUpdateSchema>
+export type RoleListParams = z.infer<typeof RoleListParamsSchema>

--- a/lib/hooks/useRoles.ts
+++ b/lib/hooks/useRoles.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { rolesApi, getPermissions } from "@/lib/api/roles"
+import type { Role, RoleCreate, RoleUpdate } from "@/lib/contracts/role"
+import { createCrudHooks } from "./createCrudHooks"
+
+const {
+  keys: roleKeys,
+  useList,
+  useDetail,
+  useCreate,
+  useUpdate,
+  useDelete,
+} = createCrudHooks<Role, RoleCreate, RoleUpdate>("roles", rolesApi, {
+  created: "Rôle créé avec succès",
+  updated: "Rôle mis à jour",
+  deleted: "Rôle supprimé",
+})
+
+export { roleKeys }
+export const useRoles = useList
+export const useRole = useDetail
+export const useCreateRole = useCreate
+export const useUpdateRole = useUpdate
+export const useDeleteRole = useDelete
+
+/** Liste toutes les permissions disponibles */
+export function usePermissions() {
+  return useQuery({
+    queryKey: ["permissions"],
+    queryFn: getPermissions,
+    staleTime: 1000 * 60 * 10,
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
@@ -2342,6 +2343,92 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",


### PR DESCRIPTION
## Description

- Page CRUD `/admin/roles` pour la gestion des rôles
- Contrats Zod : `RoleSchema`, `PermissionSchema`, `PermissionModuleSchema`
- API layer via `createCrudApi` + endpoint custom `/permissions`
- Hooks TanStack Query via `createCrudHooks` + `usePermissions`
- Table avec `CrudTable` partagé (nom, description, nb permissions)
- Modals création/édition avec formulaire React Hook Form + Zod
- **Matrice de permissions** : checkboxes groupées par module (inscriptions, notes, paiements, présences, emploi du temps, utilisateurs, paramètres, notifications) avec sélection/désélection par module et état indeterminate
- Composant `Checkbox` Shadcn/ui ajouté (`@radix-ui/react-checkbox`)
- Skeleton loading, error boundary, page server component

## Closes

Closes #38

## Checklist

- [ ] Tests passent (`npm test`)
- [ ] Linting passe (`npm run lint`)
- [ ] Type-check OK (`npm run type-check`)
- [ ] Build OK (`npm run build`)
- [ ] Branche à jour avec develop