### PR TITLE
feat(enrollments): redesign /admin/enrollments queue-first (chips, inline Valider)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -104,6 +104,7 @@ npm run test:e2e
 @rules/data-fetching.md
 @rules/auth-architecture.md
 @rules/ux-target-user-reality.md
+@rules/redesign-premium.md
 @rules/deploy.md
 @rules/git.md
 @rules/changelog.md

--- a/.claude/rules/redesign-premium.md
+++ b/.claude/rules/redesign-premium.md
@@ -1,0 +1,329 @@
+# Rule: Redesign Premium — Pattern Persona-First Ultra-Détaillé
+
+## Quand s'active
+
+Cette rule s'active automatiquement quand je :
+- Audite une page/composant existant pour un redesign
+- Ajoute une nouvelle feature majeure (>1 jour de dev)
+- Transforme une UX cosmétique en UX persona-first
+- Reçois un brief avec scope ambitieux (3+ features groupées)
+- Vois un screenshot prod et l'utilisateur dit « il y a un problème de design »
+
+## Principe fondamental
+
+**Le persona-first ne consiste pas à « moins de features », mais à « features qui chacune amène à une action claire ».**
+
+Chaque info affichée doit passer le test : *« Quel est le PROCHAIN tap que l'utilisateur va vouloir faire ? »*. Si la réponse est *« rien »*, l'info est du bruit.
+
+Référence persona : Mme Diallo (52 ans, Itel S661, plein soleil, 3G, papier-based). Voir rule sœur `ux-target-user-reality.md`. **Le test ultime** : *« Mme Diallo, papier en main, peut-elle le faire sans formation ? »*.
+
+---
+
+## Le pattern de session — 7 étapes obligatoires
+
+### 1. Audit ultrathink AVANT toute action
+
+À partir d'un screenshot ou de la page live, lister TOUS les problèmes :
+- **Bugs** (data fausses, états cassés, KPIs inconsistants)
+- **Bruit** (info non-actionnable, redondance, démographie sans suite)
+- **Manques** (info critique absente — ex : la classe d'un élève)
+- **Friction** (taps inutiles, scroll inutile, états greyed invisibles plein soleil)
+
+Puis ranker par **impact persona-first**, pas par effort.
+
+### 2. /plan-and-confirm FULL avec critic
+
+JAMAIS de redesign en `--quick`. Le critic doit pouvoir **BLOCK** :
+- Scope trop large → split en PRs incrémentales
+- Security gaps (PII export, bulk destructive sans confirm count)
+- Pre-existing bugs masqués par le redesign
+- Architecture qui aggrave la dette (god-class, drift de convention)
+
+### 3. Si le critic dit RETHINK — écouter
+
+Le critic peut splitter en N PRs. Ne pas pousser pour bundler. Re-discuter en passe 2 si désaccord, sinon implémenter ses changements. **Marcel peut override mais doit entendre le critic verbatim.**
+
+### 4. Path A-refined > Path C original
+
+Toujours préférer le **scope minimum qui transforme l'expérience persona**, défer le reste. La prod nous apprend plus que le brainstorm. Ship → mesurer → itérer.
+
+### 5. Ship + Visual-check + Submit-test
+
+Pas de « feature complete » sans :
+- Render snapshot (AI accessibility)
+- **Submit/CTA test** (mandatory pour formulaire/modal/badge actionable) — voir lesson 2026-04-27
+- Mobile 375x812
+- Hard reload post-deploy (cache bundle Next.js immutable)
+
+### 6. Ultrathink retro
+
+Après ship, revenir prendre du recul, sans coder :
+- Ce qui a marché (à reproduire)
+- Ce qui est imparfait (honest, pas de feel-good summary)
+- Ce qui aurait été plus simple (simplification Da Vinci)
+- Ce qui a été déféré (priorisation v1.2+ ranked par valeur/risque)
+- Lessons (pour rules futures)
+
+### 7. Cristalliser dans rule
+
+Si un pattern est reproductible (chips bar, MobileEntityListItem, with_loader_criteria...), le coder UNE FOIS comme primitive partagée. Si une leçon est durable, l'écrire dans une rule (cette rule, ses sœurs).
+
+---
+
+## 12 principes de design — chacun avec exemple shippé
+
+### 1. Subtitle > KPI cards démographiques
+
+| ❌ | ✅ |
+|---|---|
+| 3 cards 200px de haut « Total: 5 / Garçons: 5 / Filles: 5 » (et bug-prone : 5/5/5 bug réel session 2026-04-27) | Subtitle 1 ligne `5 élèves au total · 4 à inscrire` (lien orange cliquable vers filtre) |
+
+**Gain** : 200px verticaux + action immédiate. **Référence** : `/admin/students` PR #116.
+
+### 2. Filter chips > select dropdowns
+
+| ❌ | ✅ |
+|---|---|
+| Bouton « Filtres » ouvrant un panel avec 5 selects | Chips horizontal `Tous (5) · À inscrire (4) · 6ème A (1)`. 1 tap = 1 filtre |
+
+**Gain** : 1 tap au lieu de 3, mobile-friendly horizontal-scroll, counts visibles. **Référence** : PR #117.
+
+### 3. Statut « X à action » actionable > badge passif
+
+| ❌ | ✅ |
+|---|---|
+| Badge gris « Pas inscrit cette année » (info sans suite) | Badge orange cliquable « À inscrire » → ouvre `/admin/enrollments?action=create&student_id=X` pré-rempli |
+
+**Gain** : Wave Mobile Money style — chaque info = 1 tap vers action. 5 lignes de code, gain UX exponentiel.
+
+### 4. Drop colonne, **garde data**
+
+| ❌ | ✅ |
+|---|---|
+| Colonne `Genre` dédiée avec badge Masc/Fém | Mini ♀/♂ inline next to name. **Genre KEEP IN DATA** (DREN reports + bulletin honorifics + MENA forms) |
+
+**Gain** : 1 colonne récupérée, data pas perdue. **Règle** : drop l'affichage, jamais le modèle, sans grep de toutes les consommations.
+
+### 5. Mobile = liste minimal, PAS card
+
+| ❌ | ✅ |
+|---|---|
+| Card avec 8 fields, action menu, photo grand format | List item minimaliste : avatar + name + secondary + status + chevron. Tap = fiche. |
+
+**Gain** : 4 infos visibles, friction zéro, scroll rapide sur 3G. **Composant** : `<MobileEntityListItem>` partagé.
+
+### 6. Helper text VISIBLE, pas juste greyed
+
+| ❌ | ✅ |
+|---|---|
+| Subject Select disabled greyed (invisible plein soleil Itel S661) | Subject Select disabled + paragraphe `<p className="text-xs text-muted-foreground">Choisissez d'abord la classe</p>` sous le champ |
+
+**Gain** : lisible plein soleil, intentionnalité claire. **Référence** : EvaluationCreateModal cascade.
+
+### 7. Drop colonnes redondantes
+
+| ❌ | ✅ |
+|---|---|
+| Colonne `Matricule` séparée + matricule en sous-titre du nom | Matricule **UNIQUEMENT** en sous-titre du nom |
+
+**Gain** : densité utile, plus de bruit visuel.
+
+### 8. Honest > impressive
+
+| ❌ | ✅ |
+|---|---|
+| Frais column avec seuil `<30% rouge` en octobre = punit familles en plan échelonné (95% rouge faux) | Drop la colonne tant qu'on n'a pas `expected_so_far` schedule-aware. **Mieux pas de signal qu'un faux signal.** |
+
+**Référence** : ultrathink 2026-04-27, déféré en v1.2.
+
+### 9. shadcn/ui primitives, **jamais recréer**
+
+✅ Toujours utiliser `Badge`, `Button`, `Checkbox`, `Progress` de shadcn/ui. Customisation via Tailwind, pas override de composant. Voir `components.md`.
+
+### 10. Single accent + monochrome
+
+| ❌ | ✅ |
+|---|---|
+| Garçons bleu, Filles rose, 4 statuts colorés = 6 accents | Primary KLASSCI bleu (`#0F3F8C`) + accent orange (`#F58220`). **Sémantique seulement** (succès/warning/erreur). |
+
+Voir `marcel-global-preferences.md`.
+
+### 11. Touch targets ≥ h-11
+
+✅ Tous les boutons mobile : `h-11` minimum. Standard Wave Mobile Money. Voir `ux-target-user-reality.md`.
+
+### 12. Français propre, pas d'em dash
+
+✅ « Choisir une classe », pas « Pick » ni « Choisir — une classe ». Apostrophes courbes typographiques pas obligatoires mais accents OUI tous corrects.
+
+---
+
+## Architecture data — patterns
+
+### `with_loader_criteria` > window function
+
+Pour « latest related entity per parent » en SQLAlchemy 2.0 async :
+
+```python
+from sqlalchemy.orm import selectinload, with_loader_criteria
+
+stmt = (
+    select(Student)
+    .options(
+        selectinload(Student.enrollments).options(selectinload(Enrollment.class_)),
+        with_loader_criteria(
+            Enrollment,
+            and_(
+                Enrollment.academic_year_id == current_ay_id,
+                Enrollment.status == EnrollmentStatus.VALIDE,
+            ),
+        ),
+    )
+)
+```
+
+`with_loader_criteria` filtre **AU NIVEAU SQL**. Combiné à une `UniqueConstraint(parent_id, scope_id)`, on a au plus 1 entité par parent. Plus simple que window function, MySQL-version-agnostic, pas de denorm column. **Référence** : PR #82.
+
+### Endpoint counts vs enrichi list
+
+Counts pour chips bar = **endpoint dédié** `/admin/<resource>/filters` cacheable.
+**NE PAS** enrichir la liste paginée avec des aggregates (re-counts par page = waste, couples concerns).
+
+### Single source of truth predicate
+
+Quand un même filtre s'applique en list-side ET write-side validator, écrire le **prédicat SQLAlchemy** UNE FOIS et l'importer côté repo et côté validator. Zero drift entre filter et validation.
+
+```python
+def subject_for_class_predicate(class_obj: Class) -> ColumnElement[bool]:
+    return and_(
+        or_(Subject.level_id.is_(None), Subject.level_id == class_obj.level_id),
+        or_(Subject.series_id.is_(None), Subject.series_id == class_obj.series_id),
+    )
+```
+
+**Référence** : PR #76 cascade subjects.
+
+### JSON column + Pydantic dump
+
+`data.model_dump()` retourne types Python natifs (`datetime.date`, Enum). **Audit JSON column** nécessite `model_dump(mode="json")`. Sinon `TypeError` re-raised → 500 plain text → FE affiche « Erreur serveur » générique.
+
+**Référence** : hotfix #80 audit JSON mode.
+
+---
+
+## Mobile responsive — pattern Tailwind
+
+### `hidden md:block` + `md:hidden` (CSS-only, zéro JS)
+
+```tsx
+<div className="hidden md:block">
+  <CrudTable ... />
+</div>
+<div className="space-y-2 md:hidden">
+  {items.map(s => <MobileEntityListItem ... />)}
+</div>
+```
+
+Un seul layout visible à la fois. Pas de JS viewport detection.
+
+### `<MobileEntityListItem>` API
+
+```typescript
+interface MobileEntityListItemProps {
+  href: string                          // CAST `as Route` côté consommateur (typedRoutes Next.js)
+  avatar: ReactNode                     // Avatar partagé (photo + initials fallback)
+  primary: ReactNode                    // Nom + ♀/♂ inline
+  secondary?: ReactNode                 // Classe / matière / contexte
+  status?: ReactNode                    // Badge optionnel (Valide / À inscrire / etc.)
+}
+```
+
+Réutilisable sur `/admin/teachers`, `/staff`, `/parents`, `/classes`. Voir `components/shared/MobileEntityListItem.tsx`.
+
+---
+
+## Anti-patterns à bloquer en review
+
+1. **3+ KPI cards en hero** sans action click possible → drop, mettre subtitle
+2. **Bouton Filtres** boîte noire (pas de chips visibles) → chips toujours
+3. **Colonne Genre / Sex** dédiée → mini-icône inline suffit
+4. **Matricule colonne ET sous-titre** → un seul (sous-titre)
+5. **Badge passif** sans next action → rendre cliquable ou drop
+6. **Disabled greyed sans helper text visible** → ajouter paragraphe sous le champ
+7. **Card mobile avec 8 fields** → MobileEntityListItem 4 props max
+8. **Frais % avec seuil binaire** sans `expected_so_far` → drop ou refonte calcul
+9. **Sort par matricule ASC** par défaut → toujours `nom ASC` (admin cherche par nom)
+10. **Em dashes en français** (`—`) → virgule, point, ou rien
+11. **Double rendering Table+Cards** sans `display:none` Tailwind → flicker
+12. **Tests skip** sur endpoint sensible (PII export, bulk archive) → BLOCK PR
+13. **`window.confirm()` ou `window.alert()`** → utiliser `<AlertDialog>` shadcn
+14. **Tri par matricule alphabétique** comme ordre par défaut → tri par nom
+15. **Bulk action sans confirm count exact** → « Archiver 50 élèves ? » avec count
+
+---
+
+## Pièges techniques pré-existants
+
+### 1. `pnpm build` complet > `tsc --noEmit`
+
+`tsc` standalone ne checke pas les **typedRoutes** Next.js. Toujours `pnpm build` complet en local OU laisser CI fail puis hotfix. **Lesson** : commit 3544123 hotfix Route cast.
+
+### 2. Cache bundle Next.js `immutable`
+
+Post-deploy, real users ouvrent l'app avec ANCIEN bundle (Cache-Control: immutable 1 an sur chunks). Hard reload (Ctrl+Shift+R) ou attendre nouveau deploy avec hash chunks différents. Voir `auth-architecture.md` section « Cache-bust ».
+
+### 3. Branch hygiene en monorepo
+
+`cd ... &&` chaîné dans Bash crée des cas limites où le commit part sur la mauvaise branche. **Toujours** `git branch --show-current` AVANT chaque commit important.
+
+### 4. Visual-check ≠ feature-complete
+
+Le visual-check valide le **render**, pas le **submit**. Pour modal/CTA/badge actionable, exercer le submit via `page.evaluate(fetch...)` et vérifier 2xx. Voir lesson session 2026-04-27 cascade subject.
+
+### 5. Pydantic dump + JSON column
+
+`data.model_dump()` → types Python (`date`, Enum). Audit JSON col attend strings → `TypeError` re-raised → 500 plain text. Toujours `model_dump(mode="json")` pour audit / JSON storage.
+
+---
+
+## Exemples de redesigns shippés (référence)
+
+| Refonte | Issues | Patterns appliqués |
+|---|---|---|
+| Cascade Subject Select dans EvaluationCreateModal | BE #76, FE #112 | Predicate SQL unique partagé filter+validator, helper text visible disabled, drop dropdown noise |
+| Mode Dictée vocale plein écran | BE #44, FE #108 | Voice + touch hybrid, retour audio plein soleil, persona Mme Diallo |
+| Permissions Matrix UI | FE #108 | Hierarchique groupé 2 niveaux, recherche, pastilles |
+| Students list redesign Persona | BE #82, FE #116 | Subtitle > KPI cards, chips bar, « À inscrire » badge actionable, MobileEntityListItem primitive, with_loader_criteria, drop noise |
+| Hotfix audit JSON mode | BE #80 | mode=json convention drift fix |
+
+---
+
+## Pattern de session (template TL;DR)
+
+```
+1. /ultrathink → audit problèmes ranked persona-first
+2. /plan-and-confirm FULL → critic 4-axes, accept RETHINK si valide
+3. Path minimum viable enrichi (drop ce qui pas critique)
+4. BE first (data + tests pytest), FE après
+5. shared primitives (MobileEntityListItem, etc.) extracted day 1
+6. /commit → push → PR feat→develop → merge
+7. PR develop→main → deploy auto
+8. /visual-check (render + SUBMIT TEST sur form/modal/badge)
+9. /ultrathink retro → cristalliser patterns dans rules
+10. /schedule agent dans 1-2 semaines pour collecter feedback persona réel
+```
+
+---
+
+## Voir aussi
+
+- `ux-target-user-reality.md` — persona Mme Diallo, anti-patterns mobile
+- `components.md` — règles techniques composants Server/Client
+- `forms.md` — patterns RHF + Zod
+- `data-fetching.md` — TanStack Query patterns + invalidation
+- `auth-architecture.md` — flow auth + cache-bust deploy
+- `~/.claude/skills/visual-check/SKILL.md` — submit test mandatory (Step 4)
+- `~/.claude/skills/plan-and-confirm/SKILL.md` — FULL mode + critic 4-axes
+- `~/.claude/rules/marcel-global-preferences.md` — no AI slop, mobile-first, 1 accent color
+- `klassci-backend/.claude/rules/python.md` — async + SQLAlchemy 2.0 + Pydantic v2
+- Memory : `feedback_persona_first_design.md`, `feedback_be_fe_contract_drift.md`, `project_session_2026_04_27_students_redesign.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Page Inscriptions repensée queue-first : on voit d'un coup d'œil la queue à valider, on valide une inscription en un tap depuis la liste avec confirmation, plus de cartes de KPI redondantes *(admin)* (#121).
 - Confirmation propre par dialogue (au lieu du dialogue système du navigateur) avant de quitter le mode dictée avec des saisies non enregistrées *(enseignant)* (#108).
 - Page Élèves repensée : on voit enfin la classe de chaque élève d'un coup d'œil, on filtre par classe ou « à inscrire » d'un tap, et la version mobile s'aligne sur le terrain *(admin)* (#116).
 - Création d'évaluation : la liste des matières se filtre automatiquement selon la classe choisie, plus rapide à parcourir et impossible de se tromper de matière *(admin)* (#112).

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -1,59 +1,29 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useSearchParams } from "next/navigation"
-import { Plus, GraduationCap, Users, CheckCircle, Clock } from "lucide-react"
+import { GraduationCap, Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
 import { EnrollmentsTable } from "./EnrollmentsTable"
 import { EnrollmentCreateModal } from "./EnrollmentCreateModal"
 import { useEnrollments } from "@/lib/hooks/useEnrollments"
 
-function EnrollmentKpis() {
-  const { data } = useEnrollments({ size: 1 })
-  const { data: validated } = useEnrollments({ status: "valide", size: 1 })
-  const { data: pending } = useEnrollments({ status: "en_validation", size: 1 })
-
-  const total = data?.total ?? 0
-  const totalValidated = validated?.total ?? 0
-  const totalPending = pending?.total ?? 0
-
+// Subtitle informatif sans redondance avec les chips. Le total renseigne
+// l'admin sur la volumétrie de la queue ; les counts par statut sont sur
+// la chips bar juste en dessous.
+function EnrollmentsSubtitle() {
+  const { data, isLoading } = useEnrollments({ size: 1 })
+  if (isLoading || !data) {
+    return <p className="text-sm text-muted-foreground">Gérez les inscriptions des élèves</p>
+  }
+  const total = data.total ?? 0
+  if (total === 0) {
+    return <p className="text-sm text-muted-foreground">Aucune inscription pour le moment</p>
+  }
   return (
-    <div className="grid grid-cols-3 gap-4">
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-4 flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
-            <Users className="h-4 w-4 text-primary" />
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">Total</p>
-            <p className="text-xl font-bold">{total}</p>
-          </div>
-        </CardContent>
-      </Card>
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-4 flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-100">
-            <CheckCircle className="h-4 w-4 text-emerald-600" />
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">Validées</p>
-            <p className="text-xl font-bold">{totalValidated}</p>
-          </div>
-        </CardContent>
-      </Card>
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-4 flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-100">
-            <Clock className="h-4 w-4 text-amber-600" />
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">En validation</p>
-            <p className="text-xl font-bold">{totalPending}</p>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <p className="text-sm text-muted-foreground">
+      {total} inscription{total > 1 ? "s" : ""} au total
+    </p>
   )
 }
 
@@ -76,9 +46,7 @@ export function EnrollmentsPageClient() {
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Inscriptions</h1>
-            <p className="text-sm text-muted-foreground">
-              Gérez les inscriptions des élèves
-            </p>
+            <EnrollmentsSubtitle />
           </div>
         </div>
         <Button onClick={() => setCreateOpen(true)} className="h-10">
@@ -87,14 +55,9 @@ export function EnrollmentsPageClient() {
         </Button>
       </div>
 
-      <EnrollmentKpis />
-
       <EnrollmentsTable />
 
-      <EnrollmentCreateModal
-        open={createOpen}
-        onClose={() => setCreateOpen(false)}
-      />
+      <EnrollmentCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
     </div>
   )
 }

--- a/components/admin/enrollments/EnrollmentsTable.tsx
+++ b/components/admin/enrollments/EnrollmentsTable.tsx
@@ -2,145 +2,376 @@
 
 import { useCallback, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
+import type { Route } from "next"
 import type { ColumnDef } from "@tanstack/react-table"
-import { useEnrollments, useDeleteEnrollment } from "@/lib/hooks/useEnrollments"
-import type { Enrollment, EnrollmentListParams } from "@/lib/contracts/enrollment"
+import { Check } from "lucide-react"
+import { useDeleteEnrollment, useEnrollments, useValidateEnrollment } from "@/lib/hooks/useEnrollments"
+import type { Enrollment } from "@/lib/contracts/enrollment"
 import { Badge } from "@/components/ui/badge"
-import { CrudTable, type FilterConfig } from "@/components/shared/CrudTable"
-import { EnrollmentEditModal } from "./EnrollmentEditModal"
+import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { CrudTable } from "@/components/shared/CrudTable"
+import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
 import { useDebounce } from "@/lib/hooks/useDebounce"
+import { cn } from "@/lib/utils"
 
-const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  prospect: { label: "Prospect", variant: "outline" },
-  en_validation: { label: "En validation", variant: "secondary" },
-  valide: { label: "Validé", variant: "default" },
-  rejete: { label: "Rejeté", variant: "destructive" },
-  annule: { label: "Annulé", variant: "destructive" },
+// Cohorte « À valider » = prospect + en_validation. La sémantique queue : c'est
+// ce que l'admin doit traiter activement à la rentrée.
+const TO_VALIDATE_STATUSES = new Set<Enrollment["status"]>(["prospect", "en_validation"])
+
+const statusLabels: Record<Enrollment["status"], string> = {
+  prospect: "Prospect",
+  en_validation: "En validation",
+  valide: "Validé",
+  rejete: "Rejeté",
+  annule: "Annulé",
 }
 
-const statusFilterOptions = [
-  { value: "prospect", label: "Prospect" },
-  { value: "en_validation", label: "En validation" },
-  { value: "valide", label: "Validé" },
-  { value: "rejete", label: "Rejeté" },
-  { value: "annule", label: "Annulé" },
-]
+const PAGE_SIZE = 20
 
-const filterConfigs: FilterConfig[] = [
-  { key: "status", label: "Statut", type: "select", options: statusFilterOptions },
-]
-
-interface EnrollmentsTableProps {
-  filters?: EnrollmentListParams
+// Avatar inline avec initiales — pas de photo (les enrollments n'en exposent
+// pas, l'admin verra la photo dans la fiche élève).
+function StudentInitialsAvatar({
+  firstName,
+  lastName,
+  size = "md",
+}: {
+  firstName: string | null | undefined
+  lastName: string | null | undefined
+  size?: "sm" | "md"
+}) {
+  const initials = `${firstName?.[0] ?? ""}${lastName?.[0] ?? ""}`.toUpperCase() || "?"
+  const sizeClass = size === "sm" ? "h-9 w-9" : "h-8 w-8"
+  return (
+    <div
+      className={cn(
+        sizeClass,
+        "flex shrink-0 items-center justify-center rounded-lg border border-border bg-primary/10",
+      )}
+    >
+      <span className="text-xs font-semibold text-primary">{initials}</span>
+    </div>
+  )
 }
 
-export function EnrollmentsTable({ filters: externalFilters = {} }: EnrollmentsTableProps) {
+// Chip de filtre cohorte — duplication locale du pattern StudentsTable. À
+// extraire dans `components/shared/FilterChip.tsx` au 3e consommateur (rule
+// 3-strikes, redesign-premium.md §architecture).
+function FilterChip({
+  label,
+  count,
+  isActive,
+  onClick,
+  tone = "default",
+}: {
+  label: string
+  count: number
+  isActive: boolean
+  onClick: () => void
+  tone?: "default" | "warning"
+}) {
+  const baseClasses =
+    "inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full border px-3 text-sm font-medium transition-colors"
+  const activeClasses = isActive
+    ? tone === "warning"
+      ? "border-amber-500 bg-amber-100 text-amber-900"
+      : "border-primary bg-primary text-primary-foreground"
+    : "border-border bg-muted/40 text-foreground hover:bg-muted"
+  return (
+    <button type="button" onClick={onClick} className={cn(baseClasses, activeClasses)}>
+      <span>{label}</span>
+      <span
+        className={cn(
+          "rounded-full px-1.5 text-[11px] font-semibold tabular-nums",
+          isActive
+            ? tone === "warning"
+              ? "bg-amber-200 text-amber-900"
+              : "bg-primary-foreground/20 text-primary-foreground"
+            : "bg-background text-muted-foreground",
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  )
+}
+
+type ChipKey = "a_valider" | "validees"
+
+export function EnrollmentsTable() {
   const router = useRouter()
   const [page, setPage] = useState(1)
   const [search, setSearch] = useState("")
-  const [filters, setFilters] = useState<Record<string, string>>({})
+  const [activeChip, setActiveChip] = useState<ChipKey>("a_valider")
+  const [validateTarget, setValidateTarget] = useState<Enrollment | null>(null)
   const debouncedSearch = useDebounce(search)
 
-  const handleFilterChange = useCallback((key: string, value: string) => {
-    setFilters((prev) => ({ ...prev, [key]: value }))
-    setPage(1)
-  }, [])
+  // On charge tout d'un coup (size=200) pour dériver les counts client-side
+  // sans endpoint /filters dédié. Acceptable ≤200 enrollments par tenant — au
+  // delà, on ajoutera GET /admin/enrollments/filters (déféré).
+  const params = useMemo(
+    () => ({
+      size: 200,
+      page: 1,
+      ...(debouncedSearch ? { search: debouncedSearch } : {}),
+    }),
+    [debouncedSearch],
+  )
+
+  const { data, isLoading, isError, error, refetch } = useEnrollments(params)
+  const deleteMutation = useDeleteEnrollment()
+  const validateMutation = useValidateEnrollment()
+
+  const allItems = data?.items ?? []
+
+  const counts = useMemo(() => {
+    let aValider = 0
+    let validees = 0
+    for (const e of allItems) {
+      if (TO_VALIDATE_STATUSES.has(e.status)) aValider += 1
+      else if (e.status === "valide") validees += 1
+    }
+    return { aValider, validees }
+  }, [allItems])
+
+  const filteredItems = useMemo(() => {
+    if (activeChip === "a_valider") {
+      return allItems.filter((e) => TO_VALIDATE_STATUSES.has(e.status))
+    }
+    return allItems.filter((e) => e.status === "valide")
+  }, [allItems, activeChip])
+
+  const paginatedItems = useMemo(
+    () => filteredItems.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
+    [filteredItems, page],
+  )
 
   const handleSearchChange = useCallback((value: string) => {
     setSearch(value)
     setPage(1)
   }, [])
 
-  const params = useMemo(() => ({
-    ...externalFilters,
-    page,
-    ...(debouncedSearch && { search: debouncedSearch }),
-    ...(filters.status && { status: filters.status }),
-  }), [externalFilters, page, debouncedSearch, filters])
+  const handleChipClick = useCallback((key: ChipKey) => {
+    setActiveChip(key)
+    setPage(1)
+  }, [])
 
-  const { data, isLoading, isError, error, refetch } = useEnrollments(params)
-  const deleteMutation = useDeleteEnrollment()
+  const handleValidate = useCallback(() => {
+    if (!validateTarget) return
+    validateMutation.mutate(validateTarget.id, {
+      onSettled: () => setValidateTarget(null),
+    })
+  }, [validateMutation, validateTarget])
 
-  const columns: ColumnDef<Enrollment>[] = useMemo(() => [
-    {
-      accessorKey: "id",
-      header: "N°",
-      cell: ({ row }) => (
-        <span className="font-mono text-xs text-muted-foreground">
-          #{row.original.id}
-        </span>
-      ),
-      size: 60,
-    },
-    {
-      accessorKey: "student_id",
-      header: "Élève",
-      cell: ({ row }) => {
-        const first = row.original.student_first_name
-        const last = row.original.student_last_name
-        const initials = `${(first?.[0] ?? "")}${(last?.[0] ?? "")}`.toUpperCase()
-        if (first || last) {
+  const isToValidate = (e: Enrollment) => TO_VALIDATE_STATUSES.has(e.status)
+
+  const columns: ColumnDef<Enrollment>[] = useMemo(
+    () => [
+      {
+        accessorKey: "student_id",
+        header: "Élève",
+        cell: ({ row }) => {
+          const e = row.original
           return (
             <div className="flex items-center gap-3">
-              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 border border-border">
-                <span className="text-xs font-semibold text-primary">{initials || "?"}</span>
+              <StudentInitialsAvatar
+                firstName={e.student_first_name}
+                lastName={e.student_last_name}
+              />
+              <div className="min-w-0">
+                <p className="truncate font-medium">
+                  {e.student_first_name} {e.student_last_name}
+                </p>
+                <p className="truncate text-[11px] text-muted-foreground">
+                  #{e.id} · {e.academic_year_name}
+                </p>
               </div>
-              <span className="font-medium">{first} {last}</span>
             </div>
           )
-        }
-        return <span className="font-medium text-muted-foreground">#{row.original.student_id}</span>
+        },
       },
-    },
-    {
-      accessorKey: "class_id",
-      header: "Classe",
-      cell: ({ row }) => row.original.class_name ?? `#${row.original.class_id}`,
-    },
-    {
-      accessorKey: "academic_year_name",
-      header: "Année",
-    },
-    {
-      accessorKey: "status",
-      header: "Statut",
-      cell: ({ row }) => {
-        const status = statusConfig[row.original.status]
-        return (
-          <Badge variant={status?.variant ?? "outline"}>
-            {status?.label ?? row.original.status}
+      {
+        accessorKey: "class_id",
+        header: "Classe",
+        cell: ({ row }) => (
+          <Badge variant="outline" className="text-xs font-medium">
+            {row.original.class_name ?? `#${row.original.class_id}`}
           </Badge>
-        )
+        ),
       },
-    },
-  ], [])
+      {
+        accessorKey: "status",
+        header: "Statut",
+        cell: ({ row }) => (
+          <Badge variant="secondary" className="text-xs">
+            {statusLabels[row.original.status] ?? row.original.status}
+          </Badge>
+        ),
+      },
+      {
+        id: "validate-action",
+        header: "",
+        cell: ({ row }) => {
+          const e = row.original
+          if (!isToValidate(e)) return null
+          return (
+            <Button
+              type="button"
+              size="sm"
+              className="h-9 bg-emerald-600 text-white hover:bg-emerald-700"
+              onClick={(ev) => {
+                ev.stopPropagation()
+                setValidateTarget(e)
+              }}
+            >
+              <Check className="mr-1 h-4 w-4" />
+              Valider
+            </Button>
+          )
+        },
+      },
+    ],
+    [],
+  )
 
   return (
-    <CrudTable<Enrollment>
-      data={data}
-      columns={columns}
-      isLoading={isLoading}
-      isError={isError}
-      error={error}
-      refetch={refetch}
-      deleteMutation={deleteMutation}
-      onRowClick={(item) => router.push(`/admin/enrollments/${item.id}`)}
-      renderEditModal={({ itemId, open, onClose }) => (
-        <EnrollmentEditModal enrollmentId={itemId} open={open} onClose={onClose} />
-      )}
-      getItemLabel={(e) => `#${e.id}`}
-      emptyMessage="Aucune inscription trouvée"
-      errorMessage="Impossible de charger les inscriptions"
-      deleteTitle="Supprimer l'inscription"
-      deleteDescription="Cette action est irréversible. L'inscription sera définitivement supprimée."
-      page={page}
-      onPageChange={setPage}
-      searchPlaceholder="Rechercher une inscription..."
-      searchValue={search}
-      onSearchChange={handleSearchChange}
-      filterConfigs={filterConfigs}
-      filterValues={filters}
-      onFilterChange={handleFilterChange}
-    />
+    <div className="space-y-4">
+      {/* Chips bar — pipeline de validation. « À valider » sélectionnée par
+          défaut car c'est la queue d'action de l'admin. */}
+      <div className="flex gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-x-visible">
+        <FilterChip
+          label="À valider"
+          count={counts.aValider}
+          isActive={activeChip === "a_valider"}
+          onClick={() => handleChipClick("a_valider")}
+          tone="warning"
+        />
+        <FilterChip
+          label="Validées"
+          count={counts.validees}
+          isActive={activeChip === "validees"}
+          onClick={() => handleChipClick("validees")}
+        />
+      </div>
+
+      {/* Desktop : table dense via CrudTable. Mobile : liste minimaliste +
+          bouton Valider distinct (Wave-style — la zone tap-to-drill n'avale
+          pas l'action). */}
+      <div className="hidden md:block">
+        <CrudTable<Enrollment>
+          data={{
+            items: paginatedItems,
+            total: filteredItems.length,
+            page,
+            size: PAGE_SIZE,
+            total_pages: Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE)),
+          }}
+          columns={columns}
+          isLoading={isLoading}
+          isError={isError}
+          error={error}
+          refetch={refetch}
+          deleteMutation={deleteMutation}
+          onRowClick={(item) => router.push(`/admin/enrollments/${item.id}`)}
+          renderEditModal={() => null}
+          getItemLabel={(e) => `#${e.id}`}
+          emptyMessage="Aucune inscription trouvée"
+          errorMessage="Impossible de charger les inscriptions"
+          deleteTitle="Supprimer l'inscription"
+          deleteDescription="Cette action est irréversible. L'inscription sera définitivement supprimée."
+          page={page}
+          onPageChange={setPage}
+          searchPlaceholder="Rechercher une inscription..."
+          searchValue={search}
+          onSearchChange={handleSearchChange}
+        />
+      </div>
+
+      <div className="space-y-2 md:hidden">
+        {isLoading && (
+          <p className="rounded-lg border bg-muted/30 p-4 text-center text-sm text-muted-foreground">
+            Chargement…
+          </p>
+        )}
+        {!isLoading && paginatedItems.length === 0 && (
+          <p className="rounded-lg border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+            Aucune inscription trouvée
+          </p>
+        )}
+        {paginatedItems.map((e) => (
+          <div key={e.id} className="space-y-2">
+            <MobileEntityListItem
+              href={`/admin/enrollments/${e.id}` as Route}
+              avatar={
+                <StudentInitialsAvatar
+                  firstName={e.student_first_name}
+                  lastName={e.student_last_name}
+                  size="sm"
+                />
+              }
+              primary={
+                <span>
+                  {e.student_first_name} {e.student_last_name}
+                </span>
+              }
+              secondary={`${e.class_name ?? `#${e.class_id}`} · ${e.academic_year_name}`}
+              status={
+                <Badge variant="secondary" className="text-[10px]">
+                  {statusLabels[e.status] ?? e.status}
+                </Badge>
+              }
+            />
+            {isToValidate(e) && (
+              <Button
+                type="button"
+                onClick={() => setValidateTarget(e)}
+                className="h-11 w-full bg-emerald-600 text-white hover:bg-emerald-700"
+              >
+                <Check className="mr-1.5 h-4 w-4" />
+                Valider l&apos;inscription
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <AlertDialog
+        open={validateTarget !== null}
+        onOpenChange={(open) => !open && setValidateTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Valider l&apos;inscription ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Vous êtes sur le point de valider l&apos;inscription de{" "}
+              <strong>
+                {validateTarget?.student_first_name} {validateTarget?.student_last_name}
+              </strong>{" "}
+              en {validateTarget?.class_name ?? "—"} pour {validateTarget?.academic_year_name}. L&apos;inscription
+              passera au statut « validé ».
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={validateMutation.isPending}>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleValidate}
+              disabled={validateMutation.isPending}
+              className="bg-emerald-600 hover:bg-emerald-700 focus:ring-emerald-600"
+            >
+              {validateMutation.isPending ? "Validation…" : "Valider"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
   )
 }

--- a/lib/api/enrollments.ts
+++ b/lib/api/enrollments.ts
@@ -28,4 +28,8 @@ export const enrollmentsApi = {
   getFeeVariants: async (classId: number) => {
     return apiFetch<FeeVariantOption[]>(`/enrollments/fee-variants?class_id=${classId}`)
   },
+
+  validate: async (id: number) => {
+    return apiFetch<Enrollment>(`/enrollments/${id}/validate`, { method: "POST" })
+  },
 }

--- a/lib/hooks/useEnrollments.ts
+++ b/lib/hooks/useEnrollments.ts
@@ -62,3 +62,18 @@ export function useFeeVariants(classId: number | undefined) {
     enabled: !!classId,
   })
 }
+
+export function useValidateEnrollment() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => enrollmentsApi.validate(id),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: enrollmentKeys.all })
+      queryClient.invalidateQueries({ queryKey: enrollmentKeys.detail(data.id) })
+      toast.success("Inscription validée")
+    },
+    onError: (error: Error) => {
+      toast.error("Validation impossible", { description: error.message })
+    },
+  })
+}


