### PR TITLE
fix(contracts): replace stringly-typed status comparisons with Zod enum values

### DIFF
--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -36,6 +36,7 @@ import { PaymentCreateModal } from "./PaymentCreateModal"
 import { usePayments, useFinancialSummary, useValidatePayment, useCancelPayment } from "@/lib/hooks/usePayments"
 import { paymentsApi } from "@/lib/api/payments"
 import { downloadBlob } from "@/lib/utils"
+import { PaymentStatusSchema } from "@/lib/contracts/payment"
 import type { PaymentListParams, PaymentStatus, PaymentMethod, Payment } from "@/lib/contracts/payment"
 
 const STATUS_CONFIG: Record<PaymentStatus, { label: string; variant: "default" | "secondary" | "destructive" }> = {
@@ -222,7 +223,7 @@ export function PaymentsPageClient() {
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex items-center justify-end gap-1">
-                        {payment.status === "en_attente" && (
+                        {payment.status === PaymentStatusSchema.Values.en_attente && (
                           <>
                             <Button
                               size="icon"

--- a/components/admin/reports/BulletinList.tsx
+++ b/components/admin/reports/BulletinList.tsx
@@ -18,6 +18,7 @@ import { BulletinListSkeleton } from "./BulletinListSkeleton"
 import { useBulletins, usePublishBulletins } from "@/lib/hooks/useBulletins"
 import { bulletinsApi } from "@/lib/api/bulletins"
 import { getMentionColor, downloadBlob } from "@/lib/utils"
+import { BulletinStatusSchema } from "@/lib/contracts/bulletin"
 import type { BulletinListParams, Bulletin } from "@/lib/contracts/bulletin"
 
 interface BulletinListProps {
@@ -47,7 +48,7 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
 
   const bulletins = useMemo(() => data?.data ?? [], [data])
   const hasDrafts = useMemo(
-    () => bulletins.some((b) => b.status === "brouillon"),
+    () => bulletins.some((b) => b.status === BulletinStatusSchema.Values.brouillon),
     [bulletins],
   )
 

--- a/components/admin/reports/council/CouncilDeliberationTable.tsx
+++ b/components/admin/reports/council/CouncilDeliberationTable.tsx
@@ -25,6 +25,7 @@ import { CouncilDecisionBadge } from "./CouncilDecisionBadge"
 import { CouncilValidateButton } from "./CouncilValidateButton"
 import { useUpdateDecisions } from "@/lib/hooks/useCouncil"
 import { councilApi } from "@/lib/api/council"
+import { CouncilStatusSchema } from "@/lib/contracts/council"
 import type { CouncilMinutes, CouncilDecision, CouncilDecisionUpdate } from "@/lib/contracts/council"
 
 // Calcul automatique de la décision basé sur la MGA (système ivoirien)
@@ -44,7 +45,7 @@ interface CouncilDeliberationTableProps {
 }
 
 export function CouncilDeliberationTable({ minutes, classId, trimester, onDirtyChange }: CouncilDeliberationTableProps) {
-  const isReadOnly = minutes.status === "valide"
+  const isReadOnly = minutes.status === CouncilStatusSchema.Values.valide
   const { mutate: saveDecisions, isPending: isSaving } = useUpdateDecisions(classId, trimester)
 
   // État local des décisions modifiées

--- a/components/admin/reports/council/CouncilPageClient.tsx
+++ b/components/admin/reports/council/CouncilPageClient.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/dialog"
 import { CouncilDeliberationTable } from "./CouncilDeliberationTable"
 import { useCouncilMinutes } from "@/lib/hooks/useCouncil"
+import { CouncilStatusSchema } from "@/lib/contracts/council"
 import { useClasses } from "@/lib/hooks/useClasses"
 
 export function CouncilPageClient() {
@@ -114,8 +115,8 @@ export function CouncilPageClient() {
         </Select>
 
         {minutes && (
-          <Badge variant={minutes.status === "valide" ? "default" : "secondary"}>
-            {minutes.status === "valide" ? "Validé" : "Brouillon"}
+          <Badge variant={minutes.status === CouncilStatusSchema.Values.valide ? "default" : "secondary"}>
+            {minutes.status === CouncilStatusSchema.Values.valide ? "Validé" : "Brouillon"}
           </Badge>
         )}
       </div>

--- a/components/student/StudentBulletinsClient.tsx
+++ b/components/student/StudentBulletinsClient.tsx
@@ -11,6 +11,7 @@ import { downloadBlob } from "@/lib/utils"
 import { useStudentBulletins } from "@/lib/hooks/useStudentPortal"
 import { studentPortalApi } from "@/lib/api/student-portal"
 import { DataError } from "@/components/shared/DataError"
+import { BulletinStatusSchema } from "@/lib/contracts/bulletin"
 import type { StudentBulletin } from "@/lib/contracts/student-portal"
 
 export function StudentBulletinsClient() {
@@ -61,7 +62,7 @@ function BulletinCard({ bulletin }: { bulletin: StudentBulletin }) {
     }
   }, [bulletin.id, bulletin.trimester, bulletin.academic_year])
 
-  const isPublished = bulletin.status === "publie"
+  const isPublished = bulletin.status === BulletinStatusSchema.Values.publie
 
   return (
     <Card className="border-0 shadow-sm ring-1 ring-border">


### PR DESCRIPTION
## Summary
Replace raw string literals with `Schema.Values.*` constants from Zod enums in 5 files.

If the backend ever renames a status value, TypeScript will catch it at compile time instead of failing silently at runtime.

| File | Before | After |
|------|--------|-------|
| CouncilDeliberationTable | `"valide"` | `CouncilStatusSchema.Values.valide` |
| CouncilPageClient | `"valide"` (×2) | `CouncilStatusSchema.Values.valide` |
| BulletinList | `"brouillon"` | `BulletinStatusSchema.Values.brouillon` |
| PaymentsPageClient | `"en_attente"` | `PaymentStatusSchema.Values.en_attente` |
| StudentBulletinsClient | `"publie"` | `BulletinStatusSchema.Values.publie` |

Closes #64