### PR TITLE
refactor(enrollments): migrate to createCrudApi and createCrudHooks

### DIFF
--- a/components/admin/enrollments/EnrollmentsTable.tsx
+++ b/components/admin/enrollments/EnrollmentsTable.tsx
@@ -1,46 +1,17 @@
 "use client"
 
-import { useState } from "react"
-import {
-  useReactTable,
-  getCoreRowModel,
-  flexRender,
-  type ColumnDef,
-} from "@tanstack/react-table"
-import { Pencil, Trash2, MoreHorizontal } from "lucide-react"
+import { useMemo, useState } from "react"
+import type { ColumnDef } from "@tanstack/react-table"
 import { useEnrollments, useDeleteEnrollment } from "@/lib/hooks/useEnrollments"
 import type { Enrollment, EnrollmentListParams } from "@/lib/contracts/enrollment"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Skeleton } from "@/components/ui/skeleton"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+import { CrudTable } from "@/components/shared/CrudTable"
 import { EnrollmentEditModal } from "./EnrollmentEditModal"
 
 const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  affecte: { label: "Affecte", variant: "default" },
-  reaffecte: { label: "Reaffecte", variant: "secondary" },
-  non_affecte: { label: "Non affecte", variant: "outline" },
+  affecte: { label: "Affecté", variant: "default" },
+  reaffecte: { label: "Réaffecté", variant: "secondary" },
+  non_affecte: { label: "Non affecté", variant: "outline" },
 }
 
 interface EnrollmentsTableProps {
@@ -48,15 +19,14 @@ interface EnrollmentsTableProps {
 }
 
 export function EnrollmentsTable({ filters = {} }: EnrollmentsTableProps) {
-  const { data, isLoading, error } = useEnrollments(filters)
+  const [page, setPage] = useState(1)
+  const { data, isLoading, isError, error, refetch } = useEnrollments({ ...filters, page })
   const deleteMutation = useDeleteEnrollment()
-  const [editId, setEditId] = useState<number | null>(null)
-  const [deleteId, setDeleteId] = useState<number | null>(null)
 
-  const columns: ColumnDef<Enrollment>[] = [
+  const columns: ColumnDef<Enrollment>[] = useMemo(() => [
     {
       accessorKey: "id",
-      header: "N",
+      header: "N°",
       cell: ({ row }) => (
         <span className="font-mono text-xs text-muted-foreground">
           #{row.original.id}
@@ -66,7 +36,7 @@ export function EnrollmentsTable({ filters = {} }: EnrollmentsTableProps) {
     },
     {
       accessorKey: "student_name",
-      header: "Eleve",
+      header: "Élève",
       cell: ({ row }) => (
         <span className="font-medium">{row.original.student_name}</span>
       ),
@@ -77,7 +47,7 @@ export function EnrollmentsTable({ filters = {} }: EnrollmentsTableProps) {
     },
     {
       accessorKey: "academic_year_label",
-      header: "Annee",
+      header: "Année",
     },
     {
       accessorKey: "assignment_status",
@@ -91,145 +61,27 @@ export function EnrollmentsTable({ filters = {} }: EnrollmentsTableProps) {
         )
       },
     },
-    {
-      id: "actions",
-      header: "",
-      size: 50,
-      cell: ({ row }) => (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => setEditId(row.original.id)}>
-              <Pencil className="mr-2 h-4 w-4" />
-              Modifier
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-destructive focus:text-destructive"
-              onClick={() => setDeleteId(row.original.id)}
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Supprimer
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ),
-    },
-  ]
-
-  const table = useReactTable({
-    data: data?.data ?? [],
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-  })
-
-  if (error) {
-    return (
-      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-6 text-center">
-        <p className="text-sm text-destructive">{error.message}</p>
-      </div>
-    )
-  }
+  ], [])
 
   return (
-    <>
-      <div className="rounded-lg border bg-card">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id} style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(header.column.columnDef.header, header.getContext())}
-                  </TableHead>
-                ))}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
-              Array.from({ length: 5 }).map((_, i) => (
-                <TableRow key={i}>
-                  {columns.map((_, j) => (
-                    <TableCell key={j}>
-                      <Skeleton className="h-4 w-full" />
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : table.getRowModel().rows.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
-                  Aucune inscription trouvee
-                </TableCell>
-              </TableRow>
-            ) : (
-              table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-
-        {data && data.total_pages > 1 && (
-          <div className="flex items-center justify-between border-t px-4 py-3">
-            <p className="text-sm text-muted-foreground">
-              {data.total} inscription{data.total > 1 ? "s" : ""} au total
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Page {data.page} / {data.total_pages}
-            </p>
-          </div>
-        )}
-      </div>
-
-      {/* Edit modal */}
-      <EnrollmentEditModal
-        enrollmentId={editId}
-        open={editId !== null}
-        onClose={() => setEditId(null)}
-      />
-
-      {/* Delete confirmation */}
-      <Dialog open={deleteId !== null} onOpenChange={() => setDeleteId(null)}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Supprimer l&apos;inscription</DialogTitle>
-            <DialogDescription>
-              Cette action est irreversible. Voulez-vous continuer ?
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="gap-2 sm:gap-0">
-            <Button variant="outline" onClick={() => setDeleteId(null)}>
-              Annuler
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={deleteMutation.isPending}
-              onClick={() => {
-                if (deleteId) {
-                  deleteMutation.mutate(deleteId, {
-                    onSuccess: () => setDeleteId(null),
-                  })
-                }
-              }}
-            >
-              {deleteMutation.isPending ? "Suppression..." : "Supprimer"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+    <CrudTable<Enrollment>
+      data={data}
+      columns={columns}
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+      refetch={refetch}
+      deleteMutation={deleteMutation}
+      renderEditModal={({ itemId, open, onClose }) => (
+        <EnrollmentEditModal enrollmentId={itemId} open={open} onClose={onClose} />
+      )}
+      getItemLabel={(e) => e.student_name}
+      emptyMessage="Aucune inscription trouvée"
+      errorMessage="Impossible de charger les inscriptions"
+      deleteTitle="Supprimer l'inscription"
+      deleteDescription="Cette action est irréversible. L'inscription sera définitivement supprimée."
+      page={page}
+      onPageChange={setPage}
+    />
   )
 }

--- a/lib/api/enrollments.ts
+++ b/lib/api/enrollments.ts
@@ -1,54 +1,8 @@
-import { apiFetch, safeValidate } from "./client"
-import {
+import { EnrollmentSchema } from "@/lib/contracts/enrollment"
+import type { Enrollment, EnrollmentCreate, EnrollmentUpdate } from "@/lib/contracts/enrollment"
+import { createCrudApi } from "./createCrudApi"
+
+export const enrollmentsApi = createCrudApi<Enrollment, EnrollmentCreate, EnrollmentUpdate>(
+  "/enrollments",
   EnrollmentSchema,
-  type Enrollment,
-  type EnrollmentCreate,
-  type EnrollmentUpdate,
-  type EnrollmentListParams,
-} from "@/lib/contracts/enrollment"
-import { PaginatedResponseSchema, type PaginatedResponse } from "@/lib/contracts"
-
-const PaginatedEnrollments = PaginatedResponseSchema(EnrollmentSchema)
-
-export type { Enrollment, EnrollmentCreate, EnrollmentUpdate, EnrollmentListParams }
-export type { PaginatedResponse }
-
-export const enrollmentsApi = {
-  list: async (params: EnrollmentListParams = {}): Promise<PaginatedResponse<Enrollment>> => {
-    const query = new URLSearchParams()
-    Object.entries(params).forEach(([key, value]) => {
-      if (value !== undefined && value !== "") {
-        query.set(key, String(value))
-      }
-    })
-    return apiFetch(`/enrollments?${query.toString()}`, { schema: PaginatedEnrollments })
-  },
-
-  getById: async (id: number): Promise<Enrollment> => {
-    const res = await apiFetch<{ data?: Enrollment }>(`/enrollments/${id}`)
-    const enrollment = (res as { data?: Enrollment }).data ?? (res as unknown as Enrollment)
-    return safeValidate(EnrollmentSchema, enrollment, `/enrollments/${id}`)
-  },
-
-  create: async (data: EnrollmentCreate): Promise<Enrollment> => {
-    const res = await apiFetch<{ data?: Enrollment }>("/enrollments", {
-      method: "POST",
-      body: JSON.stringify(data),
-    })
-    const enrollment = (res as { data?: Enrollment }).data ?? (res as unknown as Enrollment)
-    return safeValidate(EnrollmentSchema, enrollment, "POST /enrollments")
-  },
-
-  update: async (id: number, data: EnrollmentUpdate): Promise<Enrollment> => {
-    const res = await apiFetch<{ data?: Enrollment }>(`/enrollments/${id}`, {
-      method: "PATCH",
-      body: JSON.stringify(data),
-    })
-    const enrollment = (res as { data?: Enrollment }).data ?? (res as unknown as Enrollment)
-    return safeValidate(EnrollmentSchema, enrollment, `PATCH /enrollments/${id}`)
-  },
-
-  remove: async (id: number): Promise<void> => {
-    await apiFetch(`/enrollments/${id}`, { method: "DELETE" })
-  },
-}
+)

--- a/lib/hooks/useEnrollments.ts
+++ b/lib/hooks/useEnrollments.ts
@@ -1,162 +1,25 @@
 "use client"
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import { toast } from "sonner"
 import { enrollmentsApi } from "@/lib/api/enrollments"
-import type {
-  Enrollment,
-  EnrollmentListParams,
-  EnrollmentCreate,
-  EnrollmentUpdate,
-} from "@/lib/contracts/enrollment"
-import type { PaginatedResponse } from "@/lib/contracts"
+import type { Enrollment, EnrollmentCreate, EnrollmentUpdate } from "@/lib/contracts/enrollment"
+import { createCrudHooks } from "./createCrudHooks"
 
-export const enrollmentKeys = {
-  all: ["enrollments"] as const,
-  list: (params: EnrollmentListParams) => ["enrollments", "list", params] as const,
-  detail: (id: number) => ["enrollments", id] as const,
-}
+const {
+  keys: enrollmentKeys,
+  useList,
+  useDetail,
+  useCreate,
+  useUpdate,
+  useDelete,
+} = createCrudHooks<Enrollment, EnrollmentCreate, EnrollmentUpdate>("enrollments", enrollmentsApi, {
+  created: "Inscription créée avec succès",
+  updated: "Inscription mise à jour",
+  deleted: "Inscription supprimée",
+})
 
-export function useEnrollments(params: EnrollmentListParams = {}) {
-  return useQuery({
-    queryKey: enrollmentKeys.list(params),
-    queryFn: () => enrollmentsApi.list(params),
-    staleTime: 1000 * 60 * 5,
-  })
-}
-
-export function useEnrollment(id: number) {
-  return useQuery({
-    queryKey: enrollmentKeys.detail(id),
-    queryFn: () => enrollmentsApi.getById(id),
-    enabled: !!id,
-  })
-}
-
-export function useCreateEnrollment() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: (data: EnrollmentCreate) => enrollmentsApi.create(data),
-    onMutate: async (newData) => {
-      await queryClient.cancelQueries({ queryKey: enrollmentKeys.all })
-      const queries = queryClient.getQueriesData<PaginatedResponse<Enrollment>>({
-        queryKey: enrollmentKeys.all,
-      })
-      const previous = new Map(queries)
-
-      for (const [key, old] of queries) {
-        if (!old) continue
-        queryClient.setQueryData(key, {
-          ...old,
-          total: old.total + 1,
-          data: [
-            { ...newData, id: -Date.now(), student_name: "", class_name: "", academic_year_label: "", created_at: "", updated_at: "" } as Enrollment,
-            ...old.data,
-          ],
-        })
-      }
-      return { previous }
-    },
-    onError: (_err, _vars, context) => {
-      if (context?.previous) {
-        for (const [key, data] of context.previous) {
-          queryClient.setQueryData(key, data)
-        }
-      }
-      toast.error("Erreur", { description: _err.message })
-    },
-    onSuccess: () => {
-      toast.success("Inscription creee avec succes")
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: enrollmentKeys.all })
-    },
-  })
-}
-
-export function useUpdateEnrollment(id: number) {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: (data: EnrollmentUpdate) => enrollmentsApi.update(id, data),
-    onMutate: async (newData) => {
-      await queryClient.cancelQueries({ queryKey: enrollmentKeys.all })
-      await queryClient.cancelQueries({ queryKey: enrollmentKeys.detail(id) })
-
-      const previousDetail = queryClient.getQueryData<Enrollment>(enrollmentKeys.detail(id))
-      const queries = queryClient.getQueriesData<PaginatedResponse<Enrollment>>({
-        queryKey: enrollmentKeys.all,
-      })
-      const previousList = new Map(queries)
-
-      if (previousDetail) {
-        queryClient.setQueryData(enrollmentKeys.detail(id), { ...previousDetail, ...newData })
-      }
-
-      for (const [key, old] of queries) {
-        if (!old) continue
-        queryClient.setQueryData(key, {
-          ...old,
-          data: old.data.map((e) => (e.id === id ? { ...e, ...newData } : e)),
-        })
-      }
-
-      return { previousDetail, previousList }
-    },
-    onError: (_err, _vars, context) => {
-      if (context?.previousDetail) {
-        queryClient.setQueryData(enrollmentKeys.detail(id), context.previousDetail)
-      }
-      if (context?.previousList) {
-        for (const [key, data] of context.previousList) {
-          queryClient.setQueryData(key, data)
-        }
-      }
-      toast.error("Erreur", { description: _err.message })
-    },
-    onSuccess: () => {
-      toast.success("Inscription mise a jour")
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: enrollmentKeys.all })
-      queryClient.invalidateQueries({ queryKey: enrollmentKeys.detail(id) })
-    },
-  })
-}
-
-export function useDeleteEnrollment() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: (id: number) => enrollmentsApi.remove(id),
-    onMutate: async (deletedId) => {
-      await queryClient.cancelQueries({ queryKey: enrollmentKeys.all })
-      const queries = queryClient.getQueriesData<PaginatedResponse<Enrollment>>({
-        queryKey: enrollmentKeys.all,
-      })
-      const previous = new Map(queries)
-
-      for (const [key, old] of queries) {
-        if (!old) continue
-        queryClient.setQueryData(key, {
-          ...old,
-          total: old.total - 1,
-          data: old.data.filter((e) => e.id !== deletedId),
-        })
-      }
-      return { previous }
-    },
-    onError: (_err, _vars, context) => {
-      if (context?.previous) {
-        for (const [key, data] of context.previous) {
-          queryClient.setQueryData(key, data)
-        }
-      }
-      toast.error("Erreur", { description: _err.message })
-    },
-    onSuccess: () => {
-      toast.success("Inscription supprimee")
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: enrollmentKeys.all })
-    },
-  })
-}
+export { enrollmentKeys }
+export const useEnrollments = useList
+export const useEnrollment = useDetail
+export const useCreateEnrollment = useCreate
+export const useUpdateEnrollment = useUpdate
+export const useDeleteEnrollment = useDelete


### PR DESCRIPTION
## Summary
Migrate the enrollments module to use the generic CRUD infrastructure, matching the pattern of the 5 other entities (students, teachers, staff, subjects, classes).

### Changes (-331 lines net)
| File | Before | After | Reduction |
|------|--------|-------|-----------|
| `lib/api/enrollments.ts` | 54 lines | 8 lines | -85% |
| `lib/hooks/useEnrollments.ts` | 163 lines | 27 lines | -83% |
| `EnrollmentsTable.tsx` | 235 lines | 86 lines | -63% |

### What changed
- **API layer**: replaced hand-rolled fetch functions with `createCrudApi`
- **Hooks**: replaced manual optimistic updates with `createCrudHooks` (consistent rollback behavior)
- **Table**: replaced hand-rolled table with `CrudTable` (shared skeleton, empty state, pagination, action dropdown)
- All export names preserved — zero consumer changes needed

## Test plan
- [ ] Enrollment list loads with pagination
- [ ] Create enrollment works via modal
- [ ] Edit enrollment works via modal
- [ ] Delete enrollment works with confirmation
- [ ] `pnpm tsc --noEmit` passes

Closes #54