### PR TITLE
fix(bulletins): repoint admin bulletin flow to /reports/bulletins/*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Bulletins côté admin : la liste, la prévisualisation, la génération, la publication et le téléchargement PDF étaient tous cassés en silence (404 ou réponse Celery vide) car ils visaient les anciens endpoints racine. Tout pointe désormais sur `/reports/bulletins/*` et la génération retourne immédiatement les bulletins créés *(admin)* (#142).
+
 ### Added
 
 - Promotion en masse de fin d'année : nouvelle page « Promotions » qui aide l'admin à transformer en quelques clics les inscriptions valides d'une année vers la suivante, avec aperçu des élèves promus, avertissements de capacité et rapport détaillé des exceptions *(admin)* (#133).

--- a/components/admin/reports/BulletinList.tsx
+++ b/components/admin/reports/BulletinList.tsx
@@ -96,8 +96,12 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
   }
 
   function handlePublish() {
-    if (!params.class_id || !params.trimester) return
-    publish({ classId: params.class_id, trimester: String(params.trimester) })
+    if (!params.class_id || !params.trimester || !params.academic_year_id) return
+    publish({
+      classId: params.class_id,
+      trimester: params.trimester,
+      academicYearId: params.academic_year_id,
+    })
   }
 
   return (

--- a/lib/api/bulletins.ts
+++ b/lib/api/bulletins.ts
@@ -6,49 +6,77 @@ import {
   type BulletinListParams,
   type BulletinGenerate,
 } from "@/lib/contracts/bulletin"
-import { PaginatedResponseSchema, type PaginatedResponse } from "@/lib/contracts"
 
-const PaginatedBulletinSchema = PaginatedResponseSchema(BulletinSchema)
 const BulletinArraySchema = z.array(BulletinSchema)
+const BulletinListResponseSchema = z.object({
+  items: BulletinArraySchema,
+  total: z.number(),
+})
+
+export interface BulletinListResult {
+  items: Bulletin[]
+  total: number
+  page: number
+  size: number
+}
+
+export interface BulletinGenerateResult {
+  message: string
+  generated: number
+  bulletins: Bulletin[]
+}
+
+export interface BulletinPublishResult {
+  message: string
+  count: number
+}
 
 export const bulletinsApi = {
-  list: async (params: BulletinListParams = {}): Promise<PaginatedResponse<Bulletin>> => {
+  list: async (params: BulletinListParams = {}): Promise<BulletinListResult> => {
     const query = new URLSearchParams(
       Object.entries(params)
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => [k, String(v)]),
     ).toString()
-    const json = await apiFetch<PaginatedResponse<Bulletin> | Bulletin[]>(
-      `/bulletins${query ? `?${query}` : ""}`,
+    const json = await apiFetch<unknown>(
+      `/reports/bulletins${query ? `?${query}` : ""}`,
     )
-    if (Array.isArray(json)) {
-      const arr = safeValidate(BulletinArraySchema, json, "GET /bulletins")
-      return { items: arr, total: arr.length, page: 1, size: arr.length, total_pages: 1 }
+    const validated = safeValidate(BulletinListResponseSchema, json, "GET /reports/bulletins")
+    return {
+      ...validated,
+      page: 1,
+      size: validated.items.length || 1,
     }
-    return safeValidate(PaginatedBulletinSchema, json, "GET /bulletins") as PaginatedResponse<Bulletin>
   },
 
   getById: async (id: number): Promise<Bulletin> => {
-    const json = await apiFetch<{ data?: Bulletin } | Bulletin>(`/bulletins/${id}`)
-    const bulletin = (json as { data?: Bulletin }).data ?? (json as Bulletin)
-    return safeValidate(BulletinSchema, bulletin, `GET /bulletins/${id}`)
+    const json = await apiFetch<unknown>(`/reports/bulletins/${id}`)
+    return safeValidate(BulletinSchema, json, `GET /reports/bulletins/${id}`)
   },
 
-  generate: async (data: BulletinGenerate): Promise<{ message: string; count: number }> => {
-    return apiFetch("/bulletins/generate", {
+  generate: async (data: BulletinGenerate): Promise<BulletinGenerateResult> => {
+    return apiFetch("/reports/bulletins/generate", {
       method: "POST",
       body: JSON.stringify(data),
     })
   },
 
-  publish: async (classId: number, trimester: string): Promise<{ message: string; count: number }> => {
-    return apiFetch("/bulletins/publish", {
+  publish: async (
+    classId: number,
+    trimester: number,
+    academicYearId: number,
+  ): Promise<BulletinPublishResult> => {
+    const query = new URLSearchParams({
+      class_id: String(classId),
+      trimester: String(trimester),
+      academic_year_id: String(academicYearId),
+    }).toString()
+    return apiFetch(`/reports/bulletins/publish?${query}`, {
       method: "POST",
-      body: JSON.stringify({ class_id: classId, trimester }),
     })
   },
 
   downloadPdf: async (id: number): Promise<Blob> => {
-    return apiFetchBlob(`/bulletins/${id}/pdf`)
+    return apiFetchBlob(`/reports/bulletins/${id}/pdf`)
   },
 }

--- a/lib/hooks/useBulletins.ts
+++ b/lib/hooks/useBulletins.ts
@@ -33,7 +33,7 @@ export function useGenerateBulletins() {
   return useMutation({
     mutationFn: (data: BulletinGenerate) => bulletinsApi.generate(data),
     onSuccess: (result) => {
-      toast.success(`${result.count} bulletin(s) généré(s) avec succès`)
+      toast.success(`${result.generated} bulletin(s) généré(s) avec succès`)
       queryClient.invalidateQueries({ queryKey: bulletinKeys.all })
     },
     onError: (err) => {
@@ -45,8 +45,15 @@ export function useGenerateBulletins() {
 export function usePublishBulletins() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ classId, trimester }: { classId: number; trimester: string }) =>
-      bulletinsApi.publish(classId, trimester),
+    mutationFn: ({
+      classId,
+      trimester,
+      academicYearId,
+    }: {
+      classId: number
+      trimester: number
+      academicYearId: number
+    }) => bulletinsApi.publish(classId, trimester, academicYearId),
     onSuccess: (result) => {
       toast.success(`${result.count} bulletin(s) publié(s)`)
       queryClient.invalidateQueries({ queryKey: bulletinKeys.all })


### PR DESCRIPTION
## Summary

- 🐛 Le flow bulletins admin était cassé en silence : 4/5 endpoints en 404, le 5ème hit Celery Puppeteer broken.
- 🩹 Repoint complet vers \`/reports/bulletins/*\` après cleanup BE.
- 🔗 PR BE coordonnée : [klassci-college-backend#104](https://github.com/African-DC/klassci-college-backend/pull/104). **Merger BE en premier**, ce PR FE immédiatement après.

## Changes FE

- \`lib/api/bulletins.ts\` : 5 endpoints repointés vers \`/reports/bulletins/*\`
  - \`list\` retourne \`BulletinListResult\` (items + total + page/size synthétiques pour la pagination UI existante)
  - \`getById\` hit le nouveau single-bulletin endpoint
  - \`generate\` attend \`{message, generated, bulletins}\` (sync WeasyPrint, pas Celery task_id)
  - \`publish\` envoie class_id + trimester + academic_year_id en query params
  - \`downloadPdf\` hit \`/reports/bulletins/{id}/pdf\`
- \`lib/hooks/useBulletins.ts\` :
  - \`useGenerateBulletins\` lit \`result.generated\` pour le toast (au lieu de \`result.count\` qui était undefined)
  - \`usePublishBulletins\` accepte \`academicYearId\` (BE le requiert)
- \`components/admin/reports/BulletinList.tsx\` : passe \`academic_year_id\` au moment du publish

## Test plan

- [ ] CI : pnpm tsc + lint vert
- [ ] /visual-check post-merge BE+FE : admin /reports → générer bulletins → publier → télécharger PDF (full E2E authentifié)
- [ ] Vérifier que les toasts affichent les bons compteurs (n bulletin(s) généré(s) avec succès)

## Out of scope

- \`lib/api/dren.ts:20\` PDF/Excel URLs (même URL backend) : nécessite endpoint BE dédié ; PR séparé
- DocumentsTab admin + portail parent : Plan B-revised PRs futurs

## Closes

Closes #142