### PR TITLE
fix(dashboard): replace mock data with real API, show current year

### DIFF
--- a/components/admin/dashboard/DashboardCharts.tsx
+++ b/components/admin/dashboard/DashboardCharts.tsx
@@ -14,30 +14,51 @@ import {
   Legend,
 } from "recharts"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-
-// Données de démo — sera remplacé par l'API /dashboard/charts
-const enrollmentData = [
-  { level: "6ème", count: 87 },
-  { level: "5ème", count: 72 },
-  { level: "4ème", count: 65 },
-  { level: "3ème", count: 58 },
-  { level: "2nde", count: 45 },
-  { level: "1ère", count: 38 },
-  { level: "Tle", count: 32 },
-]
-
-const statusData = [
-  { name: "Validées", value: 342, color: "hsl(var(--primary))" },
-  { name: "En attente", value: 45, color: "hsl(var(--accent))" },
-  { name: "Rejetées", value: 10, color: "hsl(var(--destructive))" },
-]
+import { Skeleton } from "@/components/ui/skeleton"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { useDrenStats } from "@/lib/hooks/useDrenStats"
 
 export function DashboardCharts() {
+  const { data: yearsData } = useAcademicYears()
+  const currentYear = yearsData?.items?.find((y) => y.is_current)
+
+  const { data: stats, isLoading } = useDrenStats(currentYear?.id)
+
+  const enrollmentData = stats?.levels?.map((l) => ({
+    level: l.level_name,
+    count: l.total_students,
+  })) ?? []
+
+  const totalStudents = stats?.total_students ?? 0
+  const maleCount = stats?.male_count ?? 0
+  const femaleCount = stats?.female_count ?? 0
+
+  const genderData = totalStudents > 0
+    ? [
+        { name: "Garçons", value: maleCount, color: "hsl(var(--primary))" },
+        { name: "Filles", value: femaleCount, color: "hsl(var(--accent))" },
+      ]
+    : []
+
   const hasData = enrollmentData.some((d) => d.count > 0)
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4">
+        <Card className="border-0 shadow-sm ring-1 ring-border">
+          <CardHeader><Skeleton className="h-5 w-48" /></CardHeader>
+          <CardContent><Skeleton className="h-[280px] w-full" /></CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm ring-1 ring-border">
+          <CardHeader><Skeleton className="h-5 w-48" /></CardHeader>
+          <CardContent><Skeleton className="h-[280px] w-full" /></CardContent>
+        </Card>
+      </div>
+    )
+  }
 
   return (
     <div className="grid gap-4">
-      {/* Bar chart — enrollment by level */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardHeader>
           <CardTitle className="text-base font-medium">
@@ -70,19 +91,18 @@ export function DashboardCharts() {
         </CardContent>
       </Card>
 
-      {/* Pie chart — enrollment status */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardHeader>
           <CardTitle className="text-base font-medium">
-            Statut des inscriptions
+            Répartition garçons / filles
           </CardTitle>
         </CardHeader>
         <CardContent>
-          {hasData ? (
+          {genderData.length > 0 ? (
             <ResponsiveContainer width="100%" height={280}>
               <PieChart>
                 <Pie
-                  data={statusData}
+                  data={genderData}
                   cx="50%"
                   cy="50%"
                   innerRadius={60}
@@ -90,7 +110,7 @@ export function DashboardCharts() {
                   paddingAngle={4}
                   dataKey="value"
                 >
-                  {statusData.map((entry) => (
+                  {genderData.map((entry) => (
                     <Cell key={entry.name} fill={entry.color} />
                   ))}
                 </Pie>

--- a/components/admin/dashboard/RecentActivity.tsx
+++ b/components/admin/dashboard/RecentActivity.tsx
@@ -1,105 +1,93 @@
+"use client"
+
 import {
   UserPlus,
   CreditCard,
   ClipboardList,
-  CalendarDays,
+  Bell,
   AlertTriangle,
   type LucideIcon,
 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
+import { useNotifications } from "@/lib/hooks/useNotifications"
+import type { Notification } from "@/lib/contracts/notification"
 
-interface ActivityItem {
-  id: number
-  icon: LucideIcon
-  label: string
-  detail: string
-  time: string
-  variant: "blue" | "orange" | "emerald" | "violet" | "rose"
+const typeConfig: Record<string, { icon: LucideIcon; variant: string }> = {
+  enrollment_status: { icon: UserPlus, variant: "bg-primary/10 text-primary" },
+  payment_due: { icon: CreditCard, variant: "bg-accent/10 text-accent" },
+  payment_received: { icon: CreditCard, variant: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400" },
+  grade_available: { icon: ClipboardList, variant: "bg-violet-500/10 text-violet-600 dark:text-violet-400" },
+  bulletin_published: { icon: ClipboardList, variant: "bg-violet-500/10 text-violet-600 dark:text-violet-400" },
+  absence_recorded: { icon: AlertTriangle, variant: "bg-rose-500/10 text-rose-600 dark:text-rose-400" },
+  system: { icon: Bell, variant: "bg-muted text-muted-foreground" },
 }
 
-const variantStyles: Record<ActivityItem["variant"], string> = {
-  blue: "bg-primary/10 text-primary",
-  orange: "bg-accent/10 text-accent",
-  emerald: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
-  violet: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
-  rose: "bg-rose-500/10 text-rose-600 dark:text-rose-400",
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return "À l'instant"
+  if (minutes < 60) return `Il y a ${minutes} min`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `Il y a ${hours}h`
+  const days = Math.floor(hours / 24)
+  return `Il y a ${days}j`
 }
 
-// Données de démo — sera remplacé par l'API /dashboard/activity
-const activities: ActivityItem[] = [
-  {
-    id: 1,
-    icon: UserPlus,
-    label: "Nouvelle inscription",
-    detail: "Jean Mbala — 3ème B",
-    time: "Il y a 12 min",
-    variant: "blue",
-  },
-  {
-    id: 2,
-    icon: CreditCard,
-    label: "Paiement reçu",
-    detail: "Marie Loko — 45 000 FC",
-    time: "Il y a 28 min",
-    variant: "orange",
-  },
-  {
-    id: 3,
-    icon: ClipboardList,
-    label: "Notes saisies",
-    detail: "Maths 4ème A — M. Kabongo",
-    time: "Il y a 1h",
-    variant: "emerald",
-  },
-  {
-    id: 4,
-    icon: CalendarDays,
-    label: "Emploi du temps modifié",
-    detail: "6ème C — Lundi matin",
-    time: "Il y a 2h",
-    variant: "violet",
-  },
-  {
-    id: 5,
-    icon: AlertTriangle,
-    label: "Alerte absence",
-    detail: "3 absences non justifiées — 5ème A",
-    time: "Il y a 3h",
-    variant: "rose",
-  },
-]
+function ActivityItem({ notification }: { notification: Notification }) {
+  const config = typeConfig[notification.type] ?? typeConfig.system
+  const Icon = config.icon
+
+  return (
+    <div className="flex items-start gap-3">
+      <div className={cn("flex h-9 w-9 shrink-0 items-center justify-center rounded-lg", config.variant)}>
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium leading-none">{notification.title}</p>
+        <p className="mt-1 text-xs text-muted-foreground truncate">{notification.body}</p>
+      </div>
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {timeAgo(notification.created_at)}
+      </span>
+    </div>
+  )
+}
 
 export function RecentActivity() {
+  const { data, isLoading } = useNotifications({ size: 5 })
+
   return (
     <Card className="border-0 shadow-sm ring-1 ring-border">
       <CardHeader>
         <CardTitle className="text-base font-medium">Activité récente</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="space-y-4">
-          {activities.map((activity) => (
-            <div key={activity.id} className="flex items-start gap-3">
-              <div
-                className={cn(
-                  "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-                  variantStyles[activity.variant]
-                )}
-              >
-                <activity.icon className="h-4 w-4" />
+        {isLoading ? (
+          <div className="space-y-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-start gap-3">
+                <Skeleton className="h-9 w-9 rounded-lg" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-3.5 w-32" />
+                  <Skeleton className="h-3 w-48" />
+                </div>
+                <Skeleton className="h-3 w-16" />
               </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium leading-none">{activity.label}</p>
-                <p className="mt-1 text-xs text-muted-foreground truncate">
-                  {activity.detail}
-                </p>
-              </div>
-              <span className="shrink-0 text-xs text-muted-foreground">
-                {activity.time}
-              </span>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        ) : data && data.length > 0 ? (
+          <div className="space-y-4">
+            {data.map((n) => (
+              <ActivityItem key={n.id} notification={n} />
+            ))}
+          </div>
+        ) : (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            Aucune activité récente
+          </p>
+        )}
       </CardContent>
     </Card>
   )

--- a/components/admin/dashboard/WelcomeHeader.tsx
+++ b/components/admin/dashboard/WelcomeHeader.tsx
@@ -1,11 +1,15 @@
 "use client"
 
 import { useSession } from "next-auth/react"
-import { CalendarDays } from "lucide-react"
+import { CalendarDays, GraduationCap } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 
 export function WelcomeHeader() {
   const { data: session, status } = useSession()
+  const { data: yearsData } = useAcademicYears()
+
+  const currentYear = yearsData?.items?.find((y) => y.is_current)
 
   const today = new Date().toLocaleDateString("fr-FR", {
     weekday: "long",
@@ -19,12 +23,10 @@ export function WelcomeHeader() {
   }
 
   const rawName = session?.user?.email?.split("@")[0] ?? "Administrateur"
-  // Capitalise et prend la partie avant . ou _ (jean.mbala → Jean)
   const firstName = rawName.split(/[._]/)[0].replace(/^\w/, (c) => c.toUpperCase())
 
   return (
     <div className="relative overflow-hidden rounded-xl bg-gradient-to-br from-primary to-primary/80 p-6 text-primary-foreground shadow-sm sm:p-8">
-      {/* Decorative circles */}
       <div className="absolute -right-12 -top-12 h-40 w-40 rounded-full bg-white/5" />
       <div className="absolute -bottom-8 -left-8 h-32 w-32 rounded-full bg-white/5" />
       <div className="absolute right-1/4 top-1/2 h-20 w-20 rounded-full bg-white/[0.03]" />
@@ -33,9 +35,17 @@ export function WelcomeHeader() {
         <h1 className="font-serif text-2xl tracking-tight sm:text-3xl">
           Bonjour, {firstName}
         </h1>
-        <div className="flex items-center gap-2 text-sm text-primary-foreground/70">
-          <CalendarDays className="h-4 w-4" />
-          <span className="capitalize" suppressHydrationWarning>{today}</span>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-primary-foreground/70">
+          <span className="flex items-center gap-2">
+            <CalendarDays className="h-4 w-4" />
+            <span className="capitalize" suppressHydrationWarning>{today}</span>
+          </span>
+          {currentYear && (
+            <span className="flex items-center gap-2 rounded-full bg-white/10 px-3 py-0.5 text-xs font-medium text-primary-foreground">
+              <GraduationCap className="h-3.5 w-3.5" />
+              Année {currentYear.name}
+            </span>
+          )}
         </div>
         <p className="text-sm text-primary-foreground/60 max-w-lg">
           Voici un aperçu de votre établissement. Consultez les indicateurs clés et les activités récentes.


### PR DESCRIPTION
## Summary

- **WelcomeHeader**: affiche l'année académique courante (badge « Année 2025-2026 »)
- **RecentActivity**: remplace les 5 activités hardcodées par `/notifications?size=5`
- **DashboardCharts**: remplace les données mock par `/reports/dren-stats/{yearId}`
  - Bar chart: inscriptions par niveau (depuis les stats DREN)
  - Pie chart: répartition garçons/filles (depuis les stats DREN)

## Changes
- 3 fichiers modifiés, 0 fichiers créés
- Aucune donnée hardcodée restante dans le dashboard
- Skeleton loaders pendant le chargement
- État vide propre si pas de données

## Test plan
- [ ] Dashboard affiche « Année 2025-2026 » dans le header
- [ ] Activité récente affiche les vraies notifications (ou « Aucune activité »)
- [ ] Charts affichent les vraies données ou état vide