### PR TITLE
feat(documents): UI for certificat de scolarite + attestation de frequentation + signature settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Onglet « Documents » fonctionnel sur la fiche élève admin : deux cartes pour télécharger le certificat de scolarité et l'attestation de fréquentation au format PDF officiel République de Côte d'Ivoire en un clic. Boutons mobile-friendly h-11 *(admin)* (#145).
+- Page « Documents » côté portail parent : `/parent/children/[id]/documents` permet au parent de télécharger lui-même le certificat de scolarité et l'attestation de fréquentation de son enfant depuis son téléphone. Layout Wave-style mobile-first *(parent)* (#145).
+- Bouton « Documents » ajouté à côté de « Notes » et « Frais » sur la liste des enfants côté parent *(parent)* (#145).
+- Champs « Nom du chef d'établissement » et « Titre / fonction » dans les paramètres de l'établissement, indispensables pour signer les documents officiels *(admin)* (#145).
 - Promotion en masse de fin d'année : nouvelle page « Promotions » qui aide l'admin à transformer en quelques clics les inscriptions valides d'une année vers la suivante, avec aperçu des élèves promus, avertissements de capacité et rapport détaillé des exceptions *(admin)* (#133).
 - Mode dictée vocal plein écran pour saisir les notes sans regarder l'écran, optimisé Chrome Android et iOS Safari *(enseignant)* (#108).
 - Création d'évaluation déléguée : un admin ou un personnel administratif peut créer une évaluation au nom d'un enseignant, avec sélection explicite du titulaire *(admin)* (#108).

--- a/app/(parent)/parent/children/[id]/documents/page.tsx
+++ b/app/(parent)/parent/children/[id]/documents/page.tsx
@@ -1,0 +1,15 @@
+import { notFound } from "next/navigation"
+import { ParentChildDocumentsClient } from "@/components/parent/ParentChildDocumentsClient"
+
+export const metadata = { title: "Documents | KLASSCI" }
+
+export default async function ParentChildDocumentsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const numId = Number(id)
+  if (!Number.isInteger(numId) || numId <= 0) notFound()
+  return <ParentChildDocumentsClient childId={numId} />
+}

--- a/components/admin/settings/SchoolInfoSection.tsx
+++ b/components/admin/settings/SchoolInfoSection.tsx
@@ -32,6 +32,8 @@ export function SchoolInfoSection({ settings }: SchoolInfoSectionProps) {
       phone: settings.phone ?? "",
       email: settings.email ?? "",
       ministry_code: settings.ministry_code ?? "",
+      head_master_name: settings.head_master_name ?? "",
+      head_master_title: settings.head_master_title ?? "",
     },
   })
 
@@ -106,7 +108,7 @@ export function SchoolInfoSection({ settings }: SchoolInfoSectionProps) {
                   <FormItem>
                     <FormLabel>Téléphone</FormLabel>
                     <FormControl>
-                      <Input placeholder="+243 ..." {...field} />
+                      <Input placeholder="+225 ..." {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -119,12 +121,47 @@ export function SchoolInfoSection({ settings }: SchoolInfoSectionProps) {
                   <FormItem>
                     <FormLabel>Email</FormLabel>
                     <FormControl>
-                      <Input type="email" placeholder="contact@ecole.cd" {...field} />
+                      <Input type="email" placeholder="contact@ecole.ci" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
+            </div>
+
+            <div className="rounded-lg border bg-muted/30 p-4 space-y-4">
+              <p className="text-sm font-medium">Documents officiels</p>
+              <p className="text-xs text-muted-foreground -mt-2">
+                Apparaît sur les certificats, attestations et bulletins signés.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="head_master_name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nom du chef d&apos;établissement</FormLabel>
+                      <FormControl>
+                        <Input placeholder="M. Konan Kouamé" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="head_master_title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Titre / fonction</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Directeur" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
             </div>
 
             <div className="flex justify-end pt-2">

--- a/components/admin/students/StudentDetailClient.tsx
+++ b/components/admin/students/StudentDetailClient.tsx
@@ -323,7 +323,7 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
         </TabsContent>
 
         <TabsContent value="documents">
-          <DocumentsTab studentId={studentId} />
+          <DocumentsTab studentId={studentId} studentLastName={student.last_name} />
         </TabsContent>
       </Tabs>
 

--- a/components/parent/ParentChildDocumentsClient.tsx
+++ b/components/parent/ParentChildDocumentsClient.tsx
@@ -1,15 +1,15 @@
 "use client"
 
 import { useState } from "react"
-import { Award, FileCheck2, Loader2 } from "lucide-react"
+import { ArrowLeft, Award, FileCheck2, Loader2 } from "lucide-react"
+import Link from "next/link"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { studentDocumentsApi } from "@/lib/api/student-documents"
 import { downloadBlob } from "@/lib/utils"
 
-interface DocumentsTabProps {
-  studentId: number
-  studentLastName?: string
+interface ParentChildDocumentsClientProps {
+  childId: number
 }
 
 type DocKind = "certificate" | "attendance"
@@ -26,7 +26,7 @@ const DOCS: {
     kind: "certificate",
     title: "Certificat de scolarité",
     description:
-      "Atteste que l'élève est régulièrement inscrit cette année. Document officiel signé par le chef d'établissement.",
+      "Atteste que votre enfant est régulièrement inscrit cette année. Utile pour une banque, une bourse ou un transfert d'établissement.",
     icon: Award,
     download: studentDocumentsApi.downloadCertificateScolarite,
     filenameBase: "certificat_scolarite",
@@ -35,28 +35,29 @@ const DOCS: {
     kind: "attendance",
     title: "Attestation de fréquentation",
     description:
-      "Récapitule les présences de l'élève sur l'année courante avec un taux de fréquentation calculé.",
+      "Présente le taux de présence de votre enfant cette année avec le détail des présences, retards et absences.",
     icon: FileCheck2,
     download: studentDocumentsApi.downloadAttestationFrequentation,
     filenameBase: "attestation_frequentation",
   },
 ]
 
-export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) {
+export function ParentChildDocumentsClient({
+  childId,
+}: ParentChildDocumentsClientProps) {
   const [downloading, setDownloading] = useState<DocKind | null>(null)
 
   async function handleDownload(doc: (typeof DOCS)[number]) {
     setDownloading(doc.kind)
     try {
-      const blob = await doc.download(studentId)
-      const safeName = (studentLastName ?? `eleve_${studentId}`)
-        .toUpperCase()
-        .replace(/\s+/g, "_")
-      downloadBlob(blob, `${doc.filenameBase}_${safeName}.pdf`)
+      const blob = await doc.download(childId)
+      downloadBlob(blob, `${doc.filenameBase}_enfant_${childId}.pdf`)
       toast.success(`${doc.title} téléchargé(e)`)
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "Erreur lors du téléchargement"
+        err instanceof Error
+          ? err.message
+          : "Erreur lors du téléchargement"
       toast.error(message)
     } finally {
       setDownloading(null)
@@ -64,40 +65,47 @@ export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) 
   }
 
   return (
-    <div className="space-y-4">
-      <div>
-        <h3 className="text-base font-semibold">Documents officiels</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Génération à la demande pour remettre au parent ou l&apos;élève.
-        </p>
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link
+          href="/parent/children"
+          className="flex h-11 w-11 items-center justify-center rounded-lg border hover:bg-muted"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <div>
+          <h1 className="text-xl font-semibold">Documents officiels</h1>
+          <p className="text-sm text-muted-foreground">
+            Téléchargez les documents administratifs de votre enfant.
+          </p>
+        </div>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="space-y-3">
         {DOCS.map((doc) => {
           const Icon = doc.icon
           const isDownloading = downloading === doc.kind
           return (
             <div
               key={doc.kind}
-              className="flex flex-col gap-3 rounded-lg border bg-card p-4"
+              className="flex flex-col gap-3 rounded-xl border bg-card p-4"
             >
               <div className="flex items-start gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                  <Icon className="h-5 w-5" />
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <Icon className="h-6 w-6" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium">{doc.title}</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
+                  <p className="text-base font-medium">{doc.title}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
                     {doc.description}
                   </p>
                 </div>
               </div>
               <Button
-                size="sm"
-                variant="outline"
+                size="lg"
                 onClick={() => handleDownload(doc)}
                 disabled={isDownloading}
-                className="h-11 w-full sm:h-9"
+                className="h-11 w-full"
               >
                 {isDownloading ? (
                   <>

--- a/components/parent/ParentChildrenClient.tsx
+++ b/components/parent/ParentChildrenClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { Users, GraduationCap, Wallet, AlertCircle, ChevronRight } from "lucide-react"
+import { Users, GraduationCap, Wallet, AlertCircle, ChevronRight, FileText } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -92,22 +92,27 @@ function ChildDetailCard({ child }: { child: ParentChild }) {
         </div>
 
         {/* Actions */}
-        <div className="flex gap-2">
+        <div className="grid grid-cols-3 gap-2">
           <Link
             href={`/parent/children/${child.id}/grades`}
-            className="flex flex-1 items-center justify-center gap-1 rounded-md bg-primary/5 px-3 py-2.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+            className="flex items-center justify-center gap-1 rounded-md bg-primary/5 px-2 py-2.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
           >
             <GraduationCap className="h-3.5 w-3.5" />
-            Voir les notes
-            <ChevronRight className="h-3 w-3" />
+            Notes
           </Link>
           <Link
             href={`/parent/children/${child.id}/fees`}
-            className="flex flex-1 items-center justify-center gap-1 rounded-md bg-primary/5 px-3 py-2.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+            className="flex items-center justify-center gap-1 rounded-md bg-primary/5 px-2 py-2.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
           >
             <Wallet className="h-3.5 w-3.5" />
-            Voir les frais
-            <ChevronRight className="h-3 w-3" />
+            Frais
+          </Link>
+          <Link
+            href={`/parent/children/${child.id}/documents`}
+            className="flex items-center justify-center gap-1 rounded-md bg-primary/5 px-2 py-2.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Documents
           </Link>
         </div>
       </CardContent>

--- a/lib/api/student-documents.ts
+++ b/lib/api/student-documents.ts
@@ -1,0 +1,16 @@
+import { apiFetchBlob } from "./client"
+
+/**
+ * Documents officiels par eleve (certificat de scolarite, attestation
+ * de frequentation). Le backend expose ces endpoints via le router
+ * student_documents (#107, #109).
+ */
+export const studentDocumentsApi = {
+  /** Telecharge le PDF du certificat de scolarite. */
+  downloadCertificateScolarite: (studentId: number): Promise<Blob> =>
+    apiFetchBlob(`/students/${studentId}/documents/certificat-scolarite.pdf`),
+
+  /** Telecharge le PDF de l'attestation de frequentation (avec stats). */
+  downloadAttestationFrequentation: (studentId: number): Promise<Blob> =>
+    apiFetchBlob(`/students/${studentId}/documents/attestation-frequentation.pdf`),
+}

--- a/lib/contracts/settings.ts
+++ b/lib/contracts/settings.ts
@@ -19,6 +19,10 @@ export const SchoolSettingsSchema = z.object({
   email: z.string().nullable(),
   logo_url: z.string().nullable(),
   ministry_code: z.string().nullable().optional(),
+  // Official documents (PR #105)
+  signature_image_url: z.string().nullable().optional(),
+  head_master_name: z.string().nullable().optional(),
+  head_master_title: z.string().nullable().optional(),
   enrollment_number_pattern: z.string().nullable().optional(),
   enrollment_number_counter: z.number().optional().default(0),
   // --- UI-only fields (not yet in backend, optional with defaults) ---
@@ -37,6 +41,8 @@ export const SchoolInfoUpdateSchema = z.object({
   phone: z.string().optional(),
   email: z.string().email("Email invalide").optional().or(z.literal("")),
   ministry_code: z.string().optional(),
+  head_master_name: z.string().optional(),
+  head_master_title: z.string().optional(),
 })
 
 export const TrimesterUpdateSchema = z.object({


### PR DESCRIPTION
## Summary

PR #6 du Plan B-revised. **FE complet pour Documents Admin** — wire up BE PRs #107 (#108) + #109 (#110) + #105 (#106).

⚠ Cette PR FE peut être mergée APRÈS la chain BE (#106 → #108 → #110). Si elle est mergée avant, les boutons retournent 404 jusqu'au deploy BE.

## Persona delivery

- **Admin (Mme Diallo bureau, Type A desktop)** : onglet Documents fonctionnel sur fiche élève avec 2 cartes Certificat / Attestation, click → PDF téléchargé
- **Parent (Mme Diallo téléphone, Type B mobile)** : page \`/parent/children/[id]/documents\` Wave-style, accessible via chip "Documents" sur la liste des enfants (à côté de Notes / Frais)
- **Admin Settings** : champs "Nom du chef d'établissement" + "Titre / fonction" pour signer les documents officiels

## Changes (9 files, +168 / -20)

### NEW files
- \`lib/api/student-documents.ts\` (api client mince, 2 fonctions)
- \`app/(parent)/parent/children/[id]/documents/page.tsx\` (route group page)
- \`components/parent/ParentChildDocumentsClient.tsx\` (composant Wave-style mobile)

### MODIFIED files
- \`components/admin/students/tabs/DocumentsTab.tsx\` : remplace placeholder par 2 cartes fonctionnelles
- \`components/admin/students/StudentDetailClient.tsx\` : passe \`studentLastName\` à DocumentsTab
- \`components/parent/ParentChildrenClient.tsx\` : ajoute chip "Documents" en grid 3 cols
- \`components/admin/settings/SchoolInfoSection.tsx\` : sous-section "Documents officiels" + 2 inputs
- \`lib/contracts/settings.ts\` : Zod schemas alignés avec Pydantic BE (PR #105)
- \`CHANGELOG.md\`

## Test plan

- [ ] CI : pnpm tsc + lint vert
- [ ] /visual-check post-merge BE+FE :
  - login admin → étudiants → choisir 1 → onglet Documents → cliquer Télécharger PDF Certificat → vérifier que PDF s'ouvre avec logo + signature
  - login parent → enfants → cliquer Documents → vérifier que page mobile s'affiche → cliquer Télécharger
  - login admin → Paramètres → onglet Établissement → vérifier que les 2 nouveaux champs apparaissent et que la sauvegarde marche

## Quality gate (4 axes)

| Axe | Verdict | Note |
|---|---|---|
| Architecture | PASS | Pas de hook (3-strikes pas atteint, 2 consumers inline OK), API client mince, persona-driven UI séparé admin/parent |
| Quality vs Speed | WARN | Pas de tests automatisés (pas d'infra Playwright à ce stade pour ces flows), mais visual-check post-merge couvre |
| Production-grade | PASS | Mobile-first h-11 sur parent, toast d'erreur préserve le message BE 422, filename safe avec student last name uppercased |
| SOLID | PASS | DocumentsTab + ParentChildDocumentsClient partagent le même pattern \`DOCS\` array, extensible pour relevé de notes / situation financière futurs |

## Out of scope

- Signature image upload UI : endpoint BE existe (\`POST /admin/settings/signature\` PR #106), UI deferred (admin peut upload via direct API call si urgent)
- DREN PDF/Excel URL fix
- Hook \`useStudentDocuments\` : differable, 3-strikes pas atteint

## Closes

Closes le issue créé ci-dessus