### PR TITLE
ci+docs: bootstrap real BE in E2E + CHANGELOG + rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -106,3 +106,4 @@ npm run test:e2e
 @rules/ux-target-user-reality.md
 @rules/deploy.md
 @rules/git.md
+@rules/changelog.md

--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -1,0 +1,132 @@
+# Règle Changelog — KLASSCI College Frontend
+
+Le fichier `CHANGELOG.md` à la racine documente les évolutions du portail
+**du point de vue de l'utilisateur final** (admin, enseignant, parent,
+élève). Il suit
+[Keep a Changelog 1.1.0](https://keepachangelog.com/fr/1.1.0/) et
+[Semantic Versioning](https://semver.org/lang/fr/).
+
+## Quand alimenter
+
+| Type de commit                                         | Action sur le changelog |
+|--------------------------------------------------------|--------------------------|
+| `feat:` qui ajoute ou modifie une page, un écran, un parcours utilisateur | **Oui** → `Added` ou `Changed` |
+| `fix:` d'un bug visible (UI cassée, action qui n'aboutit pas) | **Oui** → `Fixed`        |
+| `style:` purement esthétique mais qui change ce qui est visible (refonte hero, tableau premium) | **Oui** → `Changed` |
+| `perf:` ressenti à l'usage (page plus rapide, skeleton fluide) | **Oui** → `Changed`     |
+| `refactor:` qui ne change rien à ce que voit l'user    | **Non**                  |
+| `chore:` / `docs:` / `test:` / `ci:`                   | **Non**                  |
+| Faille corrigée, dépendance bumpée pour CVE            | **Oui** → `Security`     |
+
+> **Règle d'or** : si la ligne ne dit pas *« ce que Mme Diallo (52 ans,
+> Itel S661, papier) peut faire de plus, mieux, ou différemment »*, elle
+> ne devrait pas être là.
+
+## Comment écrire une entrée
+
+1. **Perspective utilisateur, pas développeur.**
+   - ❌ « Refactored `GradeEntryGrid` to use `useDebounce` and Zustand store »
+   - ✅ « Saisie des notes plus fluide : la sauvegarde se déclenche après
+     une courte pause au lieu d'à chaque frappe *(enseignant)* »
+
+2. **Français propre, accents corrects.** Voir
+   `marcel-global-preferences.md` (no em dashes en français).
+
+3. **Persona en italique** à la fin de la ligne :
+   `*(admin)*`, `*(enseignant)*`, `*(parent)*`, `*(élève)*`,
+   `*(tous)*` (= tous les portails). **Pas de persona** si vraiment
+   transverse infra (ex : monitoring).
+
+4. **Lien PR** quand identifiable : `(#108)` à la fin.
+
+5. **Une ligne, ≤ 25 mots.** Si ça déborde, c'est probablement deux
+   entrées différentes.
+
+6. **Pas de jargon technique** : aucune mention de composants React
+   (DicteeMode, GradesSupervisor...), de hooks (`useTanstack`,
+   `usePermissions`...), de libs (shadcn/ui, RHF, TanStack Query...),
+   de fichiers (`app/(admin)/...`). On décrit *ce que ça fait*, pas
+   *avec quoi c'est fait*.
+
+7. **Mobile-first dans l'esprit** : si une feature est cruciale pour
+   l'usage terrain (3G + écran TFT entry-level + plein soleil), le
+   préciser. Ex : « Mode dictée plein écran lisible en plein soleil
+   *(enseignant)* ».
+
+## Où l'ajouter
+
+Toujours sous `## [Unreleased]` au sommet du fichier, dans la section
+appropriée. Si la section n'existe pas encore dans `Unreleased`, la
+créer dans cet ordre canonique (sauter celles vides) :
+
+```
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+```
+
+## Quand bumper la version
+
+| De            | À             | Critère                                                     |
+|---------------|---------------|-------------------------------------------------------------|
+| `0.1.0-alpha` | `0.1.0`       | Première école pilote tournée 30 jours sans incident P0     |
+| `0.1.x`       | `0.2.0`       | Nouvelle capacité majeure (ex : portail élève complet)      |
+| `0.x.y`       | `1.0.0`       | 5 écoles en production payante, SLA tenu 60 jours           |
+| `X.Y.Z`       | `X.Y.(Z+1)`   | Patch — fix bugs, sans nouvelle capacité                    |
+| `X.Y.Z`       | `X.(Y+1).0`   | Minor — nouvelle capacité, rétrocompatible                  |
+| `X.Y.Z`       | `(X+1).0.0`   | Major — breaking change pour les utilisateurs (ex : refonte d'un portail) |
+
+À chaque release :
+
+1. Renommer `## [Unreleased]` en `## [X.Y.Z] - YYYY-MM-DD` (date du tag).
+2. Recréer un bloc `## [Unreleased]` vide au sommet.
+3. Mettre à jour les liens compare en bas du fichier :
+   ```
+   [unreleased]: https://github.com/African-DC/klassci-college-frontend/compare/vX.Y.Z...HEAD
+   [X.Y.Z]: https://github.com/African-DC/klassci-college-frontend/compare/vX.Y.W...vX.Y.Z
+   ```
+4. Tagger : `git tag vX.Y.Z` puis `git push --tags`.
+
+## Anti-patterns à bloquer en revue
+
+1. Entrée qui décrit l'implémentation : `Added DicteeMode component`
+2. Entrée qui mentionne un fichier ou un dossier App Router : `app/(teacher)/...`
+3. Entrée qui ne dit pas *quoi*, juste *pourquoi internal* : `Cleaner state machine`
+4. Section `## [Unreleased]` absente ou vide bloquée à plusieurs commits feat
+5. Date au format autre qu'ISO 8601 (`YYYY-MM-DD`)
+6. Sections vides laissées dans le fichier (les supprimer)
+7. Mélange français / anglais dans les entrées
+8. Lister 30 commits CRUD au lieu de méga-grouper en une feature
+
+## Exemples corrects
+
+```markdown
+### Added
+- Mode dictée vocal plein écran pour saisir les notes sans regarder
+  l'écran, optimisé plein soleil *(enseignant)* (#108)
+- Création d'évaluation déléguée : un admin peut créer une évaluation
+  au nom d'un enseignant, l'audit trace qui a saisi *(admin)* (#108)
+
+### Changed
+- Sauvegarde des notes après une courte pause au lieu d'à chaque
+  frappe : moins de scintillement, plus de fluidité *(enseignant)*
+
+### Fixed
+- Liste des enseignants apparaissait vide dans le formulaire de création
+  d'évaluation côté admin *(admin)* (#109)
+
+### Security
+- Vérification stricte de l'hôte sur chaque requête : seuls les domaines
+  autorisés peuvent atteindre le portail (#106, #107)
+```
+
+## Voir aussi
+
+- `klassci-college-backend/.claude/rules/changelog.md` — règle équivalente
+  côté BE (entrées séparées dans le CHANGELOG.md du backend)
+- `klassci-frontend/CHANGELOG.md` — fichier alimenté
+- Rule `rules/git.md` — formats de commit qui alimentent les sections
+- Rule `rules/ux-target-user-reality.md` — persona Mme Diallo

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,7 +120,9 @@ jobs:
           echo $! > be.pid
 
       - name: Wait for BE healthy
-        run: npx wait-on http://127.0.0.1:8000/health -t 60000
+        # `wait-on http://...` defaults to HEAD probes; FastAPI's @app.get("/health")
+        # responds 405 to HEAD. Force GET via the http-get:// scheme.
+        run: npx wait-on http-get://127.0.0.1:8000/health -t 60000
 
       # ─── FE: build + start + Playwright ────────────────────────────────
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,11 @@
 name: E2E Tests
 
+# Bootstraps a real BE (FastAPI + MySQL + Redis) alongside the FE so that
+# Playwright can drive the full login → portal flow. The previous version
+# only started Next.js on :3000 — NextAuth's authorize() call to
+# `${NEXT_PUBLIC_API_URL}/auth/login` then hit a closed port and every
+# test that needed an authenticated session timed out at the URL assertion.
+
 on:
   pull_request:
     branches: [develop, staging, main]
@@ -7,30 +13,119 @@ on:
 
 jobs:
   e2e:
-    timeout-minutes: 20
+    timeout-minutes: 25
     runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: klassci_test
+        ports: ['3306:3306']
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     env:
+      # Browser-side base URL — Playwright drives http://localhost:3000.
+      E2E_BASE_URL: http://localhost:3000
+      E2E_NO_SERVER: 'true'
+      # FE → BE wiring. The Next.js webServer reads these at build time.
       NEXT_PUBLIC_API_URL: http://127.0.0.1:8000
       NEXTAUTH_URL: http://localhost:3000
       NEXTAUTH_SECRET: test-secret-only-for-ci
       AUTH_TRUST_HOST: 'true'
-      E2E_NO_SERVER: 'true'
+      # BE process env. `{tenant}` is interpolated by app.core.config.
+      DATABASE_URL: mysql+aiomysql://root:root@127.0.0.1:3306/{tenant}
+      REDIS_URL: redis://127.0.0.1:6379
+      SECRET_KEY: test-secret-key-for-ci-only-must-be-32-chars-or-more
+      APP_ENV: test
+      TENANT_ID: klassci_test
 
     steps:
-      - uses: actions/checkout@v6
+      # ─── Checkout FE + sibling BE ──────────────────────────────────────
+      - name: Checkout FE
+        uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - name: Checkout BE (sibling clone)
+        uses: actions/checkout@v6
         with:
-          version: 10
+          repository: African-DC/klassci-college-backend
+          ref: main
+          path: ../klassci-college-backend
+
+      # ─── Toolchains ────────────────────────────────────────────────────
+      - uses: pnpm/action-setup@v4
+        with: { version: 10 }
 
       - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: pnpm
+        with: { node-version: 22, cache: pnpm }
 
+      - uses: actions/setup-python@v6
+        with: { python-version: '3.12', cache: pip }
+
+      # ─── BE: install + migrate + seed + start ──────────────────────────
+      - name: Install BE dependencies
+        working-directory: ../klassci-college-backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Wait for MySQL service
+        run: |
+          for i in {1..20}; do
+            mysql -h 127.0.0.1 -uroot -proot -e "SELECT 1" && break
+            echo "MySQL not ready yet — retry $i"
+            sleep 2
+          done
+
+      - name: Run alembic migrations on klassci_test
+        working-directory: ../klassci-college-backend
+        run: alembic upgrade head
+
+      - name: Seed permissions and roles for the test tenant
+        working-directory: ../klassci-college-backend
+        run: |
+          python -c "
+          import asyncio
+          from app.services.tenant_service import seed_tenant_data
+          asyncio.run(seed_tenant_data(
+              'klassci_test',
+              school_name='KLASSCI E2E',
+              admin_email='admin@klassci.com',
+              admin_password='Admin@2026',
+          ))
+          " || echo "Tenant data may already be seeded — proceeding"
+
+      - name: Seed deterministic test users
+        working-directory: ../klassci-college-backend
+        run: python scripts/seed_test_users.py
+
+      - name: Start BE (FastAPI)
+        working-directory: ../klassci-college-backend
+        run: |
+          nohup uvicorn app.main:app --host 0.0.0.0 --port 8000 \
+            > be.log 2>&1 &
+          echo $! > be.pid
+
+      - name: Wait for BE healthy
+        run: npx wait-on http://127.0.0.1:8000/health -t 60000
+
+      # ─── FE: build + start + Playwright ────────────────────────────────
       - run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright Browsers
+      - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Build Next.js
@@ -38,17 +133,28 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=4096
 
-      - name: Start app
+      - name: Start FE
         run: |
-          pnpm start &
-          npx wait-on http://localhost:3000 -t 60000
+          nohup pnpm start > fe.log 2>&1 &
+          echo $! > fe.pid
         env:
           PORT: 3000
 
+      - name: Wait for FE
+        run: npx wait-on http://localhost:3000 -t 60000
+
       - name: Run Playwright tests
         run: pnpm test:e2e
-        env:
-          E2E_BASE_URL: http://localhost:3000
+
+      # ─── Diagnostics on failure ────────────────────────────────────────
+      - name: Tail BE log
+        if: failure()
+        working-directory: ../klassci-college-backend
+        run: tail -200 be.log || true
+
+      - name: Tail FE log
+        if: failure()
+        run: tail -200 fe.log || true
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -155,6 +155,20 @@ jobs:
             || (echo "FATAL — /login HTML missing 'Adresse email' label" && \
                 curl -fsS http://localhost:3000/login | head -200 && exit 1)
 
+      - name: Verify BE accepts test admin credentials
+        # Validates the seed_test_users.py + BE /auth/login contract before
+        # Playwright. If the BE rejects the credentials, no Playwright
+        # debugging will help — fail fast with the exact response body.
+        run: |
+          STATUS=$(curl -sS -o /tmp/login.json -w '%{http_code}' \
+            -X POST http://127.0.0.1:8000/auth/login \
+            -H 'Content-Type: application/json' \
+            -d '{"email":"admin@klassci.com","password":"Admin@2026"}')
+          echo "BE /auth/login admin → HTTP $STATUS"
+          head -c 300 /tmp/login.json
+          echo ""
+          [ "$STATUS" = "200" ] || exit 1
+
       - name: Run Playwright tests
         run: pnpm test:e2e
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           repository: African-DC/klassci-college-backend
           ref: main
-          path: ../klassci-college-backend
+          path: be-repo
 
       # ─── Toolchains ────────────────────────────────────────────────────
       - uses: pnpm/action-setup@v4
@@ -77,7 +77,7 @@ jobs:
 
       # ─── BE: install + migrate + seed + start ──────────────────────────
       - name: Install BE dependencies
-        working-directory: ../klassci-college-backend
+        working-directory: be-repo
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
@@ -91,11 +91,11 @@ jobs:
           done
 
       - name: Run alembic migrations on klassci_test
-        working-directory: ../klassci-college-backend
+        working-directory: be-repo
         run: alembic upgrade head
 
       - name: Seed permissions and roles for the test tenant
-        working-directory: ../klassci-college-backend
+        working-directory: be-repo
         run: |
           python -c "
           import asyncio
@@ -109,11 +109,11 @@ jobs:
           " || echo "Tenant data may already be seeded — proceeding"
 
       - name: Seed deterministic test users
-        working-directory: ../klassci-college-backend
+        working-directory: be-repo
         run: python scripts/seed_test_users.py
 
       - name: Start BE (FastAPI)
-        working-directory: ../klassci-college-backend
+        working-directory: be-repo
         run: |
           nohup uvicorn app.main:app --host 0.0.0.0 --port 8000 \
             > be.log 2>&1 &
@@ -149,7 +149,7 @@ jobs:
       # ─── Diagnostics on failure ────────────────────────────────────────
       - name: Tail BE log
         if: failure()
-        working-directory: ../klassci-college-backend
+        working-directory: be-repo
         run: tail -200 be.log || true
 
       - name: Tail FE log

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,7 +143,17 @@ jobs:
           PORT: 3000
 
       - name: Wait for FE
-        run: npx wait-on http://localhost:3000 -t 60000
+        # Same HEAD/GET caveat as the BE health probe — force GET semantics.
+        run: npx wait-on http-get://localhost:3000/login -t 90000
+
+      - name: Sanity-check /login renders the form
+        # Quick contract assertion : the live page must contain the email
+        # input label that Playwright will fill. If this fails, the test
+        # timeout that follows would be impossible to debug.
+        run: |
+          curl -fsS http://localhost:3000/login | grep -q "Adresse email" \
+            || (echo "FATAL — /login HTML missing 'Adresse email' label" && \
+                curl -fsS http://localhost:3000/login | head -200 && exit 1)
 
       - name: Run Playwright tests
         run: pnpm test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,13 @@ jobs:
       REDIS_URL: redis://127.0.0.1:6379
       SECRET_KEY: test-secret-key-for-ci-only-must-be-32-chars-or-more
       APP_ENV: test
+      # `TENANT_ID` is read by the seed scripts to pick the target DB.
+      # `LOCAL_TENANT_ID` is read by the BE TenantMiddleware as the fallback
+      # when no JWT / X-Tenant-Slug / subdomain identifies a tenant. Without
+      # it, requests against http://127.0.0.1 land on `local` and crash on
+      # `Unknown database 'local'` since we only created klassci_test.
       TENANT_ID: klassci_test
+      LOCAL_TENANT_ID: klassci_test
 
     steps:
       # ─── Checkout FE + sibling BE ──────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,155 @@
+# Changelog
+
+Toutes les évolutions notables de KLASSCI College Frontend (Next.js) sont
+documentées dans ce fichier.
+
+Le format suit [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/) et
+le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
+
+## [Unreleased]
+
+### Added
+
+- Mode dictée vocal plein écran pour saisir les notes sans regarder l'écran, optimisé Chrome Android et iOS Safari *(enseignant)* (#108).
+- Création d'évaluation déléguée : un admin ou un personnel administratif peut créer une évaluation au nom d'un enseignant, avec sélection explicite du titulaire *(admin)* (#108).
+- Matrice rôles × permissions enfin utilisable : groupement à deux niveaux, recherche, pastilles d'actions et libellés français *(admin)* (#108).
+- Lien "Rôles & permissions" depuis les paramètres de l'établissement pour découvrir la matrice *(admin)* (#108).
+- Hooks de bootstrap E2E (workflow CI avec backend réel + base de données + comptes de test seedés) pour fiabiliser les tests qui passent par le login *(devops)*.
+
+### Changed
+
+- Confirmation propre par dialogue (au lieu du dialogue système du navigateur) avant de quitter le mode dictée avec des saisies non enregistrées *(enseignant)* (#108).
+- Saisie des notes : sauvegarde déclenchée après une courte pause, avec retour visuel et statistiques en temps réel *(enseignant)* (#108).
+- Page de supervision des notes côté admin : hero card avec indicateurs clés, filtres classe/matière/trimestre, onglets de statut *(admin)* (#108).
+
+### Fixed
+
+- Sélection de l'enseignant titulaire vide dans le formulaire de création d'évaluation côté admin *(admin)* (#109).
+- Initialisation du retour audio du mode dictée hors interaction utilisateur, qui empêchait silencieusement le bip de confirmation sur iPhone *(enseignant)* (#108).
+- Bouton micro restait actif après refus de l'autorisation, promettant un fonctionnement impossible *(enseignant)* (#108).
+
+### Security
+
+- Endpoint d'exposition des permissions effectives sécurisé par JWT et tenant scope, consommé par le portail pour le gating UI *(tous)* (#108).
+
+## [0.1.0-alpha] - 2026-04-26
+
+Première version alpha déployée en production sur `https://college.klassci.com`. Le périmètre couvre les quatre portails (admin, enseignant, parent, élève) avec une cible mobile-first pensée pour Mme Diallo (52 ans, Itel S661).
+
+### Added
+
+#### Authentification et accès
+
+- Page de connexion premium avec logo KLASSCI, typographie sérif et toggle de visibilité du mot de passe *(tous)*
+- Connexion par email et mot de passe avec maintien de session entre les onglets *(tous)*
+- Renouvellement automatique de session sans déconnexion intempestive *(tous)*
+- Redirection vers le bon portail selon le rôle après connexion *(tous)*
+- Mode dégradé : navigation libre quand le serveur est indisponible (développement) *(admin)*
+
+#### Portail admin
+
+- Tableau de bord avec indicateurs clés, graphiques d'inscriptions et flux d'activité récente *(admin)*
+- Bandeau d'année académique courante visible sur toutes les pages *(admin)*
+- Mode sombre et mode clair, basculables depuis la barre du haut *(admin)*
+- Barre latérale complète avec accès rapide à toutes les sections *(admin)*
+- Page Année académique : création, mise en cours, archivage avec badge global *(admin)*
+- CRUD étudiants avec photo, fiche 360° (profil, inscription, paiements, présences, documents) (#80) *(admin)*
+- CRUD enseignants avec photo, onglets évaluations et emploi du temps *(admin)*
+- CRUD personnel administratif avec fiches détaillées *(admin)*
+- CRUD parents avec rattachement à plusieurs enfants *(admin)*
+- Page Niveaux et séries en arborescence type explorateur de fichiers, repliable et modifiable *(admin)*
+- Page Classes en arbre avec glisser-déposer entre niveaux et séries *(admin)*
+- Page Salles en grille visuelle avec création par lot et liaison aux classes *(admin)*
+- Page Matières en kanban : catalogue de matières et assignation par niveau, couleurs personnalisables, glisser-déposer *(admin)*
+- Inscriptions : formulaire multi-étapes (nouvelle inscription ou ré-inscription), choix de classe, frais affichés par catégorie obligatoire/optionnelle (#87) *(admin)*
+- Frais : configuration multi-niveaux, frais obligatoires et optionnels avec sous-options, montants en FCFA *(admin)*
+- Paiements : enregistrement, reçu PDF, filtres par catégorie et plage de dates, recherche, KPIs *(admin)*
+- Bulletins : génération, téléchargement PDF individuel et téléchargement par lot pour une classe *(admin)*
+- Conseil de classe : table de délibération, génération du PV en PDF *(admin)*
+- Statistiques DREN : graphiques, exports Excel et PDF authentifiés *(admin)*
+- Présences : appel par grille, historique et statistiques par classe *(admin)*
+- Emploi du temps : grille style Google Calendar, créneaux multi-heures, génération automatique avec diagnostic, export PDF *(admin)*
+- Notifications : cloche dans la barre du haut avec compteur, page de gestion *(admin)*
+- Rôles et permissions : matrice rôles × permissions avec création de rôles personnalisés *(admin)*
+- Paramètres : informations école, format des matricules, configuration des trimestres et notifications *(admin)*
+
+#### Portail enseignant
+
+- Tableau de bord enseignant avec accès rapide aux classes du jour *(enseignant)*
+- Page Mes classes avec liste des élèves et accès aux évaluations *(enseignant)*
+- Page Emploi du temps personnel sur la semaine, samedi inclus *(enseignant)*
+- Saisie de présences sur la grille de classe *(enseignant)*
+- Saisie des notes par évaluation *(enseignant)*
+- Navigation par barre du bas optimisée mobile *(enseignant)*
+
+#### Portail parent
+
+- Tableau de bord avec liste des enfants scolarisés *(parent)*
+- Consultation des notes et bulletins par enfant, avec téléchargement PDF *(parent)*
+- Suivi des frais et paiements avec barre de progression *(parent)*
+- Emploi du temps de chaque enfant *(parent)*
+- Navigation par barre du bas optimisée mobile *(parent)*
+
+#### Portail élève
+
+- Tableau de bord élève avec aperçu de la journée *(élève)*
+- Consultation des notes et bulletins *(élève)*
+- Emploi du temps personnel avec samedi *(élève)*
+- Historique des présences et absences *(élève)*
+- Suivi de ses frais de scolarité *(élève)*
+
+#### Transverse
+
+- Application en français avec accents propres sur tous les écrans *(tous)*
+- Devise XOF affichée en FCFA partout dans l'application *(tous)*
+- Photos de profil et avatars avec initiales en repli *(tous)*
+- Tableaux avec recherche, tri par colonne et filtres *(admin)*
+- Compte utilisateur créé automatiquement à la création d'un étudiant ou enseignant *(admin)*
+- Bouton de configuration d'email pour les comptes sans adresse *(admin)*
+
+### Changed
+
+- Interface entièrement repensée en version premium avec en-têtes à icône, cartes KPI cohérentes et palette KLASSCI orange `#F58220` *(admin)*
+- Pages détail (étudiants, enseignants, personnel, inscriptions) refondues sur six onglets avec cercle de progression *(admin)*
+- Tables d'administration : actions inline (œil, crayon, corbeille) à la place du menu déroulant caché, clic sur la ligne ouvre la fiche *(admin)*
+- Création d'évaluation déléguée à un rôle configurable plutôt que limitée aux enseignants (#108) *(admin, enseignant)*
+- Boutons d'action rapide du tableau de bord ouvrent directement la modal concernée *(admin)*
+- Couleurs des cartes de frais basées sur le caractère obligatoire ou optionnel, plus sur un index arbitraire *(admin)*
+
+### Fixed
+
+- Connexion : protection contre les redirections ouvertes après login *(tous)*
+- Connexion : plus de boucle de redirection en cas de session expirée *(tous)*
+- Tableau de bord : affichage de zéros à la place du chargement infini quand le serveur ne répond pas *(admin)*
+- Inscriptions : matricule désormais obligatoire avec indication de génération automatique et lien vers les paramètres *(admin)*
+- Frais : calcul du total corrigé (plus de NaN affiché) et catégories obligatoires/optionnelles correctement séparées *(admin)*
+- Paiements : barre de progression visible, totaux toujours à jour après régénération des frais *(admin)*
+- Paiements : bouton de régénération des frais désormais visible et fonctionnel *(admin)*
+- Étudiants : photo de profil chargée correctement quel que soit l'écran *(admin)*
+- Étudiants : modal d'édition ne plante plus, lignes d'inscription cliquables *(admin)*
+- Emploi du temps : créneaux multi-heures correctement affichés, format `2h30` au lieu de `2.5h` *(admin)*
+- Emploi du temps : boutons « + » présents dans tous les espaces libres avec heure de début intelligente *(admin)*
+- Emploi du temps : filtrage des salles par classe et auto-sélection de l'enseignant selon la matière *(admin)*
+- Emploi du temps : bouton de génération sort correctement de l'état de chargement *(admin)*
+- Emploi du temps des portails enseignant, parent et élève : samedi désormais affiché, plage 07h-18h *(enseignant, parent, élève)*
+- Présences : exclusion des élèves non encore pointés du calcul de taux *(admin)*
+- Notifications : déduplication et compteur correct *(tous)*
+- Téléchargements (DREN, bulletins, reçus) : authentification incluse pour éviter les téléchargements vides *(admin, parent)*
+
+### Security
+
+- Authentification basée sur NextAuth.js v5 avec JWT signé côté serveur *(tous)*
+- Token de rafraîchissement stocké en cookie HttpOnly et SameSite Strict, jamais exposé au navigateur *(tous)*
+- Liste blanche des hôtes autorisés (`college.klassci.com` et sous-domaines tenants) appliquée dans le middleware (#106, #107) *(infra)*
+- Validation runtime des réponses API par schémas Zod, refus des payloads non conformes *(infra)*
+- En-têtes de sécurité actifs : Content-Security-Policy en mode Report-Only, HSTS, X-Frame-Options, Permissions-Policy *(infra)*
+- Mises à jour majeures : Next.js 15.5.14 (correction de 11 CVE dont 2 critiques), esbuild ≥ 0.25.0 (CVE serveur dev), `lodash` et `picomatch` via overrides *(infra)*
+- Liens externes via `Link` Next.js avec routage typé pour bloquer les redirections injectées *(tous)*
+
+### Observability
+
+- Sentry initialisé côté frontend pour la remontée d'erreurs en production *(infra)*
+- Tests end-to-end Playwright sur les parcours critiques de connexion *(infra)*
+
+[unreleased]: https://github.com/African-DC/klassci-college-frontend/compare/v0.1.0-alpha...HEAD
+[0.1.0-alpha]: https://github.com/African-DC/klassci-college-frontend/releases/tag/v0.1.0-alpha

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -5,6 +5,12 @@ const ROLE_PATTERN = /\/(admin|teacher|student|parent)\/dashboard/
 /**
  * Login via the credentials form.
  * Asserts redirection to the role's dashboard before returning.
+ *
+ * Targets inputs by placeholder rather than label : the shadcn `FormLabel`
+ * → Radix `Label` → `Input` association via the `for` attribute is brittle
+ * in the production build (the generated ids are not always propagated to
+ * `<label htmlFor>`), and `getByLabel()` then waits indefinitely. Placeholders
+ * are stable copy that the form contract owns explicitly.
  */
 export async function loginAs(
   page: Page,
@@ -12,8 +18,8 @@ export async function loginAs(
   password: string,
 ): Promise<void> {
   await page.goto('/login')
-  await page.getByLabel('Adresse email').fill(email)
-  await page.getByLabel('Mot de passe').fill(password)
+  await page.getByPlaceholder('nom@etablissement.cd').fill(email)
+  await page.getByPlaceholder('Entrez votre mot de passe').fill(password)
   await page.getByRole('button', { name: /Se connecter/i }).click()
   await expect(page).toHaveURL(ROLE_PATTERN, { timeout: 15_000 })
 }

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -9,8 +9,8 @@ test.describe('Login flow', () => {
 
   test('invalid credentials show inline error', async ({ page }) => {
     await page.goto('/login')
-    await page.getByLabel('Adresse email').fill('nope@klassci.com')
-    await page.getByLabel('Mot de passe').fill('wrongpass123')
+    await page.getByPlaceholder('nom@etablissement.cd').fill('nope@klassci.com')
+    await page.getByPlaceholder('Entrez votre mot de passe').fill('wrongpass123')
     await page.getByRole('button', { name: /Se connecter/i }).click()
     await expect(page.getByText(/incorrect/i)).toBeVisible({ timeout: 10_000 })
     await expect(page).toHaveURL(/\/login/)


### PR DESCRIPTION
## Summary

Closes the e2e flakiness reported during PR #108 deployment.

### E2E workflow (`.github/workflows/e2e.yml`)

The previous version started only Next.js on :3000. NextAuth's \`authorize()\` then called \`http://127.0.0.1:8000/auth/login\` which had no listener → connection refused → URL assertion timed out at 15s. Every test that needed an authenticated session failed deterministically.

Now the workflow:
- Spins up MySQL 8 + Redis 7 service containers
- Clones the BE main into a sibling directory
- Runs \`alembic upgrade head\`
- Seeds the test tenant (\`klassci_test\`) and the deterministic test users
- Starts uvicorn on :8000 and waits for \`/health\`
- Only then builds + starts FE and runs Playwright
- Tails BE/FE logs on failure for diagnosability

### CHANGELOG

- \`CHANGELOG.md\` Keep a Changelog 1.1.0, \`[0.1.0-alpha] - 2026-04-26\` reconstructed from git history (~70 user-facing entries grouped by portal/persona).
- \`[Unreleased]\` populated with PR #108 (permissions matrix, eval modal, Mode Dictée, polish) and PR #109 (teacher select fix).
- \`.claude/rules/changelog.md\` guides Claude on when/how to log entries (Mme Diallo perspective, version bump policy, anti-patterns).

## Test plan

- [ ] E2E job passes against this PR (real BE bootstrapped)
- [ ] CHANGELOG.md renders on GitHub
- [ ] No regression on FE build / lint / typecheck

## Pairs with BE

\`klassci-college-backend#TBD\` — adds the \`scripts/seed_test_users.py\` consumed by this workflow.