### PR TITLE
refactor(admin): extract generic CreateModal and CrudPageLayout components

### DIFF
--- a/components/admin/classes/ClassCreateModal.tsx
+++ b/components/admin/classes/ClassCreateModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { CreateModal } from "@/components/shared/CreateModal"
 import { ClassForm } from "@/components/forms/ClassForm"
 
 interface ClassCreateModalProps {
@@ -10,13 +10,8 @@ interface ClassCreateModalProps {
 
 export function ClassCreateModal({ open, onClose }: ClassCreateModalProps) {
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg" aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Nouvelle classe</DialogTitle>
-        </DialogHeader>
-        <ClassForm onSuccess={onClose} />
-      </DialogContent>
-    </Dialog>
+    <CreateModal open={open} onClose={onClose} title="Nouvelle classe">
+      <ClassForm onSuccess={onClose} />
+    </CreateModal>
   )
 }

--- a/components/admin/classes/ClassesPageClient.tsx
+++ b/components/admin/classes/ClassesPageClient.tsx
@@ -1,30 +1,17 @@
 "use client"
 
-import { useState } from "react"
-import { Plus } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
 import { ClassesTable } from "./ClassesTable"
 import { ClassCreateModal } from "./ClassCreateModal"
 
 export function ClassesPageClient() {
-  const [createOpen, setCreateOpen] = useState(false)
-
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="font-serif text-2xl tracking-tight">Classes</h1>
-          <p className="text-sm text-muted-foreground">Gestion des classes et niveaux</p>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Nouvelle classe
-        </Button>
-      </div>
-
-      <ClassesTable />
-
-      <ClassCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
-    </div>
+    <CrudPageLayout
+      title="Classes"
+      subtitle="Gestion des classes et niveaux"
+      createLabel="Nouvelle classe"
+      table={<ClassesTable />}
+      createModal={(props) => <ClassCreateModal {...props} />}
+    />
   )
 }

