### PR TITLE
fix(enrollments): cap initial fetch at size=100 (BE limit, was 422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Liste des inscriptions qui restait en chargement infini après la refonte queue-first : la page demandait plus d'inscriptions à la fois que le serveur ne le permet *(admin)* (#131).
 - Sélection de l'enseignant titulaire vide dans le formulaire de création d'évaluation côté admin *(admin)* (#109).
 - Initialisation du retour audio du mode dictée hors interaction utilisateur, qui empêchait silencieusement le bip de confirmation sur iPhone *(enseignant)* (#108).
 - Bouton micro restait actif après refus de l'autorisation, promettant un fonctionnement impossible *(enseignant)* (#108).

--- a/components/admin/enrollments/EnrollmentsTable.tsx
+++ b/components/admin/enrollments/EnrollmentsTable.tsx
@@ -115,12 +115,13 @@ export function EnrollmentsTable() {
   const [validateTarget, setValidateTarget] = useState<Enrollment | null>(null)
   const debouncedSearch = useDebounce(search)
 
-  // On charge tout d'un coup (size=200) pour dériver les counts client-side
-  // sans endpoint /filters dédié. Acceptable ≤200 enrollments par tenant — au
-  // delà, on ajoutera GET /admin/enrollments/filters (déféré).
+  // On charge tout d'un coup (size=100, max BE actuel) pour dériver les
+  // counts client-side sans endpoint /filters dédié. Acceptable ≤100
+  // enrollments par tenant — au delà, on ajoutera GET /admin/enrollments/filters
+  // (déféré). 100 est la limite Pydantic `Query(20, le=100)` côté BE.
   const params = useMemo(
     () => ({
-      size: 200,
+      size: 100,
       page: 1,
       ...(debouncedSearch ? { search: debouncedSearch } : {}),
     }),


### PR DESCRIPTION
Refs #121

## Bug

Visual-check post-deploy a montré la table /admin/enrollments en skeleton infini. Investigation : le payload renvoie 422 \"\" parce que le FE demandait \`size=200\` mais le BE cappe \`size=int = Query(20, ge=1, le=100)\` à 100 (\`app/routers/enrollments.py:31\`).

## Fix

\`size=100\` au lieu de 200 dans \`EnrollmentsTable.tsx\`. C'est la limite Pydantic actuelle ; la note dans le commentaire est mise à jour.

Si on dépasse 100 enrollments par tenant, on ajoutera le \`GET /admin/enrollments/filters\` endpoint (déféré au cycle 4+).

## Severity

P1 — la nouvelle page Inscriptions reste cassée en prod jusqu'au merge.

## Test plan

- [x] tsc passe
- [ ] CI passe
- [ ] Après merge develop : auto-deploy + visual-check Ctrl+Shift+R, table loaded avec 3 inscriptions, chips counts corrects