### PR TITLE
fix(hooks): clean query key pollution and narrow invalidation scope

### DIFF
--- a/lib/hooks/useBulletins.ts
+++ b/lib/hooks/useBulletins.ts
@@ -21,9 +21,10 @@ export function useBulletins(params: BulletinListParams = {}) {
 
 export function useBulletin(id: number | null) {
   return useQuery({
-    queryKey: bulletinKeys.detail(id!),
-    queryFn: () => bulletinsApi.getById(id!),
+    queryKey: id ? bulletinKeys.detail(id) : ["bulletins", "none"],
+    queryFn: () => bulletinsApi.getById(id as number),
     enabled: id !== null && id > 0,
+    staleTime: 1000 * 60 * 5,
   })
 }
 

--- a/lib/hooks/useCouncil.ts
+++ b/lib/hooks/useCouncil.ts
@@ -15,8 +15,10 @@ export const councilKeys = {
 export function useCouncilMinutes(classId: number | undefined, trimester: string | undefined) {
   const enabled = !!classId && !!trimester
   return useQuery({
-    queryKey: councilKeys.minutes(classId ?? 0, trimester ?? ""),
-    queryFn: () => councilApi.getMinutes(classId!, trimester!),
+    queryKey: enabled
+      ? councilKeys.minutes(classId as number, trimester as string)
+      : ["council", "minutes", "none"],
+    queryFn: () => councilApi.getMinutes(classId as number, trimester as string),
     enabled,
     staleTime: 1000 * 60 * 5,
   })

--- a/lib/hooks/useDrenStats.ts
+++ b/lib/hooks/useDrenStats.ts
@@ -11,9 +11,9 @@ export const drenKeys = {
 // Récupérer les statistiques DREN pour une année académique
 export function useDrenStats(academicYearId: number | undefined) {
   return useQuery({
-    queryKey: drenKeys.stats(academicYearId ?? 0),
-    queryFn: () => drenApi.getStats(academicYearId!),
+    queryKey: academicYearId ? drenKeys.stats(academicYearId) : ["dren", "stats", "none"],
+    queryFn: () => drenApi.getStats(academicYearId as number),
     enabled: !!academicYearId,
-    staleTime: 1000 * 60 * 10, // 10 minutes — données stables
+    staleTime: 1000 * 60 * 10,
   })
 }

--- a/lib/hooks/useFees.ts
+++ b/lib/hooks/useFees.ts
@@ -30,6 +30,8 @@ export function useCreateFeeCategory() {
       queryClient.setQueryData<FeeCategory[]>(feeKeys.categories, (old) =>
         old ? [...old, created] : [created],
       )
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: feeKeys.categories })
     },
     onError: (err) => toast.error("Erreur", { description: err.message }),
@@ -83,8 +85,8 @@ export function useDeleteFeeCategory() {
 
 export function useFeeVariants(academicYearId?: number) {
   return useQuery({
-    queryKey: feeKeys.variants(academicYearId),
-    queryFn: () => feesApi.listVariants(academicYearId!),
+    queryKey: academicYearId ? feeKeys.variants(academicYearId) : ["fees", "variants", "none"],
+    queryFn: () => feesApi.listVariants(academicYearId as number),
     enabled: !!academicYearId,
     staleTime: 1000 * 60 * 10,
   })
@@ -120,7 +122,7 @@ export function useUpdateFeeVariant() {
       })
       toast.error("Erreur", { description: err.message })
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: feeKeys.all }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ["fees", "variants"] }),
   })
 }
 
@@ -140,6 +142,6 @@ export function useDeleteFeeVariant() {
       })
       toast.error("Erreur", { description: err.message })
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: feeKeys.all }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ["fees", "variants"] }),
   })
 }

--- a/lib/hooks/useGrades.ts
+++ b/lib/hooks/useGrades.ts
@@ -101,7 +101,6 @@ export function useUpdateGrades(evaluationId: number) {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: gradeKeys.grades(evaluationId) })
-      queryClient.invalidateQueries({ queryKey: gradeKeys.all })
     },
   })
 }


### PR DESCRIPTION
## Summary
Combined fix for issues #58 and #60 (shared overlap on `useFees.ts`).

### Query key pollution fixed (#58)
| Hook | Before | After |
|------|--------|-------|
| `useDrenStats` | `drenKeys.stats(academicYearId ?? 0)` | Conditional key when undefined |
| `useCouncilMinutes` | `councilKeys.minutes(classId ?? 0, trimester ?? "")` | Conditional key when undefined |
| `useBulletin` | `bulletinKeys.detail(id!)` | Conditional key when null |
| `useFeeVariants` | `feesApi.listVariants(academicYearId!)` | `as number` (safe behind enabled guard) |

### Invalidation scope narrowed (#60)
| Hook | Before | After |
|------|--------|-------|
| `useUpdateGrades` | `gradeKeys.all` (redundant) | Removed — targeted invalidation already handles it |
| `useCreateFeeCategory` | `setQueryData` + `invalidateQueries` on same key | Separated: optimistic in `onSuccess`, invalidation in `onSettled` |
| `useUpdateFeeVariant` | `feeKeys.all` | `["fees", "variants"]` (prefix match) |
| `useDeleteFeeVariant` | `feeKeys.all` | `["fees", "variants"]` (prefix match) |

## Test plan
- [ ] DREN stats load correctly
- [ ] Council deliberation loads correctly
- [ ] Bulletin preview works
- [ ] Fee category/variant CRUD works
- [ ] Grade save doesn't trigger full grade list refetch

Closes #58
Closes #60