--- a/components/admin/enrollments/EnrollmentCreateModal.tsx
+++ b/components/admin/enrollments/EnrollmentCreateModal.tsx
@@ -1,11 +1,6 @@
 "use client"
 
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+import { CreateModal } from "@/components/shared/CreateModal"
 import { EnrollmentForm } from "@/components/forms/EnrollmentForm"
 
 interface EnrollmentCreateModalProps {
@@ -15,13 +10,8 @@ interface EnrollmentCreateModalProps {
 
 export function EnrollmentCreateModal({ open, onClose }: EnrollmentCreateModalProps) {
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg" aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Nouvelle inscription</DialogTitle>
-        </DialogHeader>
-        <EnrollmentForm onSuccess={onClose} />
-      </DialogContent>
-    </Dialog>
+    <CreateModal open={open} onClose={onClose} title="Nouvelle inscription">
+      <EnrollmentForm onSuccess={onClose} />
+    </CreateModal>
   )
 }

--- a/components/admin/staff/StaffCreateModal.tsx
+++ b/components/admin/staff/StaffCreateModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { CreateModal } from "@/components/shared/CreateModal"
 import { StaffForm } from "@/components/forms/StaffForm"
 
 interface StaffCreateModalProps {
@@ -10,13 +10,8 @@ interface StaffCreateModalProps {
 
 export function StaffCreateModal({ open, onClose }: StaffCreateModalProps) {
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg" aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Nouveau personnel</DialogTitle>
-        </DialogHeader>
-        <StaffForm onSuccess={onClose} />
-      </DialogContent>
-    </Dialog>
+    <CreateModal open={open} onClose={onClose} title="Nouveau personnel">
+      <StaffForm onSuccess={onClose} />
+    </CreateModal>
   )
 }

--- a/components/admin/staff/StaffPageClient.tsx
+++ b/components/admin/staff/StaffPageClient.tsx
@@ -1,30 +1,17 @@
 "use client"
 
-import { useState } from "react"
-import { Plus } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
 import { StaffTable } from "./StaffTable"
 import { StaffCreateModal } from "./StaffCreateModal"
 
 export function StaffPageClient() {
-  const [createOpen, setCreateOpen] = useState(false)
-
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="font-serif text-2xl tracking-tight">Personnel</h1>
-          <p className="text-sm text-muted-foreground">Gestion du personnel administratif</p>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Nouveau personnel
-        </Button>
-      </div>
-
-      <StaffTable />
-
-      <StaffCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
-    </div>
+    <CrudPageLayout
+      title="Personnel"
+      subtitle="Gestion du personnel administratif"
+      createLabel="Nouveau personnel"
+      table={<StaffTable />}
+      createModal={(props) => <StaffCreateModal {...props} />}
+    />
   )
 }

--- a/components/admin/students/StudentCreateModal.tsx
+++ b/components/admin/students/StudentCreateModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { CreateModal } from "@/components/shared/CreateModal"
 import { StudentForm } from "@/components/forms/StudentForm"
 
 interface StudentCreateModalProps {
@@ -10,13 +10,8 @@ interface StudentCreateModalProps {
 
 export function StudentCreateModal({ open, onClose }: StudentCreateModalProps) {
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg" aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Nouvel élève</DialogTitle>
-        </DialogHeader>
-        <StudentForm onSuccess={onClose} />
-      </DialogContent>
-    </Dialog>
+    <CreateModal open={open} onClose={onClose} title="Nouvel élève">
+      <StudentForm onSuccess={onClose} />
+    </CreateModal>
   )
 }

--- a/components/admin/students/StudentsPageClient.tsx
+++ b/components/admin/students/StudentsPageClient.tsx
@@ -1,30 +1,17 @@
 "use client"
 
-import { useState } from "react"
-import { Plus } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
 import { StudentsTable } from "./StudentsTable"
 import { StudentCreateModal } from "./StudentCreateModal"
 
 export function StudentsPageClient() {
-  const [createOpen, setCreateOpen] = useState(false)
-
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="font-serif text-2xl tracking-tight">Élèves</h1>
-          <p className="text-sm text-muted-foreground">Gestion des élèves inscrits</p>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Nouvel élève
-        </Button>
-      </div>
-
-      <StudentsTable />
-
-      <StudentCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
-    </div>
+    <CrudPageLayout
+      title="Élèves"
+      subtitle="Gestion des élèves inscrits"
+      createLabel="Nouvel élève"
+      table={<StudentsTable />}
+      createModal={(props) => <StudentCreateModal {...props} />}
+    />
   )
 }

--- a/components/admin/subjects/SubjectCreateModal.tsx
+++ b/components/admin/subjects/SubjectCreateModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { CreateModal } from "@/components/shared/CreateModal"
 import { SubjectForm } from "@/components/forms/SubjectForm"
 
 interface SubjectCreateModalProps {
@@ -10,13 +10,8 @@ interface SubjectCreateModalProps {
 
 export function SubjectCreateModal({ open, onClose }: SubjectCreateModalProps) {
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg" aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Nouvelle matière</DialogTitle>
-        </DialogHeader>
-        <SubjectForm onSuccess={onClose} />
-      </DialogContent>
-    </Dialog>
+    <CreateModal open={open} onClose={onClose} title="Nouvelle matière">
+      <SubjectForm onSuccess={onClose} />
+    </CreateModal>
   )
 }

--- a/components/admin/subjects/SubjectsPageClient.tsx
+++ b/components/admin/subjects/SubjectsPageClient.tsx
@@ -1,30 +1,17 @@
 "use client"
 
-import { useState } from "react"
-import { Plus } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
 import { SubjectsTable } from "./SubjectsTable"
 import { SubjectCreateModal } from "./SubjectCreateModal"
 
 export function SubjectsPageClient() {
-  const [createOpen, setCreateOpen] = useState(false)
-
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="font-serif text-2xl tracking-tight">Matières</h1>
-          <p className="text-sm text-muted-foreground">Gestion des matières enseignées</p>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Nouvelle matière
-        </Button>
-      </div>
-
-      <SubjectsTable />
-
-      <SubjectCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
-    </div>
+    <CrudPageLayout
+      title="Matières"
+      subtitle="Gestion des matières enseignées"
+      createLabel="Nouvelle matière"
+      table={<SubjectsTable />}
+      createModal={(props) => <SubjectCreateModal {...props} />}
+    />
   )
 }

--- a/components/admin/teachers/TeacherCreateModal.tsx
+++ b/components/admin/teachers/TeacherCreateModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { CreateModal } from "@/components/shared/CreateModal"
 import { TeacherForm } from "@/components/forms/TeacherForm"
 
 interface TeacherCreateModalProps {
@@ -10,13 +10,8 @@ interface TeacherCreateModalProps {
 
 export function TeacherCreateModal({ open, onClose }: TeacherCreateModalProps) {
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg" aria-describedby={undefined}>
-        <DialogHeader>
-          <DialogTitle>Nouvel enseignant</DialogTitle>
-        </DialogHeader>
-        <TeacherForm onSuccess={onClose} />
-      </DialogContent>
-    </Dialog>
+    <CreateModal open={open} onClose={onClose} title="Nouvel enseignant">
+      <TeacherForm onSuccess={onClose} />
+    </CreateModal>
   )
 }

--- a/components/admin/teachers/TeachersPageClient.tsx
+++ b/components/admin/teachers/TeachersPageClient.tsx
@@ -1,30 +1,17 @@
 "use client"
 
-import { useState } from "react"
-import { Plus } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
 import { TeachersTable } from "./TeachersTable"
 import { TeacherCreateModal } from "./TeacherCreateModal"
 
 export function TeachersPageClient() {
-  const [createOpen, setCreateOpen] = useState(false)
-
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="font-serif text-2xl tracking-tight">Enseignants</h1>
-          <p className="text-sm text-muted-foreground">Gestion du corps enseignant</p>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Nouvel enseignant
-        </Button>
-      </div>
-
-      <TeachersTable />
-
-      <TeacherCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
-    </div>
+    <CrudPageLayout
+      title="Enseignants"
+      subtitle="Gestion du corps enseignant"
+      createLabel="Nouvel enseignant"
+      table={<TeachersTable />}
+      createModal={(props) => <TeacherCreateModal {...props} />}
+    />
   )
 }

--- a/components/shared/CreateModal.tsx
+++ b/components/shared/CreateModal.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface CreateModalProps {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+  className?: string
+}
+
+export function CreateModal({ open, onClose, title, children, className = "max-w-lg" }: CreateModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className={className} aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {children}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/shared/CrudPageLayout.tsx
+++ b/components/shared/CrudPageLayout.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Plus } from "lucide-react"
+
+interface CrudPageLayoutProps {
+  title: string
+  subtitle: string
+  createLabel: string
+  table: React.ReactNode
+  createModal: (props: { open: boolean; onClose: () => void }) => React.ReactNode
+}
+
+export function CrudPageLayout({ title, subtitle, createLabel, table, createModal }: CrudPageLayoutProps) {
+  const [createOpen, setCreateOpen] = useState(false)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-serif text-2xl tracking-tight">{title}</h1>
+          <p className="text-sm text-muted-foreground">{subtitle}</p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" /> {createLabel}
+        </Button>
+      </div>
+      {table}
+      {createModal({ open: createOpen, onClose: () => setCreateOpen(false) })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Extract two shared components to eliminate near-duplicate boilerplate across 11 admin files.

### New shared components
- **`CreateModal`** — generic dialog wrapper (title, children, className)
- **`CrudPageLayout`** — generic page layout (title, subtitle, create button, table slot, modal render prop)

### Files refactored
| Component | Files | Before | After |
|-----------|-------|--------|-------|
| CreateModal | 6 files (Class, Student, Teacher, Staff, Subject, Enrollment) | ~22 lines each | ~15 lines each |
| CrudPageLayout | 5 files (Classes, Students, Teachers, Staff, Subjects) | ~30 lines each | ~15 lines each |

Net: -38 lines, 11 files consolidated to use 2 shared components.

## Test plan
- [ ] All admin CRUD pages render correctly
- [ ] Create modals open/close properly
- [ ] `pnpm tsc --noEmit` passes

Closes #61