### PR TITLE
feat(super-admin): full UI — tenants + wizard + PATs + diagnose + logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Added
+
+- Section super-admin complète (`/super-admin/*`) : tableau de bord pour onboarder une école sans SSH ni terminal. Liste des tenants avec taille de base, formulaire de création en 3 étapes (nom + slug avec disponibilité vérifiée en direct, compte administrateur, détails optionnels) et progression visible des étapes pendant les 10-30 secondes du provisioning *(super-admin)* (#176).
+- Gestion des tokens d'accès personnels (`/super-admin/pats`) pour le CLI et les agents IA : création avec scopes, expiration en jours, copie en un clic du token clair (montré une seule fois), liste avec statut (actif / expiré / révoqué), révocation avec confirmation *(super-admin)* (#176).
+- Diagnostic plateforme (`/super-admin/diagnose`) : vue d'ensemble de l'état du backend, de la base, de Redis et de la configuration SMTP avec rafraîchissement automatique toutes les 30 secondes et un bouton de rafraîchissement manuel *(super-admin)* (#176).
+- Lecture des logs (`/super-admin/logs`) : viewer terminal noir, sélection du service (backend / frontend / celery / nginx), pause/reprise du tail, badges qui indiquent le nombre de secrets masqués et si la sortie est tronquée *(super-admin)* (#176).
+- Fiche détail d'un tenant (`/super-admin/tenants/[slug]`) : 6 statistiques (utilisateurs / élèves / enseignants / personnel / inscriptions / paiements), paramètres de l'établissement et version de migration en cours *(super-admin)* (#176).
+
 ### Fixed
 
 - Tableau de bord parent qui affichait toujours « Connexion au serveur impossible » depuis le ship du portail parent : on voit désormais pour chaque enfant la classe, la moyenne, le nombre d'absences et le solde restant à payer, en un coup d'œil dès la connexion *(parent)*.

--- a/app/(super-admin)/diagnose/page.tsx
+++ b/app/(super-admin)/diagnose/page.tsx
@@ -1,0 +1,5 @@
+import { DiagnoseDashboard } from "@/components/super-admin/diagnose/DiagnoseDashboard"
+
+export default function DiagnosePage() {
+  return <DiagnoseDashboard />
+}

--- a/app/(super-admin)/layout.tsx
+++ b/app/(super-admin)/layout.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next"
+import type { Route } from "next"
+import Link from "next/link"
+import { auth } from "@/auth"
+import { redirect } from "next/navigation"
+
+export const dynamic = "force-dynamic"
+
+export const metadata: Metadata = {
+  title: "Super Admin · KLASSCI",
+}
+
+const NAV: { href: Route; label: string }[] = [
+  { href: "/super-admin/tenants" as Route, label: "Tenants" },
+  { href: "/super-admin/pats" as Route, label: "Tokens" },
+  { href: "/super-admin/diagnose" as Route, label: "Diagnose" },
+  { href: "/super-admin/logs" as Route, label: "Logs" },
+]
+
+export default async function SuperAdminLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    redirect("/login?callbackUrl=/super-admin/tenants")
+  }
+  if (session.user.role !== "super_admin") {
+    redirect("/admin/dashboard")
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b bg-card">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3">
+          <div className="flex items-center gap-6">
+            <Link href={"/super-admin/tenants" as Route} className="text-lg font-semibold tracking-tight">
+              KLASSCI
+              <span className="ml-2 rounded bg-primary px-1.5 py-0.5 text-xs font-medium text-primary-foreground">
+                Super Admin
+              </span>
+            </Link>
+            <nav className="flex items-center gap-1">
+              {NAV.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </div>
+          <div className="text-sm text-muted-foreground">{session.user.email}</div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-7xl px-6 py-8">{children}</main>
+    </div>
+  )
+}

--- a/app/(super-admin)/logs/page.tsx
+++ b/app/(super-admin)/logs/page.tsx
@@ -1,0 +1,5 @@
+import { LogsViewer } from "@/components/super-admin/logs/LogsViewer"
+
+export default function LogsPage() {
+  return <LogsViewer />
+}

--- a/app/(super-admin)/page.tsx
+++ b/app/(super-admin)/page.tsx
@@ -1,0 +1,6 @@
+import type { Route } from "next"
+import { redirect } from "next/navigation"
+
+export default function SuperAdminIndex() {
+  redirect("/super-admin/tenants" as Route)
+}

--- a/app/(super-admin)/pats/page.tsx
+++ b/app/(super-admin)/pats/page.tsx
@@ -1,0 +1,5 @@
+import { PatsPanel } from "@/components/super-admin/pats/PatsPanel"
+
+export default function PatsPage() {
+  return <PatsPanel />
+}

--- a/app/(super-admin)/tenants/[slug]/page.tsx
+++ b/app/(super-admin)/tenants/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { TenantDetail } from "@/components/super-admin/tenants/TenantDetail"
+
+export default async function TenantDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <TenantDetail slug={slug} />
+}

--- a/app/(super-admin)/tenants/new/page.tsx
+++ b/app/(super-admin)/tenants/new/page.tsx
@@ -1,0 +1,5 @@
+import { WizardShell } from "@/components/super-admin/tenants-new/WizardShell"
+
+export default function NewTenantPage() {
+  return <WizardShell />
+}

--- a/app/(super-admin)/tenants/page.tsx
+++ b/app/(super-admin)/tenants/page.tsx
@@ -1,0 +1,27 @@
+import type { Route } from "next"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Plus } from "lucide-react"
+import { TenantsTable } from "@/components/super-admin/tenants/TenantsTable"
+
+export default function TenantsPage() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Tenants</h1>
+          <p className="text-sm text-muted-foreground">
+            Liste des écoles provisionnées sur la plateforme.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href={"/super-admin/tenants/new" as Route}>
+            <Plus className="mr-1.5 h-4 w-4" />
+            Nouveau tenant
+          </Link>
+        </Button>
+      </div>
+      <TenantsTable />
+    </div>
+  )
+}

