### PR TITLE
refactor(classes): drop academic_year_id from Class contract (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Création d'une classe simplifiée : plus de champ « année académique » à choisir. Les classes sont permanentes, l'année est portée par chaque inscription. Le formulaire de classe ne demande que nom, niveau, série, salle et capacité *(admin)* (#97).
+- Promotion de fin d'année simplifiée : un seul catalogue de classes pour la source et la cible, les doublons « 6ème A 2025-2026 / 6ème A 2026-2027 » disparaissent *(admin)* (#97).
 - Page Inscriptions repensée queue-first : on voit d'un coup d'œil la queue à valider, on valide une inscription en un tap depuis la liste avec confirmation, plus de cartes de KPI redondantes *(admin)* (#121).
 - Confirmation propre par dialogue (au lieu du dialogue système du navigateur) avant de quitter le mode dictée avec des saisies non enregistrées *(enseignant)* (#108).
 - Page Élèves repensée : on voit enfin la classe de chaque élève d'un coup d'œil, on filtre par classe ou « à inscrire » d'un tap, et la version mobile s'aligne sur le terrain *(admin)* (#116).

--- a/components/admin/promotions/PromotionsClient.tsx
+++ b/components/admin/promotions/PromotionsClient.tsx
@@ -53,27 +53,16 @@ export function PromotionsClient() {
   const { data: yearsData } = useAcademicYears({ size: 50, page: 1 })
   const years = yearsData?.items ?? []
 
-  const { data: sourceClassesData } = useClasses(
-    sourceAyId ? { academic_year_id: sourceAyId, size: 100, page: 1 } : { size: 1, page: 1 },
+  // Refactor #97 : Class est universel. Le même catalogue de classes sert
+  // pour la source et la cible — la distinction se fait via les AY portées
+  // par Enrollment côté BE. Plus de filtrage local par academic_year_id.
+  const { data: classesData } = useClasses({ size: 100, page: 1 })
+  const allClasses = useMemo(
+    () => classesData?.items ?? [],
+    [classesData],
   )
-  const sourceClasses = useMemo(
-    () =>
-      sourceAyId
-        ? (sourceClassesData?.items ?? []).filter((c) => c.academic_year_id === sourceAyId)
-        : [],
-    [sourceAyId, sourceClassesData],
-  )
-
-  const { data: targetClassesData } = useClasses(
-    targetAyId ? { academic_year_id: targetAyId, size: 100, page: 1 } : { size: 1, page: 1 },
-  )
-  const targetClasses = useMemo(
-    () =>
-      targetAyId
-        ? (targetClassesData?.items ?? []).filter((c) => c.academic_year_id === targetAyId)
-        : [],
-    [targetAyId, targetClassesData],
-  )
+  const sourceClasses = sourceAyId !== null ? allClasses : []
+  const targetClasses = targetAyId !== null ? allClasses : []
 
   const previewMutation = usePromotionPreview()
   const executeMutation = usePromotionExecute()
@@ -280,7 +269,6 @@ export function PromotionsClient() {
 interface ClassRow {
   id: number
   name: string
-  academic_year_id: number
   max_students?: number | null | undefined
   enrolled_count?: number | undefined
 }

--- a/components/forms/ClassForm.tsx
+++ b/components/forms/ClassForm.tsx
@@ -7,7 +7,6 @@ import { ClassCreateSchema, type ClassCreate } from "@/lib/contracts/class"
 import { useCreateClass } from "@/lib/hooks/useClasses"
 import { useLevels } from "@/lib/hooks/useLevels"
 import { useSeriesList } from "@/lib/hooks/useSeries"
-import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { useRooms } from "@/lib/hooks/useRooms"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -46,9 +45,6 @@ export function ClassForm({ onSuccess }: ClassFormProps) {
   const { data: levelsData } = useLevels({ size: 100 })
   const levels = levelsData?.items
 
-  const { data: academicYearsData } = useAcademicYears()
-  const currentYear = academicYearsData?.items?.find((y) => y.is_current)
-
   const { data: roomsData } = useRooms({ size: 100 })
   const rooms = roomsData?.items
 
@@ -66,10 +62,9 @@ export function ClassForm({ onSuccess }: ClassFormProps) {
   const { mutate, isPending, error } = useCreateClass()
 
   function onSubmit(data: ClassCreate) {
-    // Auto-assign current academic year
+    // Refactor #97 : Class est universel, pas de academic_year_id à propager.
     const payload = {
       ...data,
-      academic_year_id: currentYear?.id ?? data.academic_year_id,
       series_id: data.series_id || null,
       room_id: data.room_id || null,
     }

--- a/lib/contracts/class.ts
+++ b/lib/contracts/class.ts
@@ -1,16 +1,16 @@
 import { z } from "zod"
 
+// Refactor #97 : Class est universel, pas d'academic_year_id sur le modèle.
+// L'année est portée par Enrollment, et la capacité « occupée » dépend de l'AY.
 export const ClassSchema = z.object({
   id: z.number(),
   name: z.string(),
   level_id: z.number(),
   series_id: z.number().nullable(),
-  academic_year_id: z.number(),
   room_id: z.number().nullable(),
   max_students: z.number().nullish(),
   level_name: z.string().optional(),
   series_name: z.string().nullable().optional(),
-  academic_year_name: z.string().optional(),
   enrolled_count: z.number().optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
@@ -20,7 +20,6 @@ export const ClassCreateSchema = z.object({
   name: z.string({ required_error: "Le nom est requis" }).min(1, "Le nom est requis"),
   level_id: z.number({ required_error: "Le niveau est requis" }).positive("Le niveau est requis"),
   series_id: z.number().nullable().optional(),
-  academic_year_id: z.number().positive().optional(),
   room_id: z.number().nullable().optional(),
   max_students: z.number().positive("La capacité doit être positive").optional(),
 })


### PR DESCRIPTION
## Pourquoi

Aligne le FE sur **klassci-college-backend#98** (refactor #97 Class universal). Le BE a dropé `classes.academic_year_id`, le contract Zod et les composants qui s'en servaient doivent suivre.

## Ce que ça change

- **lib/contracts/class.ts** : `academic_year_id` et `academic_year_name` retirés de `ClassSchema` et `ClassCreateSchema`.
- **components/forms/ClassForm.tsx** : plus de `useAcademicYears`, plus d'auto-assign de l'AY courante au submit. Le formulaire ne demande plus que nom, niveau, série, salle, capacité.
- **components/admin/promotions/PromotionsClient.tsx** : un seul appel `useClasses({ size: 100, page: 1 })` (sans `academic_year_id`), un seul catalogue de classes pour la source et la cible. Le filtrage local `c.academic_year_id === sourceAyId` retiré (les classes n'ont plus d'AY).

## Compatibilité

- Pas de feature retirée côté UX visible : le formulaire de classe perd un champ que l'utilisateur ne renseignait jamais (auto-assigné).
- Promotion wizard simplifié : Marcel ne voit plus les doublons « 6ème A 2025-2026 » / « 6ème A 2026-2027 ».

## Test plan

- [ ] Créer une classe via `/admin/classes` → modal sans champ « Année académique »
- [ ] Page `/admin/promotions` → mapping classe source → classe cible fluide, pas de doublons
- [ ] `pnpm tsc --noEmit` passe (vérifié local)

⚠️ À merger **après** klassci-college-backend#98 pour éviter une fenêtre où le BE attend encore `academic_year_id` dans le payload `POST /admin/classes` (qui est maintenant ignoré côté Pydantic).

Refs #97