### PR TITLE
feat(promotions): wizard 2-step UI at /admin/promotions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Promotion en masse de fin d'année : nouvelle page « Promotions » qui aide l'admin à transformer en quelques clics les inscriptions valides d'une année vers la suivante, avec aperçu des élèves promus, avertissements de capacité et rapport détaillé des exceptions *(admin)* (#133).
 - Mode dictée vocal plein écran pour saisir les notes sans regarder l'écran, optimisé Chrome Android et iOS Safari *(enseignant)* (#108).
 - Création d'évaluation déléguée : un admin ou un personnel administratif peut créer une évaluation au nom d'un enseignant, avec sélection explicite du titulaire *(admin)* (#108).
 - Matrice rôles × permissions enfin utilisable : groupement à deux niveaux, recherche, pastilles d'actions et libellés français *(admin)* (#108).

--- a/app/(admin)/admin/promotions/page.tsx
+++ b/app/(admin)/admin/promotions/page.tsx
@@ -1,0 +1,5 @@
+import { PromotionsClient } from "@/components/admin/promotions/PromotionsClient"
+
+export default function PromotionsPage() {
+  return <PromotionsClient />
+}

--- a/components/admin/promotions/PromotionsClient.tsx
+++ b/components/admin/promotions/PromotionsClient.tsx
@@ -1,0 +1,566 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { ArrowRight, ArrowUpFromLine, Check, RotateCcw, TriangleAlert } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Badge } from "@/components/ui/badge"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { useClasses } from "@/lib/hooks/useClasses"
+import { usePromotionExecute, usePromotionPreview } from "@/lib/hooks/usePromotions"
+import type {
+  PromotionExecuteResponse,
+  PromotionPreviewResponse,
+} from "@/lib/contracts/promotion"
+import { cn } from "@/lib/utils"
+
+type WizardStep = "mapping" | "preview"
+
+export function PromotionsClient() {
+  const [sourceAyId, setSourceAyId] = useState<number | null>(null)
+  const [targetAyId, setTargetAyId] = useState<number | null>(null)
+  const [mapping, setMapping] = useState<Record<number, number>>({})
+  const [step, setStep] = useState<WizardStep>("mapping")
+  const [preview, setPreview] = useState<PromotionPreviewResponse | null>(null)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [result, setResult] = useState<PromotionExecuteResponse | null>(null)
+
+  const { data: yearsData } = useAcademicYears({ size: 50, page: 1 })
+  const years = yearsData?.items ?? []
+
+  const { data: sourceClassesData } = useClasses(
+    sourceAyId ? { academic_year_id: sourceAyId, size: 100, page: 1 } : { size: 1, page: 1 },
+  )
+  const sourceClasses = useMemo(
+    () =>
+      sourceAyId
+        ? (sourceClassesData?.items ?? []).filter((c) => c.academic_year_id === sourceAyId)
+        : [],
+    [sourceAyId, sourceClassesData],
+  )
+
+  const { data: targetClassesData } = useClasses(
+    targetAyId ? { academic_year_id: targetAyId, size: 100, page: 1 } : { size: 1, page: 1 },
+  )
+  const targetClasses = useMemo(
+    () =>
+      targetAyId
+        ? (targetClassesData?.items ?? []).filter((c) => c.academic_year_id === targetAyId)
+        : [],
+    [targetAyId, targetClassesData],
+  )
+
+  const previewMutation = usePromotionPreview()
+  const executeMutation = usePromotionExecute()
+
+  const filledMappingCount = Object.values(mapping).filter((v) => v > 0).length
+  const canPreview =
+    sourceAyId !== null &&
+    targetAyId !== null &&
+    sourceAyId !== targetAyId &&
+    filledMappingCount > 0
+
+  const stringMapping = useMemo(() => {
+    const out: Record<string, number> = {}
+    for (const [k, v] of Object.entries(mapping)) {
+      if (v > 0) out[k] = v
+    }
+    return out
+  }, [mapping])
+
+  const handlePreview = () => {
+    if (!sourceAyId || !targetAyId) return
+    previewMutation.mutate(
+      { source_ay_id: sourceAyId, target_ay_id: targetAyId, class_mapping: stringMapping },
+      {
+        onSuccess: (data) => {
+          setPreview(data)
+          setStep("preview")
+        },
+      },
+    )
+  }
+
+  const handleExecute = () => {
+    if (!sourceAyId || !targetAyId) return
+    executeMutation.mutate(
+      { source_ay_id: sourceAyId, target_ay_id: targetAyId, class_mapping: stringMapping },
+      {
+        onSuccess: (data) => {
+          setResult(data)
+          setConfirmOpen(false)
+        },
+      },
+    )
+  }
+
+  const reset = () => {
+    setStep("mapping")
+    setPreview(null)
+    setResult(null)
+    setMapping({})
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <ArrowUpFromLine className="h-5 w-5 text-primary" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Promotions</h1>
+            <p className="text-sm text-muted-foreground">
+              Promotion en masse pour préparer la rentrée
+            </p>
+          </div>
+        </div>
+        {step === "preview" && (
+          <Button variant="outline" onClick={reset} className="h-10 gap-2">
+            <RotateCcw className="h-4 w-4" />
+            Recommencer
+          </Button>
+        )}
+      </div>
+
+      {step === "mapping" && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Étape 1 — Mapping des classes</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="source-ay" className="text-sm font-medium">
+                  Année source
+                </label>
+                <Select
+                  value={sourceAyId?.toString() ?? ""}
+                  onValueChange={(v) => {
+                    setSourceAyId(Number(v))
+                    setMapping({})
+                  }}
+                >
+                  <SelectTrigger id="source-ay" className="h-11">
+                    <SelectValue placeholder="Choisir l'année source" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {years.map((y) => (
+                      <SelectItem key={y.id} value={y.id.toString()}>
+                        {y.name}
+                        {y.is_current ? " · courante" : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="target-ay" className="text-sm font-medium">
+                  Année cible
+                </label>
+                <Select
+                  value={targetAyId?.toString() ?? ""}
+                  onValueChange={(v) => setTargetAyId(Number(v))}
+                >
+                  <SelectTrigger id="target-ay" className="h-11">
+                    <SelectValue placeholder="Choisir l'année cible" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {years
+                      .filter((y) => y.id !== sourceAyId)
+                      .map((y) => (
+                        <SelectItem key={y.id} value={y.id.toString()}>
+                          {y.name}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {sourceAyId !== null && targetAyId !== null && sourceAyId === targetAyId && (
+              <p className="rounded-md bg-amber-50 p-3 text-sm text-amber-800">
+                L&apos;année source et l&apos;année cible doivent être différentes.
+              </p>
+            )}
+
+            {sourceAyId !== null && targetAyId !== null && sourceAyId !== targetAyId && (
+              <ClassMappingTable
+                sourceClasses={sourceClasses}
+                targetClasses={targetClasses}
+                mapping={mapping}
+                onMappingChange={setMapping}
+              />
+            )}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                onClick={handlePreview}
+                disabled={!canPreview || previewMutation.isPending}
+                className="h-11 gap-2"
+              >
+                {previewMutation.isPending ? "Calcul…" : "Aperçu de la promotion"}
+                <ArrowRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === "preview" && preview && (
+        <PromotionPreview
+          preview={preview}
+          targetYearName={
+            years.find((y) => y.id === targetAyId)?.name ?? `année #${targetAyId}`
+          }
+          onExecute={() => setConfirmOpen(true)}
+          isExecuting={executeMutation.isPending}
+        />
+      )}
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmer la promotion ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Vous êtes sur le point de promouvoir {preview?.promotable_count ?? 0} élève
+              {(preview?.promotable_count ?? 0) > 1 ? "s" : ""} vers{" "}
+              {years.find((y) => y.id === targetAyId)?.name ?? "l'année cible"}. Les inscriptions
+              seront créées en statut « Prospect » et apparaîtront dans la queue des inscriptions à
+              valider. Action ré-exécutable : les élèves déjà promus seront ignorés.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={executeMutation.isPending}>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleExecute}
+              disabled={executeMutation.isPending}
+              className="bg-emerald-600 hover:bg-emerald-700"
+            >
+              {executeMutation.isPending ? "Promotion…" : "Confirmer"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {result && <PromotionResultsModal result={result} onClose={reset} />}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Class mapping
+// ---------------------------------------------------------------------------
+
+interface ClassRow {
+  id: number
+  name: string
+  academic_year_id: number
+  max_students?: number | null | undefined
+  enrolled_count?: number | undefined
+}
+
+function ClassMappingTable({
+  sourceClasses,
+  targetClasses,
+  mapping,
+  onMappingChange,
+}: {
+  sourceClasses: ClassRow[]
+  targetClasses: ClassRow[]
+  mapping: Record<number, number>
+  onMappingChange: (m: Record<number, number>) => void
+}) {
+  if (sourceClasses.length === 0) {
+    return (
+      <p className="rounded-md bg-muted/40 p-3 text-sm text-muted-foreground">
+        Aucune classe trouvée pour cette année source.
+      </p>
+    )
+  }
+
+  if (targetClasses.length === 0) {
+    return (
+      <p className="rounded-md bg-amber-50 p-3 text-sm text-amber-800">
+        Aucune classe créée dans l&apos;année cible. Créez d&apos;abord les classes destination
+        depuis « Classes » avant de lancer la promotion.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-muted-foreground">
+        Pour chaque classe source, choisissez la classe destination. Laissez vide pour exclure une
+        classe (les élèves de cette classe ne seront pas promus).
+      </p>
+      <div className="overflow-hidden rounded-lg border">
+        <table className="w-full">
+          <thead className="bg-muted/40">
+            <tr className="text-left text-xs font-medium text-muted-foreground">
+              <th className="px-3 py-2">Classe source</th>
+              <th className="px-3 py-2">Classe destination</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sourceClasses.map((sc) => (
+              <tr key={sc.id} className="border-t">
+                <td className="px-3 py-2">
+                  <span className="font-medium">{sc.name}</span>
+                </td>
+                <td className="px-3 py-2">
+                  <Select
+                    value={mapping[sc.id]?.toString() ?? "none"}
+                    onValueChange={(v) => {
+                      const next = { ...mapping }
+                      if (v === "none") {
+                        delete next[sc.id]
+                      } else {
+                        next[sc.id] = Number(v)
+                      }
+                      onMappingChange(next)
+                    }}
+                  >
+                    <SelectTrigger className="h-10 w-full sm:w-64">
+                      <SelectValue placeholder="Choisir…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">— Ne pas promouvoir —</SelectItem>
+                      {targetClasses.map((tc) => (
+                        <SelectItem key={tc.id} value={tc.id.toString()}>
+                          {tc.name}
+                          {tc.max_students ? ` (max ${tc.max_students})` : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — Preview + execute
+// ---------------------------------------------------------------------------
+
+function PromotionPreview({
+  preview,
+  targetYearName,
+  onExecute,
+  isExecuting,
+}: {
+  preview: PromotionPreviewResponse
+  targetYearName: string
+  onExecute: () => void
+  isExecuting: boolean
+}) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Étape 2 — Aperçu de la promotion</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg bg-primary/5 p-4">
+            <p className="text-sm text-muted-foreground">Total à promouvoir</p>
+            <p className="font-serif text-3xl font-semibold text-primary">
+              {preview.promotable_count} élève{preview.promotable_count > 1 ? "s" : ""}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              vers <strong>{targetYearName}</strong>
+            </p>
+          </div>
+
+          {preview.capacity_warnings.length > 0 && (
+            <div className="space-y-2 rounded-lg border border-amber-300 bg-amber-50 p-3">
+              <div className="flex items-center gap-2">
+                <TriangleAlert className="h-4 w-4 text-amber-700" />
+                <p className="text-sm font-medium text-amber-900">
+                  Capacité dépassée sur {preview.capacity_warnings.length} classe
+                  {preview.capacity_warnings.length > 1 ? "s" : ""}
+                </p>
+              </div>
+              <ul className="space-y-1 pl-6 text-xs text-amber-900">
+                {preview.capacity_warnings.map((w) => (
+                  <li key={w.target_class_id}>
+                    <strong>{w.target_class_name}</strong> : {w.requested} demandés, {w.available}{" "}
+                    disponibles ({w.overflow} en surnombre)
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs text-amber-900">
+                Les élèves en surnombre apparaîtront dans les erreurs après l&apos;exécution.
+              </p>
+            </div>
+          )}
+
+          <div className="overflow-hidden rounded-lg border">
+            <table className="w-full">
+              <thead className="bg-muted/40">
+                <tr className="text-left text-xs font-medium text-muted-foreground">
+                  <th className="px-3 py-2">Classe destination</th>
+                  <th className="px-3 py-2 text-right">Élèves</th>
+                  <th className="px-3 py-2 text-right">Capacité</th>
+                  <th className="px-3 py-2 text-right">Restant</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.source_classes.map((sc) => (
+                  <tr key={sc.source_class_id} className="border-t">
+                    <td className="px-3 py-2">
+                      <span className="font-medium">{sc.target_class_name}</span>
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      {sc.students_to_promote}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                      {sc.target_capacity}
+                    </td>
+                    <td
+                      className={cn(
+                        "px-3 py-2 text-right tabular-nums",
+                        sc.target_remaining < sc.students_to_promote
+                          ? "font-medium text-amber-700"
+                          : "text-muted-foreground",
+                      )}
+                    >
+                      {sc.target_remaining}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              onClick={onExecute}
+              disabled={isExecuting || preview.promotable_count === 0}
+              className="h-11 gap-2 bg-emerald-600 text-white hover:bg-emerald-700"
+            >
+              <Check className="h-4 w-4" />
+              Confirmer la promotion ({preview.promotable_count})
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Result modal — partial-success reporting
+// ---------------------------------------------------------------------------
+
+function PromotionResultsModal({
+  result,
+  onClose,
+}: {
+  result: PromotionExecuteResponse
+  onClose: () => void
+}) {
+  return (
+    <Dialog open={true} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Résultat de la promotion</DialogTitle>
+          <DialogDescription>
+            Récapitulatif détaillé. Vous pouvez ajuster les inscriptions individuelles depuis la
+            queue Inscriptions.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="grid grid-cols-3 gap-3">
+            <div className="rounded-lg bg-emerald-50 p-3">
+              <p className="text-xs text-emerald-700">Promues</p>
+              <p className="font-serif text-2xl font-semibold text-emerald-900">
+                {result.promoted_count}
+              </p>
+            </div>
+            <div className="rounded-lg bg-muted/40 p-3">
+              <p className="text-xs text-muted-foreground">Ignorées</p>
+              <p className="font-serif text-2xl font-semibold">{result.skipped_count}</p>
+              <p className="text-[10px] text-muted-foreground">déjà promues</p>
+            </div>
+            <div
+              className={cn(
+                "rounded-lg p-3",
+                result.error_count > 0 ? "bg-rose-50" : "bg-muted/40",
+              )}
+            >
+              <p
+                className={cn(
+                  "text-xs",
+                  result.error_count > 0 ? "text-rose-700" : "text-muted-foreground",
+                )}
+              >
+                Erreurs
+              </p>
+              <p
+                className={cn(
+                  "font-serif text-2xl font-semibold",
+                  result.error_count > 0 ? "text-rose-900" : "",
+                )}
+              >
+                {result.error_count}
+              </p>
+            </div>
+          </div>
+
+          {result.errors.length > 0 && (
+            <div className="space-y-2 rounded-lg border border-rose-200 bg-rose-50/50 p-3">
+              <p className="text-sm font-medium text-rose-900">
+                Détail des erreurs ({result.errors.length})
+              </p>
+              <ul className="space-y-1 pl-2 text-xs text-rose-900">
+                {result.errors.map((e) => (
+                  <li key={e.source_enrollment_id} className="flex items-start gap-2">
+                    <Badge variant="outline" className="text-[10px]">
+                      Élève #{e.student_id}
+                    </Badge>
+                    <span>{e.reason}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose} className="h-10">
+            Fermer
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -5,6 +5,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import {
+  ArrowUpFromLine,
   LayoutDashboard,
   UserPlus,
   GraduationCap,
@@ -52,6 +53,7 @@ const navigation: NavSection[] = [
     title: "Scolarité",
     items: [
       { label: "Inscriptions", href: "/admin/enrollments", icon: UserPlus },
+      { label: "Promotions", href: "/admin/promotions" as Route, icon: ArrowUpFromLine },
       { label: "Élèves", href: "/admin/students", icon: GraduationCap },
       { label: "Enseignants", href: "/admin/teachers", icon: Users },
       { label: "Personnel", href: "/admin/staff", icon: UserCog },

--- a/lib/api/promotions.ts
+++ b/lib/api/promotions.ts
@@ -1,0 +1,21 @@
+import { apiFetch } from "./client"
+import type {
+  PromotionExecuteRequest,
+  PromotionExecuteResponse,
+  PromotionPreviewRequest,
+  PromotionPreviewResponse,
+} from "@/lib/contracts/promotion"
+
+export const promotionsApi = {
+  preview: async (data: PromotionPreviewRequest) =>
+    apiFetch<PromotionPreviewResponse>("/admin/promotions/preview", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  execute: async (data: PromotionExecuteRequest) =>
+    apiFetch<PromotionExecuteResponse>("/admin/promotions/execute", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+}

--- a/lib/contracts/promotion.ts
+++ b/lib/contracts/promotion.ts
@@ -1,0 +1,60 @@
+import { z } from "zod"
+
+// Match BE app/schemas/admin.py — promotion DTOs (cycle 3 plan B).
+
+export const PromotionPreviewRequestSchema = z.object({
+  source_ay_id: z.number().int().positive(),
+  target_ay_id: z.number().int().positive(),
+  class_mapping: z.record(z.string(), z.number().int().positive()),
+})
+export type PromotionPreviewRequest = z.infer<typeof PromotionPreviewRequestSchema>
+
+export const SourceClassSummarySchema = z.object({
+  source_class_id: z.number(),
+  target_class_id: z.number(),
+  target_class_name: z.string(),
+  students_to_promote: z.number(),
+  target_capacity: z.number(),
+  target_remaining: z.number(),
+})
+export type SourceClassSummary = z.infer<typeof SourceClassSummarySchema>
+
+export const PromotionCapacityWarningSchema = z.object({
+  source_class_id: z.number(),
+  target_class_id: z.number(),
+  target_class_name: z.string(),
+  requested: z.number(),
+  available: z.number(),
+  overflow: z.number(),
+})
+export type PromotionCapacityWarning = z.infer<typeof PromotionCapacityWarningSchema>
+
+export const PromotionPreviewResponseSchema = z.object({
+  source_ay_id: z.number(),
+  target_ay_id: z.number(),
+  source_classes: z.array(SourceClassSummarySchema),
+  capacity_warnings: z.array(PromotionCapacityWarningSchema),
+  promotable_count: z.number(),
+})
+export type PromotionPreviewResponse = z.infer<typeof PromotionPreviewResponseSchema>
+
+export const PromotionExecuteRequestSchema = PromotionPreviewRequestSchema
+export type PromotionExecuteRequest = z.infer<typeof PromotionExecuteRequestSchema>
+
+export const PromotionExecuteErrorSchema = z.object({
+  student_id: z.number(),
+  source_enrollment_id: z.number(),
+  reason: z.string(),
+})
+export type PromotionExecuteError = z.infer<typeof PromotionExecuteErrorSchema>
+
+export const PromotionExecuteResponseSchema = z.object({
+  source_ay_id: z.number(),
+  target_ay_id: z.number(),
+  promoted_count: z.number(),
+  promoted_enrollment_ids: z.array(z.number()),
+  skipped_count: z.number(),
+  error_count: z.number(),
+  errors: z.array(PromotionExecuteErrorSchema),
+})
+export type PromotionExecuteResponse = z.infer<typeof PromotionExecuteResponseSchema>

--- a/lib/hooks/usePromotions.ts
+++ b/lib/hooks/usePromotions.ts
@@ -1,0 +1,56 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { promotionsApi } from "@/lib/api/promotions"
+import type {
+  PromotionExecuteRequest,
+  PromotionPreviewRequest,
+} from "@/lib/contracts/promotion"
+
+/**
+ * Mutation pre-flight de la promotion bulk. Ne modifie rien côté BE — c'est
+ * juste un POST stateless qui retourne le summary. On utilise mutation plutôt
+ * que query pour ne le déclencher que sur demande explicite (bouton « Aperçu »),
+ * pas en auto-fetch.
+ */
+export function usePromotionPreview() {
+  return useMutation({
+    mutationFn: (data: PromotionPreviewRequest) => promotionsApi.preview(data),
+    onError: (error: Error) => {
+      toast.error("Aperçu impossible", { description: error.message })
+    },
+  })
+}
+
+/**
+ * Mutation d'exécution de la promotion bulk. Invalide les enrollments queries
+ * au succès (la queue cycle 1 doit refléter les nouveaux prospects).
+ */
+export function usePromotionExecute() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: PromotionExecuteRequest) => promotionsApi.execute(data),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["enrollments"] })
+      if (data.promoted_count > 0) {
+        toast.success(
+          `${data.promoted_count} inscription${data.promoted_count > 1 ? "s" : ""} promue${
+            data.promoted_count > 1 ? "s" : ""
+          }`,
+          {
+            description:
+              data.error_count > 0
+                ? `${data.error_count} erreur${data.error_count > 1 ? "s" : ""} rapportée${
+                    data.error_count > 1 ? "s" : ""
+                  }`
+                : undefined,
+          },
+        )
+      }
+    },
+    onError: (error: Error) => {
+      toast.error("Promotion échouée", { description: error.message })
+    },
+  })
+}


### PR DESCRIPTION
Closes #133

## Pourquoi

Cycle 3 du roadmap. BE PR #96 (mergée et déployée — endpoint preview répond 401) expose les endpoints \`POST /admin/promotions/preview\` et \`POST /admin/promotions/execute\`. Cette PR ajoute l'UI wizard 2-step pour les consommer.

**Persona Type A** : admin/secrétaire en juin sur laptop pour préparer la rentrée septembre. Pas Mme Diallo (Type B mobile). Desktop-first acceptable.

## Ce qui change visuellement

Nouvelle entrée sidebar « Promotions » sous section « Scolarité » avec icône \`ArrowUpFromLine\`, après « Inscriptions ».

Page \`/admin/promotions\` avec wizard state machine :

### Étape 1 — Mapping
- Selectors année source + année cible (filtrés mutuellement exclusifs)
- Validation FE : warning si source = target
- Empty state si année cible n'a pas encore de classes (« Créez d'abord les classes destination »)
- Tableau interactif : 1 row par classe source avec dropdown destination
- Option \"— Ne pas promouvoir —\" pour exclure une classe
- Bouton « Aperçu de la promotion » désactivé tant qu'au moins 1 mapping rempli

### Étape 2 — Preview
- KPI primary : « N élèves » à promouvoir vers \`<année cible>\`
- Bandeau warning si capacités dépassées (avec détail par classe et overflow exact)
- Tableau : Classe destination · Élèves · Capacité · Restant (cellule restant en orange si insuffisant)
- Bouton « Confirmer la promotion (N) » + AlertDialog confirmation avec count exact
- Bouton « Recommencer » revient à étape 1 et reset le mapping

### Result Modal
- 3 KPI cards : Promues (vert) · Ignorées (gris, légende « déjà promues ») · Erreurs (rouge si > 0)
- Détail des erreurs avec badge élève + raison (capacité dépassée, etc.)
- Toast success automatique post-execute via sonner

## Architecture

| Fichier | Rôle |
|---|---|
| \`app/(admin)/admin/promotions/page.tsx\` | Server wrapper |
| \`components/admin/promotions/PromotionsClient.tsx\` | Wizard state + sub-components inline |
| \`lib/contracts/promotion.ts\` | Zod schemas matching BE Pydantic |
| \`lib/api/promotions.ts\` | apiFetch preview + execute |
| \`lib/hooks/usePromotions.ts\` | TanStack Query mutations + invalidation enrollments |
| \`components/shared/Sidebar.tsx\` | Entrée menu Promotions |

## Tests

- [x] \`pnpm tsc --noEmit\` passe (typedRoutes Route cast sur href Promotions)
- [ ] CI passe (lint + tests + e2e)
- [ ] Visual-check post-deploy avec auth admin sur \`/admin/promotions\`
- [ ] Flow E2E : sélectionner source AY, target AY, mapper 1 classe, preview, execute, voir result modal

## Idempotency

Le BE skip les students déjà promus (cf. PR #96). L'admin peut donc relancer execute après avoir corrigé les exceptions sans risque de duplication. La AlertDialog l'explique explicitement.

## Hors scope cycle 3 ship

- Auto-create target classes si manquantes (cycle 4+ — UX guide pour l'instant : créer manuellement avant)
- Bulk reverse / annulation post-promotion (cycle 4+)
- Mobile-first redesign (persona Type A sur laptop)
- Smart default mapping (Class.name parsing, cycle 6+)

## Plan-and-confirm

Plan B du plan-and-confirm cycle 3 (depth=5). Cycle 1+2+3 complète la trinité enrollments queue-first + validate inline + bulk promotion.