--- a/components/super-admin/diagnose/DiagnoseDashboard.tsx
+++ b/components/super-admin/diagnose/DiagnoseDashboard.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Button } from "@/components/ui/button"
+import { CheckCircle2, AlertCircle, AlertTriangle, RefreshCw } from "lucide-react"
+import { usePlatformHealth } from "@/lib/hooks/super-admin/useDiagnose"
+
+const ICONS = {
+  ok: CheckCircle2,
+  degraded: AlertTriangle,
+  down: AlertCircle,
+} as const
+
+const COLOURS = {
+  ok: "text-emerald-600",
+  degraded: "text-amber-600",
+  down: "text-destructive",
+} as const
+
+const LABELS = {
+  ok: "Opérationnel",
+  degraded: "Dégradé",
+  down: "Hors service",
+} as const
+
+export function DiagnoseDashboard() {
+  const { data, isLoading, isError, refetch, isFetching } = usePlatformHealth()
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Diagnose</h1>
+          <p className="text-sm text-muted-foreground">
+            Vérification automatique toutes les 30 secondes.
+            {data?.timestamp && (
+              <> Dernière màj : {new Date(data.timestamp).toLocaleTimeString("fr-FR")}.</>
+            )}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCw className={`mr-1.5 h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+          Rafraîchir
+        </Button>
+      </div>
+
+      {data && (
+        <div
+          className={`rounded-md border p-4 ${
+            data.overall === "ok"
+              ? "border-emerald-300 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950"
+              : data.overall === "degraded"
+                ? "border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950"
+                : "border-destructive/40 bg-destructive/5"
+          }`}
+        >
+          <p className="text-sm font-medium">État global : {LABELS[data.overall]}</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {isLoading ? (
+          Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="pt-4">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="mt-2 h-6 w-32" />
+              </CardContent>
+            </Card>
+          ))
+        ) : isError ? (
+          <p className="col-span-full text-sm text-destructive">Échec du chargement</p>
+        ) : (
+          (data?.checks ?? []).map((check) => {
+            const Icon = ICONS[check.status]
+            return (
+              <Card key={check.component}>
+                <CardContent className="pt-4">
+                  <div className="flex items-center gap-3">
+                    <Icon className={`h-5 w-5 ${COLOURS[check.status]}`} />
+                    <div className="flex-1">
+                      <p className="text-sm font-medium capitalize">{check.component}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {LABELS[check.status]}
+                        {check.message && ` — ${check.message}`}
+                      </p>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/super-admin/logs/LogsViewer.tsx
+++ b/components/super-admin/logs/LogsViewer.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+import { Pause, Play, RefreshCw } from "lucide-react"
+import { useLogs } from "@/lib/hooks/super-admin/useLogs"
+
+const SERVICES = ["klassci-backend", "klassci-frontend", "klassci-celery", "nginx"]
+
+export function LogsViewer() {
+  const [service, setService] = useState("klassci-backend")
+  const [lines, setLines] = useState(200)
+  const [paused, setPaused] = useState(false)
+  const { data, isLoading, isError, error, refetch, isFetching } = useLogs(service, lines, !paused)
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Logs</h1>
+        <p className="text-sm text-muted-foreground">
+          Lecture du journal système. Tokens, mots de passe et emails sont automatiquement masqués.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3 rounded-md border bg-card p-4">
+        <div className="space-y-1.5">
+          <Label className="text-xs">Service</Label>
+          <Select value={service} onValueChange={setService}>
+            <SelectTrigger className="w-56">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SERVICES.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {s}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs" htmlFor="logs-lines">
+            Lignes
+          </Label>
+          <Input
+            id="logs-lines"
+            type="number"
+            min={10}
+            max={5000}
+            value={lines}
+            onChange={(e) => setLines(Number(e.target.value))}
+            className="w-24"
+          />
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => setPaused((p) => !p)}>
+            {paused ? <Play className="mr-1.5 h-3.5 w-3.5" /> : <Pause className="mr-1.5 h-3.5 w-3.5" />}
+            {paused ? "Reprendre" : "Pause"}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+            <RefreshCw className={`h-3.5 w-3.5 ${isFetching ? "animate-spin" : ""}`} />
+          </Button>
+        </div>
+      </div>
+
+      {data && (
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          <span>{data.lines.length} lignes</span>
+          {data.redacted_count > 0 && (
+            <Badge variant="secondary" className="text-xs">
+              {data.redacted_count} secret(s) masqué(s)
+            </Badge>
+          )}
+          {data.truncated && (
+            <Badge variant="outline" className="text-xs">
+              tronqué
+            </Badge>
+          )}
+        </div>
+      )}
+
+      <div className="rounded-md border bg-zinc-950 p-4 font-mono text-xs leading-relaxed text-zinc-100">
+        {isLoading ? (
+          <p className="text-zinc-500">Chargement…</p>
+        ) : isError ? (
+          <p className="text-rose-400">{(error as Error).message}</p>
+        ) : (data?.lines ?? []).length === 0 ? (
+          <p className="text-zinc-500">(aucune ligne)</p>
+        ) : (
+          <div className="max-h-[600px] overflow-auto">
+            {data!.lines.map((line, i) => (
+              <div key={i} className="whitespace-pre-wrap break-all">
+                {line.raw}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/super-admin/pats/PatsPanel.tsx
+++ b/components/super-admin/pats/PatsPanel.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Badge } from "@/components/ui/badge"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Trash2, Copy, Check } from "lucide-react"
+import { useCreatePat, usePatsList, useRevokePat } from "@/lib/hooks/super-admin/usePats"
+
+const formSchema = z.object({
+  name: z.string().min(1).max(150),
+  scopes: z.string().min(1, "Au moins un scope requis"),
+  expires_in_days: z.coerce.number().min(1).max(365),
+})
+
+type FormData = z.infer<typeof formSchema>
+
+export function PatsPanel() {
+  const { data, isLoading } = usePatsList()
+  const create = useCreatePat()
+  const revoke = useRevokePat()
+  const [createdPlaintext, setCreatedPlaintext] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [revokeId, setRevokeId] = useState<number | null>(null)
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: "", scopes: "super-admin:tenants:read", expires_in_days: 90 },
+  })
+
+  function onSubmit(values: FormData) {
+    const scopes = values.scopes
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+    create.mutate(
+      { name: values.name, scopes, expires_in_days: values.expires_in_days },
+      {
+        onSuccess: (result) => {
+          setCreatedPlaintext(result.plaintext)
+          form.reset()
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Personal Access Tokens</h1>
+        <p className="text-sm text-muted-foreground">
+          Pour le CLI <code className="rounded bg-muted px-1 text-xs">klassci</code> et les agents IA.
+          Le token clair n'est affiché qu'une seule fois — copie-le immédiatement.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Créer un token</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="name">Nom</Label>
+              <Input id="name" placeholder="dev-laptop" {...form.register("name")} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="scopes">Scopes (séparés par virgule)</Label>
+              <Input
+                id="scopes"
+                placeholder="super-admin:tenants:read"
+                {...form.register("scopes")}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="expires_in_days">Expire dans (jours)</Label>
+              <Input
+                id="expires_in_days"
+                type="number"
+                min={1}
+                max={365}
+                {...form.register("expires_in_days", { valueAsNumber: true })}
+              />
+            </div>
+            <div className="md:col-span-3">
+              <Button type="submit" disabled={create.isPending}>
+                {create.isPending ? "Création…" : "Créer le token"}
+              </Button>
+            </div>
+          </form>
+
+          {createdPlaintext && (
+            <div className="mt-4 rounded-md border border-emerald-300 bg-emerald-50 p-3 dark:border-emerald-800 dark:bg-emerald-950">
+              <p className="text-xs font-medium text-emerald-900 dark:text-emerald-100">
+                Token créé. Copie-le maintenant — il ne sera plus jamais affiché.
+              </p>
+              <div className="mt-2 flex items-center gap-2 rounded bg-background px-3 py-2 font-mono text-xs">
+                <span className="flex-1 break-all">{createdPlaintext}</span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={async () => {
+                    await navigator.clipboard.writeText(createdPlaintext)
+                    setCopied(true)
+                    setTimeout(() => setCopied(false), 2000)
+                  }}
+                >
+                  {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                </Button>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setCreatedPlaintext(null)}
+                className="mt-2 text-xs"
+              >
+                J'ai copié, masquer
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="rounded-md border">
+        <div className="border-b bg-muted/30 px-4 py-2 text-sm font-medium">Tokens existants</div>
+        <div className="divide-y">
+          {isLoading ? (
+            <div className="p-4">
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : (data?.items ?? []).length === 0 ? (
+            <div className="p-6 text-center text-sm text-muted-foreground">Aucun token</div>
+          ) : (
+            data!.items.map((pat) => {
+              const isRevoked = pat.revoked_at !== null
+              const isExpired = new Date(pat.expires_at) < new Date()
+              const inactive = isRevoked || isExpired
+              return (
+                <div key={pat.id} className="flex items-center gap-4 p-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium truncate">{pat.name}</p>
+                      {isRevoked && <Badge variant="destructive">Révoqué</Badge>}
+                      {!isRevoked && isExpired && <Badge variant="secondary">Expiré</Badge>}
+                    </div>
+                    <p className="font-mono text-xs text-muted-foreground">
+                      {pat.token_prefix}…
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Scopes : {pat.scopes.join(", ")} · Expire :{" "}
+                      {new Date(pat.expires_at).toLocaleDateString("fr-FR")}
+                      {pat.last_used_at &&
+                        ` · Dernière utilisation : ${new Date(pat.last_used_at).toLocaleString("fr-FR")}`}
+                    </p>
+                  </div>
+                  {!inactive && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setRevokeId(pat.id)}
+                      aria-label="Révoquer"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              )
+            })
+          )}
+        </div>
+      </div>
+
+      <AlertDialog open={revokeId !== null} onOpenChange={(open) => !open && setRevokeId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Révoquer ce token ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Cette action est définitive. Toute machine ou agent qui utilise ce token sera
+              déconnecté immédiatement.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (revokeId !== null) revoke.mutate(revokeId)
+                setRevokeId(null)
+              }}
+            >
+              Révoquer
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/components/super-admin/tenants-new/ProvisioningProgress.tsx
+++ b/components/super-admin/tenants-new/ProvisioningProgress.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import type { Route } from "next"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { Check, Loader2, AlertCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+const STAGES = [
+  { label: "Création de la base de données", ms: 2500 },
+  { label: "Application des migrations", ms: 4500 },
+  { label: "Insertion des données initiales", ms: 3000 },
+  { label: "Création du compte administrateur", ms: 1500 },
+  { label: "Envoi de l'email de bienvenue", ms: 2000 },
+]
+
+export function ProvisioningProgress({
+  status,
+  result,
+  errorMessage,
+}: {
+  status: "pending" | "success" | "error"
+  result?: { tenant_slug: string; url: string } | undefined
+  errorMessage?: string
+}) {
+  const [reached, setReached] = useState(0)
+
+  useEffect(() => {
+    if (status !== "pending") return
+    let i = 0
+    let cancelled = false
+    const tick = () => {
+      if (cancelled || i >= STAGES.length - 1) return
+      i++
+      setReached(i)
+      setTimeout(tick, STAGES[i].ms)
+    }
+    setTimeout(tick, STAGES[0].ms)
+    return () => {
+      cancelled = true
+    }
+  }, [status])
+
+  useEffect(() => {
+    if (status === "success") setReached(STAGES.length)
+  }, [status])
+
+  return (
+    <div className="space-y-6 rounded-md border bg-card p-6">
+      <div>
+        <h2 className="text-xl font-semibold">
+          {status === "pending"
+            ? "Provisionnement en cours…"
+            : status === "success"
+              ? "Tenant provisionné"
+              : "Échec du provisioning"}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {status === "pending"
+            ? "Cela prend généralement 10-30 secondes."
+            : status === "success"
+              ? `Le tenant ${result?.tenant_slug} est prêt.`
+              : "Vérifie les logs et réessaye."}
+        </p>
+      </div>
+
+      <ul className="space-y-3">
+        {STAGES.map((stage, i) => (
+          <li key={stage.label} className="flex items-center gap-3">
+            {i < reached ? (
+              <Check className="h-5 w-5 shrink-0 text-emerald-600" />
+            ) : i === reached && status === "pending" ? (
+              <Loader2 className="h-5 w-5 shrink-0 animate-spin text-primary" />
+            ) : status === "error" && i === reached ? (
+              <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
+            ) : (
+              <span className="h-5 w-5 shrink-0 rounded-full border-2 border-muted" />
+            )}
+            <span className={i < reached ? "font-medium" : "text-muted-foreground"}>
+              {stage.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {status === "error" && errorMessage && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+          {errorMessage}
+        </div>
+      )}
+
+      {status === "success" && result && (
+        <div className="flex items-center gap-3">
+          <Button asChild>
+            <Link href={`/super-admin/tenants/${result.tenant_slug}` as Route}>
+              Ouvrir la fiche
+            </Link>
+          </Button>
+          <a
+            href={result.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-primary hover:underline"
+          >
+            Visiter le site →
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/super-admin/tenants-new/StepAdmin.tsx
+++ b/components/super-admin/tenants-new/StepAdmin.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { useFormContext } from "react-hook-form"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { WizardData } from "./WizardSteps"
+
+export function StepAdmin() {
+  const { register, formState } = useFormContext<WizardData>()
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="admin_email">Email administrateur *</Label>
+        <Input
+          id="admin_email"
+          type="email"
+          placeholder="admin@lycee-moderne.ci"
+          autoComplete="email"
+          {...register("admin_email")}
+        />
+        {formState.errors.admin_email && (
+          <p className="text-xs text-destructive">{formState.errors.admin_email.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="admin_password">Mot de passe initial *</Label>
+        <Input
+          id="admin_password"
+          type="password"
+          placeholder="8 caractères minimum"
+          autoComplete="new-password"
+          {...register("admin_password")}
+        />
+        {formState.errors.admin_password ? (
+          <p className="text-xs text-destructive">{formState.errors.admin_password.message}</p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            L'admin pourra changer son mot de passe dès la 1re connexion.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/super-admin/tenants-new/StepOptional.tsx
+++ b/components/super-admin/tenants-new/StepOptional.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useFormContext } from "react-hook-form"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { WizardData } from "./WizardSteps"
+
+export function StepOptional() {
+  const { register, formState } = useFormContext<WizardData>()
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Ces champs sont optionnels — ils peuvent être renseignés plus tard depuis les paramètres de
+        l'établissement.
+      </p>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="school_address">Adresse</Label>
+        <Input
+          id="school_address"
+          placeholder="Cocody, Abidjan"
+          {...register("school_address")}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="school_phone">Téléphone</Label>
+          <Input id="school_phone" placeholder="+225 01 23 45 67" {...register("school_phone")} />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="school_email">Email établissement</Label>
+          <Input
+            id="school_email"
+            type="email"
+            placeholder="contact@lycee-moderne.ci"
+            {...register("school_email")}
+          />
+          {formState.errors.school_email && (
+            <p className="text-xs text-destructive">{formState.errors.school_email.message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="ministry_code">Code ministère</Label>
+        <Input id="ministry_code" placeholder="DREN-ABJ-042" {...register("ministry_code")} />
+      </div>
+    </div>
+  )
+}

--- a/components/super-admin/tenants-new/StepReview.tsx
+++ b/components/super-admin/tenants-new/StepReview.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { useFormContext } from "react-hook-form"
+import type { WizardData } from "./WizardSteps"
+
+function Row({ label, value }: { label: string; value: string | undefined }) {
+  return (
+    <div className="grid grid-cols-3 gap-3 border-b py-2 last:border-0">
+      <dt className="text-sm text-muted-foreground">{label}</dt>
+      <dd className="col-span-2 text-sm font-medium">{value || <span className="text-muted-foreground italic">non renseigné</span>}</dd>
+    </div>
+  )
+}
+
+export function StepReview() {
+  const { getValues } = useFormContext<WizardData>()
+  const v = getValues()
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-muted/30 p-4">
+        <p className="text-sm font-medium">Récapitulatif</p>
+        <dl className="mt-3">
+          <Row label="Slug" value={v.tenant_slug} />
+          <Row label="URL" value={`https://${v.tenant_slug}.college.klassci.com`} />
+          <Row label="Nom" value={v.school_name} />
+          <Row label="Admin email" value={v.admin_email} />
+          <Row label="Adresse" value={v.school_address} />
+          <Row label="Téléphone" value={v.school_phone} />
+          <Row label="Email école" value={v.school_email} />
+          <Row label="Code ministère" value={v.ministry_code} />
+        </dl>
+      </div>
+
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100">
+        ⚠ Le provisioning prend 10-30 secondes. Une base MySQL sera créée, les migrations
+        appliquées, et un email de bienvenue envoyé à l'admin (si SMTP configuré).
+      </div>
+    </div>
+  )
+}

