### PR TITLE
feat(grades): cascade subject select by class in EvaluationCreateModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ### Changed
 
 - Confirmation propre par dialogue (au lieu du dialogue système du navigateur) avant de quitter le mode dictée avec des saisies non enregistrées *(enseignant)* (#108).
+- Création d'évaluation : la liste des matières se filtre automatiquement selon la classe choisie, plus rapide à parcourir et impossible de se tromper de matière *(admin)* (#112).
 - Saisie des notes : sauvegarde déclenchée après une courte pause, avec retour visuel et statistiques en temps réel *(enseignant)* (#108).
 - Page de supervision des notes côté admin : hero card avec indicateurs clés, filtres classe/matière/trimestre, onglets de statut *(admin)* (#108).
 

--- a/components/admin/grades/EvaluationCreateModal.tsx
+++ b/components/admin/grades/EvaluationCreateModal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useMemo } from "react"
-import { useForm } from "react-hook-form"
+import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { ShieldAlert } from "lucide-react"
 import { EvaluationCreateSchema, type EvaluationCreate } from "@/lib/contracts/grade"
@@ -60,12 +60,10 @@ export function EvaluationCreateModal({
   // BE caps `size` at 100 (admin.py: Query(le=100)) — passing 200 returns 422.
   // For MVP with ~50 teachers per école, 100 covers the case ; au-delà → paginer.
   const { data: classesData } = useClasses({ size: 100 })
-  const { data: subjectsData } = useSubjects({ size: 100 })
   const { data: teachersData, error: teachersError } = useTeachers({ size: 100 })
   const { data: yearsData } = useAcademicYears({ size: 20 })
 
   const classes = classesData?.items ?? []
-  const subjects = subjectsData?.items ?? []
   const teachers = useMemo(() => {
     const list = teachersData?.items ?? []
     return [...list].sort((a, b) => {
@@ -88,6 +86,19 @@ export function EvaluationCreateModal({
       academic_year_id: currentYear?.id,
     },
   })
+
+  // Cascade Class -> Subject : on filtre les matières par la classe choisie pour
+  // ne montrer que celles enseignées à son niveau (et série), au lieu du
+  // catalogue complet. Tant qu'aucune classe n'est choisie, le BE renvoie tout
+  // (cas modal ouvert sans classe pré-sélectionnée), mais on n'expose rien dans
+  // le Select Matière — il reste disabled avec un texte d'aide.
+  const watchedClassId = useWatch({ control: form.control, name: "class_id" })
+  const { data: subjectsData, isFetching: subjectsFetching } = useSubjects({
+    class_id: watchedClassId,
+    size: 100,
+  })
+  const subjects = subjectsData?.items ?? []
+  const subjectsEmpty = !!watchedClassId && !subjectsFetching && subjects.length === 0
 
   // Pre-fill academic_year_id once years arrive (form already initialized with possibly-undefined).
   useEffect(() => {
@@ -164,7 +175,13 @@ export function EvaluationCreateModal({
                     <FormLabel>Classe *</FormLabel>
                     <Select
                       value={field.value ? String(field.value) : ""}
-                      onValueChange={(v) => field.onChange(Number(v))}
+                      onValueChange={(v) => {
+                        field.onChange(Number(v))
+                        // Reset subject_id : la liste de matières change avec la classe.
+                        // On le fait ici (pas dans un useEffect) pour éviter les
+                        // false-fires au mount et garder le reset 100% user-driven.
+                        form.setValue("subject_id", undefined as unknown as number)
+                      }}
                     >
                       <FormControl>
                         <SelectTrigger className="h-11">
@@ -194,10 +211,21 @@ export function EvaluationCreateModal({
                     <Select
                       value={field.value ? String(field.value) : ""}
                       onValueChange={(v) => field.onChange(Number(v))}
+                      disabled={!watchedClassId || subjectsEmpty}
                     >
                       <FormControl>
                         <SelectTrigger className="h-11">
-                          <SelectValue placeholder="Choisir une matière" />
+                          <SelectValue
+                            placeholder={
+                              !watchedClassId
+                                ? "Choisir d'abord une classe"
+                                : subjectsFetching
+                                  ? "Chargement…"
+                                  : subjectsEmpty
+                                    ? "Aucune matière configurée"
+                                    : "Choisir une matière"
+                            }
+                          />
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
@@ -208,6 +236,21 @@ export function EvaluationCreateModal({
                         ))}
                       </SelectContent>
                     </Select>
+                    {/*
+                      Texte d'aide visible (pas seulement le placeholder greyed) — sur
+                      Itel S661 en plein soleil, l'état disabled est quasi invisible.
+                      Mme Diallo lit le texte sous le champ, pas l'opacité du Select.
+                    */}
+                    {!watchedClassId && (
+                      <p className="text-xs text-muted-foreground">
+                        Choisissez d&apos;abord la classe pour voir les matières.
+                      </p>
+                    )}
+                    {subjectsEmpty && (
+                      <p className="text-xs text-muted-foreground">
+                        Aucune matière n&apos;est configurée pour cette classe.
+                      </p>
+                    )}
                     <FormMessage />
                   </FormItem>
                 )}


### PR DESCRIPTION
Closes #112

## Summary

Quand l'admin choisit une classe dans la modal "Nouvelle évaluation", le Subject Select se filtre automatiquement aux matières du niveau (et série) — au lieu du catalogue complet (~50 entrées). Persona Mme Diallo : moins d'options = moins d'erreurs sur 3G + plein soleil.

## Changes

- \`components/admin/grades/EvaluationCreateModal.tsx\` :
  - \`useWatch\` sur \`class_id\` ; passe au hook \`useSubjects({ class_id, size: 100 })\`.
  - Reset \`subject_id\` dans le \`onValueChange\` du Class Select (pas via \`useEffect\` — évite les false-fires au mount).
  - Subject Select \`disabled\` tant que pas de classe + **helper text visible** : "Choisissez d'abord la classe pour voir les matières."
  - Empty state : "Aucune matière n'est configurée pour cette classe."
  - Placeholder dynamique : "Choisir d'abord une classe" → "Chargement…" → "Choisir une matière" / "Aucune matière configurée".
- \`CHANGELOG.md\` : 1 ligne (Changed).

## Why visible helper text instead of just disabled state

Sur Itel S661 (entry-level Android, écran TFT) en plein soleil, les états greyed sont quasi invisibles. Le texte sous le champ est lu directement, pas l'opacité du Select.

## Test plan

- [x] \`npx tsc --noEmit\` PASS, zéro erreur TypeScript.
- [ ] Visual check sur https://college.klassci.com/admin/grades une fois mergé : ouvrir modal, vérifier Subject Select disabled + helper text → choisir une classe → Subject Select activé + filtré.
- [ ] Mobile 375x812 : Subject Select reste visible-mais-disabled (pas hidden).

## Cross-link

- BE PR : African-DC/klassci-college-backend#76 (filtre + validator)
- Le BE doit être déployé d'abord pour que le param \`?class_id\` soit accepté.

## v1.2 polish flagged (hors scope)

- Auto-fill \`teacher_id\` depuis \`subject.teacher_id\` (élimine 1 dropdown).
- Auto-focus shift vers Subject Select quand class est choisie.