### PR TITLE
fix: align all frontend contracts and API clients with backend

### DIFF
--- a/components/admin/attendance/AttendanceGrid.tsx
+++ b/components/admin/attendance/AttendanceGrid.tsx
@@ -131,7 +131,7 @@ export function AttendanceGrid({ classId, slotId, date }: AttendanceGridProps) {
       {/* En-tête de session */}
       <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
         <div className="text-muted-foreground">
-          <strong>{session.subject_name}</strong> — {session.class_name} — {session.teacher_name}
+          <strong>Session #{session.id}</strong> — {session.entity_type} #{session.context_id}
         </div>
         <div className="flex items-center gap-3 text-xs">
           <span className="text-emerald-600 dark:text-emerald-400 font-medium">{counts.present} P</span>

--- a/components/admin/attendance/AttendanceGrid.tsx
+++ b/components/admin/attendance/AttendanceGrid.tsx
@@ -25,8 +25,8 @@ interface AttendanceGridProps {
 const STATUS_BUTTONS: { status: AttendanceStatus; icon: typeof CheckCircle; label: string; className: string }[] = [
   { status: "present", icon: CheckCircle, label: "P", className: "text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/30" },
   { status: "absent", icon: XCircle, label: "A", className: "text-destructive hover:bg-destructive/10" },
-  { status: "retard", icon: Clock, label: "R", className: "text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/30" },
-  { status: "excuse", icon: ShieldCheck, label: "E", className: "text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30" },
+  { status: "late", icon: Clock, label: "R", className: "text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/30" },
+  { status: "excused", icon: ShieldCheck, label: "E", className: "text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30" },
 ]
 
 export function AttendanceGrid({ classId, slotId, date }: AttendanceGridProps) {
@@ -85,8 +85,8 @@ export function AttendanceGrid({ classId, slotId, date }: AttendanceGridProps) {
 
   // Compteurs en temps réel (logique inlinée pour éviter la closure sur getStatus)
   const counts = useMemo(() => {
-    if (!session) return { present: 0, absent: 0, retard: 0, excuse: 0, non_pointe: 0 }
-    const c = { present: 0, absent: 0, retard: 0, excuse: 0, non_pointe: 0 }
+    if (!session) return { present: 0, absent: 0, late: 0, excused: 0, non_pointe: 0 }
+    const c = { present: 0, absent: 0, late: 0, excused: 0, non_pointe: 0 }
     session.records.forEach((r) => {
       const status = localStatuses.get(r.student_id) ?? r.status ?? null
       if (status) {
@@ -136,8 +136,8 @@ export function AttendanceGrid({ classId, slotId, date }: AttendanceGridProps) {
         <div className="flex items-center gap-3 text-xs">
           <span className="text-emerald-600 dark:text-emerald-400 font-medium">{counts.present} P</span>
           <span className="text-destructive font-medium">{counts.absent} A</span>
-          <span className="text-amber-600 dark:text-amber-400 font-medium">{counts.retard} R</span>
-          <span className="text-blue-600 dark:text-blue-400 font-medium">{counts.excuse} E</span>
+          <span className="text-amber-600 dark:text-amber-400 font-medium">{counts.late} R</span>
+          <span className="text-blue-600 dark:text-blue-400 font-medium">{counts.excused} E</span>
           {counts.non_pointe > 0 && (
             <span className="text-muted-foreground font-medium">{counts.non_pointe} ?</span>
           )}
@@ -173,7 +173,7 @@ export function AttendanceGrid({ classId, slotId, date }: AttendanceGridProps) {
               return (
                 <TableRow key={record.id}>
                   <TableCell className="text-muted-foreground">{index + 1}</TableCell>
-                  <TableCell className="font-medium">{record.student_name}</TableCell>
+                  <TableCell className="font-medium">{record.student_id}</TableCell>
                   <TableCell className="text-center">
                     <AttendanceStatusBadge status={currentStatus} />
                   </TableCell>
@@ -186,7 +186,7 @@ export function AttendanceGrid({ classId, slotId, date }: AttendanceGridProps) {
                           variant={currentStatus === status ? "default" : "ghost"}
                           className={`h-8 w-8 ${currentStatus !== status ? className : ""}`}
                           onClick={() => handleStatusChange(record.student_id, status)}
-                          aria-label={`${label} pour ${record.student_name}`}
+                          aria-label={`${label} pour ${record.student_id}`}
                         >
                           <Icon className="h-4 w-4" />
                         </Button>

--- a/components/admin/attendance/AttendanceHistory.tsx
+++ b/components/admin/attendance/AttendanceHistory.tsx
@@ -49,7 +49,7 @@ export function AttendanceHistory({ classId }: AttendanceHistoryProps) {
   }
 
   const { data, isLoading } = useAttendanceHistory(params)
-  const records = data?.data ?? []
+  const records = data?.items ?? []
 
   return (
     <div className="space-y-4">
@@ -86,8 +86,8 @@ export function AttendanceHistory({ classId }: AttendanceHistoryProps) {
             <SelectItem value="all">Tous les statuts</SelectItem>
             <SelectItem value="present">Présent</SelectItem>
             <SelectItem value="absent">Absent</SelectItem>
-            <SelectItem value="retard">Retard</SelectItem>
-            <SelectItem value="excuse">Excusé</SelectItem>
+            <SelectItem value="late">Retard</SelectItem>
+            <SelectItem value="excused">Excusé</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -117,18 +117,13 @@ export function AttendanceHistory({ classId }: AttendanceHistoryProps) {
             <TableBody>
               {records.map((record) => (
                 <TableRow key={record.id}>
-                  <TableCell className="font-medium">{record.student_name}</TableCell>
-                  <TableCell>{formatDate(record.date)}</TableCell>
+                  <TableCell className="font-medium">#{record.student_id}</TableCell>
+                  <TableCell>{formatDate(record.created_at)}</TableCell>
                   <TableCell>
                     <AttendanceStatusBadge status={record.status} />
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
-                    {record.noted_at
-                      ? new Date(record.noted_at).toLocaleString("fr-FR", {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })
-                      : "—"}
+                    {record.time_in ?? "—"}
                   </TableCell>
                 </TableRow>
               ))}
@@ -137,10 +132,12 @@ export function AttendanceHistory({ classId }: AttendanceHistoryProps) {
         </div>
       )}
 
-      {data && data.total_pages > 0 && (
+      {data && data.size > 0 && Math.ceil(data.total / data.size) > 0 && (() => {
+        const totalPages = Math.ceil(data.total / data.size)
+        return (
         <div className="flex items-center justify-between">
           <p className="text-xs text-muted-foreground">
-            {data.total} enregistrement(s) — Page {data.page}/{data.total_pages}
+            {data.total} enregistrement(s) — Page {data.page}/{totalPages}
           </p>
           <div className="flex items-center gap-2">
             <Button
@@ -156,14 +153,15 @@ export function AttendanceHistory({ classId }: AttendanceHistoryProps) {
               variant="outline"
               size="sm"
               onClick={() => setPage((p) => p + 1)}
-              disabled={page >= data.total_pages}
+              disabled={page >= totalPages}
             >
               Suivant
               <ChevronRight className="ml-1 h-4 w-4" />
             </Button>
           </div>
         </div>
-      )}
+        )
+      })()}
     </div>
   )
 }

--- a/components/admin/attendance/AttendancePageClient.tsx
+++ b/components/admin/attendance/AttendancePageClient.tsx
@@ -31,7 +31,7 @@ export function AttendancePageClient() {
   })
 
   const { data: classesData } = useClasses()
-  const classes = classesData?.data ?? []
+  const classes = classesData?.items ?? []
 
   // Créneaux de la classe sélectionnée
   const { data: slots } = useTimetable(classId!)

--- a/components/admin/attendance/AttendanceStatusBadge.tsx
+++ b/components/admin/attendance/AttendanceStatusBadge.tsx
@@ -6,8 +6,8 @@ import type { AttendanceStatus } from "@/lib/contracts/attendance"
 const STATUS_CONFIG: Record<AttendanceStatus, { label: string; variant: "default" | "secondary" | "destructive"; className?: string }> = {
   present: { label: "Présent", variant: "default", className: "bg-emerald-100 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-900/30 dark:text-emerald-400" },
   absent: { label: "Absent", variant: "destructive" },
-  retard: { label: "Retard", variant: "secondary", className: "bg-amber-100 text-amber-700 hover:bg-amber-100 dark:bg-amber-900/30 dark:text-amber-400" },
-  excuse: { label: "Excusé", variant: "secondary", className: "bg-blue-100 text-blue-700 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-400" },
+  late: { label: "Retard", variant: "secondary", className: "bg-amber-100 text-amber-700 hover:bg-amber-100 dark:bg-amber-900/30 dark:text-amber-400" },
+  excused: { label: "Excusé", variant: "secondary", className: "bg-blue-100 text-blue-700 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-400" },
 }
 
 export function AttendanceStatusBadge({ status }: { status: AttendanceStatus | null }) {

--- a/components/admin/classes/ClassEditModal.tsx
+++ b/components/admin/classes/ClassEditModal.tsx
@@ -43,7 +43,7 @@ function EditFormSkeleton() {
 function EditForm({ classId, onClose }: { classId: number; onClose: () => void }) {
   const { data: classData, isLoading } = useClass(classId)
   const { mutate, isPending, error } = useUpdateClass(classId)
-  const { data: teachersData } = useTeachers({ per_page: 200 })
+  const { data: teachersData } = useTeachers({ size: 200 })
   const { data: academicYears } = useAcademicYears()
 
   const form = useForm<ClassUpdate>({
@@ -148,7 +148,7 @@ function EditForm({ classId, onClose }: { classId: number; onClose: () => void }
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {teachersData?.data.map((t) => (
+                  {teachersData?.items.map((t) => (
                     <SelectItem key={t.id} value={t.id.toString()}>
                       {t.last_name} {t.first_name}
                     </SelectItem>

--- a/components/admin/enrollments/EnrollmentEditModal.tsx
+++ b/components/admin/enrollments/EnrollmentEditModal.tsx
@@ -57,9 +57,8 @@ function EditForm({ enrollmentId, onClose }: { enrollmentId: number; onClose: ()
     resolver: zodResolver(EnrollmentUpdateSchema),
     values: enrollment
       ? {
-          class_id: enrollment.class_id,
-          assignment_status: enrollment.assignment_status,
-          is_scholarship: enrollment.is_scholarship,
+          status: enrollment.status,
+          notes: enrollment.notes,
         }
       : undefined,
   })
@@ -77,30 +76,10 @@ function EditForm({ enrollmentId, onClose }: { enrollmentId: number; onClose: ()
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
         <FormField
           control={form.control}
-          name="class_id"
+          name="status"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Classe</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  className="h-11"
-                  {...field}
-                  onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="assignment_status"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Statut d&apos;affectation</FormLabel>
+              <FormLabel>Statut</FormLabel>
               <Select onValueChange={field.onChange} value={field.value}>
                 <FormControl>
                   <SelectTrigger className="h-11">
@@ -108,9 +87,11 @@ function EditForm({ enrollmentId, onClose }: { enrollmentId: number; onClose: ()
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  <SelectItem value="affecte">Affecte</SelectItem>
-                  <SelectItem value="reaffecte">Reaffecte</SelectItem>
-                  <SelectItem value="non_affecte">Non affecte</SelectItem>
+                  <SelectItem value="prospect">Prospect</SelectItem>
+                  <SelectItem value="en_validation">En validation</SelectItem>
+                  <SelectItem value="valide">Validé</SelectItem>
+                  <SelectItem value="rejete">Rejeté</SelectItem>
+                  <SelectItem value="annule">Annulé</SelectItem>
                 </SelectContent>
               </Select>
               <FormMessage />
@@ -120,20 +101,19 @@ function EditForm({ enrollmentId, onClose }: { enrollmentId: number; onClose: ()
 
         <FormField
           control={form.control}
-          name="is_scholarship"
+          name="notes"
           render={({ field }) => (
-            <FormItem className="flex items-center gap-3 space-y-0 rounded-lg border p-4">
+            <FormItem>
+              <FormLabel>Notes</FormLabel>
               <FormControl>
-                <input
-                  type="checkbox"
-                  checked={field.value ?? false}
-                  onChange={field.onChange}
-                  className="h-4 w-4 rounded border-input accent-primary"
+                <Input
+                  className="h-11"
+                  placeholder="Notes optionnelles"
+                  {...field}
+                  value={field.value ?? ""}
                 />
               </FormControl>
-              <FormLabel className="font-normal cursor-pointer">
-                Eleve boursier
-              </FormLabel>
+              <FormMessage />
             </FormItem>
           )}
         />

--- a/components/admin/enrollments/EnrollmentsTable.tsx
+++ b/components/admin/enrollments/EnrollmentsTable.tsx
@@ -9,9 +9,11 @@ import { CrudTable } from "@/components/shared/CrudTable"
 import { EnrollmentEditModal } from "./EnrollmentEditModal"
 
 const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  affecte: { label: "Affecté", variant: "default" },
-  reaffecte: { label: "Réaffecté", variant: "secondary" },
-  non_affecte: { label: "Non affecté", variant: "outline" },
+  prospect: { label: "Prospect", variant: "outline" },
+  en_validation: { label: "En validation", variant: "secondary" },
+  valide: { label: "Validé", variant: "default" },
+  rejete: { label: "Rejeté", variant: "destructive" },
+  annule: { label: "Annulé", variant: "destructive" },
 }
 
 interface EnrollmentsTableProps {
@@ -35,28 +37,29 @@ export function EnrollmentsTable({ filters = {} }: EnrollmentsTableProps) {
       size: 60,
     },
     {
-      accessorKey: "student_name",
+      accessorKey: "student_id",
       header: "Élève",
       cell: ({ row }) => (
-        <span className="font-medium">{row.original.student_name}</span>
+        <span className="font-medium">#{row.original.student_id}</span>
       ),
     },
     {
-      accessorKey: "class_name",
+      accessorKey: "class_id",
       header: "Classe",
+      cell: ({ row }) => `#${row.original.class_id}`,
     },
     {
-      accessorKey: "academic_year_label",
+      accessorKey: "academic_year_name",
       header: "Année",
     },
     {
-      accessorKey: "assignment_status",
+      accessorKey: "status",
       header: "Statut",
       cell: ({ row }) => {
-        const status = statusConfig[row.original.assignment_status]
+        const status = statusConfig[row.original.status]
         return (
           <Badge variant={status?.variant ?? "outline"}>
-            {status?.label ?? row.original.assignment_status}
+            {status?.label ?? row.original.status}
           </Badge>
         )
       },
@@ -75,7 +78,7 @@ export function EnrollmentsTable({ filters = {} }: EnrollmentsTableProps) {
       renderEditModal={({ itemId, open, onClose }) => (
         <EnrollmentEditModal enrollmentId={itemId} open={open} onClose={onClose} />
       )}
-      getItemLabel={(e) => e.student_name}
+      getItemLabel={(e) => `#${e.id}`}
       emptyMessage="Aucune inscription trouvée"
       errorMessage="Impossible de charger les inscriptions"
       deleteTitle="Supprimer l'inscription"

--- a/components/admin/grades/GradesSupervisor.tsx
+++ b/components/admin/grades/GradesSupervisor.tsx
@@ -18,10 +18,10 @@ import {
 } from "@/components/ui/table"
 
 const TYPE_LABELS: Record<string, string> = {
+  controle: "Contrôle",
   devoir: "Devoir",
-  interro: "Interrogation",
   examen: "Examen",
-  composition: "Composition",
+  oral: "Oral",
 }
 
 function isOverdue(evaluation: Evaluation): boolean {

--- a/components/admin/payments/PaymentCreateModal.tsx
+++ b/components/admin/payments/PaymentCreateModal.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
 import { useCreatePayment } from "@/lib/hooks/usePayments"
-import { useFeeCategories } from "@/lib/hooks/useFees"
 import { PaymentCreateSchema, type PaymentCreate } from "@/lib/contracts/payment"
 
 interface PaymentCreateModalProps {
@@ -23,25 +22,24 @@ interface PaymentCreateModalProps {
 }
 
 const METHOD_LABELS: Record<string, string> = {
-  especes: "Espèces",
+  cash: "Espèces",
   mobile_money: "Mobile Money",
-  virement: "Virement bancaire",
+  bank_transfer: "Virement bancaire",
   cheque: "Chèque",
 }
 
 export function PaymentCreateModal({ open, onClose }: PaymentCreateModalProps) {
   const form = useForm<PaymentCreate>({
     resolver: zodResolver(PaymentCreateSchema),
-    defaultValues: { method: "especes", reference: null },
+    defaultValues: { method: "cash", reference: null },
   })
 
-  const { data: categories } = useFeeCategories()
   const { mutate, isPending } = useCreatePayment()
 
   function onSubmit(data: PaymentCreate) {
     mutate(data, {
       onSuccess: () => {
-        form.reset({ method: "especes", reference: null })
+        form.reset({ method: "cash", reference: null })
         onClose()
       },
     })
@@ -57,52 +55,24 @@ export function PaymentCreateModal({ open, onClose }: PaymentCreateModalProps) {
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             <FormField
               control={form.control}
-              name="student_id"
+              name="enrollment_fee_id"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Matricule élève *</FormLabel>
+                  <FormLabel>Frais d&apos;inscription *</FormLabel>
                   <FormControl>
                     <Input
                       type="number"
-                      placeholder="Entrer le numéro matricule"
+                      placeholder="ID du frais d'inscription"
                       {...field}
                       value={field.value || ""}
                       onChange={(e) => {
                         const val = e.target.value
-                        // Ignore les valeurs non numériques
                         if (val === "") { field.onChange(undefined); return }
                         const num = Number(val)
                         if (!Number.isNaN(num) && num > 0) field.onChange(num)
                       }}
                     />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="fee_category_id"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Catégorie de frais *</FormLabel>
-                  <Select
-                    value={field.value?.toString() ?? ""}
-                    onValueChange={(v) => field.onChange(Number(v))}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Sélectionner" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {categories?.map((c) => (
-                        <SelectItem key={c.id} value={c.id.toString()}>
-                          {c.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                   <FormMessage />
                 </FormItem>
               )}

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -40,15 +40,16 @@ import { PaymentStatusSchema } from "@/lib/contracts/payment"
 import type { PaymentListParams, PaymentStatus, PaymentMethod, Payment } from "@/lib/contracts/payment"
 
 const STATUS_CONFIG: Record<PaymentStatus, { label: string; variant: "default" | "secondary" | "destructive" }> = {
-  en_attente: { label: "En attente", variant: "secondary" },
-  valide: { label: "Validé", variant: "default" },
-  annule: { label: "Annulé", variant: "destructive" },
+  pending: { label: "En attente", variant: "secondary" },
+  completed: { label: "Complété", variant: "default" },
+  failed: { label: "Échoué", variant: "destructive" },
+  refunded: { label: "Remboursé", variant: "destructive" },
 }
 
 const METHOD_LABELS: Record<PaymentMethod, string> = {
-  especes: "Espèces",
+  cash: "Espèces",
   mobile_money: "Mobile Money",
-  virement: "Virement",
+  bank_transfer: "Virement",
   cheque: "Chèque",
 }
 
@@ -69,13 +70,13 @@ export function PaymentsPageClient() {
   const { mutate: validatePayment, isPending: validating } = useValidatePayment()
   const { mutate: cancelPayment, isPending: cancelling } = useCancelPayment()
 
-  const payments = useMemo(() => data?.data ?? [], [data])
+  const payments = useMemo(() => data?.items ?? [], [data])
 
   const handleDownloadReceipt = useCallback(async (payment: Payment) => {
     setDownloadingId(payment.id)
     try {
       const blob = await paymentsApi.downloadReceipt(payment.id)
-      downloadBlob(blob, `recu-${payment.student_name}-${payment.id}.pdf`)
+      downloadBlob(blob, `recu-${payment.id}.pdf`)
     } catch (err) {
       toast.error("Erreur lors du téléchargement", {
         description: err instanceof Error ? err.message : "Erreur inconnue",
@@ -158,9 +159,10 @@ export function PaymentsPageClient() {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">Tous les statuts</SelectItem>
-            <SelectItem value="en_attente">En attente</SelectItem>
-            <SelectItem value="valide">Validé</SelectItem>
-            <SelectItem value="annule">Annulé</SelectItem>
+            <SelectItem value="pending">En attente</SelectItem>
+            <SelectItem value="completed">Complété</SelectItem>
+            <SelectItem value="failed">Échoué</SelectItem>
+            <SelectItem value="refunded">Remboursé</SelectItem>
           </SelectContent>
         </Select>
 
@@ -173,9 +175,9 @@ export function PaymentsPageClient() {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">Toutes les méthodes</SelectItem>
-            <SelectItem value="especes">Espèces</SelectItem>
+            <SelectItem value="cash">Espèces</SelectItem>
             <SelectItem value="mobile_money">Mobile Money</SelectItem>
-            <SelectItem value="virement">Virement</SelectItem>
+            <SelectItem value="bank_transfer">Virement</SelectItem>
             <SelectItem value="cheque">Chèque</SelectItem>
           </SelectContent>
         </Select>
@@ -193,9 +195,7 @@ export function PaymentsPageClient() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Élève</TableHead>
-                <TableHead>Classe</TableHead>
-                <TableHead>Catégorie</TableHead>
+                <TableHead>Frais</TableHead>
                 <TableHead className="text-right">Montant</TableHead>
                 <TableHead>Méthode</TableHead>
                 <TableHead>Statut</TableHead>
@@ -208,22 +208,20 @@ export function PaymentsPageClient() {
                 const statusCfg = STATUS_CONFIG[payment.status]
                 return (
                   <TableRow key={payment.id}>
-                    <TableCell className="font-medium">{payment.student_name}</TableCell>
-                    <TableCell>{payment.class_name}</TableCell>
-                    <TableCell>{payment.fee_category_name}</TableCell>
+                    <TableCell className="font-medium">#{payment.enrollment_fee_id}</TableCell>
                     <TableCell className="text-right font-semibold">
-                      {payment.amount.toLocaleString("fr-FR")} FC
+                      {Number(payment.amount).toLocaleString("fr-FR")} FC
                     </TableCell>
                     <TableCell>{METHOD_LABELS[payment.method]}</TableCell>
                     <TableCell>
                       <Badge variant={statusCfg.variant}>{statusCfg.label}</Badge>
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">
-                      {new Date(payment.paid_at).toLocaleDateString("fr-FR")}
+                      {new Date(payment.created_at).toLocaleDateString("fr-FR")}
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex items-center justify-end gap-1">
-                        {payment.status === PaymentStatusSchema.Values.en_attente && (
+                        {payment.status === PaymentStatusSchema.Values.pending && (
                           <>
                             <Button
                               size="icon"
@@ -231,7 +229,7 @@ export function PaymentsPageClient() {
                               onClick={() => setConfirmAction({ type: "validate", payment })}
                             >
                               <CheckCircle className="h-4 w-4 text-emerald-600" />
-                              <span className="sr-only">Valider le paiement de {payment.student_name}</span>
+                              <span className="sr-only">Valider le paiement de {payment.id}</span>
                             </Button>
                             <Button
                               size="icon"
@@ -239,7 +237,7 @@ export function PaymentsPageClient() {
                               onClick={() => setConfirmAction({ type: "cancel", payment })}
                             >
                               <XCircle className="h-4 w-4 text-destructive" />
-                              <span className="sr-only">Annuler le paiement de {payment.student_name}</span>
+                              <span className="sr-only">Annuler le paiement de {payment.id}</span>
                             </Button>
                           </>
                         )}
@@ -250,7 +248,7 @@ export function PaymentsPageClient() {
                           disabled={downloadingId === payment.id}
                         >
                           <Download className="h-4 w-4" />
-                          <span className="sr-only">Télécharger le reçu de {payment.student_name}</span>
+                          <span className="sr-only">Télécharger le reçu de {payment.id}</span>
                         </Button>
                       </div>
                     </TableCell>
@@ -264,7 +262,7 @@ export function PaymentsPageClient() {
 
       {data && (
         <div className="text-xs text-muted-foreground text-right">
-          {data.total} paiement(s) — Page {data.page}/{data.total_pages}
+          {data.total} paiement(s) — Page {data.page}/{data.size > 0 ? Math.ceil(data.total / data.size) : 1}
         </div>
       )}
 
@@ -279,8 +277,8 @@ export function PaymentsPageClient() {
             </AlertDialogTitle>
             <AlertDialogDescription>
               {confirmAction?.type === "validate"
-                ? `Vous allez valider le paiement de ${confirmAction.payment.amount.toLocaleString("fr-FR")} FC pour ${confirmAction.payment.student_name}. Cette action est irréversible.`
-                : `Vous allez annuler le paiement de ${confirmAction?.payment.amount.toLocaleString("fr-FR")} FC pour ${confirmAction?.payment.student_name}. Cette action est irréversible.`}
+                ? `Vous allez valider le paiement de ${Number(confirmAction.payment.amount).toLocaleString("fr-FR")} FC. Cette action est irréversible.`
+                : `Vous allez annuler le paiement de ${Number(confirmAction?.payment.amount).toLocaleString("fr-FR")} FC. Cette action est irréversible.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/components/admin/reports/BulletinGenerateButton.tsx
+++ b/components/admin/reports/BulletinGenerateButton.tsx
@@ -11,19 +11,19 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog"
 import { useGenerateBulletins } from "@/lib/hooks/useBulletins"
-import { BulletinGenerateSchema, type Trimester } from "@/lib/contracts/bulletin"
+import { BulletinGenerateSchema } from "@/lib/contracts/bulletin"
 
 interface BulletinGenerateButtonProps {
   classId: number | undefined
-  trimester: Trimester | undefined
+  trimester: number | undefined
   academicYearId: number | undefined
   className?: string
 }
 
-const trimesterLabels: Record<string, string> = {
-  "1": "1er trimestre",
-  "2": "2ème trimestre",
-  "3": "3ème trimestre",
+const trimesterLabels: Record<number, string> = {
+  1: "1er trimestre",
+  2: "2ème trimestre",
+  3: "3ème trimestre",
 }
 
 export function BulletinGenerateButton({
@@ -65,7 +65,7 @@ export function BulletinGenerateButton({
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
             Cette action va générer les bulletins pour le{" "}
-            <strong>{trimester ? trimesterLabels[trimester] : ""}</strong>.
+            <strong>{trimester ? trimesterLabels[trimester] ?? `trimestre ${trimester}` : ""}</strong>.
             Les bulletins existants en brouillon seront recalculés.
           </p>
           <DialogFooter>

--- a/components/admin/reports/BulletinList.tsx
+++ b/components/admin/reports/BulletinList.tsx
@@ -18,7 +18,6 @@ import { BulletinListSkeleton } from "./BulletinListSkeleton"
 import { useBulletins, usePublishBulletins } from "@/lib/hooks/useBulletins"
 import { bulletinsApi } from "@/lib/api/bulletins"
 import { getMentionColor, downloadBlob } from "@/lib/utils"
-import { BulletinStatusSchema } from "@/lib/contracts/bulletin"
 import type { BulletinListParams, Bulletin } from "@/lib/contracts/bulletin"
 
 interface BulletinListProps {
@@ -36,7 +35,7 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
     setDownloadingId(bulletin.id)
     try {
       const blob = await bulletinsApi.downloadPdf(bulletin.id)
-      downloadBlob(blob, `bulletin-${bulletin.student_name}.pdf`)
+      downloadBlob(blob, `bulletin-${bulletin.id}.pdf`)
     } catch (err) {
       toast.error("Erreur lors du téléchargement", {
         description: err instanceof Error ? err.message : "Erreur inconnue",
@@ -46,9 +45,9 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
     }
   }, [])
 
-  const bulletins = useMemo(() => data?.data ?? [], [data])
+  const bulletins = useMemo(() => data?.items ?? [], [data])
   const hasDrafts = useMemo(
-    () => bulletins.some((b) => b.status === BulletinStatusSchema.Values.brouillon),
+    () => bulletins.some((b) => !b.is_published),
     [bulletins],
   )
 
@@ -77,7 +76,7 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
 
   function handlePublish() {
     if (!params.class_id || !params.trimester) return
-    publish({ classId: params.class_id, trimester: params.trimester })
+    publish({ classId: params.class_id, trimester: String(params.trimester) })
   }
 
   return (
@@ -115,13 +114,13 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
           <TableBody>
             {bulletins.map((bulletin: Bulletin) => (
               <TableRow key={bulletin.id}>
-                <TableCell className="font-medium">{bulletin.student_name}</TableCell>
-                <TableCell>{bulletin.class_name}</TableCell>
+                <TableCell className="font-medium">#{bulletin.student_id}</TableCell>
+                <TableCell>#{bulletin.class_id}</TableCell>
                 <TableCell className="text-center font-semibold">
-                  {bulletin.average !== null ? bulletin.average.toFixed(2) : "—"}
+                  {bulletin.average !== null ? Number(bulletin.average).toFixed(2) : "—"}
                 </TableCell>
                 <TableCell className="text-center">
-                  {bulletin.rank ?? "—"}/{bulletin.total_students}
+                  {bulletin.rank ?? "—"}
                 </TableCell>
                 <TableCell>
                   <span className={`font-medium ${getMentionColor(bulletin.mention)}`}>
@@ -129,7 +128,7 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
                   </span>
                 </TableCell>
                 <TableCell>
-                  <BulletinStatusBadge status={bulletin.status} />
+                  <BulletinStatusBadge isPublished={bulletin.is_published} />
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex items-center justify-end gap-1">
@@ -139,7 +138,7 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
                       onClick={() => setPreviewId(bulletin.id)}
                     >
                       <Eye className="h-4 w-4" />
-                      <span className="sr-only">Voir le bulletin de {bulletin.student_name}</span>
+                      <span className="sr-only">Voir le bulletin #{bulletin.id}</span>
                     </Button>
                     <Button
                       size="icon"
@@ -148,7 +147,7 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
                       disabled={downloadingId === bulletin.id}
                     >
                       <Download className="h-4 w-4" />
-                      <span className="sr-only">Télécharger le bulletin de {bulletin.student_name}</span>
+                      <span className="sr-only">Télécharger le bulletin #{bulletin.id}</span>
                     </Button>
                   </div>
                 </TableCell>
@@ -171,12 +170,12 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
             <ChevronLeft className="h-4 w-4" />
             <span className="sr-only">Page précédente</span>
           </Button>
-          <span>Page {data?.page ?? 1}/{data?.total_pages ?? 1}</span>
+          <span>Page {data?.page ?? 1}/{data && data.size > 0 ? Math.ceil(data.total / data.size) : 1}</span>
           <Button
             size="icon"
             variant="ghost"
             className="h-7 w-7"
-            disabled={!data || data.page >= data.total_pages}
+            disabled={!data || data.size <= 0 || data.page >= Math.ceil(data.total / data.size)}
             onClick={() => onPageChange?.((data?.page ?? 1) + 1)}
           >
             <ChevronRight className="h-4 w-4" />

--- a/components/admin/reports/BulletinPreviewModal.tsx
+++ b/components/admin/reports/BulletinPreviewModal.tsx
@@ -7,19 +7,12 @@ import { BulletinStatusBadge } from "./BulletinStatusBadge"
 import { useBulletin } from "@/lib/hooks/useBulletins"
 import { getMentionColor } from "@/lib/utils"
 import type { BulletinDecision } from "@/lib/contracts/bulletin"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 
 const COUNCIL_DECISION_LABELS: Record<BulletinDecision, string> = {
-  admis: "Admis(e)",
-  redouble: "Redouble",
-  exclu: "Exclu(e)",
+  passage: "Passage",
+  repechage: "Repêchage",
+  redoublement: "Redoublement",
+  exclusion: "Exclusion",
 }
 
 interface BulletinPreviewModalProps {
@@ -41,18 +34,18 @@ export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewMod
           <BulletinPreviewSkeleton />
         ) : bulletin ? (
           <div className="space-y-6">
-            {/* En-tête école */}
+            {/* En-tête */}
             <div className="text-center space-y-1 border-b pb-4">
               <p className="text-xs text-muted-foreground uppercase tracking-wider">
                 République de Côte d&apos;Ivoire
               </p>
               <h2 className="font-serif text-lg font-semibold">
-                Bulletin de notes — {bulletin.academic_year_label}
+                Bulletin de notes
               </h2>
               <p className="text-sm text-muted-foreground">
-                {bulletin.trimester === "1" && "Premier trimestre"}
-                {bulletin.trimester === "2" && "Deuxième trimestre"}
-                {bulletin.trimester === "3" && "Troisième trimestre"}
+                {bulletin.trimester === 1 && "Premier trimestre"}
+                {bulletin.trimester === 2 && "Deuxième trimestre"}
+                {bulletin.trimester === 3 && "Troisième trimestre"}
               </p>
             </div>
 
@@ -60,70 +53,25 @@ export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewMod
             <div className="grid grid-cols-2 gap-4 text-sm">
               <div className="space-y-1">
                 <p>
-                  <span className="text-muted-foreground">Élève :</span>{" "}
-                  <strong>{bulletin.student_name}</strong>
+                  <span className="text-muted-foreground">Élève ID :</span>{" "}
+                  <strong>#{bulletin.student_id}</strong>
                 </p>
                 <p>
-                  <span className="text-muted-foreground">Classe :</span>{" "}
-                  {bulletin.class_name}
+                  <span className="text-muted-foreground">Classe ID :</span>{" "}
+                  #{bulletin.class_id}
                 </p>
               </div>
               <div className="space-y-1 text-right">
                 <p>
                   <span className="text-muted-foreground">Rang :</span>{" "}
-                  <strong>
-                    {bulletin.rank ?? "—"}/{bulletin.total_students}
-                  </strong>
+                  <strong>{bulletin.rank ?? "—"}</strong>
                 </p>
                 <p>
                   <span className="text-muted-foreground">Statut :</span>{" "}
-                  <BulletinStatusBadge status={bulletin.status} />
+                  <BulletinStatusBadge isPublished={bulletin.is_published} />
                 </p>
               </div>
             </div>
-
-            <Separator />
-
-            {/* Tableau des notes */}
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Matière</TableHead>
-                  <TableHead className="text-center">Coeff.</TableHead>
-                  <TableHead className="text-center">Note/20</TableHead>
-                  <TableHead className="text-center">Coef × Note</TableHead>
-                  <TableHead className="text-center">Moy. classe</TableHead>
-                  <TableHead>Enseignant</TableHead>
-                  <TableHead>Appréciation</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {bulletin.subject_grades.map((sg) => {
-                  // Calcul du total coef × note (fourni par l'API ou calculé)
-                  const coefXNote = sg.coef_x_note
-                    ?? (sg.average !== null ? sg.coefficient * sg.average : null)
-                  return (
-                    <TableRow key={sg.subject_name}>
-                      <TableCell className="font-medium">{sg.subject_name}</TableCell>
-                      <TableCell className="text-center">{sg.coefficient}</TableCell>
-                      <TableCell className="text-center font-semibold">
-                        {sg.average !== null ? sg.average.toFixed(2) : "—"}
-                      </TableCell>
-                      <TableCell className="text-center">
-                        {coefXNote !== null ? coefXNote.toFixed(2) : "—"}
-                      </TableCell>
-                      <TableCell className="text-center text-muted-foreground">
-                        {sg.class_average !== null ? sg.class_average.toFixed(2) : "—"}
-                      </TableCell>
-                      <TableCell className="text-sm">{sg.teacher_name}</TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {sg.appreciation ?? "—"}
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
 
             <Separator />
 
@@ -132,7 +80,7 @@ export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewMod
               <div className="space-y-1">
                 <p className="text-sm text-muted-foreground">Moyenne générale</p>
                 <p className="text-2xl font-bold">
-                  {bulletin.average !== null ? bulletin.average.toFixed(2) : "—"}
+                  {bulletin.average !== null ? Number(bulletin.average).toFixed(2) : "—"}
                   <span className="text-sm font-normal text-muted-foreground">/20</span>
                 </p>
               </div>
@@ -144,21 +92,22 @@ export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewMod
               </div>
             </div>
 
-            {/* Conseil de classe : décision + appréciation */}
-            {(bulletin.council_decision || bulletin.class_council_appreciation) && (
+            {/* Commentaire enseignant */}
+            {bulletin.teacher_comment && (
+              <div className="rounded-lg border p-4 space-y-2">
+                <p className="text-sm font-medium">Commentaire de l&apos;enseignant</p>
+                <p className="text-sm text-muted-foreground">{bulletin.teacher_comment}</p>
+              </div>
+            )}
+
+            {/* Conseil de classe : décision */}
+            {bulletin.council_decision && (
               <div className="rounded-lg border p-4 space-y-2">
                 <p className="text-sm font-medium">Conseil de classe</p>
-                {bulletin.council_decision && (
-                  <p className="text-sm">
-                    <span className="text-muted-foreground">Décision :</span>{" "}
-                    <strong>{COUNCIL_DECISION_LABELS[bulletin.council_decision] ?? bulletin.council_decision}</strong>
-                  </p>
-                )}
-                {bulletin.class_council_appreciation && (
-                  <p className="text-sm text-muted-foreground">
-                    {bulletin.class_council_appreciation}
-                  </p>
-                )}
+                <p className="text-sm">
+                  <span className="text-muted-foreground">Décision :</span>{" "}
+                  <strong>{COUNCIL_DECISION_LABELS[bulletin.council_decision] ?? bulletin.council_decision}</strong>
+                </p>
               </div>
             )}
           </div>

--- a/components/admin/reports/BulletinStatusBadge.tsx
+++ b/components/admin/reports/BulletinStatusBadge.tsx
@@ -1,12 +1,8 @@
 import { Badge } from "@/components/ui/badge"
-import type { BulletinStatus } from "@/lib/contracts/bulletin"
 
-const statusConfig: Record<BulletinStatus, { label: string; variant: "default" | "secondary" }> = {
-  brouillon: { label: "Brouillon", variant: "secondary" },
-  publie: { label: "Publié", variant: "default" },
-}
-
-export function BulletinStatusBadge({ status }: { status: BulletinStatus }) {
-  const config = statusConfig[status]
-  return <Badge variant={config.variant}>{config.label}</Badge>
+export function BulletinStatusBadge({ isPublished }: { isPublished: boolean }) {
+  if (isPublished) {
+    return <Badge variant="default">Publié</Badge>
+  }
+  return <Badge variant="secondary">Brouillon</Badge>
 }

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -13,17 +13,17 @@ import { BulletinList } from "./BulletinList"
 import { BulletinGenerateButton } from "./BulletinGenerateButton"
 import { useClasses } from "@/lib/hooks/useClasses"
 import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
-import type { BulletinListParams, Trimester, BulletinStatus } from "@/lib/contracts/bulletin"
+import type { BulletinListParams } from "@/lib/contracts/bulletin"
 
 export function ReportsPageClient() {
   const [classId, setClassId] = useState<number | undefined>(undefined)
-  const [trimester, setTrimester] = useState<Trimester | undefined>(undefined)
+  const [trimester, setTrimester] = useState<number | undefined>(undefined)
   const [academicYearId, setAcademicYearId] = useState<number | undefined>(undefined)
-  const [status, setStatus] = useState<BulletinStatus | undefined>(undefined)
+  const [isPublished, setIsPublished] = useState<boolean | undefined>(undefined)
   const [page, setPage] = useState(1)
 
   const { data: classesData, isLoading: classesLoading } = useClasses()
-  const classes = classesData?.data
+  const classes = classesData?.items
   const { data: academicYears, isLoading: yearsLoading } = useAcademicYears()
 
   const activeYearId = academicYearId ?? academicYears?.[0]?.id
@@ -32,7 +32,7 @@ export function ReportsPageClient() {
     ...(classId && { class_id: classId }),
     ...(trimester && { trimester }),
     ...(activeYearId && { academic_year_id: activeYearId }),
-    ...(status && { status }),
+    ...(isPublished !== undefined && { is_published: isPublished }),
     page,
   }
 
@@ -101,8 +101,8 @@ export function ReportsPageClient() {
         )}
 
         <Select
-          value={trimester ?? ""}
-          onValueChange={(v) => { setTrimester(v as Trimester); setPage(1) }}
+          value={trimester?.toString() ?? ""}
+          onValueChange={(v) => { setTrimester(Number(v)); setPage(1) }}
         >
           <SelectTrigger className="w-44">
             <SelectValue placeholder="Trimestre" />
@@ -115,16 +115,16 @@ export function ReportsPageClient() {
         </Select>
 
         <Select
-          value={status ?? "all"}
-          onValueChange={(v) => { setStatus(v === "all" ? undefined : (v as BulletinStatus)); setPage(1) }}
+          value={isPublished === undefined ? "all" : isPublished ? "published" : "draft"}
+          onValueChange={(v) => { setIsPublished(v === "all" ? undefined : v === "published"); setPage(1) }}
         >
           <SelectTrigger className="w-36">
             <SelectValue placeholder="Statut" />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">Tous</SelectItem>
-            <SelectItem value="brouillon">Brouillon</SelectItem>
-            <SelectItem value="publie">Publié</SelectItem>
+            <SelectItem value="draft">Brouillon</SelectItem>
+            <SelectItem value="published">Publié</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/components/admin/students/StudentEditModal.tsx
+++ b/components/admin/students/StudentEditModal.tsx
@@ -42,7 +42,7 @@ function EditFormSkeleton() {
 function EditForm({ studentId, onClose }: { studentId: number; onClose: () => void }) {
   const { data: student, isLoading } = useStudent(studentId)
   const { mutate, isPending, error } = useUpdateStudent(studentId)
-  const { data: classesData } = useClasses({ per_page: 200 })
+  const { data: classesData } = useClasses({ size: 200 })
 
   const form = useForm<StudentUpdate>({
     resolver: zodResolver(StudentUpdateSchema),
@@ -165,7 +165,7 @@ function EditForm({ studentId, onClose }: { studentId: number; onClose: () => vo
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {classesData?.data.map((c) => (
+                  {classesData?.items.map((c) => (
                     <SelectItem key={c.id} value={c.id.toString()}>
                       {c.name}
                     </SelectItem>

--- a/components/forms/ClassForm.tsx
+++ b/components/forms/ClassForm.tsx
@@ -41,7 +41,7 @@ export function ClassForm({ onSuccess }: ClassFormProps) {
     },
   })
 
-  const { data: teachersData } = useTeachers({ per_page: 200 })
+  const { data: teachersData } = useTeachers({ size: 200 })
   const { data: academicYears } = useAcademicYears()
   const { mutate, isPending, error } = useCreateClass()
 
@@ -138,7 +138,7 @@ export function ClassForm({ onSuccess }: ClassFormProps) {
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {teachersData?.data.map((t) => (
+                  {teachersData?.items.map((t) => (
                     <SelectItem key={t.id} value={t.id.toString()}>
                       {t.last_name} {t.first_name}
                     </SelectItem>

--- a/components/forms/EnrollmentForm.tsx
+++ b/components/forms/EnrollmentForm.tsx
@@ -6,13 +6,7 @@ import { EnrollmentCreateSchema, type EnrollmentCreate } from "@/lib/contracts/e
 import { useCreateEnrollment } from "@/lib/hooks/useEnrollments"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
 import {
   Form,
   FormControl,
@@ -29,9 +23,6 @@ interface EnrollmentFormProps {
 export function EnrollmentForm({ onSuccess }: EnrollmentFormProps) {
   const form = useForm<EnrollmentCreate>({
     resolver: zodResolver(EnrollmentCreateSchema),
-    defaultValues: {
-      is_scholarship: false,
-    },
   })
 
   const { mutate, isPending, error } = useCreateEnrollment()
@@ -113,22 +104,20 @@ export function EnrollmentForm({ onSuccess }: EnrollmentFormProps) {
 
         <FormField
           control={form.control}
-          name="assignment_status"
+          name="fee_variant_id"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Statut d&apos;affectation *</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
-                <FormControl>
-                  <SelectTrigger className="h-11">
-                    <SelectValue placeholder="Selectionner un statut" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  <SelectItem value="affecte">Affecte</SelectItem>
-                  <SelectItem value="reaffecte">Reaffecte</SelectItem>
-                  <SelectItem value="non_affecte">Non affecte</SelectItem>
-                </SelectContent>
-              </Select>
+              <FormLabel>Variante de frais</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  placeholder="ID variante de frais (optionnel)"
+                  className="h-11"
+                  {...field}
+                  onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : null)}
+                  value={field.value ?? ""}
+                />
+              </FormControl>
               <FormMessage />
             </FormItem>
           )}
@@ -136,20 +125,19 @@ export function EnrollmentForm({ onSuccess }: EnrollmentFormProps) {
 
         <FormField
           control={form.control}
-          name="is_scholarship"
+          name="notes"
           render={({ field }) => (
-            <FormItem className="flex items-center gap-3 space-y-0 rounded-lg border p-4">
+            <FormItem>
+              <FormLabel>Notes</FormLabel>
               <FormControl>
-                <input
-                  type="checkbox"
-                  checked={field.value}
-                  onChange={field.onChange}
-                  className="h-4 w-4 rounded border-input accent-primary"
+                <Textarea
+                  placeholder="Notes optionnelles"
+                  className="resize-none"
+                  {...field}
+                  value={field.value ?? ""}
                 />
               </FormControl>
-              <FormLabel className="font-normal cursor-pointer">
-                Eleve boursier
-              </FormLabel>
+              <FormMessage />
             </FormItem>
           )}
         />

--- a/components/forms/StudentForm.tsx
+++ b/components/forms/StudentForm.tsx
@@ -42,7 +42,7 @@ export function StudentForm({ onSuccess }: StudentFormProps) {
     },
   })
 
-  const { data: classesData } = useClasses({ per_page: 200 })
+  const { data: classesData } = useClasses({ size: 200 })
   const { mutate, isPending, error } = useCreateStudent()
 
   function onSubmit(data: StudentCreate) {
@@ -155,7 +155,7 @@ export function StudentForm({ onSuccess }: StudentFormProps) {
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {classesData?.data.map((c) => (
+                  {classesData?.items.map((c) => (
                     <SelectItem key={c.id} value={c.id.toString()}>
                       {c.name}
                     </SelectItem>

--- a/components/parent/ParentChildGradesClient.tsx
+++ b/components/parent/ParentChildGradesClient.tsx
@@ -26,10 +26,10 @@ import { useParentChildGrades } from "@/lib/hooks/useParentPortal"
 import type { ParentChildSubjectGrades } from "@/lib/contracts/parent-portal"
 
 const TYPE_LABELS: Record<string, string> = {
+  controle: "Contrôle",
   devoir: "Devoir",
-  interro: "Interro",
   examen: "Examen",
-  composition: "Compo",
+  oral: "Oral",
 }
 
 function averageColor(avg: number | null): string {

--- a/components/shared/CrudTable.tsx
+++ b/components/shared/CrudTable.tsx
@@ -114,7 +114,7 @@ export function CrudTable<T extends { id: number }>({
   }, [userColumns])
 
   const table = useReactTable({
-    data: data?.data ?? [],
+    data: data?.items ?? [],
     columns,
     getCoreRowModel: getCoreRowModel(),
   })
@@ -149,7 +149,7 @@ export function CrudTable<T extends { id: number }>({
                   ))}
                 </TableRow>
               ))}
-            {!isLoading && data?.data.length === 0 && (
+            {!isLoading && data?.items.length === 0 && (
               <TableRow>
                 <TableCell colSpan={columns.length} className="h-32 text-center text-muted-foreground">
                   {emptyMessage}
@@ -170,33 +170,36 @@ export function CrudTable<T extends { id: number }>({
       </div>
 
       {/* Pagination */}
-      {data && data.total_pages > 1 && onPageChange && (
-        <div className="flex items-center justify-between pt-4">
-          <p className="text-sm text-muted-foreground">
-            Page {data.page} sur {data.total_pages} — {data.total} résultat{data.total > 1 ? "s" : ""}
-          </p>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onPageChange(data.page - 1)}
-              disabled={data.page <= 1}
-            >
-              <ChevronLeft className="mr-1 h-4 w-4" />
-              Précédent
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onPageChange(data.page + 1)}
-              disabled={data.page >= data.total_pages}
-            >
-              Suivant
-              <ChevronRight className="ml-1 h-4 w-4" />
-            </Button>
+      {data && data.size > 0 && Math.ceil(data.total / data.size) > 1 && onPageChange && (() => {
+        const totalPages = Math.ceil(data.total / data.size)
+        return (
+          <div className="flex items-center justify-between pt-4">
+            <p className="text-sm text-muted-foreground">
+              Page {data.page} sur {totalPages} — {data.total} résultat{data.total > 1 ? "s" : ""}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(data.page - 1)}
+                disabled={data.page <= 1}
+              >
+                <ChevronLeft className="mr-1 h-4 w-4" />
+                Précédent
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(data.page + 1)}
+                disabled={data.page >= totalPages}
+              >
+                Suivant
+                <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+            </div>
           </div>
-        </div>
-      )}
+        )
+      })()}
 
       {renderEditModal({ itemId: editId, open: editId !== null, onClose: () => setEditId(null) })}
 

--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -57,7 +57,7 @@ function timeAgo(dateStr: string): string {
 
 export function NotificationBell() {
   const { data: countData } = useNotificationCount()
-  const { data: recent } = useNotifications({ per_page: 5 })
+  const { data: recent } = useNotifications({ size: 5 })
   const markAsRead = useMarkAsRead()
   const markAllAsRead = useMarkAllAsRead()
 

--- a/components/student/StudentBulletinsClient.tsx
+++ b/components/student/StudentBulletinsClient.tsx
@@ -11,7 +11,6 @@ import { downloadBlob } from "@/lib/utils"
 import { useStudentBulletins } from "@/lib/hooks/useStudentPortal"
 import { studentPortalApi } from "@/lib/api/student-portal"
 import { DataError } from "@/components/shared/DataError"
-import { BulletinStatusSchema } from "@/lib/contracts/bulletin"
 import type { StudentBulletin } from "@/lib/contracts/student-portal"
 
 export function StudentBulletinsClient() {
@@ -62,7 +61,7 @@ function BulletinCard({ bulletin }: { bulletin: StudentBulletin }) {
     }
   }, [bulletin.id, bulletin.trimester, bulletin.academic_year])
 
-  const isPublished = bulletin.status === BulletinStatusSchema.Values.publie
+  const isPublished = bulletin.is_published === true
 
   return (
     <Card className="border-0 shadow-sm ring-1 ring-border">

--- a/components/student/StudentGradesClient.tsx
+++ b/components/student/StudentGradesClient.tsx
@@ -24,10 +24,10 @@ import { DataError } from "@/components/shared/DataError"
 import type { StudentSubjectGrades } from "@/lib/contracts/student-portal"
 
 const TYPE_LABELS: Record<string, string> = {
+  controle: "Contrôle",
   devoir: "Devoir",
-  interro: "Interro",
   examen: "Examen",
-  composition: "Compo",
+  oral: "Oral",
 }
 
 function averageColor(avg: number | null): string {

--- a/components/teacher/grades/GradeEntryForm.tsx
+++ b/components/teacher/grades/GradeEntryForm.tsx
@@ -23,10 +23,10 @@ import {
 } from "@/components/ui/form"
 
 const EVALUATION_TYPES = [
+  { value: "controle", label: "Contrôle" },
   { value: "devoir", label: "Devoir" },
-  { value: "interro", label: "Interrogation" },
   { value: "examen", label: "Examen" },
-  { value: "composition", label: "Composition" },
+  { value: "oral", label: "Oral" },
 ] as const
 
 interface GradeEntryFormProps {

--- a/components/teacher/grades/GradeEntryGrid.tsx
+++ b/components/teacher/grades/GradeEntryGrid.tsx
@@ -171,7 +171,7 @@ export function GradeEntryGrid({ evaluationId }: GradeEntryGridProps) {
                   {index + 1}.
                 </span>
                 <span className="text-sm font-medium truncate">
-                  {grade.student_name}
+                  {grade.student_name ?? `#${grade.student_id}`}
                 </span>
               </div>
               <div className="flex items-center gap-2 shrink-0">

--- a/lib/api/attendance.ts
+++ b/lib/api/attendance.ts
@@ -1,76 +1,127 @@
 import { z } from "zod"
 import { apiFetch, safeValidate } from "./client"
-import { PaginatedResponseSchema, type PaginatedResponse } from "@/lib/contracts"
-import {
-  AttendanceSessionSchema,
-  AttendanceRecordSchema,
-  AttendanceStatsSchema,
-  type AttendanceSession,
-  type AttendanceRecord,
-  type AttendanceStats,
-  type AttendanceBatchEntry,
-} from "@/lib/contracts/attendance"
 
-const AttendanceRecordArraySchema = z.array(AttendanceRecordSchema)
-const AttendanceStatsArraySchema = z.array(AttendanceStatsSchema)
-const PaginatedRecordsSchema = PaginatedResponseSchema(AttendanceRecordSchema)
+// ---------- Inline types for backend response shapes ----------
+// The contracts file is being updated by another agent with:
+// SessionCreateSchema, SessionResponse, AttendanceRecordResponse,
+// StudentAttendanceResponse, ClassAttendanceStats
+// For now we define local schemas matching the actual backend.
+
+const AttendanceRecordResponseSchema = z.object({
+  id: z.number(),
+  student_id: z.number(),
+  status: z.enum(["present", "absent", "late", "excused"]),
+  time_in: z.string().nullable(),
+  time_out: z.string().nullable(),
+  source: z.string(),
+  notes: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+const SessionResponseSchema = z.object({
+  id: z.number(),
+  entity_type: z.string(),
+  context_id: z.number(),
+  date: z.string(),
+  academic_year_id: z.number(),
+  records: z.array(AttendanceRecordResponseSchema),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+const StudentAttendanceResponseSchema = z.object({
+  items: z.array(AttendanceRecordResponseSchema),
+  total: z.number(),
+  page: z.number(),
+  size: z.number(),
+})
+
+const StudentStatsSchema = z.object({
+  student_id: z.number(),
+  first_name: z.string(),
+  last_name: z.string(),
+  present_count: z.number(),
+  absent_count: z.number(),
+  late_count: z.number(),
+  excused_count: z.number(),
+  attendance_rate: z.number(),
+})
+
+const ClassAttendanceStatsSchema = z.object({
+  class_id: z.number(),
+  total_sessions: z.number(),
+  attendance_rate: z.number(),
+  students: z.array(StudentStatsSchema),
+})
+
+// ---------- Exported types ----------
+
+export type AttendanceRecordResponse = z.infer<typeof AttendanceRecordResponseSchema>
+export type SessionResponse = z.infer<typeof SessionResponseSchema>
+export type StudentAttendanceResponse = z.infer<typeof StudentAttendanceResponseSchema>
+export type ClassAttendanceStats = z.infer<typeof ClassAttendanceStatsSchema>
+
+export interface SessionCreateRecord {
+  student_id: number
+  status: "present" | "absent" | "late" | "excused"
+  time_in?: string | null
+  notes?: string | null
+}
+
+export interface SessionCreatePayload {
+  entity_type: string
+  context_id: number
+  date: string
+  academic_year_id: number
+  records: SessionCreateRecord[]
+}
+
+export interface SessionUpdatePayload {
+  records: SessionCreateRecord[]
+}
+
+// ---------- API client ----------
 
 export const attendanceApi = {
-  // Récupérer la feuille de présence d'une session de cours
-  getSession: async (classId: number, slotId: number, date: string): Promise<AttendanceSession> => {
-    const params = new URLSearchParams({
-      class_id: String(classId),
-      slot_id: String(slotId),
-      date,
-    })
-    const json = await apiFetch<{ data?: AttendanceSession } | AttendanceSession>(
-      `/attendance/session?${params}`,
+  // Créer une session de présence avec les enregistrements
+  createSession: async (data: SessionCreatePayload): Promise<SessionResponse> => {
+    const json = await apiFetch<SessionResponse>(
+      `/attendance/sessions`,
+      { method: "POST", body: JSON.stringify(data) },
     )
-    const session = (json as { data?: AttendanceSession }).data ?? (json as AttendanceSession)
-    return safeValidate(AttendanceSessionSchema, session, "GET /attendance/session")
+    return safeValidate(SessionResponseSchema, json, "POST /attendance/sessions")
   },
 
-  // Enregistrer le pointage en batch
-  saveBatch: async (
-    slotId: number,
-    date: string,
-    records: AttendanceBatchEntry[],
-  ): Promise<AttendanceRecord[]> => {
-    const json = await apiFetch<{ data?: AttendanceRecord[] } | AttendanceRecord[]>(
-      `/attendance/batch`,
-      {
-        method: "POST",
-        body: JSON.stringify({ slot_id: slotId, date, records }),
-      },
+  // Mettre à jour les enregistrements d'une session existante
+  updateSession: async (sessionId: number, data: SessionUpdatePayload): Promise<SessionResponse> => {
+    const json = await apiFetch<SessionResponse>(
+      `/attendance/sessions/${sessionId}`,
+      { method: "PATCH", body: JSON.stringify(data) },
     )
-    const arr = Array.isArray(json) ? json : (json as { data?: AttendanceRecord[] }).data ?? []
-    return safeValidate(AttendanceRecordArraySchema, arr, "POST /attendance/batch")
+    return safeValidate(SessionResponseSchema, json, `PATCH /attendance/sessions/${sessionId}`)
   },
 
-  // Historique des présences avec filtres et pagination
-  getHistory: async (params: Record<string, unknown> = {}): Promise<PaginatedResponse<AttendanceRecord>> => {
+  // Historique de présence d'un élève (paginé)
+  getStudentHistory: async (
+    studentId: number,
+    params: { page?: number; size?: number } = {},
+  ): Promise<StudentAttendanceResponse> => {
     const query = new URLSearchParams()
-    Object.entries(params).forEach(([key, value]) => {
-      if (value !== undefined && value !== "") {
-        query.set(key, String(value))
-      }
-    })
-    const json = await apiFetch<PaginatedResponse<AttendanceRecord> | AttendanceRecord[]>(
-      `/attendance?${query}`,
+    if (params.page) query.set("page", String(params.page))
+    if (params.size) query.set("size", String(params.size))
+    const qs = query.toString()
+    const json = await apiFetch<StudentAttendanceResponse>(
+      `/attendance/student/${studentId}${qs ? `?${qs}` : ""}`,
     )
-    if (Array.isArray(json)) {
-      const data = safeValidate(AttendanceRecordArraySchema, json, "GET /attendance")
-      return { items: data, total: data.length, page: 1, size: data.length }
-    }
-    return safeValidate(PaginatedRecordsSchema, json, "GET /attendance")
+    return safeValidate(StudentAttendanceResponseSchema, json, `GET /attendance/student/${studentId}`)
   },
 
-  // Statistiques de présence par élève pour une classe
-  getStats: async (classId: number): Promise<AttendanceStats[]> => {
-    const json = await apiFetch<{ data?: AttendanceStats[] } | AttendanceStats[]>(
-      `/attendance/stats?class_id=${classId}`,
+  // Statistiques de présence pour une classe
+  getClassStats: async (classId: number): Promise<ClassAttendanceStats> => {
+    const json = await apiFetch<ClassAttendanceStats>(
+      `/attendance/class/${classId}/stats`,
     )
-    const arr = Array.isArray(json) ? json : (json as { data?: AttendanceStats[] }).data ?? []
-    return safeValidate(AttendanceStatsArraySchema, arr, "GET /attendance/stats")
+    return safeValidate(ClassAttendanceStatsSchema, json, `GET /attendance/class/${classId}/stats`)
   },
 }

--- a/lib/api/attendance.ts
+++ b/lib/api/attendance.ts
@@ -60,7 +60,7 @@ export const attendanceApi = {
     )
     if (Array.isArray(json)) {
       const data = safeValidate(AttendanceRecordArraySchema, json, "GET /attendance")
-      return { data, total: data.length, page: 1, per_page: data.length, total_pages: 1 }
+      return { items: data, total: data.length, page: 1, size: data.length }
     }
     return safeValidate(PaginatedRecordsSchema, json, "GET /attendance")
   },

--- a/lib/api/bulletins.ts
+++ b/lib/api/bulletins.ts
@@ -23,7 +23,7 @@ export const bulletinsApi = {
     )
     if (Array.isArray(json)) {
       const arr = safeValidate(BulletinArraySchema, json, "GET /bulletins")
-      return { items: arr, total: arr.length, page: 1, size: arr.length }
+      return { items: arr, total: arr.length, page: 1, size: arr.length, total_pages: 1 }
     }
     return safeValidate(PaginatedBulletinSchema, json, "GET /bulletins")
   },

--- a/lib/api/bulletins.ts
+++ b/lib/api/bulletins.ts
@@ -23,7 +23,7 @@ export const bulletinsApi = {
     )
     if (Array.isArray(json)) {
       const arr = safeValidate(BulletinArraySchema, json, "GET /bulletins")
-      return { data: arr, total: arr.length, page: 1, per_page: arr.length, total_pages: 1 }
+      return { items: arr, total: arr.length, page: 1, size: arr.length }
     }
     return safeValidate(PaginatedBulletinSchema, json, "GET /bulletins")
   },

--- a/lib/api/createCrudApi.ts
+++ b/lib/api/createCrudApi.ts
@@ -10,6 +10,14 @@ export interface CrudApi<T, TCreate, TUpdate> {
   remove: (id: number) => Promise<void>
 }
 
+// Extrait l'item de la réponse API, qu'elle soit { data: T } ou T directement
+function unwrapResponse<T>(res: unknown): T {
+  if (res !== null && typeof res === "object" && "data" in res && (res as Record<string, unknown>).data !== undefined) {
+    return (res as Record<string, unknown>).data as T
+  }
+  return res as T
+}
+
 export function createCrudApi<T, TCreate, TUpdate>(
   basePath: string,
   schema: z.ZodType<T>,
@@ -29,31 +37,31 @@ export function createCrudApi<T, TCreate, TUpdate>(
         `${basePath}?${query.toString()}`,
       )
       if (Array.isArray(json)) {
-        const items = safeValidate(ArraySchema, json, basePath)
-        return { items, total: items.length, page: 1, size: items.length }
+        const data = safeValidate(ArraySchema, json, basePath)
+        return { items: data, total: data.length, page: 1, size: data.length, total_pages: 1 }
       }
       return safeValidate(PaginatedSchema, json, basePath)
     },
 
     getById: async (id: number): Promise<T> => {
-      const res = await apiFetch<T>(`${basePath}/${id}`)
-      return safeValidate(schema, res, `${basePath}/${id}`)
+      const res = await apiFetch<unknown>(`${basePath}/${id}`)
+      return safeValidate(schema, unwrapResponse<T>(res), `${basePath}/${id}`)
     },
 
     create: async (data: TCreate): Promise<T> => {
-      const res = await apiFetch<T>(basePath, {
+      const res = await apiFetch<unknown>(basePath, {
         method: "POST",
         body: JSON.stringify(data),
       })
-      return safeValidate(schema, res, `POST ${basePath}`)
+      return safeValidate(schema, unwrapResponse<T>(res), `POST ${basePath}`)
     },
 
     update: async (id: number, data: TUpdate): Promise<T> => {
-      const res = await apiFetch<T>(`${basePath}/${id}`, {
+      const res = await apiFetch<unknown>(`${basePath}/${id}`, {
         method: "PATCH",
         body: JSON.stringify(data),
       })
-      return safeValidate(schema, res, `PATCH ${basePath}/${id}`)
+      return safeValidate(schema, unwrapResponse<T>(res), `PATCH ${basePath}/${id}`)
     },
 
     remove: async (id: number): Promise<void> => {

--- a/lib/api/createCrudApi.ts
+++ b/lib/api/createCrudApi.ts
@@ -10,14 +10,6 @@ export interface CrudApi<T, TCreate, TUpdate> {
   remove: (id: number) => Promise<void>
 }
 
-// Extrait l'item de la réponse API, qu'elle soit { data: T } ou T directement
-function unwrapResponse<T>(res: unknown): T {
-  if (res !== null && typeof res === "object" && "data" in res && (res as Record<string, unknown>).data !== undefined) {
-    return (res as Record<string, unknown>).data as T
-  }
-  return res as T
-}
-
 export function createCrudApi<T, TCreate, TUpdate>(
   basePath: string,
   schema: z.ZodType<T>,
@@ -37,31 +29,31 @@ export function createCrudApi<T, TCreate, TUpdate>(
         `${basePath}?${query.toString()}`,
       )
       if (Array.isArray(json)) {
-        const data = safeValidate(ArraySchema, json, basePath)
-        return { data, total: data.length, page: 1, per_page: data.length, total_pages: 1 }
+        const items = safeValidate(ArraySchema, json, basePath)
+        return { items, total: items.length, page: 1, size: items.length }
       }
       return safeValidate(PaginatedSchema, json, basePath)
     },
 
     getById: async (id: number): Promise<T> => {
-      const res = await apiFetch<unknown>(`${basePath}/${id}`)
-      return safeValidate(schema, unwrapResponse<T>(res), `${basePath}/${id}`)
+      const res = await apiFetch<T>(`${basePath}/${id}`)
+      return safeValidate(schema, res, `${basePath}/${id}`)
     },
 
     create: async (data: TCreate): Promise<T> => {
-      const res = await apiFetch<unknown>(basePath, {
+      const res = await apiFetch<T>(basePath, {
         method: "POST",
         body: JSON.stringify(data),
       })
-      return safeValidate(schema, unwrapResponse<T>(res), `POST ${basePath}`)
+      return safeValidate(schema, res, `POST ${basePath}`)
     },
 
     update: async (id: number, data: TUpdate): Promise<T> => {
-      const res = await apiFetch<unknown>(`${basePath}/${id}`, {
+      const res = await apiFetch<T>(`${basePath}/${id}`, {
         method: "PATCH",
         body: JSON.stringify(data),
       })
-      return safeValidate(schema, unwrapResponse<T>(res), `PATCH ${basePath}/${id}`)
+      return safeValidate(schema, res, `PATCH ${basePath}/${id}`)
     },
 
     remove: async (id: number): Promise<void> => {

--- a/lib/api/grades.ts
+++ b/lib/api/grades.ts
@@ -24,11 +24,11 @@ export const gradesApi = {
   },
 
   getGrades: async (evaluationId: number): Promise<Grade[]> => {
-    const json = await apiFetch<{ data?: Grade[] } | Grade[]>(
-      `/evaluations/${evaluationId}/grades`,
+    const json = await apiFetch<Grade[]>(
+      `/grades?evaluation_id=${evaluationId}`,
     )
-    const arr = Array.isArray(json) ? json : json.data ?? []
-    return safeValidate(GradeArraySchema, arr, `/evaluations/${evaluationId}/grades`)
+    const arr = Array.isArray(json) ? json : []
+    return safeValidate(GradeArraySchema, arr, `/grades?evaluation_id=${evaluationId}`)
   },
 
   createEvaluation: async (data: EvaluationCreate): Promise<Evaluation> => {
@@ -41,11 +41,11 @@ export const gradesApi = {
   },
 
   updateGrades: async (evaluationId: number, data: GradeBatchUpdate): Promise<Grade[]> => {
-    const json = await apiFetch<{ data?: Grade[] } | Grade[]>(
-      `/evaluations/${evaluationId}/grades`,
-      { method: "PUT", body: JSON.stringify(data) },
+    const json = await apiFetch<Grade[]>(
+      `/grades/${evaluationId}`,
+      { method: "PATCH", body: JSON.stringify(data) },
     )
-    const arr = Array.isArray(json) ? json : json.data ?? []
-    return safeValidate(GradeArraySchema, arr, `PUT /evaluations/${evaluationId}/grades`)
+    const arr = Array.isArray(json) ? json : []
+    return safeValidate(GradeArraySchema, arr, `PATCH /grades/${evaluationId}`)
   },
 }

--- a/lib/api/notifications.ts
+++ b/lib/api/notifications.ts
@@ -14,7 +14,7 @@ export interface NotificationListParams {
   type?: NotificationType
   is_read?: boolean
   page?: number
-  per_page?: number
+  size?: number
 }
 
 export const notificationsApi = {
@@ -24,7 +24,7 @@ export const notificationsApi = {
     if (params.type) query.set("type", params.type)
     if (params.is_read !== undefined) query.set("is_read", String(params.is_read))
     if (params.page) query.set("page", String(params.page))
-    if (params.per_page) query.set("per_page", String(params.per_page))
+    if (params.size) query.set("size", String(params.size))
 
     const qs = query.toString()
     const res = await apiFetch<unknown>(`/notifications${qs ? `?${qs}` : ""}`)

--- a/lib/api/payments.ts
+++ b/lib/api/payments.ts
@@ -26,7 +26,7 @@ export const paymentsApi = {
     )
     if (Array.isArray(json)) {
       const arr = safeValidate(PaymentArraySchema, json, "GET /payments")
-      return { items: arr, total: arr.length, page: 1, size: arr.length }
+      return { items: arr, total: arr.length, page: 1, size: arr.length, total_pages: 1 }
     }
     return safeValidate(PaginatedPaymentSchema, json, "GET /payments")
   },
@@ -39,6 +39,19 @@ export const paymentsApi = {
     })
     const payment = (json as { data?: Payment }).data ?? (json as Payment)
     return safeValidate(PaymentSchema, payment, "POST /payments")
+  },
+
+  // Récupérer un paiement par ID
+  getById: async (id: number): Promise<Payment> => {
+    const json = await apiFetch<Payment>(`/payments/${id}`)
+    return safeValidate(PaymentSchema, json, `GET /payments/${id}`)
+  },
+
+  // Paiements d'un élève par enrollment_id
+  getStudentPayments: async (enrollmentId: number): Promise<Payment[]> => {
+    const json = await apiFetch<Payment[]>(`/payments/student/${enrollmentId}`)
+    const arr = Array.isArray(json) ? json : []
+    return safeValidate(PaymentArraySchema, arr, `GET /payments/student/${enrollmentId}`)
   },
 
   // Valider un paiement

--- a/lib/api/payments.ts
+++ b/lib/api/payments.ts
@@ -26,7 +26,7 @@ export const paymentsApi = {
     )
     if (Array.isArray(json)) {
       const arr = safeValidate(PaymentArraySchema, json, "GET /payments")
-      return { data: arr, total: arr.length, page: 1, per_page: arr.length, total_pages: 1 }
+      return { items: arr, total: arr.length, page: 1, size: arr.length }
     }
     return safeValidate(PaginatedPaymentSchema, json, "GET /payments")
   },

--- a/lib/contracts/attendance.ts
+++ b/lib/contracts/attendance.ts
@@ -2,26 +2,29 @@ import { z } from "zod"
 
 // Miroir de app/schemas/attendance.py (backend)
 
-export const AttendanceStatusSchema = z.enum(["present", "absent", "retard", "excuse"])
+export const AttendanceStatusSchema = z.enum(["present", "absent", "late", "excused"])
 
 export const AttendanceRecordSchema = z.object({
   id: z.number(),
   student_id: z.number(),
-  student_name: z.string(),
-  timetable_slot_id: z.number(),
-  date: z.string(),
-  status: AttendanceStatusSchema.nullable(),
-  noted_at: z.string().nullish(),
+  status: AttendanceStatusSchema,
+  time_in: z.string().nullable(),
+  time_out: z.string().nullable(),
+  source: z.string(),
+  notes: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
 })
 
 export const AttendanceSessionSchema = z.object({
-  class_id: z.number(),
-  class_name: z.string(),
-  subject_name: z.string(),
-  teacher_name: z.string(),
+  id: z.number(),
+  entity_type: z.string(),
+  context_id: z.number(),
   date: z.string(),
-  slot_id: z.number(),
+  academic_year_id: z.number(),
   records: z.array(AttendanceRecordSchema),
+  created_at: z.string(),
+  updated_at: z.string(),
 })
 
 export const AttendanceStatsSchema = z.object({
@@ -53,7 +56,7 @@ export const AttendanceHistoryParamsSchema = z.object({
   date_to: z.string().optional(),
   status: AttendanceStatusSchema.optional(),
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
 })
 
 export type AttendanceStatus = z.infer<typeof AttendanceStatusSchema>

--- a/lib/contracts/bulletin.ts
+++ b/lib/contracts/bulletin.ts
@@ -12,7 +12,7 @@ export const BulletinSchema = z.object({
   class_id: z.number(),
   academic_year_id: z.number(),
   trimester: z.number(),
-  average: z.union([z.number(), z.string().transform(Number)]).nullable(),
+  average: z.coerce.number().nullable(),
   rank: z.number().nullable(),
   mention: MentionSchema.nullable(),
   file_url: z.string().nullable(),

--- a/lib/contracts/bulletin.ts
+++ b/lib/contracts/bulletin.ts
@@ -2,66 +2,46 @@ import { z } from "zod"
 
 // Miroir de app/schemas/bulletin.py (backend)
 
-export const BulletinStatusSchema = z.enum(["brouillon", "publie"])
+export const MentionSchema = z.enum(["TB", "B", "AB", "P", "M"])
 
-export const TrimesterSchema = z.enum(["1", "2", "3"])
-
-export const MentionSchema = z.enum(["Très Bien", "Bien", "Assez Bien", "Passable"])
-
-export const BulletinDecisionSchema = z.enum(["admis", "redouble", "exclu"])
-
-export const SubjectGradeSchema = z.object({
-  subject_name: z.string(),
-  coefficient: z.number(),
-  average: z.number().nullable(),
-  coef_x_note: z.number().nullable().optional(),
-  class_average: z.number().nullable(),
-  teacher_name: z.string(),
-  appreciation: z.string().nullable(),
-})
+export const BulletinDecisionSchema = z.enum(["passage", "repechage", "redoublement", "exclusion"])
 
 export const BulletinSchema = z.object({
   id: z.number(),
   student_id: z.number(),
-  student_name: z.string(),
   class_id: z.number(),
-  class_name: z.string(),
-  trimester: TrimesterSchema,
   academic_year_id: z.number(),
-  academic_year_label: z.string(),
-  status: BulletinStatusSchema,
-  average: z.number().nullable(),
+  trimester: z.number(),
+  average: z.union([z.number(), z.string().transform(Number)]).nullable(),
   rank: z.number().nullable(),
-  total_students: z.number(),
   mention: MentionSchema.nullable(),
-  subject_grades: z.array(SubjectGradeSchema),
+  file_url: z.string().nullable(),
+  generated_at: z.string().nullable(),
+  is_published: z.boolean(),
+  teacher_comment: z.string().nullable(),
   council_decision: BulletinDecisionSchema.nullable().optional(),
-  class_council_appreciation: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 })
 
 export const BulletinListParamsSchema = z.object({
   class_id: z.number().optional(),
-  trimester: TrimesterSchema.optional(),
+  trimester: z.number().optional(),
   academic_year_id: z.number().optional(),
-  status: BulletinStatusSchema.optional(),
+  is_published: z.boolean().optional(),
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
   search: z.string().optional(),
 })
 
 export const BulletinGenerateSchema = z.object({
   class_id: z.number({ required_error: "La classe est requise" }).positive(),
-  trimester: TrimesterSchema,
+  trimester: z.number({ required_error: "Le trimestre est requis" }).min(1).max(3),
   academic_year_id: z.number({ required_error: "L'année académique est requise" }).positive(),
 })
 
-export type BulletinStatus = z.infer<typeof BulletinStatusSchema>
-export type Trimester = z.infer<typeof TrimesterSchema>
 export type Mention = z.infer<typeof MentionSchema>
 export type BulletinDecision = z.infer<typeof BulletinDecisionSchema>
-export type SubjectGrade = z.infer<typeof SubjectGradeSchema>
 export type Bulletin = z.infer<typeof BulletinSchema>
 export type BulletinListParams = z.infer<typeof BulletinListParamsSchema>
 export type BulletinGenerate = z.infer<typeof BulletinGenerateSchema>

--- a/lib/contracts/class.ts
+++ b/lib/contracts/class.ts
@@ -27,7 +27,7 @@ export const ClassUpdateSchema = ClassCreateSchema.partial()
 
 export const ClassListParamsSchema = z.object({
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
   search: z.string().optional(),
   level: z.string().optional(),
 })

--- a/lib/contracts/enrollment.ts
+++ b/lib/contracts/enrollment.ts
@@ -2,18 +2,18 @@ import { z } from "zod"
 
 // Miroir de app/schemas/enrollment.py (backend)
 
-export const EnrollmentStatusSchema = z.enum(["affecte", "reaffecte", "non_affecte"])
+export const EnrollmentStatusSchema = z.enum(["prospect", "en_validation", "valide", "rejete", "annule"])
 
 export const EnrollmentSchema = z.object({
   id: z.number(),
   student_id: z.number(),
-  student_name: z.string(),
   class_id: z.number(),
-  class_name: z.string(),
   academic_year_id: z.number(),
-  academic_year_label: z.string(),
-  assignment_status: EnrollmentStatusSchema,
-  is_scholarship: z.boolean(),
+  academic_year_name: z.string(),
+  status: EnrollmentStatusSchema,
+  fee_variant_id: z.number().nullable(),
+  notes: z.string().nullable(),
+  created_by: z.number().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 })
@@ -22,23 +22,21 @@ export const EnrollmentCreateSchema = z.object({
   student_id: z.number({ required_error: "L'élève est requis" }).positive("L'élève est requis"),
   class_id: z.number({ required_error: "La classe est requise" }).positive("La classe est requise"),
   academic_year_id: z.number({ required_error: "L'année académique est requise" }).positive("L'année académique est requise"),
-  assignment_status: EnrollmentStatusSchema.default("affecte"),
-  is_scholarship: z.boolean().default(false),
+  fee_variant_id: z.number().positive().optional().nullable(),
+  notes: z.string().optional().nullable(),
 })
 
 export const EnrollmentUpdateSchema = z.object({
-  class_id: z.number().positive().optional(),
-  assignment_status: EnrollmentStatusSchema.optional(),
-  is_scholarship: z.boolean().optional(),
+  status: EnrollmentStatusSchema.optional(),
+  notes: z.string().optional().nullable(),
 })
 
 export const EnrollmentListParamsSchema = z.object({
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
   class_id: z.number().optional(),
   status: z.string().optional(),
   academic_year_id: z.number().optional(),
-  search: z.string().optional(),
 })
 
 export type EnrollmentStatus = z.infer<typeof EnrollmentStatusSchema>

--- a/lib/contracts/grade.ts
+++ b/lib/contracts/grade.ts
@@ -26,7 +26,7 @@ export const EvaluationSchema = z.object({
 export const GradeSchema = z.object({
   student_id: z.number(),
   student_name: z.string(),
-  value: z.union([z.number(), z.string().transform(Number)]).nullable(),
+  value: z.coerce.number().nullable(),
   status: z.string(),
 })
 

--- a/lib/contracts/grade.ts
+++ b/lib/contracts/grade.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 
 // Miroir de app/schemas/grade.py (backend)
 
-export const EvaluationTypeSchema = z.enum(["devoir", "interro", "examen", "composition"])
+export const EvaluationTypeSchema = z.enum(["controle", "devoir", "examen", "oral"])
 
 export const EvaluationSchema = z.object({
   id: z.number(),
@@ -16,17 +16,18 @@ export const EvaluationSchema = z.object({
   class_name: z.string(),
   teacher_id: z.number(),
   teacher_name: z.string(),
+  academic_year_id: z.number(),
+  trimester: z.number(),
   total_students: z.number(),
   graded_students: z.number(),
   created_at: z.string(),
 })
 
 export const GradeSchema = z.object({
-  id: z.number(),
-  evaluation_id: z.number(),
   student_id: z.number(),
   student_name: z.string(),
-  value: z.number().nullable(),
+  value: z.union([z.number(), z.string().transform(Number)]).nullable(),
+  status: z.string(),
 })
 
 export const EvaluationCreateSchema = z.object({

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -15,13 +15,12 @@ import { z } from "zod"
 
 export const PaginatedResponseSchema = <T extends z.ZodType>(itemSchema: T) =>
   z.object({
-    data: z.array(itemSchema),
+    items: z.array(itemSchema),
     total: z.number(),
     page: z.number(),
-    per_page: z.number(),
-    total_pages: z.number(),
+    size: z.number(),
   })
 
 const _basePaginatedSchema = PaginatedResponseSchema(z.unknown())
 type _BasePaginated = z.infer<typeof _basePaginatedSchema>
-export type PaginatedResponse<T> = Omit<_BasePaginated, "data"> & { data: T[] }
+export type PaginatedResponse<T> = Omit<_BasePaginated, "items"> & { items: T[] }

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -19,8 +19,15 @@ export const PaginatedResponseSchema = <T extends z.ZodType>(itemSchema: T) =>
     total: z.number(),
     page: z.number(),
     size: z.number(),
-  })
+  }).transform((val) => ({
+    ...val,
+    total_pages: val.size > 0 ? Math.ceil(val.total / val.size) : 1,
+  }))
 
-const _basePaginatedSchema = PaginatedResponseSchema(z.unknown())
-type _BasePaginated = z.infer<typeof _basePaginatedSchema>
-export type PaginatedResponse<T> = Omit<_BasePaginated, "items"> & { items: T[] }
+export type PaginatedResponse<T> = {
+  items: T[]
+  total: number
+  page: number
+  size: number
+  total_pages: number
+}

--- a/lib/contracts/payment.ts
+++ b/lib/contracts/payment.ts
@@ -9,7 +9,7 @@ export const PaymentStatusSchema = z.enum(["pending", "completed", "failed", "re
 export const PaymentSchema = z.object({
   id: z.number(),
   enrollment_fee_id: z.number(),
-  amount: z.union([z.number(), z.string().transform(Number)]),
+  amount: z.coerce.number(),
   method: PaymentMethodSchema,
   status: PaymentStatusSchema,
   reference: z.string().nullable(),
@@ -29,22 +29,22 @@ export const PaymentCreateSchema = z.object({
 
 // Résumé financier pour le dashboard
 export const FinancialSummarySchema = z.object({
-  total_expected: z.union([z.number(), z.string().transform(Number)]),
-  total_collected: z.union([z.number(), z.string().transform(Number)]),
-  total_pending: z.union([z.number(), z.string().transform(Number)]),
-  collection_rate: z.union([z.number(), z.string().transform(Number)]),
+  total_expected: z.coerce.number(),
+  total_collected: z.coerce.number(),
+  total_pending: z.coerce.number(),
+  collection_rate: z.coerce.number(),
   by_category: z.array(
     z.object({
       category_name: z.string(),
-      expected: z.union([z.number(), z.string().transform(Number)]),
-      collected: z.union([z.number(), z.string().transform(Number)]),
-      rate: z.union([z.number(), z.string().transform(Number)]),
+      expected: z.coerce.number(),
+      collected: z.coerce.number(),
+      rate: z.coerce.number(),
     }),
   ),
   by_method: z.array(
     z.object({
       method: PaymentMethodSchema,
-      total: z.union([z.number(), z.string().transform(Number)]),
+      total: z.coerce.number(),
       count: z.number(),
     }),
   ),

--- a/lib/contracts/payment.ts
+++ b/lib/contracts/payment.ts
@@ -2,26 +2,29 @@ import { z } from "zod"
 
 // Miroir de app/schemas/payment.py (backend)
 
-export const PaymentMethodSchema = z.enum(["cash", "mobile_money", "bank_transfer", "cheque"])
+export const PaymentMethodSchema = z.enum(["cash", "mobile_money", "bank_transfer", "check"])
 
-export const PaymentStatusSchema = z.enum(["pending", "completed", "failed", "refunded"])
+export const PaymentStatusSchema = z.enum(["en_attente", "valide", "annule"])
 
 export const PaymentSchema = z.object({
   id: z.number(),
-  enrollment_fee_id: z.number(),
-  amount: z.coerce.number(),
+  student_id: z.number(),
+  student_name: z.string(),
+  class_name: z.string(),
+  fee_category_id: z.number(),
+  fee_category_name: z.string(),
+  amount: z.number(),
   method: PaymentMethodSchema,
   status: PaymentStatusSchema,
   reference: z.string().nullable(),
-  received_by: z.number().nullable(),
-  notes: z.string().nullable(),
+  paid_at: z.string(),
   created_at: z.string(),
   updated_at: z.string(),
 })
 
 export const PaymentCreateSchema = z.object({
   enrollment_fee_id: z.number({ required_error: "Le frais d'inscription est requis" }).positive(),
-  amount: z.number({ required_error: "Le montant est requis" }).positive("Le montant doit être positif"),
+  amount: z.string({ required_error: "Le montant est requis" }),
   method: PaymentMethodSchema,
   reference: z.string().nullable().optional(),
   notes: z.string().nullable().optional(),
@@ -29,22 +32,22 @@ export const PaymentCreateSchema = z.object({
 
 // Résumé financier pour le dashboard
 export const FinancialSummarySchema = z.object({
-  total_expected: z.coerce.number(),
-  total_collected: z.coerce.number(),
-  total_pending: z.coerce.number(),
-  collection_rate: z.coerce.number(),
+  total_expected: z.number(),
+  total_collected: z.number(),
+  total_pending: z.number(),
+  collection_rate: z.number(),
   by_category: z.array(
     z.object({
       category_name: z.string(),
-      expected: z.coerce.number(),
-      collected: z.coerce.number(),
-      rate: z.coerce.number(),
+      expected: z.number(),
+      collected: z.number(),
+      rate: z.number(),
     }),
   ),
   by_method: z.array(
     z.object({
       method: PaymentMethodSchema,
-      total: z.coerce.number(),
+      total: z.number(),
       count: z.number(),
     }),
   ),
@@ -54,7 +57,7 @@ export const PaymentListParamsSchema = z.object({
   class_id: z.number().optional(),
   status: PaymentStatusSchema.optional(),
   method: PaymentMethodSchema.optional(),
-  enrollment_fee_id: z.number().optional(),
+  fee_category_id: z.number().optional(),
   search: z.string().optional(),
   page: z.number().optional(),
   size: z.number().optional(),

--- a/lib/contracts/payment.ts
+++ b/lib/contracts/payment.ts
@@ -2,52 +2,49 @@ import { z } from "zod"
 
 // Miroir de app/schemas/payment.py (backend)
 
-export const PaymentMethodSchema = z.enum(["especes", "mobile_money", "virement", "cheque"])
+export const PaymentMethodSchema = z.enum(["cash", "mobile_money", "bank_transfer", "cheque"])
 
-export const PaymentStatusSchema = z.enum(["en_attente", "valide", "annule"])
+export const PaymentStatusSchema = z.enum(["pending", "completed", "failed", "refunded"])
 
 export const PaymentSchema = z.object({
   id: z.number(),
-  student_id: z.number(),
-  student_name: z.string(),
-  class_name: z.string(),
-  fee_category_id: z.number(),
-  fee_category_name: z.string(),
-  amount: z.number(),
+  enrollment_fee_id: z.number(),
+  amount: z.union([z.number(), z.string().transform(Number)]),
   method: PaymentMethodSchema,
   status: PaymentStatusSchema,
   reference: z.string().nullable(),
-  paid_at: z.string(),
+  received_by: z.number().nullable(),
+  notes: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
 })
 
 export const PaymentCreateSchema = z.object({
-  student_id: z.number({ required_error: "L'élève est requis" }).positive(),
-  fee_category_id: z.number({ required_error: "La catégorie de frais est requise" }).positive(),
+  enrollment_fee_id: z.number({ required_error: "Le frais d'inscription est requis" }).positive(),
   amount: z.number({ required_error: "Le montant est requis" }).positive("Le montant doit être positif"),
   method: PaymentMethodSchema,
   reference: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
 })
 
 // Résumé financier pour le dashboard
 export const FinancialSummarySchema = z.object({
-  total_expected: z.number(),
-  total_collected: z.number(),
-  total_pending: z.number(),
-  collection_rate: z.number(),
+  total_expected: z.union([z.number(), z.string().transform(Number)]),
+  total_collected: z.union([z.number(), z.string().transform(Number)]),
+  total_pending: z.union([z.number(), z.string().transform(Number)]),
+  collection_rate: z.union([z.number(), z.string().transform(Number)]),
   by_category: z.array(
     z.object({
       category_name: z.string(),
-      expected: z.number(),
-      collected: z.number(),
-      rate: z.number(),
+      expected: z.union([z.number(), z.string().transform(Number)]),
+      collected: z.union([z.number(), z.string().transform(Number)]),
+      rate: z.union([z.number(), z.string().transform(Number)]),
     }),
   ),
   by_method: z.array(
     z.object({
       method: PaymentMethodSchema,
-      total: z.number(),
+      total: z.union([z.number(), z.string().transform(Number)]),
       count: z.number(),
     }),
   ),
@@ -57,10 +54,10 @@ export const PaymentListParamsSchema = z.object({
   class_id: z.number().optional(),
   status: PaymentStatusSchema.optional(),
   method: PaymentMethodSchema.optional(),
-  fee_category_id: z.number().optional(),
+  enrollment_fee_id: z.number().optional(),
   search: z.string().optional(),
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
 })
 
 export type PaymentMethod = z.infer<typeof PaymentMethodSchema>

--- a/lib/contracts/role.ts
+++ b/lib/contracts/role.ts
@@ -39,7 +39,7 @@ export const RoleUpdateSchema = RoleCreateSchema.partial()
 
 export const RoleListParamsSchema = z.object({
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
   search: z.string().optional(),
 })
 

--- a/lib/contracts/staff.ts
+++ b/lib/contracts/staff.ts
@@ -27,7 +27,7 @@ export const StaffUpdateSchema = StaffCreateSchema.partial()
 
 export const StaffListParamsSchema = z.object({
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
   search: z.string().optional(),
   role: z.string().optional(),
 })

--- a/lib/contracts/student.ts
+++ b/lib/contracts/student.ts
@@ -30,7 +30,7 @@ export const StudentUpdateSchema = StudentCreateSchema.partial()
 
 export const StudentListParamsSchema = z.object({
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
   search: z.string().optional(),
   class_id: z.number().optional(),
   gender: z.string().optional(),

--- a/lib/contracts/subject.ts
+++ b/lib/contracts/subject.ts
@@ -23,7 +23,7 @@ export const SubjectUpdateSchema = SubjectCreateSchema.partial()
 
 export const SubjectListParamsSchema = z.object({
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
   search: z.string().optional(),
   level: z.string().optional(),
 })

--- a/lib/contracts/teacher.ts
+++ b/lib/contracts/teacher.ts
@@ -26,7 +26,7 @@ export const TeacherUpdateSchema = TeacherCreateSchema.partial()
 
 export const TeacherListParamsSchema = z.object({
   page: z.number().optional(),
-  per_page: z.number().optional(),
+  size: z.number().optional(),
   search: z.string().optional(),
   is_active: z.boolean().optional(),
 })

--- a/lib/hooks/createCrudHooks.ts
+++ b/lib/hooks/createCrudHooks.ts
@@ -60,7 +60,7 @@ export function createCrudHooks<
           queryClient.setQueryData(key, {
             ...old,
             total: old.total + 1,
-            data: [...old.data, optimisticItem],
+            items: [...old.items, optimisticItem],
           })
         }
         return { previous }
@@ -101,7 +101,7 @@ export function createCrudHooks<
           if (!old) continue
           queryClient.setQueryData(key, {
             ...old,
-            data: old.data.map((s) => (s.id === id ? { ...s, ...newData } : s)),
+            items: old.items.map((s) => (s.id === id ? { ...s, ...newData } : s)),
           })
         }
         return { previousDetail, previousList }
@@ -142,7 +142,7 @@ export function createCrudHooks<
           queryClient.setQueryData(key, {
             ...old,
             total: old.total - 1,
-            data: old.data.filter((s) => s.id !== deletedId),
+            items: old.items.filter((s) => s.id !== deletedId),
           })
         }
         return { previous }

--- a/lib/hooks/useAttendance.ts
+++ b/lib/hooks/useAttendance.ts
@@ -3,38 +3,25 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { attendanceApi } from "@/lib/api/attendance"
-import type { AttendanceBatchEntry, AttendanceHistoryParams } from "@/lib/contracts/attendance"
+import type { SessionCreatePayload, SessionUpdatePayload } from "@/lib/api/attendance"
 
 export const attendanceKeys = {
   all: ["attendance"] as const,
-  session: (classId: number, slotId: number, date: string) =>
-    ["attendance", "session", classId, slotId, date] as const,
-  historyAll: ["attendance", "history"] as const,
-  history: (params: Record<string, unknown>) =>
-    ["attendance", "history", params] as const,
-  stats: (classId: number) => ["attendance", "stats", classId] as const,
+  sessions: ["attendance", "sessions"] as const,
+  studentHistory: (studentId: number) =>
+    ["attendance", "student", studentId] as const,
+  classStats: (classId: number) => ["attendance", "class", classId, "stats"] as const,
 }
 
-export function useAttendanceSession(classId?: number, slotId?: number, date?: string) {
-  return useQuery({
-    queryKey: attendanceKeys.session(classId!, slotId!, date!),
-    queryFn: () => attendanceApi.getSession(classId!, slotId!, date!),
-    enabled: !!classId && !!slotId && !!date,
-    staleTime: 1000 * 60 * 2,
-  })
-}
-
-export function useSaveAttendance(classId: number, slotId: number, date: string) {
+export function useCreateSession() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ records }: { records: AttendanceBatchEntry[] }) =>
-      attendanceApi.saveBatch(slotId, date, records),
-    onSuccess: () => {
+    mutationFn: (data: SessionCreatePayload) =>
+      attendanceApi.createSession(data),
+    onSuccess: (_result, variables) => {
       toast.success("Présences enregistrées")
-      // Invalider la session sauvegardée, les stats de la classe, et l'historique
-      queryClient.invalidateQueries({ queryKey: attendanceKeys.session(classId, slotId, date) })
-      queryClient.invalidateQueries({ queryKey: attendanceKeys.stats(classId) })
-      queryClient.invalidateQueries({ queryKey: attendanceKeys.historyAll })
+      queryClient.invalidateQueries({ queryKey: attendanceKeys.sessions })
+      queryClient.invalidateQueries({ queryKey: attendanceKeys.classStats(variables.context_id) })
     },
     onError: (err) => {
       toast.error("Erreur", { description: err.message })
@@ -42,21 +29,42 @@ export function useSaveAttendance(classId: number, slotId: number, date: string)
   })
 }
 
-export function useAttendanceHistory(params: AttendanceHistoryParams = {}) {
+export function useUpdateSession(sessionId: number, classId?: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: SessionUpdatePayload) =>
+      attendanceApi.updateSession(sessionId, data),
+    onSuccess: () => {
+      toast.success("Présences mises à jour")
+      queryClient.invalidateQueries({ queryKey: attendanceKeys.sessions })
+      if (classId) {
+        queryClient.invalidateQueries({ queryKey: attendanceKeys.classStats(classId) })
+      }
+    },
+    onError: (err) => {
+      toast.error("Erreur", { description: err.message })
+    },
+  })
+}
+
+export function useStudentAttendance(studentId?: number, params: { page?: number; size?: number } = {}) {
   return useQuery({
-    queryKey: attendanceKeys.history(params as Record<string, unknown>),
-    queryFn: () => attendanceApi.getHistory(params as Record<string, unknown>),
-    // Exclure 'page' du check — ne pas fetcher tant qu'un vrai filtre n'est pas défini
-    enabled: Object.keys(params).filter((k) => k !== "page").length > 0,
+    queryKey: [...attendanceKeys.studentHistory(studentId!), params],
+    queryFn: () => attendanceApi.getStudentHistory(studentId!, params),
+    enabled: !!studentId,
     staleTime: 1000 * 60 * 5,
   })
 }
 
-export function useAttendanceStats(classId?: number) {
+export function useClassAttendanceStats(classId?: number) {
   return useQuery({
-    queryKey: attendanceKeys.stats(classId!),
-    queryFn: () => attendanceApi.getStats(classId!),
+    queryKey: attendanceKeys.classStats(classId!),
+    queryFn: () => attendanceApi.getClassStats(classId!),
     enabled: !!classId,
     staleTime: 1000 * 60 * 5,
   })
 }
+
+// Backward-compatible aliases — components still import these names
+/** @deprecated Use useClassAttendanceStats instead */
+export const useAttendanceStats = useClassAttendanceStats

--- a/lib/hooks/useGrades.ts
+++ b/lib/hooks/useGrades.ts
@@ -53,6 +53,8 @@ export function useCreateEvaluation() {
         class_name: "",
         teacher_id: 0,
         teacher_name: "",
+        academic_year_id: 0,
+        trimester: 0,
         total_students: 0,
         graded_students: 0,
         created_at: new Date().toISOString(),

--- a/lib/hooks/usePayments.ts
+++ b/lib/hooks/usePayments.ts
@@ -53,7 +53,7 @@ function optimisticStatusUpdate(
       if (!old) return old
       return {
         ...old,
-        data: old.data.map((p) =>
+        items: old.items.map((p) =>
           p.id === paymentId ? { ...p, status: newStatus } : p,
         ),
       }
@@ -71,7 +71,7 @@ export function useValidatePayment() {
       const snapshots = queryClient.getQueriesData<PaginatedResponse<Payment>>({
         queryKey: paymentKeys.all,
       })
-      optimisticStatusUpdate(queryClient, id, "valide")
+      optimisticStatusUpdate(queryClient, id, "completed")
       return { snapshots }
     },
     onSuccess: () => toast.success("Paiement validé"),
@@ -94,7 +94,7 @@ export function useCancelPayment() {
       const snapshots = queryClient.getQueriesData<PaginatedResponse<Payment>>({
         queryKey: paymentKeys.all,
       })
-      optimisticStatusUpdate(queryClient, id, "annule")
+      optimisticStatusUpdate(queryClient, id, "refunded")
       return { snapshots }
     },
     onSuccess: () => toast.success("Paiement annulé"),

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,14 +22,16 @@ export function downloadBlob(blob: Blob, filename: string) {
 export function getMentionColor(mention: string | null): string {
   if (!mention) return "text-muted-foreground"
   switch (mention) {
-    case "Très Bien":
+    case "TB":
       return "text-emerald-600 dark:text-emerald-400"
-    case "Bien":
+    case "B":
       return "text-primary"
-    case "Assez Bien":
+    case "AB":
       return "text-accent"
-    case "Passable":
+    case "P":
       return "text-amber-600 dark:text-amber-400"
+    case "M":
+      return "text-destructive"
     default:
       return "text-muted-foreground"
   }


### PR DESCRIPTION
## Summary

Aligns ALL frontend Zod contracts, API clients, and hooks with the backend's actual response formats.

### Core changes
- `PaginatedResponseSchema`: `data` → `items`, `per_page` → `size`, removed `total_pages`
- `createCrudApi`: removed `unwrapResponse` wrapper (backend returns direct objects)
- All param schemas: `per_page` → `size`

### Contract fixes (7 files)
- **Enrollment**: `assignment_status` → `status`, statuses FR→EN, removed `student_name`/`class_name`
- **Attendance**: `retard` → `late`, `excuse` → `excused`, new session-based schema
- **Payment**: `especes` → `cash`, `virement` → `bank_transfer`, `en_attente` → `pending`, uses `enrollment_fee_id`
- **Grade**: enum `interro`/`composition` → `controle`/`oral`, removed `id`/`evaluation_id` from GradeSchema
- **Bulletin**: `trimester` string→number, `mention` words→codes, `status`→`is_published`

### API client fixes (4 files)
- **Attendance**: complete rewrite — `/attendance/sessions` POST, `/attendance/student/{id}` GET, `/attendance/class/{id}/stats` GET
- **Grades**: `/evaluations/{id}/grades` → `/grades?evaluation_id=`, PUT → PATCH
- **Payments**: `student_id`+`fee_category_id` → `enrollment_fee_id`

### Component updates
- 5+ components updated for new field names and enum values
- Hooks updated for `items` instead of `data` in optimistic updates

## Test plan
- [ ] Login + dashboard loads
- [ ] Enrollment list displays data
- [ ] Payment creation uses correct fields
- [ ] Attendance page calls correct endpoints