--- a/components/super-admin/tenants-new/StepSchool.tsx
+++ b/components/super-admin/tenants-new/StepSchool.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useFormContext } from "react-hook-form"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Check, Loader2, X } from "lucide-react"
+import { useSlugCheck } from "@/lib/hooks/super-admin/useTenants"
+import type { WizardData } from "./WizardSteps"
+
+function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+  return debounced
+}
+
+export function StepSchool() {
+  const { register, watch, formState } = useFormContext<WizardData>()
+  const slug = watch("tenant_slug") ?? ""
+  const debouncedSlug = useDebouncedValue(slug, 400)
+  const { data: slugCheck, isFetching } = useSlugCheck(
+    debouncedSlug,
+    debouncedSlug.length >= 2 && !formState.errors.tenant_slug,
+  )
+
+  const showStatus = debouncedSlug.length >= 2 && !formState.errors.tenant_slug
+  const isAvailable = slugCheck?.available === true
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="school_name">Nom de l'établissement *</Label>
+        <Input
+          id="school_name"
+          placeholder="Lycée Moderne d'Abidjan"
+          {...register("school_name")}
+        />
+        {formState.errors.school_name && (
+          <p className="text-xs text-destructive">{formState.errors.school_name.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="tenant_slug">
+          Identifiant unique (slug) *
+          <span className="ml-2 text-xs font-normal text-muted-foreground">
+            sera utilisé dans l'URL
+          </span>
+        </Label>
+        <div className="relative">
+          <Input
+            id="tenant_slug"
+            placeholder="lycee-moderne"
+            autoComplete="off"
+            {...register("tenant_slug")}
+          />
+          {showStatus && (
+            <div className="absolute right-3 top-1/2 -translate-y-1/2">
+              {isFetching ? (
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              ) : isAvailable ? (
+                <Check className="h-4 w-4 text-emerald-600" />
+              ) : (
+                <X className="h-4 w-4 text-destructive" />
+              )}
+            </div>
+          )}
+        </div>
+        {formState.errors.tenant_slug ? (
+          <p className="text-xs text-destructive">{formState.errors.tenant_slug.message}</p>
+        ) : showStatus && !isFetching && slugCheck && !slugCheck.available ? (
+          <p className="text-xs text-destructive">{slugCheck.reason ?? "Slug indisponible"}</p>
+        ) : slug ? (
+          <p className="font-mono text-xs text-muted-foreground">
+            URL : https://{slug}.college.klassci.com
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">2-63 car., minuscules + chiffres + tirets</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/super-admin/tenants-new/WizardShell.tsx
+++ b/components/super-admin/tenants-new/WizardShell.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useState } from "react"
+import { FormProvider, useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Button } from "@/components/ui/button"
+import { useCreateTenant } from "@/lib/hooks/super-admin/useTenants"
+import { ProvisioningProgress } from "./ProvisioningProgress"
+import { StepAdmin } from "./StepAdmin"
+import { StepOptional } from "./StepOptional"
+import { StepReview } from "./StepReview"
+import { StepSchool } from "./StepSchool"
+import { STEPS, type WizardData, wizardSchema } from "./WizardSteps"
+
+export function WizardShell() {
+  const [step, setStep] = useState(0)
+  const methods = useForm<WizardData>({
+    resolver: zodResolver(wizardSchema),
+    mode: "onTouched",
+    defaultValues: {
+      tenant_slug: "",
+      school_name: "",
+      admin_email: "",
+      admin_password: "",
+      school_address: "",
+      school_phone: "",
+      school_email: "",
+      ministry_code: "",
+    },
+  })
+  const mutation = useCreateTenant()
+
+  async function next() {
+    const fields = STEPS[step].fields as readonly (keyof WizardData)[]
+    const valid = fields.length === 0 ? true : await methods.trigger(fields)
+    if (valid) setStep((s) => Math.min(s + 1, STEPS.length - 1))
+  }
+
+  function onSubmit(data: WizardData) {
+    const cleaned = {
+      ...data,
+      school_address: data.school_address || undefined,
+      school_phone: data.school_phone || undefined,
+      school_email: data.school_email || undefined,
+      ministry_code: data.ministry_code || undefined,
+    }
+    mutation.mutate(cleaned)
+  }
+
+  if (mutation.isPending || mutation.isSuccess || mutation.isError) {
+    return (
+      <ProvisioningProgress
+        status={mutation.isPending ? "pending" : mutation.isSuccess ? "success" : "error"}
+        result={mutation.data ? { tenant_slug: mutation.data.tenant_slug, url: mutation.data.url } : undefined}
+        errorMessage={mutation.isError ? (mutation.error as Error).message : undefined}
+      />
+    )
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <div className="mx-auto max-w-2xl space-y-6">
+        <ol className="flex gap-2">
+          {STEPS.map((s, i) => (
+            <li
+              key={s.id}
+              className={`h-1.5 flex-1 rounded-full ${
+                i < step ? "bg-primary" : i === step ? "bg-primary/60" : "bg-muted"
+              }`}
+              aria-current={i === step ? "step" : undefined}
+            />
+          ))}
+        </ol>
+
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Étape {step + 1} / {STEPS.length}
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight">{STEPS[step].title}</h1>
+          <p className="text-sm text-muted-foreground">{STEPS[step].description}</p>
+        </div>
+
+        <form
+          onSubmit={methods.handleSubmit(onSubmit)}
+          className="rounded-md border bg-card p-6"
+        >
+          {step === 0 && <StepSchool />}
+          {step === 1 && <StepAdmin />}
+          {step === 2 && <StepOptional />}
+          {step === 3 && <StepReview />}
+
+          <div className="mt-6 flex items-center justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setStep((s) => Math.max(0, s - 1))}
+              disabled={step === 0}
+            >
+              Retour
+            </Button>
+            {step < STEPS.length - 1 ? (
+              <Button type="button" onClick={next}>
+                Suivant
+              </Button>
+            ) : (
+              <Button type="submit">Créer le tenant</Button>
+            )}
+          </div>
+        </form>
+      </div>
+    </FormProvider>
+  )
+}

--- a/components/super-admin/tenants-new/WizardSteps.ts
+++ b/components/super-admin/tenants-new/WizardSteps.ts
@@ -1,0 +1,47 @@
+import { z } from "zod"
+
+export const wizardSchema = z.object({
+  tenant_slug: z
+    .string()
+    .min(2, "2 caractères min")
+    .max(63, "63 caractères max")
+    .regex(/^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/, "minuscules + chiffres + tirets"),
+  school_name: z.string().min(1, "Nom requis").max(255),
+  admin_email: z.string().email("Email invalide"),
+  admin_password: z.string().min(8, "8 caractères min"),
+  school_address: z.string().optional(),
+  school_phone: z.string().optional(),
+  school_email: z.string().email("Email invalide").or(z.literal("")).optional(),
+  ministry_code: z.string().optional(),
+})
+
+export type WizardData = z.infer<typeof wizardSchema>
+
+export const STEPS = [
+  {
+    id: "school",
+    title: "École",
+    description: "Identifiant et nom de l'établissement",
+    fields: ["tenant_slug", "school_name"] as const,
+  },
+  {
+    id: "admin",
+    title: "Administrateur",
+    description: "Compte de connexion initial",
+    fields: ["admin_email", "admin_password"] as const,
+  },
+  {
+    id: "optional",
+    title: "Détails optionnels",
+    description: "Adresse, téléphone, code ministère",
+    fields: ["school_address", "school_phone", "school_email", "ministry_code"] as const,
+  },
+  {
+    id: "review",
+    title: "Vérification",
+    description: "Confirmer avant provisioning",
+    fields: [] as const,
+  },
+] as const
+
+export type StepId = (typeof STEPS)[number]["id"]

--- a/components/super-admin/tenants/TenantDetail.tsx
+++ b/components/super-admin/tenants/TenantDetail.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Button } from "@/components/ui/button"
+import { ExternalLink } from "lucide-react"
+import { useTenant } from "@/lib/hooks/super-admin/useTenants"
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  const units = ["KB", "MB", "GB"]
+  let value = bytes / 1024
+  let i = 0
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024
+    i++
+  }
+  return `${value.toFixed(1)} ${units[i]}`
+}
+
+export function TenantDetail({ slug }: { slug: string }) {
+  const { data, isLoading, isError, error, refetch } = useTenant(slug)
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/5 p-6 text-sm">
+        <p className="font-medium text-destructive">Erreur de chargement</p>
+        <p className="mt-1 text-muted-foreground">{(error as Error).message}</p>
+        <Button onClick={() => refetch()} variant="outline" size="sm" className="mt-3">
+          Réessayer
+        </Button>
+      </div>
+    )
+  }
+
+  if (!data) return null
+
+  const counts = data.counts
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {data.school_settings?.school_name ?? data.slug}
+          </h1>
+          <a
+            href={data.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground hover:underline"
+          >
+            {data.url}
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+        <div className="text-right text-xs text-muted-foreground">
+          <p>
+            Slug : <span className="font-mono">{data.slug}</span>
+          </p>
+          <p>
+            Migration : <span className="font-mono">{data.alembic_head ?? "—"}</span>
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6">
+        <Stat label="Utilisateurs" value={counts.users} />
+        <Stat label="Élèves" value={counts.students} />
+        <Stat label="Enseignants" value={counts.teachers} />
+        <Stat label="Personnel" value={counts.staff} />
+        <Stat label="Inscriptions" value={counts.enrollments} />
+        <Stat label="Paiements" value={counts.payments} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Paramètres de l'établissement</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="space-y-2 text-sm">
+            <Row label="Nom" value={data.school_settings?.school_name} />
+            <Row label="Adresse" value={data.school_settings?.address} />
+            <Row label="Téléphone" value={data.school_settings?.phone} />
+            <Row label="Email" value={data.school_settings?.email} />
+            <Row label="Code ministère" value={data.school_settings?.ministry_code} />
+            <Row label="Taille DB" value={formatBytes(data.db_size_bytes)} />
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <Card>
+      <CardContent className="pt-4">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+        <p className="mt-1 text-2xl font-semibold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="grid grid-cols-3 gap-3 border-b py-2 last:border-0">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="col-span-2 font-medium">
+        {value || <span className="italic text-muted-foreground">non renseigné</span>}
+      </dd>
+    </div>
+  )
+}

