### PR TITLE
fix(ui): stack /admin/classes header vertically on mobile (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ### Fixed
 
 - En-tête des pages Inscriptions et Élèves qui débordait à droite sur mobile (le bouton « Nouvelle inscription » mangeait la place du titre) : on empile désormais titre et bouton sur petit écran et on ajuste la taille du titre *(admin)*.
+- En-tête de la page Classes qui débordait sur mobile (bouton « Nouvelle classe » coupé hors écran) : même empilement vertical mobile + boutons toggle Arbre/Table qui passent à la ligne si nécessaire *(admin)*.
 - Liste des inscriptions qui restait en chargement infini après la refonte queue-first : la page demandait plus d'inscriptions à la fois que le serveur ne le permet *(admin)* (#131).
 - Sélection de l'enseignant titulaire vide dans le formulaire de création d'évaluation côté admin *(admin)* (#109).
 - Initialisation du retour audio du mode dictée hors interaction utilisateur, qui empêchait silencieusement le bip de confirmation sur iPhone *(enseignant)* (#108).

--- a/components/admin/classes/ClassesPageClient.tsx
+++ b/components/admin/classes/ClassesPageClient.tsx
@@ -14,17 +14,17 @@ export function ClassesPageClient() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
             <School className="h-5 w-5 text-primary" />
           </div>
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">Classes</h1>
+          <div className="min-w-0">
+            <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Classes</h1>
             <p className="text-sm text-muted-foreground">Gestion des classes par niveau et série</p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {/* View toggle */}
           <div className="flex items-center rounded-lg border p-1">
             <Button
@@ -46,8 +46,8 @@ export function ClassesPageClient() {
               Table
             </Button>
           </div>
-          <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
+          <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
+            <Plus className="h-4 w-4" />
             Nouvelle classe
           </Button>
         </div>


### PR DESCRIPTION
## Pourquoi

Mobile 375px overflow sur `/admin/classes` : le bouton « Nouvelle classe » sortait du viewport. Le PR #132 (cycle 1 redesign) avait patché Inscriptions et Élèves mais oublié Classes.

Constaté en `/visual-check` post-deploy refactor #97 (2026-04-28).

## Ce que ça change

`components/admin/classes/ClassesPageClient.tsx` :
- Outer header : `flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between` (au lieu de `flex items-center justify-between`)
- Bloc title : `min-w-0` + icône `shrink-0` + titre `text-xl sm:text-2xl`
- Groupe droite (toggle Arbre/Table + Nouvelle classe) : `flex flex-wrap items-center gap-2`
- Bouton CTA : `h-11 sm:h-10 gap-2` (touch target mobile h-11 per redesign-premium rule)

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [ ] Visual mobile 375x812 sur prod après merge : bouton « Nouvelle classe » fully visible
- [ ] Desktop ≥640px inchangé (toggle + bouton sur même ligne que le titre)

## Why pas de scope creep

Aligné strictement sur le pattern PR #132 — pas de nouvelle abstraction, pas de partial reset. 9 lignes touchées, scope minimal.

Closes #137
Refs #97