### PR TITLE
fix(students): polish post-redesign #139 — payments mobile + photo gating + Profil cure (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 - Fiche élève repensée pour le terrain : Vue d'ensemble centrée sur l'action (solde de paiements, parents avec téléphone clickable « Appeler »), bandeau bleu Wave-style pour le reste à payer, accès direct à la classe en un tap. Plus de doublon entre Vue d'ensemble et Profil *(admin)* (#139).
 - Fiche élève sur mobile : plus de débordement horizontal, photo réduite, onglets ré-ordonnés par usage (Vue, Paiements, Parents, Inscriptions...), boutons d'action regroupés dans un menu pour éviter les suppressions accidentelles *(admin)* (#139).
+- Onglet Paiements de la fiche élève : les boutons d'action « Régénérer les frais » et « Enregistrer un paiement » s'empilent verticalement sur mobile au lieu de déborder hors de l'écran *(admin)* (#141).
+- Onglet Profil allégé : le matricule, le genre et l'email apparaissent une seule fois (déjà visibles dans l'en-tête ou la section Compte) au lieu d'être répétés *(admin)* (#141).
+- Statut du compte utilisateur plus juste : « En attente » (orange) si l'élève n'a jamais ouvert le portail, « Désactivé » (rouge) seulement si le compte a été explicitement désactivé. Plus de « Inactif » rouge alarmant pour un simple compte non-encore-utilisé *(admin)* (#141).
 - Création d'une classe simplifiée : plus de champ « année académique » à choisir. Les classes sont permanentes, l'année est portée par chaque inscription. Le formulaire de classe ne demande que nom, niveau, série, salle et capacité *(admin)* (#97).
 - Promotion de fin d'année simplifiée : un seul catalogue de classes pour la source et la cible, les doublons « 6ème A 2025-2026 / 6ème A 2026-2027 » disparaissent *(admin)* (#97).
 - Page Inscriptions repensée queue-first : on voit d'un coup d'œil la queue à valider, on valide une inscription en un tap depuis la liste avec confirmation, plus de cartes de KPI redondantes *(admin)* (#121).

--- a/components/admin/students/StudentDetailClient.tsx
+++ b/components/admin/students/StudentDetailClient.tsx
@@ -78,6 +78,7 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
   const [photoPreview, setPhotoPreview] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [activeTab, setActiveTab] = useState("overview")
+  const [photoLoaded, setPhotoLoaded] = useState(false)
 
   const { data: student, isLoading, isError, refetch } = useStudent(studentId)
   const { mutate: deleteStudent, isPending: deleting } = useDeleteStudent()
@@ -141,13 +142,20 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
         {/* Avatar shadcn — handles 404 via AvatarImage onError → AvatarFallback */}
         <button
           type="button"
-          onClick={() => photoSrc && setPhotoPreview(true)}
-          aria-label={photoSrc ? "Voir la photo en grand" : "Photo de l'élève"}
+          onClick={() => photoLoaded && setPhotoPreview(true)}
+          aria-label={photoLoaded ? "Voir la photo en grand" : "Photo de l'élève"}
           className="shrink-0 overflow-hidden rounded-2xl border-2 border-border focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-default"
-          disabled={!photoSrc}
+          disabled={!photoLoaded}
         >
           <Avatar className="h-16 w-16 rounded-2xl sm:h-24 sm:w-24">
-            {photoSrc ? <AvatarImage src={photoSrc} alt={fullName} className="object-cover" /> : null}
+            {photoSrc ? (
+              <AvatarImage
+                src={photoSrc}
+                alt={fullName}
+                className="object-cover"
+                onLoadingStatusChange={(status) => setPhotoLoaded(status === "loaded")}
+              />
+            ) : null}
             <AvatarFallback className="rounded-2xl bg-primary/10 text-xl font-semibold text-primary sm:text-2xl">
               {initials}
             </AvatarFallback>
@@ -189,7 +197,7 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
               <Camera className="mr-2 h-4 w-4" />
               {photoSrc ? "Changer la photo" : "Ajouter une photo"}
             </DropdownMenuItem>
-            {photoSrc && (
+            {photoSrc && photoLoaded && (
               <DropdownMenuItem onClick={handleDeletePhoto}>
                 <Trash2 className="mr-2 h-4 w-4" />
                 Supprimer la photo

--- a/components/admin/students/tabs/PaymentsTab.tsx
+++ b/components/admin/students/tabs/PaymentsTab.tsx
@@ -123,15 +123,15 @@ export function PaymentsTab({ studentId }: PaymentsTabProps) {
             value={feesRate}
             className="h-3 bg-primary-foreground/20 [&>div]:bg-primary-foreground"
           />
-          <div className="mt-3 flex items-center justify-between">
+          <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-primary-foreground/80">
               Reste à payer : <span className="font-semibold">{formatFCFA(feesRemaining as number)}</span>
             </p>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <Button
                 size="sm"
                 variant="ghost"
-                className="text-xs text-primary-foreground/90 hover:text-primary-foreground hover:bg-primary-foreground/10 border border-primary-foreground/30"
+                className="h-10 text-xs text-primary-foreground/90 hover:text-primary-foreground hover:bg-primary-foreground/10 border border-primary-foreground/30 sm:h-9"
                 onClick={handleRegenerateFees}
                 disabled={regenerating}
               >
@@ -141,7 +141,7 @@ export function PaymentsTab({ studentId }: PaymentsTabProps) {
               <Button
                 size="sm"
                 variant="secondary"
-                className="text-xs"
+                className="h-10 text-xs sm:h-9"
                 onClick={() => setPaymentOpen(true)}
               >
                 <Plus className="mr-1.5 h-3.5 w-3.5" />

--- a/components/admin/students/tabs/ProfileTab.tsx
+++ b/components/admin/students/tabs/ProfileTab.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { User, CalendarDays, BookOpen, Mail, KeyRound, Shield, UserPlus, MapPin } from "lucide-react"
+import { User, CalendarDays, Mail, KeyRound, Shield, UserPlus, MapPin } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -46,8 +46,6 @@ export function ProfileTab({ student, fullData }: ProfileTabProps) {
         year: "numeric",
       })
     : null
-
-  const genre = student.genre === "M" ? "Masculin" : student.genre === "F" ? "Féminin" : null
 
   const userEmail = fullData.user_email ? String(fullData.user_email) : null
   const isActive = fullData.is_active === true
@@ -96,7 +94,8 @@ export function ProfileTab({ student, fullData }: ProfileTabProps) {
 
   return (
     <div className="space-y-4">
-      {/* Informations personnelles */}
+      {/* Informations personnelles — drop Matricule + Genre (déjà dans header)
+          et Email (déduplique avec Compte utilisateur Email de connexion) */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardContent className="p-6">
           <h3 className="text-sm font-medium text-muted-foreground mb-4">Informations personnelles</h3>
@@ -104,9 +103,6 @@ export function ProfileTab({ student, fullData }: ProfileTabProps) {
             <InfoField label="Nom" value={student.last_name} icon={User} />
             <InfoField label="Prénom" value={student.first_name} icon={User} />
             <InfoField label="Date de naissance" value={birthDate} icon={CalendarDays} />
-            <InfoField label="Genre" value={genre} icon={User} />
-            <InfoField label="Matricule" value={student.enrollment_number} icon={BookOpen} />
-            <InfoField label="Email" value={userEmail ?? (fullData.email ? String(fullData.email) : null)} icon={Mail} />
             <InfoField label="Ville" value={student.city} icon={MapPin} />
             <InfoField label="Commune" value={student.commune} icon={MapPin} />
           </div>
@@ -120,12 +116,27 @@ export function ProfileTab({ student, fullData }: ProfileTabProps) {
             <>
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm font-medium text-muted-foreground">Compte utilisateur</h3>
-                <Badge
-                  variant={isActive ? "default" : "destructive"}
-                  className={isActive ? "bg-emerald-600 hover:bg-emerald-600/80 text-[10px]" : "text-[10px]"}
-                >
-                  {isActive ? "Actif" : "Inactif"}
-                </Badge>
+                {(() => {
+                  // Tri-état : Actif (déjà connecté + actif), En attente (jamais
+                  // connecté → orange amber, neutre), Désactivé (déjà connecté
+                  // mais désactivé → rouge alarmant). Évite le « Inactif » rouge
+                  // alarmiste pour un compte simplement pas encore activé.
+                  if (isActive && lastLogin) {
+                    return (
+                      <Badge className="bg-emerald-600 hover:bg-emerald-600/80 text-[10px]">
+                        Actif
+                      </Badge>
+                    )
+                  }
+                  if (!isActive) {
+                    return <Badge variant="destructive" className="text-[10px]">Désactivé</Badge>
+                  }
+                  return (
+                    <Badge className="bg-amber-100 text-amber-700 hover:bg-amber-100/80 dark:bg-amber-900/30 dark:text-amber-400 text-[10px]">
+                      En attente
+                    </Badge>
+                  )
+                })()}
               </div>
               <div className="grid gap-5 sm:grid-cols-3">
                 <InfoField


### PR DESCRIPTION
3 polish items détectés en visual-check post-PR #140 :

## Commit 1 — Photo gating (`6bc7d6b`)
- Track AvatarImage load status via Radix `onLoadingStatusChange`
- DropdownMenu « Supprimer la photo » + bouton « Voir en grand » disabled tant que l'image n'a pas réellement chargé
- Évite l'UX confuse : menu montrait « Supprimer la photo » alors que l'avatar affichait des initiales (case photo_url 404)

## Commit 2 — PaymentsTab mobile overflow (`888d921`)
- Hero footer : « Reste à payer » + 2 boutons (`Régénérer les frais` + `Enregistrer un paiement`) débordaient sur 375px (~400px total > viewport)
- Pattern flex-col gap-3 sm:flex-row + flex-wrap sur le groupe boutons
- h-10 mobile h-9 desktop sur les boutons (touch target Wave-style)

## Commit 3 — Profil tab cure (`aa1cae8`)
- Drop 3 fields redondants : Matricule + Genre (déjà header) + Email (déjà Compte utilisateur)
- 8 → 5 fields dans Informations personnelles
- Tri-état badge compte : Actif (vert, déjà connecté) / En attente (amber, jamais connecté) / Désactivé (rouge, isActive=false)
- Évite le « Inactif » rouge alarmiste pour un compte simplement non-encore-activé

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [ ] Visual check post-deploy : avatar avec photo manquante → menu n'affiche pas « Supprimer la photo »
- [ ] Visual check mobile 375px : PaymentsTab hero buttons stack verticalement
- [ ] Visual check : Profil tab montre 5 fields (pas 8) + badge « En attente » amber

Closes #141
Refs #139