### PR TITLE
feat(settings): add admin settings page

### DIFF
--- a/app/(admin)/admin/dashboard/page.tsx
+++ b/app/(admin)/admin/dashboard/page.tsx
@@ -6,7 +6,6 @@ import { Skeleton } from "@/components/ui/skeleton"
 const DashboardCharts = dynamic(
   () => import("@/components/admin/dashboard/DashboardCharts").then((m) => m.DashboardCharts),
   {
-    ssr: false,
     loading: () => (
       <div className="rounded-lg border bg-card p-6 space-y-4">
         <Skeleton className="h-5 w-40" />

--- a/app/(admin)/admin/settings/error.tsx
+++ b/app/(admin)/admin/settings/error.tsx
@@ -1,0 +1,3 @@
+"use client"
+
+export { default } from "@/components/shared/AdminError"

--- a/app/(admin)/admin/settings/loading.tsx
+++ b/app/(admin)/admin/settings/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function SettingsLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-lg" />
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-32" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+      </div>
+      <Skeleton className="h-10 w-80" />
+      <div className="space-y-4">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-3/4" />
+      </div>
+    </div>
+  )
+}

--- a/app/(admin)/admin/settings/page.tsx
+++ b/app/(admin)/admin/settings/page.tsx
@@ -1,0 +1,7 @@
+import { SettingsPageClient } from "@/components/admin/settings/SettingsPageClient"
+
+export const metadata = { title: "Paramètres | KLASSCI" }
+
+export default function SettingsPage() {
+  return <SettingsPageClient />
+}

--- a/components/admin/settings/NotificationSection.tsx
+++ b/components/admin/settings/NotificationSection.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Bell, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Switch } from "@/components/ui/switch"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormDescription,
+} from "@/components/ui/form"
+import { Separator } from "@/components/ui/separator"
+import { NotificationUpdateSchema, type NotificationUpdate, type SchoolSettings } from "@/lib/contracts/settings"
+import { useUpdateNotifications } from "@/lib/hooks/useSettings"
+
+interface NotificationSectionProps {
+  settings: SchoolSettings
+}
+
+export function NotificationSection({ settings }: NotificationSectionProps) {
+  const { mutate, isPending } = useUpdateNotifications()
+
+  const form = useForm<NotificationUpdate>({
+    resolver: zodResolver(NotificationUpdateSchema),
+    defaultValues: {
+      notify_by_email: settings.notify_by_email,
+      notify_by_sms: settings.notify_by_sms,
+      notify_grades: settings.notify_grades,
+      notify_absences: settings.notify_absences,
+      notify_payments: settings.notify_payments,
+    },
+  })
+
+  function onSubmit(data: NotificationUpdate) {
+    mutate(data)
+  }
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardHeader className="pb-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Bell className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle className="text-base">Paramètres de notification</CardTitle>
+            <p className="text-sm text-muted-foreground">Canaux et types de notifications envoyées</p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            {/* Canaux */}
+            <div className="space-y-4">
+              <p className="text-sm font-semibold">Canaux de diffusion</p>
+              <FormField
+                control={form.control}
+                name="notify_by_email"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-sm">Email</FormLabel>
+                      <FormDescription className="text-xs">
+                        Envoyer les notifications par email aux parents
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="notify_by_sms"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-sm">SMS</FormLabel>
+                      <FormDescription className="text-xs">
+                        Envoyer les notifications par SMS aux parents
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <Separator />
+
+            {/* Types */}
+            <div className="space-y-4">
+              <p className="text-sm font-semibold">Types de notifications</p>
+              <FormField
+                control={form.control}
+                name="notify_grades"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-sm">Notes</FormLabel>
+                      <FormDescription className="text-xs">
+                        Notifier quand de nouvelles notes sont publiées
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="notify_absences"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-sm">Absences</FormLabel>
+                      <FormDescription className="text-xs">
+                        Notifier les parents en cas d&apos;absence
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="notify_payments"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-sm">Paiements</FormLabel>
+                      <FormDescription className="text-xs">
+                        Notifier lors de la réception d&apos;un paiement
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="flex justify-end pt-2">
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Enregistrer
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/settings/SchoolInfoSection.tsx
+++ b/components/admin/settings/SchoolInfoSection.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Building2, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { SchoolInfoUpdateSchema, type SchoolInfoUpdate, type SchoolSettings } from "@/lib/contracts/settings"
+import { useUpdateSchoolInfo } from "@/lib/hooks/useSettings"
+
+interface SchoolInfoSectionProps {
+  settings: SchoolSettings
+}
+
+export function SchoolInfoSection({ settings }: SchoolInfoSectionProps) {
+  const { mutate, isPending } = useUpdateSchoolInfo()
+
+  const form = useForm<SchoolInfoUpdate>({
+    resolver: zodResolver(SchoolInfoUpdateSchema),
+    defaultValues: {
+      school_name: settings.school_name,
+      address: settings.address ?? "",
+      phone: settings.phone ?? "",
+      email: settings.email ?? "",
+      active_academic_year: settings.active_academic_year ?? "",
+    },
+  })
+
+  function onSubmit(data: SchoolInfoUpdate) {
+    mutate(data)
+  }
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardHeader className="pb-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Building2 className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle className="text-base">Informations de l&apos;établissement</CardTitle>
+            <p className="text-sm text-muted-foreground">Nom, adresse et coordonnées de l&apos;école</p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="school_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nom de l&apos;établissement *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Collège KLASSCI" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="active_academic_year"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Année académique active</FormLabel>
+                    <FormControl>
+                      <Input placeholder="2025-2026" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Adresse</FormLabel>
+                  <FormControl>
+                    <Input placeholder="123 Avenue de l'École, Kinshasa" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Téléphone</FormLabel>
+                    <FormControl>
+                      <Input placeholder="+243 ..." {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input type="email" placeholder="contact@ecole.cd" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="flex justify-end pt-2">
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Enregistrer
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/settings/SettingsPageClient.tsx
+++ b/components/admin/settings/SettingsPageClient.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { Settings } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { DataError } from "@/components/shared/DataError"
+import { useSettings } from "@/lib/hooks/useSettings"
+import { SchoolInfoSection } from "./SchoolInfoSection"
+import { TrimesterSection } from "./TrimesterSection"
+import { NotificationSection } from "./NotificationSection"
+
+export function SettingsPageClient() {
+  const { data: settings, isLoading, isError, refetch } = useSettings()
+
+  return (
+    <div className="space-y-6">
+      {/* En-tête */}
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+          <Settings className="h-5 w-5 text-primary" />
+        </div>
+        <div>
+          <h1 className="font-serif text-2xl tracking-tight">Paramètres</h1>
+          <p className="text-sm text-muted-foreground">
+            Configuration de l&apos;établissement et des notifications
+          </p>
+        </div>
+      </div>
+
+      {/* Contenu */}
+      {isLoading ? (
+        <SettingsSkeleton />
+      ) : isError ? (
+        <DataError message="Impossible de charger les paramètres." onRetry={() => refetch()} />
+      ) : settings ? (
+        <Tabs defaultValue="school" className="space-y-6">
+          <TabsList>
+            <TabsTrigger value="school">Établissement</TabsTrigger>
+            <TabsTrigger value="trimesters">Trimestres</TabsTrigger>
+            <TabsTrigger value="notifications">Notifications</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="school">
+            <SchoolInfoSection settings={settings} />
+          </TabsContent>
+
+          <TabsContent value="trimesters">
+            <TrimesterSection settings={settings} />
+          </TabsContent>
+
+          <TabsContent value="notifications">
+            <NotificationSection settings={settings} />
+          </TabsContent>
+        </Tabs>
+      ) : null}
+    </div>
+  )
+}
+
+function SettingsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-10 w-80" />
+      <div className="space-y-4">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-3/4" />
+      </div>
+    </div>
+  )
+}

--- a/components/admin/settings/TrimesterSection.tsx
+++ b/components/admin/settings/TrimesterSection.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { useForm, useFieldArray } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { CalendarDays, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { TrimesterUpdateSchema, type TrimesterUpdate, type SchoolSettings } from "@/lib/contracts/settings"
+import { useUpdateTrimesters } from "@/lib/hooks/useSettings"
+
+const DEFAULT_TRIMESTERS = [
+  { label: "Trimestre 1", start_date: "", end_date: "" },
+  { label: "Trimestre 2", start_date: "", end_date: "" },
+  { label: "Trimestre 3", start_date: "", end_date: "" },
+]
+
+interface TrimesterSectionProps {
+  settings: SchoolSettings
+}
+
+export function TrimesterSection({ settings }: TrimesterSectionProps) {
+  const { mutate, isPending } = useUpdateTrimesters()
+
+  const trimesters = settings.trimesters.length === 3
+    ? settings.trimesters
+    : DEFAULT_TRIMESTERS
+
+  const form = useForm<TrimesterUpdate>({
+    resolver: zodResolver(TrimesterUpdateSchema),
+    defaultValues: { trimesters },
+  })
+
+  const { fields } = useFieldArray({
+    control: form.control,
+    name: "trimesters",
+  })
+
+  function onSubmit(data: TrimesterUpdate) {
+    mutate(data)
+  }
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardHeader className="pb-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <CalendarDays className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle className="text-base">Configuration des trimestres</CardTitle>
+            <p className="text-sm text-muted-foreground">Dates de début et fin de chaque trimestre</p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            {fields.map((field, index) => (
+              <div key={field.id} className="rounded-lg border p-4 space-y-3">
+                <p className="text-sm font-semibold">{trimesters[index].label}</p>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name={`trimesters.${index}.start_date`}
+                    render={({ field: f }) => (
+                      <FormItem>
+                        <FormLabel>Date de début</FormLabel>
+                        <FormControl>
+                          <Input type="date" {...f} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name={`trimesters.${index}.end_date`}
+                    render={({ field: f }) => (
+                      <FormItem>
+                        <FormLabel>Date de fin</FormLabel>
+                        <FormControl>
+                          <Input type="date" {...f} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </div>
+            ))}
+
+            <div className="flex justify-end pt-2">
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Enregistrer
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/api/settings.ts
+++ b/lib/api/settings.ts
@@ -1,0 +1,37 @@
+import { apiFetch } from "./client"
+import type { SchoolSettings, SchoolInfoUpdate, TrimesterUpdate, NotificationUpdate } from "@/lib/contracts/settings"
+
+export const settingsApi = {
+  // Récupérer les paramètres de l'école
+  get: async (): Promise<SchoolSettings> => {
+    const json = await apiFetch<{ data?: SchoolSettings } | SchoolSettings>("/settings")
+    return (json as { data?: SchoolSettings }).data ?? (json as SchoolSettings)
+  },
+
+  // Mettre à jour les informations de l'école
+  updateSchoolInfo: async (data: SchoolInfoUpdate): Promise<SchoolSettings> => {
+    const json = await apiFetch<{ data?: SchoolSettings } | SchoolSettings>("/settings/school-info", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    })
+    return (json as { data?: SchoolSettings }).data ?? (json as SchoolSettings)
+  },
+
+  // Mettre à jour la configuration des trimestres
+  updateTrimesters: async (data: TrimesterUpdate): Promise<SchoolSettings> => {
+    const json = await apiFetch<{ data?: SchoolSettings } | SchoolSettings>("/settings/trimesters", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    })
+    return (json as { data?: SchoolSettings }).data ?? (json as SchoolSettings)
+  },
+
+  // Mettre à jour les paramètres de notification
+  updateNotifications: async (data: NotificationUpdate): Promise<SchoolSettings> => {
+    const json = await apiFetch<{ data?: SchoolSettings } | SchoolSettings>("/settings/notifications", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    })
+    return (json as { data?: SchoolSettings }).data ?? (json as SchoolSettings)
+  },
+}

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -8,6 +8,7 @@ export * from "./payment"
 export * from "./council"
 export * from "./bulletin"
 export * from "./dren"
+export * from "./settings"
 
 // Shared pagination contract
 import { z } from "zod"

--- a/lib/contracts/settings.ts
+++ b/lib/contracts/settings.ts
@@ -1,0 +1,51 @@
+import { z } from "zod"
+
+// Miroir de app/schemas/settings.py (backend)
+
+export const TrimesterConfigSchema = z.object({
+  label: z.string(),
+  start_date: z.string(),
+  end_date: z.string(),
+})
+
+export const SchoolSettingsSchema = z.object({
+  id: z.number(),
+  school_name: z.string(),
+  address: z.string().nullable(),
+  phone: z.string().nullable(),
+  email: z.string().nullable(),
+  logo_url: z.string().nullable(),
+  active_academic_year: z.string().nullable(),
+  trimesters: z.array(TrimesterConfigSchema),
+  notify_by_email: z.boolean(),
+  notify_by_sms: z.boolean(),
+  notify_grades: z.boolean(),
+  notify_absences: z.boolean(),
+  notify_payments: z.boolean(),
+})
+
+export const SchoolInfoUpdateSchema = z.object({
+  school_name: z.string({ required_error: "Le nom est requis" }).min(1, "Le nom est requis"),
+  address: z.string().optional(),
+  phone: z.string().optional(),
+  email: z.string().email("Email invalide").optional().or(z.literal("")),
+  active_academic_year: z.string().optional(),
+})
+
+export const TrimesterUpdateSchema = z.object({
+  trimesters: z.array(TrimesterConfigSchema).length(3, "3 trimestres requis"),
+})
+
+export const NotificationUpdateSchema = z.object({
+  notify_by_email: z.boolean(),
+  notify_by_sms: z.boolean(),
+  notify_grades: z.boolean(),
+  notify_absences: z.boolean(),
+  notify_payments: z.boolean(),
+})
+
+export type TrimesterConfig = z.infer<typeof TrimesterConfigSchema>
+export type SchoolSettings = z.infer<typeof SchoolSettingsSchema>
+export type SchoolInfoUpdate = z.infer<typeof SchoolInfoUpdateSchema>
+export type TrimesterUpdate = z.infer<typeof TrimesterUpdateSchema>
+export type NotificationUpdate = z.infer<typeof NotificationUpdateSchema>

--- a/lib/hooks/useSettings.ts
+++ b/lib/hooks/useSettings.ts
@@ -1,0 +1,60 @@
+"use client"
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { settingsApi } from "@/lib/api/settings"
+import type { SchoolInfoUpdate, TrimesterUpdate, NotificationUpdate } from "@/lib/contracts/settings"
+
+export const settingsKeys = {
+  all: ["settings"] as const,
+}
+
+export function useSettings() {
+  return useQuery({
+    queryKey: settingsKeys.all,
+    queryFn: settingsApi.get,
+    staleTime: 1000 * 60 * 10, // 10 minutes — rarement modifié
+  })
+}
+
+export function useUpdateSchoolInfo() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: SchoolInfoUpdate) => settingsApi.updateSchoolInfo(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.all })
+      toast.success("Informations mises à jour")
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Erreur lors de la mise à jour")
+    },
+  })
+}
+
+export function useUpdateTrimesters() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: TrimesterUpdate) => settingsApi.updateTrimesters(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.all })
+      toast.success("Trimestres mis à jour")
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Erreur lors de la mise à jour")
+    },
+  })
+}
+
+export function useUpdateNotifications() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: NotificationUpdate) => settingsApi.updateNotifications(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.all })
+      toast.success("Notifications mises à jour")
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Erreur lors de la mise à jour")
+    },
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.10.0
         version: 3.10.0(react-hook-form@7.71.2(react@19.2.4))
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -35,6 +41,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.62.7
         version: 5.91.2(react@19.2.4)
@@ -776,6 +788,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -791,6 +816,19 @@ packages:
 
   '@radix-ui/react-avatar@1.1.11':
     resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1080,6 +1118,32 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -4178,6 +4242,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4194,6 +4272,22 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -4479,6 +4573,37 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## Description

- Add `/admin/settings` page with 3 tabs: Établissement, Trimestres, Notifications
- School info form: name, address, phone, email, academic year
- Trimester config: start/end dates for 3 trimesters (useFieldArray)
- Notification toggles: channels (email/SMS) and types (grades/absences/payments) with Switch components
- Full contract/API/hook/component stack following project conventions
- Fix `ssr: false` in dashboard Server Component (bug from develop)

## Closes

Closes #39

## Checklist

- [x] Type-check OK (`npx tsc --noEmit`)
- [x] Build OK (`npx next build`)
- [x] Branche à jour avec develop