--- a/components/super-admin/tenants/TenantsTable.tsx
+++ b/components/super-admin/tenants/TenantsTable.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import type { Route } from "next"
+import Link from "next/link"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useTenantsList } from "@/lib/hooks/super-admin/useTenants"
+import { ExternalLink } from "lucide-react"
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  const units = ["KB", "MB", "GB"]
+  let value = bytes / 1024
+  let i = 0
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024
+    i++
+  }
+  return `${value.toFixed(1)} ${units[i]}`
+}
+
+export function TenantsTable() {
+  const { data, isLoading, isError, error, refetch } = useTenantsList()
+
+  if (isError) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/5 p-6 text-sm">
+        <p className="font-medium text-destructive">Erreur de chargement</p>
+        <p className="mt-1 text-muted-foreground">{(error as Error).message}</p>
+        <Button onClick={() => refetch()} variant="outline" size="sm" className="mt-3">
+          Réessayer
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Slug</TableHead>
+            <TableHead>URL</TableHead>
+            <TableHead className="text-right">Taille DB</TableHead>
+            <TableHead className="w-12" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {isLoading
+            ? Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  <TableCell>
+                    <Skeleton className="h-4 w-32" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-64" />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Skeleton className="ml-auto h-4 w-16" />
+                  </TableCell>
+                  <TableCell />
+                </TableRow>
+              ))
+            : (data?.items ?? []).length === 0
+              ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="py-12 text-center text-sm text-muted-foreground">
+                      Aucun tenant pour le moment.
+                      <Link href={"/super-admin/tenants/new" as Route} className="ml-2 text-primary hover:underline">
+                        Créer le premier
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                )
+              : data!.items.map((tenant) => (
+                  <TableRow key={tenant.slug} className="hover:bg-muted/50">
+                    <TableCell className="font-medium">
+                      <Link
+                        href={`/super-admin/tenants/${tenant.slug}` as Route}
+                        className="text-primary hover:underline"
+                      >
+                        {tenant.slug}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      <a
+                        href={tenant.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+                      >
+                        {tenant.url}
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatBytes(tenant.db_size_bytes)}
+                    </TableCell>
+                    <TableCell />
+                  </TableRow>
+                ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/lib/api/super-admin/diagnose.ts
+++ b/lib/api/super-admin/diagnose.ts
@@ -1,0 +1,10 @@
+import { apiFetch } from "@/lib/api/client"
+import { type PlatformHealth, platformHealthSchema } from "@/lib/contracts/super-admin"
+
+export const diagnoseApi = {
+  platform: async (): Promise<PlatformHealth> => {
+    return apiFetch<PlatformHealth>("/super-admin/diagnose", {
+      schema: platformHealthSchema,
+    })
+  },
+}

--- a/lib/api/super-admin/logs.ts
+++ b/lib/api/super-admin/logs.ts
@@ -1,0 +1,25 @@
+import { apiFetch } from "@/lib/api/client"
+import { z } from "zod"
+
+const logsResponseSchema = z.object({
+  service: z.string(),
+  lines: z.array(
+    z.object({
+      timestamp: z.string().nullable(),
+      raw: z.string(),
+    }),
+  ),
+  truncated: z.boolean(),
+  redacted_count: z.number(),
+})
+
+export type LogsResponse = z.infer<typeof logsResponseSchema>
+
+export const logsApi = {
+  read: async (service: string, lines: number): Promise<LogsResponse> => {
+    const params = new URLSearchParams({ service, lines: String(lines) })
+    return apiFetch<LogsResponse>(`/super-admin/logs?${params.toString()}`, {
+      schema: logsResponseSchema,
+    })
+  },
+}

--- a/lib/api/super-admin/pats.ts
+++ b/lib/api/super-admin/pats.ts
@@ -1,0 +1,33 @@
+import { apiFetch } from "@/lib/api/client"
+import {
+  type PATCreateResponse,
+  patCreateResponseSchema,
+  patListResponseSchema,
+} from "@/lib/contracts/super-admin"
+import type { z } from "zod"
+
+type PATListResponse = z.infer<typeof patListResponseSchema>
+
+export const patsApi = {
+  list: async (): Promise<PATListResponse> => {
+    return apiFetch<PATListResponse>("/super-admin/pats", {
+      schema: patListResponseSchema,
+    })
+  },
+
+  create: async (data: {
+    name: string
+    scopes: string[]
+    expires_in_days?: number
+  }): Promise<PATCreateResponse> => {
+    return apiFetch<PATCreateResponse>("/super-admin/pats", {
+      method: "POST",
+      body: JSON.stringify(data),
+      schema: patCreateResponseSchema,
+    })
+  },
+
+  revoke: async (id: number): Promise<void> => {
+    await apiFetch<void>(`/super-admin/pats/${id}`, { method: "DELETE" })
+  },
+}

--- a/lib/api/super-admin/tenants.ts
+++ b/lib/api/super-admin/tenants.ts
@@ -1,0 +1,45 @@
+import { apiFetch } from "@/lib/api/client"
+import {
+  type TenantDetail,
+  type TenantListResponse,
+  type TenantProvisionRequest,
+  type SlugCheckResponse,
+  tenantDetailSchema,
+  tenantListResponseSchema,
+  slugCheckResponseSchema,
+} from "@/lib/contracts/super-admin"
+
+export const tenantsApi = {
+  list: async (): Promise<TenantListResponse> => {
+    return apiFetch<TenantListResponse>("/super-admin/tenants", {
+      schema: tenantListResponseSchema,
+    })
+  },
+
+  get: async (slug: string): Promise<TenantDetail> => {
+    return apiFetch<TenantDetail>(`/super-admin/tenants/${encodeURIComponent(slug)}`, {
+      schema: tenantDetailSchema,
+    })
+  },
+
+  checkSlug: async (slug: string): Promise<SlugCheckResponse> => {
+    return apiFetch<SlugCheckResponse>("/super-admin/tenants/check-slug", {
+      method: "POST",
+      body: JSON.stringify({ slug }),
+      schema: slugCheckResponseSchema,
+    })
+  },
+
+  create: async (data: TenantProvisionRequest) => {
+    return apiFetch<{
+      tenant_slug: string
+      database: string
+      admin_email: string
+      status: string
+      url: string
+    }>("/super-admin/tenants", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+  },
+}

--- a/lib/contracts/super-admin.ts
+++ b/lib/contracts/super-admin.ts
@@ -1,0 +1,101 @@
+import { z } from "zod"
+
+export const tenantListItemSchema = z.object({
+  slug: z.string(),
+  url: z.string(),
+  db_size_bytes: z.number(),
+})
+export type TenantListItem = z.infer<typeof tenantListItemSchema>
+
+export const tenantListResponseSchema = z.object({
+  items: z.array(tenantListItemSchema),
+  total: z.number(),
+})
+export type TenantListResponse = z.infer<typeof tenantListResponseSchema>
+
+export const tenantSchoolSettingsSchema = z.object({
+  school_name: z.string().nullable(),
+  address: z.string().nullable(),
+  phone: z.string().nullable(),
+  email: z.string().nullable(),
+  ministry_code: z.string().nullable(),
+})
+
+export const tenantCountsSchema = z.object({
+  users: z.number(),
+  students: z.number(),
+  teachers: z.number(),
+  staff: z.number(),
+  enrollments: z.number(),
+  payments: z.number(),
+})
+export type TenantCounts = z.infer<typeof tenantCountsSchema>
+
+export const tenantDetailSchema = z.object({
+  slug: z.string(),
+  url: z.string(),
+  school_settings: tenantSchoolSettingsSchema.nullable(),
+  counts: tenantCountsSchema,
+  alembic_head: z.string().nullable(),
+  db_size_bytes: z.number(),
+})
+export type TenantDetail = z.infer<typeof tenantDetailSchema>
+
+export const tenantProvisionRequestSchema = z.object({
+  tenant_slug: z
+    .string()
+    .min(2)
+    .max(63)
+    .regex(/^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/, "minuscules + chiffres + tirets, sans tiret en début/fin"),
+  school_name: z.string().min(1).max(255),
+  admin_email: z.string().email(),
+  admin_password: z.string().min(8),
+  school_address: z.string().nullable().optional(),
+  school_phone: z.string().nullable().optional(),
+  school_email: z.string().email().nullable().optional().or(z.literal("")),
+  ministry_code: z.string().nullable().optional(),
+})
+export type TenantProvisionRequest = z.infer<typeof tenantProvisionRequestSchema>
+
+export const slugCheckResponseSchema = z.object({
+  slug: z.string(),
+  available: z.boolean(),
+  valid_format: z.boolean(),
+  reason: z.string().nullable(),
+})
+export type SlugCheckResponse = z.infer<typeof slugCheckResponseSchema>
+
+export const patListItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  token_prefix: z.string(),
+  scopes: z.array(z.string()),
+  expires_at: z.string(),
+  last_used_at: z.string().nullable(),
+  revoked_at: z.string().nullable(),
+  created_at: z.string(),
+})
+export type PATListItem = z.infer<typeof patListItemSchema>
+
+export const patListResponseSchema = z.object({
+  items: z.array(patListItemSchema),
+  total: z.number(),
+})
+
+export const patCreateResponseSchema = patListItemSchema.extend({
+  plaintext: z.string(),
+})
+export type PATCreateResponse = z.infer<typeof patCreateResponseSchema>
+
+export const platformHealthSchema = z.object({
+  overall: z.enum(["ok", "degraded", "down"]),
+  checks: z.array(
+    z.object({
+      component: z.string(),
+      status: z.enum(["ok", "degraded", "down"]),
+      message: z.string().nullable(),
+    }),
+  ),
+  timestamp: z.string(),
+})
+export type PlatformHealth = z.infer<typeof platformHealthSchema>

--- a/lib/hooks/super-admin/useDiagnose.ts
+++ b/lib/hooks/super-admin/useDiagnose.ts
@@ -1,0 +1,16 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { diagnoseApi } from "@/lib/api/super-admin/diagnose"
+
+export const diagnoseKeys = {
+  platform: ["super-admin", "diagnose", "platform"] as const,
+}
+
+export function usePlatformHealth(refetchIntervalMs = 30_000) {
+  return useQuery({
+    queryKey: diagnoseKeys.platform,
+    queryFn: () => diagnoseApi.platform(),
+    refetchInterval: refetchIntervalMs,
+  })
+}

--- a/lib/hooks/super-admin/useLogs.ts
+++ b/lib/hooks/super-admin/useLogs.ts
@@ -1,0 +1,18 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { logsApi } from "@/lib/api/super-admin/logs"
+
+export const logsKeys = {
+  read: (service: string, lines: number) =>
+    ["super-admin", "logs", service, lines] as const,
+}
+
+export function useLogs(service: string, lines: number, enabled = true) {
+  return useQuery({
+    queryKey: logsKeys.read(service, lines),
+    queryFn: () => logsApi.read(service, lines),
+    enabled,
+    refetchInterval: enabled ? 5_000 : false,
+  })
+}

--- a/lib/hooks/super-admin/usePats.ts
+++ b/lib/hooks/super-admin/usePats.ts
@@ -1,0 +1,37 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { patsApi } from "@/lib/api/super-admin/pats"
+
+export const patKeys = {
+  all: ["super-admin", "pats"] as const,
+  list: () => ["super-admin", "pats", "list"] as const,
+}
+
+export function usePatsList() {
+  return useQuery({
+    queryKey: patKeys.list(),
+    queryFn: () => patsApi.list(),
+    staleTime: 30_000,
+  })
+}
+
+export function useCreatePat() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: patsApi.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: patKeys.all })
+    },
+  })
+}
+
+export function useRevokePat() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => patsApi.revoke(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: patKeys.all })
+    },
+  })
+}

