### PR TITLE
fix(ui): stack admin header vertically on mobile + smaller title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- En-tête des pages Inscriptions et Élèves qui débordait à droite sur mobile (le bouton « Nouvelle inscription » mangeait la place du titre) : on empile désormais titre et bouton sur petit écran et on ajuste la taille du titre *(admin)*.
 - Liste des inscriptions qui restait en chargement infini après la refonte queue-first : la page demandait plus d'inscriptions à la fois que le serveur ne le permet *(admin)* (#131).
 - Sélection de l'enseignant titulaire vide dans le formulaire de création d'évaluation côté admin *(admin)* (#109).
 - Initialisation du retour audio du mode dictée hors interaction utilisateur, qui empêchait silencieusement le bip de confirmation sur iPhone *(enseignant)* (#108).

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -39,18 +39,18 @@ export function EnrollmentsPageClient() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
             <GraduationCap className="h-5 w-5 text-primary" />
           </div>
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">Inscriptions</h1>
+          <div className="min-w-0">
+            <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Inscriptions</h1>
             <EnrollmentsSubtitle />
           </div>
         </div>
-        <Button onClick={() => setCreateOpen(true)} className="h-10">
-          <Plus className="mr-2 h-4 w-4" />
+        <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
+          <Plus className="h-4 w-4" />
           Nouvelle inscription
         </Button>
       </div>

--- a/components/admin/students/StudentsPageClient.tsx
+++ b/components/admin/students/StudentsPageClient.tsx
@@ -30,12 +30,12 @@ export function StudentsPageClient() {
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
             <Users className="h-5 w-5 text-primary" />
           </div>
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">Élèves</h1>
+          <div className="min-w-0">
+            <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Élèves</h1>
             <p className="text-sm text-muted-foreground">
               {total} {total > 1 ? "élèves au total" : "élève au total"}
               {noCurrent > 0 && (


### PR DESCRIPTION
Refs #121

## Bug

Visual-check post-deploy a montré un overflow header sur mobile 375px : le titre « Inscriptions » + subtitle « 3 inscriptions au total » ​rentrait en compétition avec le bouton « Nouvelle inscription » qui se faisait tronquer à droite.

## Fix

Pattern cohérent sur les 2 pages admin (Inscriptions + Élèves) :
- \`flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between\` (stack vertical mobile, horizontal desktop)
- Titre \`text-xl sm:text-2xl\` (plus compact mobile)
- \`min-w-0\` sur le bloc titre pour permettre la réduction sous le contenu
- \`shrink-0\` sur l'icône avatar
- Bouton \`h-11 mobile sm:h-10 desktop\` (touch target persona Itel S661)

Visual-check effectué desktop + mobile post-deploy avant ouverture de cette PR (cycle 1 ultrathink retro lesson #5 : visual-check authentifié dès le premier check).

## Test plan

- [x] tsc passe
- [ ] CI passe
- [ ] Mobile 375x812 : header tient sans overflow, bouton plein largeur sous titre
- [ ] Desktop : layout horizontal préservé