### PR TITLE
fix(dashboard): quick action opens enrollment create modal directly

### DIFF
--- a/components/admin/dashboard/QuickActions.tsx
+++ b/components/admin/dashboard/QuickActions.tsx
@@ -16,7 +16,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 const actions: { label: string; href: Route; icon: LucideIcon; color: string }[] = [
   {
     label: "Nouvelle inscription",
-    href: "/admin/enrollments",
+    href: "/admin/enrollments?action=create" as Route,
     icon: UserPlus,
     color: "text-primary bg-primary/10",
   },

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -1,13 +1,21 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
+import { useSearchParams } from "next/navigation"
 import { Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { EnrollmentsTable } from "./EnrollmentsTable"
 import { EnrollmentCreateModal } from "./EnrollmentCreateModal"
 
 export function EnrollmentsPageClient() {
+  const searchParams = useSearchParams()
   const [createOpen, setCreateOpen] = useState(false)
+
+  useEffect(() => {
+    if (searchParams.get("action") === "create") {
+      setCreateOpen(true)
+    }
+  }, [searchParams])
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
Adds ?action=create query param to the enrollment quick action link. EnrollmentsPageClient reads the param and auto-opens the create modal.