### PR DESCRIPTION
Closes #121

## Pourquoi

La page \`/admin/enrollments\` ressemblait à un annuaire classique (3 KPI cards + table avec filtre dropdown), mais c'est une **queue de validation** : l'admin l'ouvre pour traiter les prospects. Plan-and-confirm depth=5 a fait apparaître l'erreur catégorielle (annuaire vs queue), critic + Devil's Advocate ont poussé RETHINK, plan A queue-first adopté.

## BE prerequisite déjà mergé + déployé

PR backend #94 (\`POST /enrollments/{id}/validate\`) est mergée et déployée. Endpoint vérifié vivant :

\`\`\`
POST /api-be/enrollments/1/validate → 401 (auth requise, endpoint existe)
GET  /api-be/enrollments/1/validate → 405 (méthode invalide, endpoint existe)
\`\`\`

## Ce qui change visuellement

| Avant | Après |
|---|---|
| 3 KPI cards Total / Validées / En validation (200px verticaux pour info passive) | Subtitle « N inscriptions au total » dans le header (1 ligne) |
| Filtre dropdown « Statut » (1 tap pour ouvrir, 1 tap pour choisir) | Chips bar « À valider (N) » + « Validées (N) » — 1 tap, count visible |
| Pour valider une inscription : tap row → fiche → bouton « Modifier » → champ Statut → \"valide\" → Submit | Tap « Valider » sur la row → AlertDialog confirmation → 1 tap |
| Mobile : table responsive cassée | Liste minimaliste \`MobileEntityListItem\` + bouton \`h-11\` Valider distinct |

## Architecture

- **Counts dérivés client-side** (load \`size=200\` puis filter) — pas d'endpoint \`/filters\` dédié, suffisant ≤200 enrollments par tenant. Si scale change, on ajoutera \`GET /admin/enrollments/filters\` (cycle 4+).
- **Pagination client-side** sur le résultat filtré par chip.
- **Mutation TanStack Query** : \`useValidateEnrollment\` invalide \`enrollmentKeys.all\` + détail.
- **Confirmation AlertDialog shadcn/ui** : pas de \`window.confirm\`.
- **\`<MobileEntityListItem>\`** réutilisé (extrait en PR #116).
- **\`FilterChip\` local** : duplication du pattern StudentsTable, à extraire dans \`components/shared/FilterChip.tsx\` au 3ème consommateur (rule 3-strikes).

## Hors scope (déféré aux cycles suivants)

- Endpoint BE \`/admin/enrollments/filters\` → cycle 4+ si volume justifie
- \`<UnifiedDarkHero>\` extraction → cycle 3+ après 3 consommateurs concrets
- Redesign tab Vue d'ensemble \`/admin/enrollments/[id]\` → cycle 3
- Endpoint \`/reject\` symétrique → cycle 4+ si demande utilisateur
- Frais column avec \`expected_so_far\` → cycle 2

## Test plan

- [x] \`pnpm tsc --noEmit\` passe (typedRoutes Route cast respecté sur \`MobileEntityListItem.href\`)
- [ ] CI build + lint passe
- [ ] Après merge develop : auto-deploy EC2 + visual-check Ctrl+Shift+R sur \`/admin/enrollments\`
- [ ] Test manuel sur prod : login admin, voir chip « À valider » sélectionnée par défaut, tap « Valider » → AlertDialog → confirmer → row passe en chip « Validées »

## Plan-and-confirm

Validé en cycle 1 plan A queue-first (depth=5 ultrathink). Cycle 2 = Frais column \`expected_so_far\`. Cycle 3 = redesign détail enrollment. Cycle 5 = promotions wizard (deadline juin).