### PR TITLE
fix(super-admin): /dashboard redirects to /tenants

### DIFF
--- a/app/(super-admin)/dashboard/page.tsx
+++ b/app/(super-admin)/dashboard/page.tsx
@@ -1,0 +1,6 @@
+import type { Route } from "next"
+import { redirect } from "next/navigation"
+
+export default function SuperAdminDashboard() {
+  redirect("/super-admin/tenants" as Route)
+}


### PR DESCRIPTION
Hotfix follow-up to PR #176: post-login redirect lands on /super-admin/dashboard which 404'd. Adds a thin redirect page.