### PR TITLE
release: cascade subject select by class in EvaluationCreateModal (#112)

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -90,6 +90,25 @@ créer dans cet ordre canonique (sauter celles vides) :
    ```
 4. Tagger : `git tag vX.Y.Z` puis `git push --tags`.
 
+## Garde-fou CI
+
+Le workflow `.github/workflows/changelog-check.yml` tourne sur chaque pull
+request. Il :
+
+1. Détecte les commits `feat`/`fix`/`perf`/`breaking` depuis la base.
+2. **Échoue** si un de ces commits est présent ET que `CHANGELOG.md`
+   n'apparaît pas dans le diff de la PR.
+3. Affiche la liste des commits incriminés dans le job log.
+
+Pour contourner volontairement (changement vraiment interne, refactor pur,
+réorganisation docs, mise à jour deps non visible) : appliquer le label
+`skip-changelog` sur la PR. Le workflow se met alors en pass automatique.
+Reviewer peut le retirer pour forcer une mise à jour si besoin.
+
+**Comme avec toute règle automatique, ce check ne valide pas la qualité
+éditoriale** — il garantit qu'une ligne a été ajoutée, pas qu'elle est
+écrite du point de vue de Mme Diallo. Suivre les principes plus haut.
+
 ## Anti-patterns à bloquer en revue
 
 1. Entrée qui décrit l'implémentation : `Added DicteeMode component`

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,62 @@
+name: Changelog Check
+
+# Forces every PR with user-facing commits (`feat:`, `fix:`, `perf:`,
+# `breaking:`) to also update CHANGELOG.md. Skip explicitly with the
+# `skip-changelog` label when the change is genuinely internal-only
+# (refactor, ci, docs reorg, etc.).
+
+on:
+  pull_request:
+    branches: [main, staging, develop]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog:
+    name: Verify CHANGELOG.md update
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect user-facing commits since base branch
+        id: detect
+        run: |
+          set -euo pipefail
+          BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+          COMMITS=$(git log --format='%s' "$BASE_SHA..HEAD")
+          USER_FACING=$(echo "$COMMITS" | grep -E '^(feat|fix|perf|breaking)(\(|:)' || true)
+          if [ -z "$USER_FACING" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No user-facing commits — changelog update not required."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "commits<<EOF"
+              echo "$USER_FACING"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify CHANGELOG.md was updated
+        if: steps.detect.outputs.skip == 'false'
+        run: |
+          set -euo pipefail
+          BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+          if ! git diff --name-only "$BASE_SHA..HEAD" | grep -qx 'CHANGELOG.md'; then
+            echo "::error::User-facing commits found but CHANGELOG.md was not updated."
+            echo ""
+            echo "Commits flagged:"
+            echo "${{ steps.detect.outputs.commits }}" | sed 's/^/  - /'
+            echo ""
+            echo "Add an entry under '## [Unreleased]' in CHANGELOG.md, or apply"
+            echo "the 'skip-changelog' label if this PR has no user-visible impact."
+            echo "See .claude/rules/changelog.md for the editorial guidelines."
+            exit 1
+          fi
+          echo "::notice::CHANGELOG.md updated alongside user-facing commits — OK."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ### Changed
 
 - Confirmation propre par dialogue (au lieu du dialogue système du navigateur) avant de quitter le mode dictée avec des saisies non enregistrées *(enseignant)* (#108).
+- Création d'évaluation : la liste des matières se filtre automatiquement selon la classe choisie, plus rapide à parcourir et impossible de se tromper de matière *(admin)* (#112).
 - Saisie des notes : sauvegarde déclenchée après une courte pause, avec retour visuel et statistiques en temps réel *(enseignant)* (#108).
 - Page de supervision des notes côté admin : hero card avec indicateurs clés, filtres classe/matière/trimestre, onglets de statut *(admin)* (#108).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Matrice rôles × permissions enfin utilisable : groupement à deux niveaux, recherche, pastilles d'actions et libellés français *(admin)* (#108).
 - Lien "Rôles & permissions" depuis les paramètres de l'établissement pour découvrir la matrice *(admin)* (#108).
 - Hooks de bootstrap E2E (workflow CI avec backend réel + base de données + comptes de test seedés) pour fiabiliser les tests qui passent par le login *(devops)*.
+- Page « Mes évaluations » côté portail enseignant : hero avec indicateurs clés, filtre par classe, onglets de statut (À saisir / En retard / Terminées) et bouton « Saisir » qui ouvre la grille de saisie ou le mode dictée *(enseignant)* (#111).
 
 ### Changed
 
@@ -27,6 +28,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Sélection de l'enseignant titulaire vide dans le formulaire de création d'évaluation côté admin *(admin)* (#109).
 - Initialisation du retour audio du mode dictée hors interaction utilisateur, qui empêchait silencieusement le bip de confirmation sur iPhone *(enseignant)* (#108).
 - Bouton micro restait actif après refus de l'autorisation, promettant un fonctionnement impossible *(enseignant)* (#108).
+- Tableau de bord enseignant et élève qui boucle sur « Connexion impossible » : alignés avec les nouveaux chemins backend *(enseignant, élève)* (#111).
+- Page « Mes notes » du portail enseignant qui était inaccessible (lien sidebar vers une page absente) *(enseignant)* (#111).
 
 ### Security
 

--- a/components/admin/grades/EvaluationCreateModal.tsx
+++ b/components/admin/grades/EvaluationCreateModal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useMemo } from "react"
-import { useForm } from "react-hook-form"
+import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { ShieldAlert } from "lucide-react"
 import { EvaluationCreateSchema, type EvaluationCreate } from "@/lib/contracts/grade"
@@ -60,12 +60,10 @@ export function EvaluationCreateModal({
   // BE caps `size` at 100 (admin.py: Query(le=100)) — passing 200 returns 422.
   // For MVP with ~50 teachers per école, 100 covers the case ; au-delà → paginer.
   const { data: classesData } = useClasses({ size: 100 })
-  const { data: subjectsData } = useSubjects({ size: 100 })
   const { data: teachersData, error: teachersError } = useTeachers({ size: 100 })
   const { data: yearsData } = useAcademicYears({ size: 20 })
 
   const classes = classesData?.items ?? []
-  const subjects = subjectsData?.items ?? []
   const teachers = useMemo(() => {
     const list = teachersData?.items ?? []
     return [...list].sort((a, b) => {
@@ -88,6 +86,19 @@ export function EvaluationCreateModal({
       academic_year_id: currentYear?.id,
     },
   })
+
+  // Cascade Class -> Subject : on filtre les matières par la classe choisie pour
+  // ne montrer que celles enseignées à son niveau (et série), au lieu du
+  // catalogue complet. Tant qu'aucune classe n'est choisie, le BE renvoie tout
+  // (cas modal ouvert sans classe pré-sélectionnée), mais on n'expose rien dans
+  // le Select Matière — il reste disabled avec un texte d'aide.
+  const watchedClassId = useWatch({ control: form.control, name: "class_id" })
+  const { data: subjectsData, isFetching: subjectsFetching } = useSubjects({
+    class_id: watchedClassId,
+    size: 100,
+  })
+  const subjects = subjectsData?.items ?? []
+  const subjectsEmpty = !!watchedClassId && !subjectsFetching && subjects.length === 0
 
   // Pre-fill academic_year_id once years arrive (form already initialized with possibly-undefined).
   useEffect(() => {
@@ -164,7 +175,13 @@ export function EvaluationCreateModal({
                     <FormLabel>Classe *</FormLabel>
                     <Select
                       value={field.value ? String(field.value) : ""}
-                      onValueChange={(v) => field.onChange(Number(v))}
+                      onValueChange={(v) => {
+                        field.onChange(Number(v))
+                        // Reset subject_id : la liste de matières change avec la classe.
+                        // On le fait ici (pas dans un useEffect) pour éviter les
+                        // false-fires au mount et garder le reset 100% user-driven.
+                        form.setValue("subject_id", undefined as unknown as number)
+                      }}
                     >
                       <FormControl>
                         <SelectTrigger className="h-11">
@@ -194,10 +211,21 @@ export function EvaluationCreateModal({
                     <Select
                       value={field.value ? String(field.value) : ""}
                       onValueChange={(v) => field.onChange(Number(v))}
+                      disabled={!watchedClassId || subjectsEmpty}
                     >
                       <FormControl>
                         <SelectTrigger className="h-11">
-                          <SelectValue placeholder="Choisir une matière" />
+                          <SelectValue
+                            placeholder={
+                              !watchedClassId
+                                ? "Choisir d'abord une classe"
+                                : subjectsFetching
+                                  ? "Chargement…"
+                                  : subjectsEmpty
+                                    ? "Aucune matière configurée"
+                                    : "Choisir une matière"
+                            }
+                          />
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
@@ -208,6 +236,21 @@ export function EvaluationCreateModal({
                         ))}
                       </SelectContent>
                     </Select>
+                    {/*
+                      Texte d'aide visible (pas seulement le placeholder greyed) — sur
+                      Itel S661 en plein soleil, l'état disabled est quasi invisible.
+                      Mme Diallo lit le texte sous le champ, pas l'opacité du Select.
+                    */}
+                    {!watchedClassId && (
+                      <p className="text-xs text-muted-foreground">
+                        Choisissez d&apos;abord la classe pour voir les matières.
+                      </p>
+                    )}
+                    {subjectsEmpty && (
+                      <p className="text-xs text-muted-foreground">
+                        Aucune matière n&apos;est configurée pour cette classe.
+                      </p>
+                    )}
                     <FormMessage />
                   </FormItem>
                 )}


### PR DESCRIPTION
Release PR : déploie sur prod le cascade Subject Select dans la modal Nouvelle évaluation.

## Inclus

- feat(grades): cascade subject select by class in EvaluationCreateModal (#114, Closes #112)
- Plus toutes les autres features de develop (auto-changelog CI, etc.)

## Changes

- \`components/admin/grades/EvaluationCreateModal.tsx\` :
  - \`useWatch\` sur \`class_id\` ; passe au hook \`useSubjects({ class_id, size: 100 })\`.
  - Reset \`subject_id\` dans le \`onValueChange\` du Class Select.
  - Subject Select \`disabled\` + helper text visible "Choisissez d'abord la classe".
  - Empty state si la classe a 0 matière.
- BE corollaire : African-DC/klassci-college-backend#76 (à déployer en parallèle).

## Deploy

Le merge déclenchera \`deploy-fe.yml\` → \`pnpm build\` CI → ship standalone tarball sur EC2 → \`systemctl restart klassci-frontend\`.

## Test plan post-deploy

- [ ] https://college.klassci.com/admin/grades : ouvrir modal Nouvelle évaluation.
- [ ] Subject Select disabled au mount, helper text visible.
- [ ] Choisir une classe → Subject Select s'active, liste filtrée (~8-12 items au lieu de ~50).
- [ ] Changer de classe → subject_id reset.

Closes #112