### PR TITLE
feat: enrollment redesign — global year, multi-step form, academic years page

### DIFF
--- a/app/(admin)/admin/academic-years/page.tsx
+++ b/app/(admin)/admin/academic-years/page.tsx
@@ -1,0 +1,7 @@
+import { AcademicYearsPageClient } from "@/components/admin/academic-years/AcademicYearsPageClient"
+
+export const metadata = { title: "Annees academiques | KLASSCI" }
+
+export default function AcademicYearsPage() {
+  return <AcademicYearsPageClient />
+}

--- a/components/admin/academic-years/AcademicYearCreateModal.tsx
+++ b/components/admin/academic-years/AcademicYearCreateModal.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { CreateModal } from "@/components/shared/CreateModal"
+import { AcademicYearForm } from "./AcademicYearForm"
+
+interface AcademicYearCreateModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function AcademicYearCreateModal({ open, onClose }: AcademicYearCreateModalProps) {
+  return (
+    <CreateModal open={open} onClose={onClose} title="Nouvelle annee academique">
+      <AcademicYearForm onSuccess={onClose} />
+    </CreateModal>
+  )
+}

--- a/components/admin/academic-years/AcademicYearEditModal.tsx
+++ b/components/admin/academic-years/AcademicYearEditModal.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { AcademicYearUpdateSchema, type AcademicYearUpdate } from "@/lib/contracts/academic-year"
+import { useAcademicYear, useUpdateAcademicYear } from "@/lib/hooks/useAcademicYears"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+
+function EditFormSkeleton() {
+  return (
+    <div className="space-y-5">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-11 w-full" />
+        </div>
+      ))}
+      <Skeleton className="h-11 w-full" />
+    </div>
+  )
+}
+
+function EditForm({ yearId, onClose }: { yearId: number; onClose: () => void }) {
+  const { data: yearData, isLoading } = useAcademicYear(yearId)
+  const { mutate, isPending, error } = useUpdateAcademicYear(yearId)
+
+  const form = useForm<AcademicYearUpdate>({
+    resolver: zodResolver(AcademicYearUpdateSchema),
+    values: yearData
+      ? {
+          name: yearData.name,
+          start_date: yearData.start_date,
+          end_date: yearData.end_date,
+        }
+      : undefined,
+  })
+
+  if (isLoading || !yearData) return <EditFormSkeleton />
+
+  function onSubmit(data: AcademicYearUpdate) {
+    mutate(data, { onSuccess: onClose })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nom</FormLabel>
+              <FormControl>
+                <Input className="h-11" placeholder="2025-2026" {...field} value={field.value ?? ""} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="start_date"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Date de debut</FormLabel>
+                <FormControl>
+                  <Input type="date" className="h-11" {...field} value={field.value ?? ""} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="end_date"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Date de fin</FormLabel>
+                <FormControl>
+                  <Input type="date" className="h-11" {...field} value={field.value ?? ""} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
+            <p className="text-sm text-destructive">{error.message}</p>
+          </div>
+        )}
+
+        <Button type="submit" size="lg" className="w-full h-11 font-semibold" disabled={isPending}>
+          {isPending ? "Enregistrement..." : "Mettre a jour"}
+        </Button>
+      </form>
+    </Form>
+  )
+}
+
+interface AcademicYearEditModalProps {
+  yearId: number | null
+  open: boolean
+  onClose: () => void
+}
+
+export function AcademicYearEditModal({ yearId, open, onClose }: AcademicYearEditModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Modifier l&apos;annee academique</DialogTitle>
+        </DialogHeader>
+        {yearId && <EditForm yearId={yearId} onClose={onClose} />}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/academic-years/AcademicYearForm.tsx
+++ b/components/admin/academic-years/AcademicYearForm.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { AcademicYearCreateSchema, type AcademicYearCreate } from "@/lib/contracts/academic-year"
+import { useCreateAcademicYear } from "@/lib/hooks/useAcademicYears"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+
+interface AcademicYearFormProps {
+  onSuccess: () => void
+}
+
+export function AcademicYearForm({ onSuccess }: AcademicYearFormProps) {
+  const form = useForm<AcademicYearCreate>({
+    resolver: zodResolver(AcademicYearCreateSchema),
+    defaultValues: {
+      name: "",
+      start_date: "",
+      end_date: "",
+      is_current: false,
+    },
+  })
+
+  const { mutate, isPending, error } = useCreateAcademicYear()
+
+  function onSubmit(data: AcademicYearCreate) {
+    mutate(data, {
+      onSuccess: () => {
+        form.reset()
+        onSuccess()
+      },
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nom *</FormLabel>
+              <FormControl>
+                <Input className="h-11" placeholder="2025-2026" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="start_date"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Date de debut *</FormLabel>
+                <FormControl>
+                  <Input type="date" className="h-11" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="end_date"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Date de fin *</FormLabel>
+                <FormControl>
+                  <Input type="date" className="h-11" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
+            <p className="text-sm text-destructive">{error.message}</p>
+          </div>
+        )}
+
+        <Button type="submit" size="lg" className="w-full h-11 font-semibold" disabled={isPending}>
+          {isPending ? "Enregistrement..." : "Enregistrer"}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/components/admin/academic-years/AcademicYearsPageClient.tsx
+++ b/components/admin/academic-years/AcademicYearsPageClient.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
+import { AcademicYearsTable } from "./AcademicYearsTable"
+import { AcademicYearCreateModal } from "./AcademicYearCreateModal"
+
+export function AcademicYearsPageClient() {
+  return (
+    <CrudPageLayout
+      title="Annees academiques"
+      subtitle="Gestion des annees scolaires et definition de l'annee courante"
+      createLabel="Nouvelle annee"
+      table={<AcademicYearsTable />}
+      createModal={(props) => <AcademicYearCreateModal {...props} />}
+    />
+  )
+}

--- a/components/admin/academic-years/AcademicYearsTable.tsx
+++ b/components/admin/academic-years/AcademicYearsTable.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import type { ColumnDef } from "@tanstack/react-table"
+import { CheckCircle2, Circle } from "lucide-react"
+import { useAcademicYears, useDeleteAcademicYear, useSetCurrentYear } from "@/lib/hooks/useAcademicYears"
+import type { AcademicYear } from "@/lib/contracts/academic-year"
+import { CrudTable } from "@/components/shared/CrudTable"
+import { AcademicYearEditModal } from "./AcademicYearEditModal"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+export function AcademicYearsTable() {
+  const [page, setPage] = useState(1)
+  const { data, isLoading, isError, error, refetch } = useAcademicYears({ page })
+  const deleteMutation = useDeleteAcademicYear()
+  const setCurrentMutation = useSetCurrentYear()
+
+  const columns: ColumnDef<AcademicYear>[] = useMemo(() => [
+    {
+      accessorKey: "name",
+      header: "Nom",
+      cell: ({ row }) => <span className="font-medium">{row.original.name}</span>,
+    },
+    {
+      accessorKey: "start_date",
+      header: "Debut",
+      cell: ({ row }) => (
+        <span className="text-sm text-muted-foreground">
+          {new Date(row.original.start_date).toLocaleDateString("fr-FR")}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "end_date",
+      header: "Fin",
+      cell: ({ row }) => (
+        <span className="text-sm text-muted-foreground">
+          {new Date(row.original.end_date).toLocaleDateString("fr-FR")}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "is_current",
+      header: "Statut",
+      cell: ({ row }) => {
+        const isCurrent = row.original.is_current
+        if (isCurrent) {
+          return (
+            <Badge variant="default" className="gap-1">
+              <CheckCircle2 className="h-3 w-3" />
+              Courante
+            </Badge>
+          )
+        }
+        return (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1 text-muted-foreground hover:text-primary"
+            disabled={setCurrentMutation.isPending}
+            onClick={() => setCurrentMutation.mutate(row.original.id)}
+          >
+            <Circle className="h-3 w-3" />
+            Definir comme courante
+          </Button>
+        )
+      },
+    },
+  ], [setCurrentMutation])
+
+  return (
+    <CrudTable<AcademicYear>
+      data={data}
+      columns={columns}
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+      refetch={refetch}
+      deleteMutation={deleteMutation}
+      renderEditModal={({ itemId, open, onClose }) => (
+        <AcademicYearEditModal yearId={itemId} open={open} onClose={onClose} />
+      )}
+      getItemLabel={(y) => y.name}
+      emptyMessage="Aucune annee academique trouvee"
+      errorMessage="Impossible de charger les annees academiques"
+      deleteDescription="Cette action est irreversible. L'annee academique sera definitivement supprimee."
+      page={page}
+      onPageChange={setPage}
+    />
+  )
+}

--- a/components/admin/classes/ClassEditModal.tsx
+++ b/components/admin/classes/ClassEditModal.tsx
@@ -42,7 +42,8 @@ function EditFormSkeleton() {
 function EditForm({ classId, onClose }: { classId: number; onClose: () => void }) {
   const { data: classData, isLoading } = useClass(classId)
   const { mutate, isPending, error } = useUpdateClass(classId)
-  const { data: academicYears } = useAcademicYears()
+  const { data: academicYearsData } = useAcademicYears()
+  const academicYears = academicYearsData?.items
 
   const form = useForm<ClassUpdate>({
     resolver: zodResolver(ClassUpdateSchema),
@@ -140,7 +141,7 @@ function EditForm({ classId, onClose }: { classId: number; onClose: () => void }
                 <SelectContent>
                   {academicYears?.map((ay) => (
                     <SelectItem key={ay.id} value={ay.id.toString()}>
-                      {ay.label}
+                      {ay.name}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/components/admin/dashboard/WelcomeHeader.tsx
+++ b/components/admin/dashboard/WelcomeHeader.tsx
@@ -1,15 +1,11 @@
 "use client"
 
 import { useSession } from "next-auth/react"
-import { CalendarDays, GraduationCap } from "lucide-react"
+import { CalendarDays } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
-import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 
 export function WelcomeHeader() {
   const { data: session, status } = useSession()
-  const { data: yearsData } = useAcademicYears()
-
-  const currentYear = yearsData?.items?.find((y) => y.is_current)
 
   const today = new Date().toLocaleDateString("fr-FR", {
     weekday: "long",
@@ -40,12 +36,6 @@ export function WelcomeHeader() {
             <CalendarDays className="h-4 w-4" />
             <span className="capitalize" suppressHydrationWarning>{today}</span>
           </span>
-          {currentYear && (
-            <span className="flex items-center gap-2 rounded-full bg-white/10 px-3 py-0.5 text-xs font-medium text-primary-foreground">
-              <GraduationCap className="h-3.5 w-3.5" />
-              Année {currentYear.name}
-            </span>
-          )}
         </div>
         <p className="text-sm text-primary-foreground/60 max-w-lg">
           Voici un aperçu de votre établissement. Consultez les indicateurs clés et les activités récentes.

--- a/components/admin/enrollments/EnrollmentCreateModal.tsx
+++ b/components/admin/enrollments/EnrollmentCreateModal.tsx
@@ -10,7 +10,7 @@ interface EnrollmentCreateModalProps {
 
 export function EnrollmentCreateModal({ open, onClose }: EnrollmentCreateModalProps) {
   return (
-    <CreateModal open={open} onClose={onClose} title="Nouvelle inscription">
+    <CreateModal open={open} onClose={onClose} title="Nouvelle inscription" className="max-w-2xl">
       <EnrollmentForm onSuccess={onClose} />
     </CreateModal>
   )

--- a/components/admin/fees/FeesPageClient.tsx
+++ b/components/admin/fees/FeesPageClient.tsx
@@ -39,8 +39,8 @@ export function FeesPageClient() {
   const [editVariant, setEditVariant] = useState<FeeVariant | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<{ type: "category" | "variant"; id: number; name: string } | null>(null)
 
-  const { data: academicYears } = useAcademicYears()
-  const currentYearId = academicYears?.[0]?.id
+  const { data: academicYearsData } = useAcademicYears()
+  const currentYearId = academicYearsData?.items?.[0]?.id
 
   const { data: categories, isLoading: loadingCategories } = useFeeCategories()
   const { data: variants, isLoading: loadingVariants } = useFeeVariants(currentYearId)

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -24,7 +24,8 @@ export function ReportsPageClient() {
 
   const { data: classesData, isLoading: classesLoading } = useClasses()
   const classes = classesData?.items
-  const { data: academicYears, isLoading: yearsLoading } = useAcademicYears()
+  const { data: academicYearsData, isLoading: yearsLoading } = useAcademicYears()
+  const academicYears = academicYearsData?.items
 
   const activeYearId = academicYearId ?? academicYears?.[0]?.id
 
@@ -73,7 +74,7 @@ export function ReportsPageClient() {
             <SelectContent>
               {academicYears?.map((y) => (
                 <SelectItem key={y.id} value={y.id.toString()}>
-                  {y.label}
+                  {y.name}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/components/admin/reports/dren/DrenPageClient.tsx
+++ b/components/admin/reports/dren/DrenPageClient.tsx
@@ -22,7 +22,8 @@ import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { drenApi } from "@/lib/api/dren"
 
 export function DrenPageClient() {
-  const { data: academicYears } = useAcademicYears()
+  const { data: academicYearsData } = useAcademicYears()
+  const academicYears = academicYearsData?.items
   const [academicYearId, setAcademicYearId] = useState<number | undefined>(undefined)
   const activeYearId = academicYearId ?? academicYears?.[0]?.id
   const { data: stats, isLoading, isError } = useDrenStats(activeYearId)
@@ -78,7 +79,7 @@ export function DrenPageClient() {
         <SelectContent>
           {(academicYears ?? []).map((y) => (
             <SelectItem key={y.id} value={y.id.toString()}>
-              {y.label}
+              {y.name}
             </SelectItem>
           ))}
         </SelectContent>

--- a/components/forms/ClassForm.tsx
+++ b/components/forms/ClassForm.tsx
@@ -40,7 +40,8 @@ export function ClassForm({ onSuccess }: ClassFormProps) {
     },
   })
 
-  const { data: academicYears } = useAcademicYears()
+  const { data: academicYearsData } = useAcademicYears()
+  const academicYears = academicYearsData?.items
   const { mutate, isPending, error } = useCreateClass()
 
   function onSubmit(data: ClassCreate) {
@@ -131,7 +132,7 @@ export function ClassForm({ onSuccess }: ClassFormProps) {
                 <SelectContent>
                   {academicYears?.map((ay) => (
                     <SelectItem key={ay.id} value={ay.id.toString()}>
-                      {ay.label}
+                      {ay.name}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/components/forms/EnrollmentForm.tsx
+++ b/components/forms/EnrollmentForm.tsx
@@ -1,12 +1,45 @@
 "use client"
 
+import { useState, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { EnrollmentCreateSchema, type EnrollmentCreate } from "@/lib/contracts/enrollment"
-import { useCreateEnrollment } from "@/lib/hooks/useEnrollments"
+import {
+  UserPlus,
+  RefreshCw,
+  GraduationCap,
+  CreditCard,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+} from "lucide-react"
+import {
+  NewEnrollmentSchema,
+  ReEnrollmentSchema,
+  type NewEnrollment,
+  type ReEnrollment,
+  type FeeVariantOption,
+} from "@/lib/contracts/enrollment"
+import type { Student } from "@/lib/contracts/student"
+import type { Class } from "@/lib/contracts/class"
+import { useCreateWithStudent, useReEnroll, useFeeVariants } from "@/lib/hooks/useEnrollments"
+import { useStudents } from "@/lib/hooks/useStudents"
+import { useClasses } from "@/lib/hooks/useClasses"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   Form,
   FormControl,
@@ -15,148 +48,924 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+
+type EnrollmentType = "new" | "re-enrollment"
+
+const STEPS = [
+  { id: "type", label: "Type", icon: GraduationCap },
+  { id: "student", label: "Eleve", icon: UserPlus },
+  { id: "class", label: "Classe", icon: GraduationCap },
+  { id: "summary", label: "Resume", icon: Check },
+] as const
+
+const RELATIONSHIP_TYPES = [
+  { value: "father", label: "Pere" },
+  { value: "mother", label: "Mere" },
+  { value: "guardian", label: "Tuteur" },
+  { value: "other", label: "Autre" },
+] as const
 
 interface EnrollmentFormProps {
   onSuccess: () => void
 }
 
+// Unified type for the discriminated form
+type EnrollmentFormData = NewEnrollment | ReEnrollment
+
 export function EnrollmentForm({ onSuccess }: EnrollmentFormProps) {
-  const form = useForm<EnrollmentCreate>({
-    resolver: zodResolver(EnrollmentCreateSchema),
+  const [step, setStep] = useState(0)
+  const [enrollmentType, setEnrollmentType] = useState<EnrollmentType | null>(null)
+  const [showParentFields, setShowParentFields] = useState(false)
+  const [maxReachedStep, setMaxReachedStep] = useState(0)
+
+  // Mutations
+  const createWithStudent = useCreateWithStudent()
+  const reEnroll = useReEnroll()
+
+  // Data queries
+  const { data: studentsData, isLoading: studentsLoading } = useStudents({ size: 200 })
+  const { data: classesData, isLoading: classesLoading } = useClasses({ size: 200 })
+
+  const students: Student[] = studentsData?.items ?? []
+  const classes: Class[] = classesData?.items ?? []
+
+  // New enrollment form
+  const newForm = useForm<NewEnrollment>({
+    resolver: zodResolver(NewEnrollmentSchema),
+    defaultValues: {
+      type: "new",
+      first_name: "",
+      last_name: "",
+      birth_date: null,
+      genre: null,
+      enrollment_number: null,
+      parent: null,
+      class_id: undefined,
+      fee_variant_id: null,
+      notes: null,
+    },
   })
 
-  const { mutate, isPending, error } = useCreateEnrollment()
+  // Re-enrollment form
+  const reForm = useForm<ReEnrollment>({
+    resolver: zodResolver(ReEnrollmentSchema),
+    defaultValues: {
+      type: "re-enrollment",
+      student_id: undefined,
+      class_id: undefined,
+      fee_variant_id: null,
+      notes: null,
+    },
+  })
 
-  function onSubmit(data: EnrollmentCreate) {
-    mutate(data, {
-      onSuccess: () => {
-        form.reset()
-        onSuccess()
-      },
-    })
+  const watchedClassId = enrollmentType === "new"
+    ? newForm.watch("class_id")
+    : reForm.watch("class_id")
+
+  // Fee variants for selected class
+  const { data: feeVariants, isLoading: feeVariantsLoading } = useFeeVariants(
+    watchedClassId && watchedClassId > 0 ? watchedClassId : undefined
+  )
+
+  // Selected student for re-enrollment
+  const selectedStudentId = enrollmentType === "re-enrollment" ? reForm.watch("student_id") : undefined
+  const selectedStudent = useMemo(
+    () => students.find((s) => s.id === selectedStudentId),
+    [students, selectedStudentId]
+  )
+
+  // Selected class name for summary
+  const selectedClassName = useMemo(
+    () => classes.find((c) => c.id === watchedClassId)?.name ?? "",
+    [classes, watchedClassId]
+  )
+
+  // Selected fee variant for summary
+  const selectedFeeVariantId = enrollmentType === "new"
+    ? newForm.watch("fee_variant_id")
+    : reForm.watch("fee_variant_id")
+  const selectedFeeVariant = useMemo(
+    () => feeVariants?.find((v) => v.id === selectedFeeVariantId),
+    [feeVariants, selectedFeeVariantId]
+  )
+
+  const isPending = createWithStudent.isPending || reEnroll.isPending
+
+  function goToStep(target: number) {
+    setStep(target)
+    if (target > maxReachedStep) {
+      setMaxReachedStep(target)
+    }
+  }
+
+  async function handleNext() {
+    if (step === 0) {
+      if (!enrollmentType) return
+      goToStep(1)
+      return
+    }
+
+    if (step === 1) {
+      if (enrollmentType === "new") {
+        const valid = await newForm.trigger(["first_name", "last_name", "birth_date", "genre", "enrollment_number"])
+        if (!valid) return
+        // Validate parent fields if shown
+        if (showParentFields) {
+          const parentValid = await newForm.trigger(["parent.first_name", "parent.last_name", "parent.phone", "parent.email", "parent.relationship_type"])
+          if (!parentValid) return
+        }
+      } else {
+        const valid = await reForm.trigger(["student_id"])
+        if (!valid) return
+      }
+      goToStep(2)
+      return
+    }
+
+    if (step === 2) {
+      if (enrollmentType === "new") {
+        const valid = await newForm.trigger(["class_id"])
+        if (!valid) return
+      } else {
+        const valid = await reForm.trigger(["class_id"])
+        if (!valid) return
+      }
+      goToStep(3)
+      return
+    }
+  }
+
+  function handlePrevious() {
+    if (step > 0) setStep(step - 1)
+  }
+
+  function handleSubmit() {
+    if (enrollmentType === "new") {
+      newForm.handleSubmit((data) => {
+        // Clean up parent if not filled
+        if (!showParentFields) {
+          data.parent = null
+        }
+        createWithStudent.mutate(data, {
+          onSuccess: () => {
+            newForm.reset()
+            onSuccess()
+          },
+        })
+      })()
+    } else {
+      reForm.handleSubmit((data) => {
+        reEnroll.mutate(data, {
+          onSuccess: () => {
+            reForm.reset()
+            onSuccess()
+          },
+        })
+      })()
+    }
   }
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
-        <FormField
-          control={form.control}
-          name="student_id"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Eleve *</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  placeholder="ID de l'eleve"
-                  className="h-11"
-                  {...field}
-                  onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+    <div className="flex flex-col gap-6">
+      {/* Step indicator */}
+      <Tabs value={STEPS[step].id} className="w-full">
+        <TabsList className="grid w-full grid-cols-4">
+          {STEPS.map((s, i) => (
+            <TabsTrigger
+              key={s.id}
+              value={s.id}
+              disabled={i > maxReachedStep || (i > 0 && !enrollmentType)}
+              onClick={() => {
+                if (i <= maxReachedStep) setStep(i)
+              }}
+              className="text-xs sm:text-sm"
+            >
+              <s.icon className="mr-1.5 h-3.5 w-3.5 hidden sm:inline-block" />
+              {s.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
 
-        <FormField
-          control={form.control}
-          name="class_id"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Classe *</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  placeholder="ID de la classe"
-                  className="h-11"
-                  {...field}
-                  onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+      {/* Step 0: Type selection */}
+      {step === 0 && (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Choisissez le type d&apos;inscription a effectuer.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Card
+              className={cn(
+                "cursor-pointer transition-colors hover:border-primary/50",
+                enrollmentType === "new" && "border-primary ring-2 ring-primary/20"
+              )}
+              onClick={() => setEnrollmentType("new")}
+            >
+              <CardContent className="flex flex-col items-center gap-3 pt-6 pb-4">
+                <div className={cn(
+                  "rounded-full p-3",
+                  enrollmentType === "new" ? "bg-primary text-primary-foreground" : "bg-muted"
+                )}>
+                  <UserPlus className="h-6 w-6" />
+                </div>
+                <div className="text-center">
+                  <p className="font-semibold">Nouvelle inscription</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Inscrire un nouvel eleve
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
 
-        <FormField
-          control={form.control}
-          name="academic_year_id"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Annee academique *</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  placeholder="ID de l'annee academique"
-                  className="h-11"
-                  {...field}
-                  onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="fee_variant_id"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Variante de frais</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  placeholder="ID variante de frais (optionnel)"
-                  className="h-11"
-                  {...field}
-                  onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : null)}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="notes"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Notes</FormLabel>
-              <FormControl>
-                <Textarea
-                  placeholder="Notes optionnelles"
-                  className="resize-none"
-                  {...field}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        {error && (
-          <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
-            <p className="text-sm text-destructive">{error.message}</p>
+            <Card
+              className={cn(
+                "cursor-pointer transition-colors hover:border-primary/50",
+                enrollmentType === "re-enrollment" && "border-primary ring-2 ring-primary/20"
+              )}
+              onClick={() => setEnrollmentType("re-enrollment")}
+            >
+              <CardContent className="flex flex-col items-center gap-3 pt-6 pb-4">
+                <div className={cn(
+                  "rounded-full p-3",
+                  enrollmentType === "re-enrollment" ? "bg-primary text-primary-foreground" : "bg-muted"
+                )}>
+                  <RefreshCw className="h-6 w-6" />
+                </div>
+                <div className="text-center">
+                  <p className="font-semibold">Reinscription</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Reinscrire un eleve existant
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
           </div>
-        )}
+        </div>
+      )}
 
+      {/* Step 1: Student info */}
+      {step === 1 && enrollmentType === "new" && (
+        <Form {...newForm}>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Renseignez les informations de l&apos;eleve.
+            </p>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FormField
+                control={newForm.control}
+                name="first_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Prenom *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Prenom de l'eleve" className="h-10" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={newForm.control}
+                name="last_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nom *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nom de l'eleve" className="h-10" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FormField
+                control={newForm.control}
+                name="birth_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date de naissance</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="date"
+                        className="h-10"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={newForm.control}
+                name="genre"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Genre</FormLabel>
+                    <Select
+                      value={field.value ?? ""}
+                      onValueChange={(v) => field.onChange(v || null)}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="h-10">
+                          <SelectValue placeholder="Selectionner" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="M">Masculin</SelectItem>
+                        <SelectItem value="F">Feminin</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={newForm.control}
+              name="enrollment_number"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Matricule</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Numero de matricule (optionnel)"
+                      className="h-10"
+                      {...field}
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <Separator />
+
+            {/* Parent section */}
+            <button
+              type="button"
+              className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => {
+                setShowParentFields(!showParentFields)
+                if (showParentFields) {
+                  newForm.setValue("parent", null)
+                } else {
+                  newForm.setValue("parent", {
+                    first_name: "",
+                    last_name: "",
+                    phone: null,
+                    email: null,
+                    relationship_type: "guardian",
+                  })
+                }
+              }}
+            >
+              {showParentFields ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              Informations parent (optionnel)
+            </button>
+
+            {showParentFields && (
+              <div className="space-y-4 pl-2 border-l-2 border-muted">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField
+                    control={newForm.control}
+                    name="parent.first_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Prenom du parent *</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Prenom" className="h-10" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={newForm.control}
+                    name="parent.last_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Nom du parent *</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Nom" className="h-10" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField
+                    control={newForm.control}
+                    name="parent.phone"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Telephone</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder="Numero de telephone"
+                            className="h-10"
+                            {...field}
+                            value={field.value ?? ""}
+                            onChange={(e) => field.onChange(e.target.value || null)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={newForm.control}
+                    name="parent.email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="email"
+                            placeholder="Adresse email"
+                            className="h-10"
+                            {...field}
+                            value={field.value ?? ""}
+                            onChange={(e) => field.onChange(e.target.value || null)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <FormField
+                  control={newForm.control}
+                  name="parent.relationship_type"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Lien de parente</FormLabel>
+                      <Select
+                        value={field.value ?? "guardian"}
+                        onValueChange={field.onChange}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="h-10">
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {RELATIONSHIP_TYPES.map((r) => (
+                            <SelectItem key={r.value} value={r.value}>
+                              {r.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+          </div>
+        </Form>
+      )}
+
+      {/* Step 1: Re-enrollment - student selection */}
+      {step === 1 && enrollmentType === "re-enrollment" && (
+        <Form {...reForm}>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Selectionnez l&apos;eleve a reinscrire.
+            </p>
+
+            <FormField
+              control={reForm.control}
+              name="student_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Eleve *</FormLabel>
+                  <Select
+                    value={field.value ? String(field.value) : ""}
+                    onValueChange={(v) => field.onChange(Number(v))}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="h-10">
+                        <SelectValue placeholder={studentsLoading ? "Chargement..." : "Selectionner un eleve"} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {students.map((s) => (
+                        <SelectItem key={s.id} value={String(s.id)}>
+                          {s.first_name} {s.last_name}
+                          {s.enrollment_number ? ` (${s.enrollment_number})` : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {selectedStudent && (
+              <Card>
+                <CardContent className="pt-4 pb-4">
+                  <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                    <dt className="text-muted-foreground">Nom complet</dt>
+                    <dd className="font-medium">{selectedStudent.first_name} {selectedStudent.last_name}</dd>
+                    {selectedStudent.enrollment_number && (
+                      <>
+                        <dt className="text-muted-foreground">Matricule</dt>
+                        <dd>{selectedStudent.enrollment_number}</dd>
+                      </>
+                    )}
+                    {selectedStudent.genre && (
+                      <>
+                        <dt className="text-muted-foreground">Genre</dt>
+                        <dd>{selectedStudent.genre === "M" ? "Masculin" : "Feminin"}</dd>
+                      </>
+                    )}
+                    {selectedStudent.birth_date && (
+                      <>
+                        <dt className="text-muted-foreground">Date de naissance</dt>
+                        <dd>{selectedStudent.birth_date}</dd>
+                      </>
+                    )}
+                  </dl>
+                </CardContent>
+              </Card>
+            )}
+
+            <FormField
+              control={reForm.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Notes</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Notes optionnelles"
+                      className="resize-none"
+                      {...field}
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value || null)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </Form>
+      )}
+
+      {/* Step 2: Class and fees */}
+      {step === 2 && (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Choisissez la classe et la formule de frais.
+          </p>
+
+          {enrollmentType === "new" ? (
+            <ClassAndFeesFields
+              classes={classes}
+              classesLoading={classesLoading}
+              feeVariants={feeVariants ?? []}
+              feeVariantsLoading={feeVariantsLoading}
+              classId={newForm.watch("class_id")}
+              feeVariantId={newForm.watch("fee_variant_id")}
+              notes={newForm.watch("notes")}
+              onClassChange={(id) => newForm.setValue("class_id", id, { shouldValidate: true })}
+              onFeeVariantChange={(id) => newForm.setValue("fee_variant_id", id)}
+              onNotesChange={(val) => newForm.setValue("notes", val)}
+              classError={newForm.formState.errors.class_id?.message}
+            />
+          ) : (
+            <ClassAndFeesFields
+              classes={classes}
+              classesLoading={classesLoading}
+              feeVariants={feeVariants ?? []}
+              feeVariantsLoading={feeVariantsLoading}
+              classId={reForm.watch("class_id")}
+              feeVariantId={reForm.watch("fee_variant_id")}
+              notes={reForm.watch("notes")}
+              onClassChange={(id) => reForm.setValue("class_id", id, { shouldValidate: true })}
+              onFeeVariantChange={(id) => reForm.setValue("fee_variant_id", id)}
+              onNotesChange={(val) => reForm.setValue("notes", val)}
+              classError={reForm.formState.errors.class_id?.message}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Step 3: Summary */}
+      {step === 3 && (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Verifiez les informations avant de valider.
+          </p>
+
+          <Card>
+            <CardContent className="pt-4 pb-4 space-y-4">
+              {/* Student info */}
+              <div>
+                <h4 className="text-sm font-semibold text-primary mb-2 flex items-center gap-2">
+                  <UserPlus className="h-4 w-4" />
+                  Eleve
+                </h4>
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                  {enrollmentType === "new" ? (
+                    <>
+                      <dt className="text-muted-foreground">Nom</dt>
+                      <dd className="font-medium">{newForm.getValues("first_name")} {newForm.getValues("last_name")}</dd>
+                      {newForm.getValues("birth_date") && (
+                        <>
+                          <dt className="text-muted-foreground">Date de naissance</dt>
+                          <dd>{newForm.getValues("birth_date")}</dd>
+                        </>
+                      )}
+                      {newForm.getValues("genre") && (
+                        <>
+                          <dt className="text-muted-foreground">Genre</dt>
+                          <dd>{newForm.getValues("genre") === "M" ? "Masculin" : "Feminin"}</dd>
+                        </>
+                      )}
+                      {newForm.getValues("enrollment_number") && (
+                        <>
+                          <dt className="text-muted-foreground">Matricule</dt>
+                          <dd>{newForm.getValues("enrollment_number")}</dd>
+                        </>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <dt className="text-muted-foreground">Nom</dt>
+                      <dd className="font-medium">
+                        {selectedStudent ? `${selectedStudent.first_name} ${selectedStudent.last_name}` : `#${reForm.getValues("student_id")}`}
+                      </dd>
+                    </>
+                  )}
+                </dl>
+              </div>
+
+              {/* Parent info (new enrollment only) */}
+              {enrollmentType === "new" && showParentFields && newForm.getValues("parent") && (
+                <>
+                  <Separator />
+                  <div>
+                    <h4 className="text-sm font-semibold text-primary mb-2">Parent</h4>
+                    <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                      <dt className="text-muted-foreground">Nom</dt>
+                      <dd>{newForm.getValues("parent.first_name")} {newForm.getValues("parent.last_name")}</dd>
+                      {newForm.getValues("parent.phone") && (
+                        <>
+                          <dt className="text-muted-foreground">Telephone</dt>
+                          <dd>{newForm.getValues("parent.phone")}</dd>
+                        </>
+                      )}
+                      {newForm.getValues("parent.email") && (
+                        <>
+                          <dt className="text-muted-foreground">Email</dt>
+                          <dd>{newForm.getValues("parent.email")}</dd>
+                        </>
+                      )}
+                      <dt className="text-muted-foreground">Lien</dt>
+                      <dd>
+                        {RELATIONSHIP_TYPES.find(
+                          (r) => r.value === newForm.getValues("parent.relationship_type")
+                        )?.label ?? "Tuteur"}
+                      </dd>
+                    </dl>
+                  </div>
+                </>
+              )}
+
+              <Separator />
+
+              {/* Class info */}
+              <div>
+                <h4 className="text-sm font-semibold text-primary mb-2 flex items-center gap-2">
+                  <GraduationCap className="h-4 w-4" />
+                  Classe
+                </h4>
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                  <dt className="text-muted-foreground">Classe</dt>
+                  <dd className="font-medium">{selectedClassName || `#${watchedClassId}`}</dd>
+                </dl>
+              </div>
+
+              {/* Fee info */}
+              {selectedFeeVariant && (
+                <>
+                  <Separator />
+                  <div>
+                    <h4 className="text-sm font-semibold text-primary mb-2 flex items-center gap-2">
+                      <CreditCard className="h-4 w-4" />
+                      Frais
+                    </h4>
+                    <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                      <dt className="text-muted-foreground">Formule</dt>
+                      <dd>{selectedFeeVariant.description ?? "Frais standard"}</dd>
+                      <dt className="text-muted-foreground">Montant</dt>
+                      <dd className="font-semibold text-primary">
+                        {new Intl.NumberFormat("fr-FR", { style: "currency", currency: "XOF" }).format(selectedFeeVariant.amount)}
+                      </dd>
+                    </dl>
+                  </div>
+                </>
+              )}
+
+              {/* Notes */}
+              {enrollmentType === "re-enrollment" && reForm.getValues("notes") && (
+                <>
+                  <Separator />
+                  <div>
+                    <h4 className="text-sm font-semibold text-muted-foreground mb-1">Notes</h4>
+                    <p className="text-sm">{reForm.getValues("notes")}</p>
+                  </div>
+                </>
+              )}
+              {enrollmentType === "new" && newForm.getValues("notes") && (
+                <>
+                  <Separator />
+                  <div>
+                    <h4 className="text-sm font-semibold text-muted-foreground mb-1">Notes</h4>
+                    <p className="text-sm">{newForm.getValues("notes")}</p>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Server errors */}
+          {(createWithStudent.error || reEnroll.error) && (
+            <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
+              <p className="text-sm text-destructive">
+                {createWithStudent.error?.message || reEnroll.error?.message}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between pt-2">
         <Button
-          type="submit"
-          size="lg"
-          className="w-full h-11 font-semibold"
-          disabled={isPending}
+          type="button"
+          variant="outline"
+          onClick={handlePrevious}
+          disabled={step === 0 || isPending}
         >
-          {isPending ? "Enregistrement..." : "Enregistrer l'inscription"}
+          <ChevronLeft className="mr-1.5 h-4 w-4" />
+          Precedent
         </Button>
-      </form>
-    </Form>
+
+        {step < 3 ? (
+          <Button
+            type="button"
+            onClick={handleNext}
+            disabled={step === 0 && !enrollmentType}
+          >
+            Suivant
+            <ChevronRight className="ml-1.5 h-4 w-4" />
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isPending}
+          >
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {isPending ? "Enregistrement..." : "Enregistrer l'inscription"}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Shared fields for class selection, fee variant, and notes
+// Used by both new enrollment and re-enrollment forms in step 2
+interface ClassFeesFieldsProps {
+  classes: Class[]
+  classesLoading: boolean
+  feeVariants: FeeVariantOption[]
+  feeVariantsLoading: boolean
+  classId: number | undefined
+  feeVariantId: number | null | undefined
+  notes: string | null | undefined
+  onClassChange: (id: number) => void
+  onFeeVariantChange: (id: number | null) => void
+  onNotesChange: (val: string | null) => void
+  classError?: string
+}
+
+function ClassAndFeesFields({
+  classes,
+  classesLoading,
+  feeVariants,
+  feeVariantsLoading,
+  classId,
+  feeVariantId,
+  notes,
+  onClassChange,
+  onFeeVariantChange,
+  onNotesChange,
+  classError,
+}: ClassFeesFieldsProps) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label className="text-sm font-medium leading-none">Classe *</label>
+        <Select
+          value={classId ? String(classId) : ""}
+          onValueChange={(v) => {
+            onClassChange(Number(v))
+            onFeeVariantChange(null)
+          }}
+        >
+          <SelectTrigger className="h-10">
+            <SelectValue placeholder={classesLoading ? "Chargement..." : "Selectionner une classe"} />
+          </SelectTrigger>
+          <SelectContent>
+            {classes.map((c) => (
+              <SelectItem key={c.id} value={String(c.id)}>
+                {c.name}
+                {c.max_students != null ? ` (max: ${c.max_students})` : ""}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {classError && <p className="text-sm font-medium text-destructive">{classError}</p>}
+      </div>
+
+      {/* Fee variants loading */}
+      {feeVariantsLoading && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Chargement des frais...
+        </div>
+      )}
+
+      {/* Fee variant cards */}
+      {feeVariants.length > 0 && (
+        <div className="space-y-2">
+          <label className="text-sm font-medium leading-none">Formule de frais</label>
+          <div className="grid grid-cols-1 gap-2">
+            {feeVariants.map((variant) => (
+              <Card
+                key={variant.id}
+                className={cn(
+                  "cursor-pointer transition-colors hover:border-primary/50",
+                  feeVariantId === variant.id && "border-primary ring-2 ring-primary/20"
+                )}
+                onClick={() => onFeeVariantChange(variant.id)}
+              >
+                <CardContent className="flex items-center justify-between py-3 px-4">
+                  <div className="flex items-center gap-3">
+                    <div className={cn(
+                      "h-4 w-4 rounded-full border-2 flex items-center justify-center",
+                      feeVariantId === variant.id
+                        ? "border-primary"
+                        : "border-muted-foreground/30"
+                    )}>
+                      {feeVariantId === variant.id && (
+                        <div className="h-2 w-2 rounded-full bg-primary" />
+                      )}
+                    </div>
+                    <span className="text-sm">
+                      {variant.description ?? "Frais standard"}
+                    </span>
+                  </div>
+                  <Badge variant="secondary" className="font-mono">
+                    {new Intl.NumberFormat("fr-FR", { style: "currency", currency: "XOF" }).format(variant.amount)}
+                  </Badge>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Notes */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium leading-none">Notes</label>
+        <Textarea
+          placeholder="Notes optionnelles"
+          className="resize-none"
+          value={notes ?? ""}
+          onChange={(e) => onNotesChange(e.target.value || null)}
+        />
+      </div>
+    </div>
   )
 }

--- a/components/shared/AcademicYearBadge.tsx
+++ b/components/shared/AcademicYearBadge.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { GraduationCap, AlertTriangle } from "lucide-react"
+import { useAcademicYearStore } from "@/lib/stores/useAcademicYearStore"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function AcademicYearBadge() {
+  const { currentYear, isLoading } = useAcademicYearStore()
+
+  if (isLoading) return <Skeleton className="h-7 w-32" />
+
+  if (!currentYear) {
+    return (
+      <div className="flex items-center gap-1.5 rounded-full bg-destructive/10 px-3 py-1 text-xs font-medium text-destructive">
+        <AlertTriangle className="h-3.5 w-3.5" />
+        Aucune annee definie
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+      <GraduationCap className="h-3.5 w-3.5" />
+      {currentYear.name}
+    </div>
+  )
+}

--- a/components/shared/AcademicYearProvider.tsx
+++ b/components/shared/AcademicYearProvider.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { useEffect } from "react"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { useAcademicYearStore } from "@/lib/stores/useAcademicYearStore"
+
+export function AcademicYearProvider({ children }: { children: React.ReactNode }) {
+  const { data, isLoading } = useAcademicYears()
+  const { setCurrentYear, setLoading } = useAcademicYearStore()
+
+  useEffect(() => {
+    if (!isLoading && data) {
+      const current = data.items?.find((y) => y.is_current) ?? null
+      setCurrentYear(current)
+    }
+    setLoading(isLoading)
+  }, [data, isLoading, setCurrentYear, setLoading])
+
+  return <>{children}</>
+}

--- a/components/shared/AdminShell.tsx
+++ b/components/shared/AdminShell.tsx
@@ -4,23 +4,28 @@ import { useState } from "react"
 import { Toaster } from "sonner"
 import { Sidebar } from "@/components/shared/Sidebar"
 import { Navbar } from "@/components/shared/Navbar"
+import { AcademicYearProvider } from "@/components/shared/AcademicYearProvider"
+import { NoCurrentYearBanner } from "@/components/shared/NoCurrentYearBanner"
 
 export function AdminShell({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   return (
-    <div className="flex h-screen overflow-hidden bg-background">
-      <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+    <AcademicYearProvider>
+      <div className="flex h-screen overflow-hidden bg-background">
+        <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <Navbar onMenuClick={() => setSidebarOpen(true)} />
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <Navbar onMenuClick={() => setSidebarOpen(true)} />
 
-        <main className="flex-1 overflow-y-auto bg-muted/30 p-4 lg:p-6">
-          {children}
-        </main>
+          <main className="flex-1 overflow-y-auto bg-muted/30 p-4 lg:p-6">
+            <NoCurrentYearBanner />
+            {children}
+          </main>
+        </div>
+
+        <Toaster richColors />
       </div>
-
-      <Toaster richColors />
-    </div>
+    </AcademicYearProvider>
   )
 }

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { NotificationBell } from "@/components/shared/NotificationBell"
+import { AcademicYearBadge } from "@/components/shared/AcademicYearBadge"
 
 interface NavbarProps {
   onMenuClick: () => void
@@ -45,6 +46,8 @@ export function Navbar({ onMenuClick }: NavbarProps) {
 
       {/* Right side actions */}
       <div className="flex items-center gap-2">
+        <AcademicYearBadge />
+
         {/* Theme toggle */}
         <Button
           variant="ghost"

--- a/components/shared/NoCurrentYearBanner.tsx
+++ b/components/shared/NoCurrentYearBanner.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import Link from "next/link"
+import type { Route } from "next"
+import { useAcademicYearStore } from "@/lib/stores/useAcademicYearStore"
+import { Button } from "@/components/ui/button"
+
+export function NoCurrentYearBanner() {
+  const { currentYear, isLoading } = useAcademicYearStore()
+
+  if (isLoading || currentYear) return null
+
+  return (
+    <div className="mb-4 flex items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+      <AlertTriangle className="h-5 w-5 shrink-0 text-destructive" />
+      <div className="flex-1">
+        <p className="text-sm font-medium text-destructive">Aucune annee academique courante</p>
+        <p className="text-sm text-muted-foreground">
+          Veuillez definir l&apos;annee academique courante pour utiliser l&apos;application.
+        </p>
+      </div>
+      <Button variant="outline" size="sm" asChild>
+        <Link href={"/admin/academic-years" as Route}>Configurer</Link>
+      </Button>
+    </div>
+  )
+}

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Wallet,
   CreditCard,
   CalendarDays,
+  CalendarRange,
   ClipboardList,
   UserCheck,
   FileText,
@@ -57,6 +58,7 @@ const navigation: NavSection[] = [
   {
     title: "Academique",
     items: [
+      { label: "Annees scolaires", href: "/admin/academic-years" as Route, icon: CalendarRange },
       { label: "Classes", href: "/admin/classes", icon: School },
       { label: "Matieres", href: "/admin/subjects", icon: BookOpen },
     ],

--- a/lib/api/academic-years.ts
+++ b/lib/api/academic-years.ts
@@ -1,20 +1,17 @@
-import { z } from "zod"
-import { apiFetch, safeValidate } from "./client"
-
-export const AcademicYearSchema = z.object({
-  id: z.number(),
-  label: z.string(),
-})
-
-export type AcademicYear = z.infer<typeof AcademicYearSchema>
-
-const ArraySchema = z.array(AcademicYearSchema)
+import { AcademicYearSchema } from "@/lib/contracts/academic-year"
+import type { AcademicYear, AcademicYearCreate, AcademicYearUpdate } from "@/lib/contracts/academic-year"
+import { createCrudApi } from "./createCrudApi"
+import { apiFetch } from "./client"
 
 export const academicYearsApi = {
-  list: async (): Promise<AcademicYear[]> => {
-    const data = await apiFetch<unknown>("/academic-years")
-    // L'API peut retourner un tableau ou un objet paginé
-    const raw = Array.isArray(data) ? data : (data as { data: unknown[] }).data ?? data
-    return safeValidate(ArraySchema, raw, "/academic-years")
+  ...createCrudApi<AcademicYear, AcademicYearCreate, AcademicYearUpdate>(
+    "/admin/academic-years",
+    AcademicYearSchema,
+  ),
+
+  setAsCurrent: async (yearId: number): Promise<AcademicYear> => {
+    return apiFetch<AcademicYear>(`/admin/academic-years/${yearId}/set-current`, {
+      method: "PATCH",
+    })
   },
 }

--- a/lib/api/enrollments.ts
+++ b/lib/api/enrollments.ts
@@ -1,8 +1,31 @@
 import { EnrollmentSchema } from "@/lib/contracts/enrollment"
-import type { Enrollment, EnrollmentCreate, EnrollmentUpdate } from "@/lib/contracts/enrollment"
+import type { Enrollment, EnrollmentCreate, EnrollmentUpdate, NewEnrollment, ReEnrollment, FeeVariantOption } from "@/lib/contracts/enrollment"
 import { createCrudApi } from "./createCrudApi"
+import { apiFetch } from "./client"
 
-export const enrollmentsApi = createCrudApi<Enrollment, EnrollmentCreate, EnrollmentUpdate>(
-  "/enrollments",
-  EnrollmentSchema,
-)
+export const enrollmentsApi = {
+  ...createCrudApi<Enrollment, EnrollmentCreate, EnrollmentUpdate>(
+    "/enrollments",
+    EnrollmentSchema,
+  ),
+
+  createWithStudent: async (data: NewEnrollment) => {
+    const { type, ...payload } = data
+    return apiFetch<Enrollment>("/enrollments/with-student", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    })
+  },
+
+  reEnroll: async (data: ReEnrollment) => {
+    const { type, ...payload } = data
+    return apiFetch<Enrollment>("/enrollments/re-enroll", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    })
+  },
+
+  getFeeVariants: async (classId: number) => {
+    return apiFetch<FeeVariantOption[]>(`/enrollments/fee-variants?class_id=${classId}`)
+  },
+}

--- a/lib/contracts/academic-year.ts
+++ b/lib/contracts/academic-year.ts
@@ -1,0 +1,25 @@
+import { z } from "zod"
+
+export const AcademicYearSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  label: z.string().optional(),
+  start_date: z.string(),
+  end_date: z.string(),
+  is_current: z.boolean(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+}).passthrough()
+
+export const AcademicYearCreateSchema = z.object({
+  name: z.string({ required_error: "Le nom est requis" }).min(1, "Le nom est requis"),
+  start_date: z.string({ required_error: "La date de début est requise" }).min(1, "La date de début est requise"),
+  end_date: z.string({ required_error: "La date de fin est requise" }).min(1, "La date de fin est requise"),
+  is_current: z.boolean().default(false),
+})
+
+export const AcademicYearUpdateSchema = AcademicYearCreateSchema.partial()
+
+export type AcademicYear = z.infer<typeof AcademicYearSchema>
+export type AcademicYearCreate = z.infer<typeof AcademicYearCreateSchema>
+export type AcademicYearUpdate = z.infer<typeof AcademicYearUpdateSchema>

--- a/lib/contracts/enrollment.ts
+++ b/lib/contracts/enrollment.ts
@@ -44,3 +44,49 @@ export type Enrollment = z.infer<typeof EnrollmentSchema>
 export type EnrollmentCreate = z.infer<typeof EnrollmentCreateSchema>
 export type EnrollmentUpdate = z.infer<typeof EnrollmentUpdateSchema>
 export type EnrollmentListParams = z.infer<typeof EnrollmentListParamsSchema>
+
+// --- Multi-step enrollment form schemas ---
+
+export const ParentInputSchema = z.object({
+  first_name: z.string().min(1, "Le prenom est requis"),
+  last_name: z.string().min(1, "Le nom est requis"),
+  phone: z.string().nullable().optional(),
+  email: z.string().email("Email invalide").nullable().optional(),
+  relationship_type: z.enum(["father", "mother", "guardian", "other"]).default("guardian"),
+})
+
+export const NewEnrollmentSchema = z.object({
+  type: z.literal("new"),
+  // Student info
+  first_name: z.string().min(1, "Le prenom est requis"),
+  last_name: z.string().min(1, "Le nom est requis"),
+  birth_date: z.string().nullable().optional(),
+  genre: z.enum(["M", "F"]).nullable().optional(),
+  enrollment_number: z.string().nullable().optional(),
+  // Parent info (optional)
+  parent: ParentInputSchema.nullable().optional(),
+  // Class
+  class_id: z.number({ required_error: "La classe est requise" }).positive(),
+  fee_variant_id: z.number().positive().nullable().optional(),
+  notes: z.string().nullable().optional(),
+})
+
+export const ReEnrollmentSchema = z.object({
+  type: z.literal("re-enrollment"),
+  student_id: z.number({ required_error: "L'eleve est requis" }).positive(),
+  class_id: z.number({ required_error: "La classe est requise" }).positive(),
+  fee_variant_id: z.number().positive().nullable().optional(),
+  notes: z.string().nullable().optional(),
+})
+
+export const FeeVariantOptionSchema = z.object({
+  id: z.number(),
+  fee_category_id: z.number(),
+  amount: z.coerce.number(),
+  description: z.string().nullable(),
+})
+
+export type ParentInput = z.infer<typeof ParentInputSchema>
+export type NewEnrollment = z.infer<typeof NewEnrollmentSchema>
+export type ReEnrollment = z.infer<typeof ReEnrollmentSchema>
+export type FeeVariantOption = z.infer<typeof FeeVariantOptionSchema>

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,3 +1,4 @@
+export * from "./academic-year"
 export * from "./auth"
 export * from "./attendance"
 export * from "./enrollment"

--- a/lib/hooks/useAcademicYears.ts
+++ b/lib/hooks/useAcademicYears.ts
@@ -1,12 +1,48 @@
 "use client"
 
-import { useQuery } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
 import { academicYearsApi } from "@/lib/api/academic-years"
+import type { AcademicYear, AcademicYearCreate, AcademicYearUpdate } from "@/lib/contracts/academic-year"
+import { createCrudHooks } from "./createCrudHooks"
+import { useAcademicYearStore } from "@/lib/stores/useAcademicYearStore"
 
-export function useAcademicYears() {
-  return useQuery({
-    queryKey: ["academic-years"],
-    queryFn: () => academicYearsApi.list(),
-    staleTime: 1000 * 60 * 30, // 30 min — données rarement modifiées
+const {
+  keys: academicYearKeys,
+  useList,
+  useDetail,
+  useCreate,
+  useUpdate,
+  useDelete,
+} = createCrudHooks<AcademicYear, AcademicYearCreate, AcademicYearUpdate>(
+  "academic-years",
+  academicYearsApi,
+  {
+    created: "Annee academique creee avec succes",
+    updated: "Annee academique mise a jour",
+    deleted: "Annee academique supprimee",
+  },
+)
+
+export { academicYearKeys }
+export const useAcademicYears = useList
+export const useAcademicYear = useDetail
+export const useCreateAcademicYear = useCreate
+export const useUpdateAcademicYear = useUpdate
+export const useDeleteAcademicYear = useDelete
+
+export function useSetCurrentYear() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (yearId: number) => academicYearsApi.setAsCurrent(yearId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: academicYearKeys.all })
+      useAcademicYearStore.getState().setCurrentYear(data)
+      toast.success("Annee academique courante mise a jour")
+    },
+    onError: (err) => {
+      toast.error("Erreur", { description: err.message })
+    },
   })
 }

--- a/lib/hooks/useEnrollments.ts
+++ b/lib/hooks/useEnrollments.ts
@@ -1,7 +1,9 @@
 "use client"
 
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
 import { enrollmentsApi } from "@/lib/api/enrollments"
-import type { Enrollment, EnrollmentCreate, EnrollmentUpdate } from "@/lib/contracts/enrollment"
+import type { Enrollment, EnrollmentCreate, EnrollmentUpdate, NewEnrollment, ReEnrollment } from "@/lib/contracts/enrollment"
 import { createCrudHooks } from "./createCrudHooks"
 
 const {
@@ -12,9 +14,9 @@ const {
   useUpdate,
   useDelete,
 } = createCrudHooks<Enrollment, EnrollmentCreate, EnrollmentUpdate>("enrollments", enrollmentsApi, {
-  created: "Inscription créée avec succès",
-  updated: "Inscription mise à jour",
-  deleted: "Inscription supprimée",
+  created: "Inscription creee avec succes",
+  updated: "Inscription mise a jour",
+  deleted: "Inscription supprimee",
 })
 
 export { enrollmentKeys }
@@ -23,3 +25,40 @@ export const useEnrollment = useDetail
 export const useCreateEnrollment = useCreate
 export const useUpdateEnrollment = useUpdate
 export const useDeleteEnrollment = useDelete
+
+export function useCreateWithStudent() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: NewEnrollment) => enrollmentsApi.createWithStudent(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["enrollments"] })
+      queryClient.invalidateQueries({ queryKey: ["students"] })
+      toast.success("Inscription enregistree")
+    },
+    onError: (error: Error) => {
+      toast.error("Erreur", { description: error.message })
+    },
+  })
+}
+
+export function useReEnroll() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: ReEnrollment) => enrollmentsApi.reEnroll(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["enrollments"] })
+      toast.success("Reinscription enregistree")
+    },
+    onError: (error: Error) => {
+      toast.error("Erreur", { description: error.message })
+    },
+  })
+}
+
+export function useFeeVariants(classId: number | undefined) {
+  return useQuery({
+    queryKey: ["enrollments", "fee-variants", classId],
+    queryFn: () => enrollmentsApi.getFeeVariants(classId!),
+    enabled: !!classId,
+  })
+}

--- a/lib/stores/useAcademicYearStore.ts
+++ b/lib/stores/useAcademicYearStore.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand"
+import type { AcademicYear } from "@/lib/contracts/academic-year"
+
+interface AcademicYearState {
+  currentYear: AcademicYear | null
+  isLoading: boolean
+  setCurrentYear: (year: AcademicYear | null) => void
+  setLoading: (loading: boolean) => void
+}
+
+export const useAcademicYearStore = create<AcademicYearState>((set) => ({
+  currentYear: null,
+  isLoading: true,
+  setCurrentYear: (year) => set({ currentYear: year, isLoading: false }),
+  setLoading: (loading) => set({ isLoading: loading }),
+}))


### PR DESCRIPTION
## Summary

Major enrollment system redesign.

### Global academic year
- Zustand store (`useAcademicYearStore`) holds the current year app-wide
- `AcademicYearProvider` fetches on boot, populates store
- `AcademicYearBadge` in header shows current year (or warning if none set)
- `NoCurrentYearBanner` blocks operations when no year is configured
- New admin page `/admin/academic-years` with CRUD + "Definir comme courante" button

### Multi-step enrollment form (4 steps)
- Step 1: Type (nouvelle inscription / reinscription)
- Step 2: Student info (new) or select existing (re-enrollment)
- Step 3: Class selection with fee variants preview
- Step 4: Summary + confirm
- Calls `POST /enrollments/with-student` or `POST /enrollments/re-enroll`

### Files changed
- 28 files, ~1600 lines added
- 8 new components created
- Sidebar updated with academic years link

## Test plan
- [ ] Academic years page loads and CRUD works
- [ ] "Definir comme courante" sets the year globally
- [ ] Badge shows in header across all pages
- [ ] Banner shows when no year is set
- [ ] Multi-step form completes new enrollment
- [ ] Re-enrollment flow selects existing student