--- a/lib/hooks/super-admin/useTenants.ts
+++ b/lib/hooks/super-admin/useTenants.ts
@@ -1,0 +1,48 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { tenantsApi } from "@/lib/api/super-admin/tenants"
+import type { TenantProvisionRequest } from "@/lib/contracts/super-admin"
+
+export const tenantKeys = {
+  all: ["super-admin", "tenants"] as const,
+  list: () => ["super-admin", "tenants", "list"] as const,
+  detail: (slug: string) => ["super-admin", "tenants", "detail", slug] as const,
+  slugCheck: (slug: string) => ["super-admin", "tenants", "slug-check", slug] as const,
+}
+
+export function useTenantsList() {
+  return useQuery({
+    queryKey: tenantKeys.list(),
+    queryFn: () => tenantsApi.list(),
+    staleTime: 30_000,
+  })
+}
+
+export function useTenant(slug: string) {
+  return useQuery({
+    queryKey: tenantKeys.detail(slug),
+    queryFn: () => tenantsApi.get(slug),
+    enabled: !!slug,
+    staleTime: 60_000,
+  })
+}
+
+export function useCreateTenant() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: TenantProvisionRequest) => tenantsApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantKeys.all })
+    },
+  })
+}
+
+export function useSlugCheck(slug: string, enabled: boolean) {
+  return useQuery({
+    queryKey: tenantKeys.slugCheck(slug),
+    queryFn: () => tenantsApi.checkSlug(slug),
+    enabled: enabled && slug.length >= 2,
+    staleTime: 5_000,
+  })
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { extractHostname, isHostAllowed } from "@/lib/utils/allowed-hosts"
 
-const PORTALS = ["admin", "teacher", "student", "parent"] as const
+const PORTALS = ["admin", "teacher", "student", "parent", "super-admin"] as const
 type Portal = (typeof PORTALS)[number]
 
 const ROLE_TO_PORTAL: Record<string, Portal> = {
@@ -11,6 +11,7 @@ const ROLE_TO_PORTAL: Record<string, Portal> = {
   teacher: "teacher",
   student: "student",
   parent: "parent",
+  super_admin: "super-admin",
 }
 
 function getPortalFromPath(pathname: string): Portal | null {

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,7 +1,7 @@
 import "next-auth"
 import "next-auth/jwt"
 
-export type UserRole = "admin" | "teacher" | "student" | "parent"
+export type UserRole = "admin" | "teacher" | "student" | "parent" | "super_admin"
 
 declare module "next-auth" {
   interface User {


### PR DESCRIPTION
## Summary

Frontend pour le super-admin onboarding, paire avec [klassci-college-backend PR #134](https://github.com/African-DC/klassci-college-backend/pull/134) (7 commits, 13 endpoints, 10 commandes CLI).

Cinq pages, layout dédié, gating middleware-level via le nouveau rôle \`super_admin\`. Auth réutilise NextAuth + apiFetch existant. TanStack Query pour tout le server state.

## Pages livrées

| Route | Tâche | Description |
|---|---|---|
| /super-admin/tenants | FE-2 | Liste + CTA \"Nouveau tenant\" + bouton vers fiche |
| /super-admin/tenants/new | FE-3 | Wizard 3 étapes + review + progression honnête |
| /super-admin/tenants/[slug] | FE-4 | 6 stats + paramètres école |
| /super-admin/pats | FE-4 | Création (token clair une seule fois) + liste + revoke |
| /super-admin/diagnose | FE-5 | Health backend/DB/Redis/SMTP, auto-refresh 30 s |
| /super-admin/logs | FE-5 | Viewer journalctl avec masquage et auto-tail 5 s |

## Highlights techniques

- **Slug validation live** : debounce 400 ms, montre coche/croix inline + preview URL.
- **Wizard step gate** : \`trigger(stepFields)\` valide la slice courante avant d'avancer.
- **Honest fake-progress** : 5 stages cap-au-pénultième pendant pending, jump à done à la réponse réelle (pattern Stripe Atlas), highlight stage actif si erreur.
- **Token clair one-shot** : copy-to-clipboard avec confirmation, AlertDialog sur revoke (jamais \`window.confirm\` per rule globale).
- **Logs viewer** : pause/play, terminal noir mono, badges redacted_count + truncated.
- **TanStack Query keys** centralisés pour invalidation ciblée (tenantKeys, patKeys, diagnoseKeys, logsKeys).
- **Zod schemas** miroir des Pydantic BE dans \`lib/contracts/super-admin.ts\`.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [ ] \`pnpm build\` (CI)
- [ ] /visual-check post-deploy : login en super_admin → /super-admin/tenants → liste rendu, wizard ouverture, slug check live, PATs création copy, diagnose auto-refresh
- [ ] Vérifier accès interdit pour rôle \`admin\` (redirect /admin/dashboard)

## Out of scope

- \`PATCH /tenants/{slug}/status\` (suspend/restore) — endpoint BE pas livré dans la PR backend (déféré BE-5).
- Édition des paramètres école depuis la fiche détail — read-only pour l'instant.
- Recherche / filtres sur la liste des tenants — < 50 tenants attendus, drop pour l'instant.
- Per-tenant student/teacher/class browse depuis l'UI — disponible via le CLI \`klassci student list --tenant=X\` pour le moment ; UI éventuellement v1.2.