### PR TITLE
fix(types): replace as never casts with proper Route typing on all navigation hrefs

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,3 +1,4 @@
+import type { Route } from "next"
 import { auth } from "@/auth"
 import { redirect } from "next/navigation"
 import { LoginForm } from "@/components/forms/LoginForm"
@@ -7,7 +8,7 @@ export default async function LoginPage() {
 
   if (session?.user && !session.error) {
     const portal = session.user.role ?? "admin"
-    redirect(`/${portal}/dashboard` as never)
+    redirect(`/${portal}/dashboard` as Route)
   }
 
   return (

--- a/app/(teacher)/teacher/grades/[classId]/[evaluationId]/page.tsx
+++ b/app/(teacher)/teacher/grades/[classId]/[evaluationId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Route } from "next"
 import { ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
@@ -14,7 +15,7 @@ export default async function GradeEntryPage({ params }: GradeEntryPageProps) {
     <div className="mx-auto max-w-2xl space-y-6 px-4 py-6">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" asChild className="shrink-0">
-          <Link href={`/teacher/grades` as never}>
+          <Link href={`/teacher/grades` as Route}>
             <ArrowLeft className="h-5 w-5" />
           </Link>
         </Button>

--- a/components/admin/dashboard/QuickActions.tsx
+++ b/components/admin/dashboard/QuickActions.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { Route } from "next"
 import Link from "next/link"
 import {
   UserPlus,
@@ -61,7 +62,7 @@ export function QuickActions() {
           {actions.map((action) => (
             <Link
               key={action.href}
-              href={action.href as never}
+              href={action.href as Route}
               className="flex flex-col items-center gap-2 rounded-xl p-4 text-center transition-colors hover:bg-muted"
             >
               <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${action.color}`}>

--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { Route } from "next"
 import { useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { signIn } from "next-auth/react"
@@ -49,7 +50,7 @@ export function LoginForm() {
         return
       }
 
-      router.push(callbackUrl as never)
+      router.push(callbackUrl as Route)
       router.refresh()
     } catch {
       setError("Erreur de connexion au serveur")

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -131,7 +132,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
               return (
                 <Link
                   key={item.href}
-                  href={item.href as never}
+                  href={item.href as Route}
                   onClick={onClose}
                   className={cn(
                     "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",

--- a/components/shared/StudentNav.tsx
+++ b/components/shared/StudentNav.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { Route } from "next"
 import { useState, useEffect, useRef } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -65,7 +66,7 @@ export function StudentNav() {
               return (
                 <Link
                   key={item.href}
-                  href={item.href as never}
+                  href={item.href as Route}
                   role="menuitem"
                   onClick={() => setMoreOpen(false)}
                   className={cn(
@@ -101,7 +102,7 @@ export function StudentNav() {
             return (
               <Link
                 key={item.href}
-                href={item.href as never}
+                href={item.href as Route}
                 className={cn(
                   "flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
                   isActive ? "text-primary" : "text-muted-foreground",

--- a/components/shared/TeacherNav.tsx
+++ b/components/shared/TeacherNav.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { Route } from "next"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { signOut } from "next-auth/react"
@@ -24,7 +25,7 @@ export function TeacherNav() {
           return (
             <Link
               key={item.href}
-              href={item.href as never}
+              href={item.href as Route}
               className={cn(
                 "flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
                 isActive


### PR DESCRIPTION
## Summary
Replace all 8 `as never` type casts with `as Route` from `'next'` across 7 files.

Per [Next.js docs](https://nextjs.org/docs/app/api-reference/config/typescript#statically-typed-links), `as Route` is the correct cast for dynamic strings with `typedRoutes: true`. `as never` suppresses all type checking.

### Files changed
| File | Fix |
|------|-----|
| `app/(auth)/login/page.tsx` | redirect with dynamic portal |
| `app/(teacher)/teacher/grades/.../page.tsx` | Link href |
| `components/admin/dashboard/QuickActions.tsx` | Link href |
| `components/forms/LoginForm.tsx` | router.push with callbackUrl |
| `components/shared/Sidebar.tsx` | Link href |
| `components/shared/StudentNav.tsx` | Link href (×2) |
| `components/shared/TeacherNav.tsx` | Link href |

## Test plan
- [ ] All navigation links work correctly
- [ ] Zero `as never` remaining in codebase

Closes #56