### PR TITLE
fix(auth): /login redirect loop when access token is expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Page de connexion qui boucle en `ERR_TOO_MANY_REDIRECTS` quand le jeton d'accès est expiré : avec `RefreshTokenError`, le middleware redirigeait `/login → /<portail> → /login` à l'infini car la session restait techniquement « connectée ». La page de connexion est désormais toujours accessible quand la session est en erreur, ce qui permet à l'utilisateur de se reconnecter *(tous)* (#151).
 - Bulletins côté admin : la liste, la prévisualisation, la génération, la publication et le téléchargement PDF étaient tous cassés en silence (404 ou réponse Celery vide) car ils visaient les anciens endpoints racine. Tout pointe désormais sur `/reports/bulletins/*` et la génération retourne immédiatement les bulletins créés *(admin)* (#142).
 
 ### Added

--- a/middleware.ts
+++ b/middleware.ts
@@ -50,7 +50,11 @@ const authMiddleware = auth((req) => {
     return NextResponse.next()
   }
 
-  if (pathname === "/login" && isLoggedIn) {
+  // A session in error state (RefreshTokenError) must be allowed to reach /login
+  // so the user can sign in again. Otherwise rule 1 above redirects /<portal> →
+  // /login while this rule redirects /login → /<portal>, producing an infinite
+  // ERR_TOO_MANY_REDIRECTS loop in the browser.
+  if (pathname === "/login" && isLoggedIn && !session.error) {
     const dest = getDefaultRedirect(session.user.role)
     if (dest !== "/login") {
       const url = req.nextUrl.clone()


### PR DESCRIPTION
## Summary

Hotfix : la page \`/login\` boucle en \`ERR_TOO_MANY_REDIRECTS\` quand l'utilisateur a un token expiré dans ses cookies. Détecté lors du visual-check post-merge Plan B-revised.

## Root cause

Voir l'issue #151 pour le diagnostic complet. TL;DR : middleware.ts règle 3 ne check pas \`session.error\`, donc quand le token expiré garde session.user défini, on est piégé entre /login (redirect → portal) et /portal (redirect → /login).

## Fix

\`\`\`ts
if (pathname === \"/login\" && isLoggedIn && !session.error) {
\`\`\`

Une seule ligne, défensif. Sessions saines : aucun changement. Sessions en erreur : peuvent atteindre /login pour re-login.

## Test plan

- [ ] CI : pnpm tsc + lint
- [ ] /visual-check post-deploy : ouvrir browser avec cookies expirés sur college.klassci.com/login → page render sans boucle
- [ ] /visual-check : login → /admin/dashboard render → laisser expirer (manuellement modifier le cookie ou attendre 1h) → naviguer /admin/students → redirect vers /login propre, pas de boucle

## Out of scope (deferred)

- Silent refresh via \`/api-be/auth/refresh\` httpOnly cookie. Le commentaire dans auth.ts dit \"For now, force re-login when access token expires\" — long-term on devrait appeler le endpoint refresh au lieu de juste flagger l'erreur. À tracker séparément.
- Clearing \`session.user\` quand \`session.error\` est set. Plus propre architecturalement mais risqué (faut vérifier chaque \`useSession\` consumer qui pourrait assumer que session.user est toujours présent).

## Closes

Closes #151