### PR TITLE
fix(api): use apiFetchBlob and downloadBlob in dren and student modules

### DIFF
--- a/components/admin/reports/dren/DrenPageClient.tsx
+++ b/components/admin/reports/dren/DrenPageClient.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { toast } from "sonner"
+import { downloadBlob } from "@/lib/utils"
 import { EnrollmentByLevelChart } from "./EnrollmentByLevelChart"
 import { SuccessRateChart } from "./SuccessRateChart"
 import { LevelStatsTable } from "./LevelStatsTable"
@@ -37,12 +38,7 @@ export function DrenPageClient() {
       const blob = type === "excel"
         ? await drenApi.downloadExcel(academicYearId)
         : await drenApi.downloadPdf(academicYearId)
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = `stats-dren-${academicYearId}.${type === "excel" ? "xlsx" : "pdf"}`
-      a.click()
-      URL.revokeObjectURL(url)
+      downloadBlob(blob, `stats-dren-${academicYearId}.${type === "excel" ? "xlsx" : "pdf"}`)
     } catch (err) {
       console.error(`[DREN] ${type} download failed:`, err)
       toast.error(err instanceof Error ? err.message : `Impossible de télécharger le fichier ${type.toUpperCase()}`)

--- a/components/student/StudentBulletinsClient.tsx
+++ b/components/student/StudentBulletinsClient.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { toast } from "sonner"
+import { downloadBlob } from "@/lib/utils"
 import { useStudentBulletins } from "@/lib/hooks/useStudentPortal"
 import { studentPortalApi } from "@/lib/api/student-portal"
 import { DataError } from "@/components/shared/DataError"
@@ -51,12 +52,7 @@ function BulletinCard({ bulletin }: { bulletin: StudentBulletin }) {
     setIsDownloading(true)
     try {
       const blob = await studentPortalApi.downloadBulletin(bulletin.id)
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = `bulletin-${bulletin.trimester}-${bulletin.academic_year}.pdf`
-      a.click()
-      URL.revokeObjectURL(url)
+      downloadBlob(blob, `bulletin-${bulletin.trimester}-${bulletin.academic_year}.pdf`)
     } catch (err) {
       console.error("[StudentBulletins] Download failed:", err)
       toast.error(err instanceof Error ? err.message : "Impossible de télécharger le bulletin")

--- a/lib/api/dren.ts
+++ b/lib/api/dren.ts
@@ -1,5 +1,4 @@
-import { getSession } from "next-auth/react"
-import { apiFetch, safeValidate } from "./client"
+import { apiFetch, apiFetchBlob, safeValidate } from "./client"
 import { DrenStatsSchema, type DrenStats } from "@/lib/contracts/dren"
 
 export const drenApi = {
@@ -13,28 +12,10 @@ export const drenApi = {
   },
 
   // Télécharger l'export Excel (authentifié)
-  downloadExcel: async (academicYearId: number): Promise<Blob> => {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL
-    if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
-    const session = await getSession()
-    if (!session?.accessToken) throw new Error("Session expirée — reconnectez-vous")
-    const res = await fetch(`${baseUrl}/reports/dren/excel?academic_year_id=${academicYearId}`, {
-      headers: { Authorization: `Bearer ${session.accessToken}` },
-    })
-    if (!res.ok) throw new Error("Impossible de télécharger le fichier Excel")
-    return res.blob()
-  },
+  downloadExcel: (academicYearId: number): Promise<Blob> =>
+    apiFetchBlob(`/reports/dren/excel?academic_year_id=${academicYearId}`),
 
   // Télécharger l'export PDF (authentifié)
-  downloadPdf: async (academicYearId: number): Promise<Blob> => {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL
-    if (!baseUrl) throw new Error("NEXT_PUBLIC_API_URL is not defined")
-    const session = await getSession()
-    if (!session?.accessToken) throw new Error("Session expirée — reconnectez-vous")
-    const res = await fetch(`${baseUrl}/reports/dren/pdf?academic_year_id=${academicYearId}`, {
-      headers: { Authorization: `Bearer ${session.accessToken}` },
-    })
-    if (!res.ok) throw new Error("Impossible de télécharger le fichier PDF")
-    return res.blob()
-  },
+  downloadPdf: (academicYearId: number): Promise<Blob> =>
+    apiFetchBlob(`/reports/dren/pdf?academic_year_id=${academicYearId}`),
 }


### PR DESCRIPTION
## Summary
- `lib/api/dren.ts`: replace manual `getSession()` + `fetch()` + Bearer header with `apiFetchBlob()`
- `StudentBulletinsClient.tsx`: replace inline blob download with `downloadBlob()` from `lib/utils`
- `DrenPageClient.tsx`: same — use `downloadBlob()` utility

Net -27 lines of duplicated code.

## Test plan
- [ ] DREN Excel/PDF download works with auth
- [ ] Student bulletin PDF download works
- [ ] `pnpm tsc --noEmit` passes

Closes #55