### PR TITLE
feat(auth): multi-tenant login via X-Tenant-Slug header from URL/cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Connexion multi-tenant : un utilisateur d'établissement arrive sur `college.klassci.com/login?c=<slug>` (lien WhatsApp, email d'invitation), l'établissement s'affiche au-dessus du formulaire et reste mémorisé pour les visites suivantes *(admin, enseignant, parent, élève)* (#183).
+- Aperçu du lien de connexion généré dans le formulaire de création de tenant, avec conseil de choisir un slug court et mémorable (ex : `lmab`, `cca-2026`) — l'admin du super-admin sait exactement ce que recevra le nouvel établissement *(super-admin)* (#183).
 - Section super-admin complète (`/super-admin/*`) : tableau de bord pour onboarder une école sans SSH ni terminal. Liste des tenants avec taille de base, formulaire de création en 3 étapes (nom + slug avec disponibilité vérifiée en direct, compte administrateur, détails optionnels) et progression visible des étapes pendant les 10-30 secondes du provisioning *(super-admin)* (#176).
 - Gestion des tokens d'accès personnels (`/super-admin/pats`) pour le CLI et les agents IA : création avec scopes, expiration en jours, copie en un clic du token clair (montré une seule fois), liste avec statut (actif / expiré / révoqué), révocation avec confirmation *(super-admin)* (#176).
 - Diagnostic plateforme (`/super-admin/diagnose`) : vue d'ensemble de l'état du backend, de la base, de Redis et de la configuration SMTP avec rafraîchissement automatique toutes les 30 secondes et un bouton de rafraîchissement manuel *(super-admin)* (#176).

--- a/auth.ts
+++ b/auth.ts
@@ -12,15 +12,23 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       credentials: {
         email: {},
         password: {},
+        tenant_code: {},
       },
       async authorize(credentials) {
         const email = credentials.email as string
         const password = credentials.password as string
+        // ``tenant_code`` is the user-facing tenant slug, sourced by the
+        // LoginForm from the URL query (?c=<slug>) or the persisted
+        // cookie. Forwarded to the BE via X-Tenant-Slug so the
+        // TenantMiddleware can resolve the correct tenant DB before
+        // checking credentials. Empty/undefined → BE falls back to
+        // LOCAL_TENANT_ID (super-admin login pattern).
+        const tenantCode = (credentials.tenant_code as string | undefined) || undefined
 
         if (!email || !password) return null
 
         try {
-          const data = await authApi.login(email, password)
+          const data = await authApi.login(email, password, tenantCode)
           return {
             id: String(data.user.id),
             email: data.user.email,

--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import type { Route } from "next"
 import { useRouter, useSearchParams } from "next/navigation"
 import { signIn } from "next-auth/react"
@@ -19,6 +19,36 @@ import {
   FormMessage,
 } from "@/components/ui/form"
 
+// Cookie used to remember the tenant slug between visits (so the user
+// who first arrived via a WhatsApp link doesn't need the ?c= every time).
+// Not HttpOnly: the slug is non-sensitive (also visible in the URL) and
+// must be readable from client JS to pre-fill the signIn call.
+const TENANT_CODE_COOKIE = "tenant_code"
+// RFC 1123 slug : 2-63 lowercase alnum + hyphen, no leading/trailing hyphen.
+// Mirror of the BE regex in app/core/slug.py.
+const TENANT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/
+
+function isValidTenantSlug(value: string): boolean {
+  return TENANT_SLUG_REGEX.test(value)
+}
+
+function readTenantCookie(): string | null {
+  if (typeof document === "undefined") return null
+  const match = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${TENANT_CODE_COOKIE}=`))
+  if (!match) return null
+  const value = decodeURIComponent(match.slice(TENANT_CODE_COOKIE.length + 1))
+  return isValidTenantSlug(value) ? value : null
+}
+
+function writeTenantCookie(slug: string): void {
+  if (typeof document === "undefined") return
+  if (!isValidTenantSlug(slug)) return
+  const secure = window.location.protocol === "https:" ? "; Secure" : ""
+  document.cookie = `${TENANT_CODE_COOKIE}=${encodeURIComponent(slug)}; path=/; max-age=31536000; SameSite=Lax${secure}`
+}
+
 export function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -26,6 +56,16 @@ export function LoginForm() {
   const callbackUrl = rawCallback.startsWith("/") && !rawCallback.startsWith("//") ? rawCallback : "/"
   const [error, setError] = useState<string | null>(null)
   const [showPassword, setShowPassword] = useState(false)
+  const [tenantCode, setTenantCode] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fromUrl = searchParams.get("c")
+    if (fromUrl && isValidTenantSlug(fromUrl)) {
+      setTenantCode(fromUrl)
+      return
+    }
+    setTenantCode(readTenantCookie())
+  }, [searchParams])
 
   const form = useForm<LoginRequest>({
     resolver: zodResolver(LoginRequestSchema),
@@ -42,6 +82,7 @@ export function LoginForm() {
       const result = await signIn("credentials", {
         email: data.email,
         password: data.password,
+        tenant_code: tenantCode ?? "",
         redirect: false,
       })
 
@@ -49,6 +90,8 @@ export function LoginForm() {
         setError("Email ou mot de passe incorrect")
         return
       }
+
+      if (tenantCode) writeTenantCookie(tenantCode)
 
       router.push(callbackUrl as Route)
       router.refresh()
@@ -60,6 +103,13 @@ export function LoginForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        {tenantCode && (
+          <div className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs">
+            <span className="text-muted-foreground">Établissement : </span>
+            <span className="font-mono font-medium text-primary">{tenantCode}</span>
+          </div>
+        )}
+
         <FormField
           control={form.control}
           name="email"

--- a/components/super-admin/tenants-new/ProvisioningProgress.tsx
+++ b/components/super-admin/tenants-new/ProvisioningProgress.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 import Link from "next/link"
 import { Check, Loader2, AlertCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { tenantUrl } from "@/lib/super-admin/tenant-display"
 
 const STAGES = [
   { label: "Création de la base de données", ms: 2500 },
@@ -20,7 +21,7 @@ export function ProvisioningProgress({
   errorMessage,
 }: {
   status: "pending" | "success" | "error"
-  result?: { tenant_slug: string; url: string } | undefined
+  result?: { tenant_slug: string } | undefined
   errorMessage?: string
 }) {
   const [reached, setReached] = useState(0)
@@ -97,7 +98,7 @@ export function ProvisioningProgress({
             </Link>
           </Button>
           <a
-            href={result.url}
+            href={tenantUrl(result.tenant_slug)}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-primary hover:underline"

--- a/components/super-admin/tenants-new/StepSchool.tsx
+++ b/components/super-admin/tenants-new/StepSchool.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Check, Loader2, X } from "lucide-react"
 import { useSlugCheck } from "@/lib/hooks/super-admin/useTenants"
+import { tenantUrl } from "@/lib/super-admin/tenant-display"
 import type { WizardData } from "./WizardSteps"
 
 function useDebouncedValue<T>(value: T, delay: number): T {
@@ -75,20 +76,23 @@ export function StepSchool() {
           <p className="text-xs text-destructive">{slugCheck.reason ?? "Slug indisponible"}</p>
         ) : (
           <p className="text-xs text-muted-foreground">
-            2-63 car., minuscules + chiffres + tirets. Stable, immuable après création.
+            2-63 car., minuscules + chiffres + tirets. Conseil : court et mémorable
+            (ex. <span className="font-mono">lmab</span>, <span className="font-mono">cca-2026</span>).
+            Immuable après création.
           </p>
         )}
       </div>
 
-      <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-100">
-        <p className="font-medium">Note : ce slug n'est pas une URL.</p>
-        <p className="mt-1">
-          Les utilisateurs de l'établissement se connectent via{" "}
-          <span className="font-mono">https://college.klassci.com/login</span> avec leur
-          email et mot de passe — le slug sert uniquement d'identifiant interne pour la
-          base, l'API super-admin et les opérations CLI.
-        </p>
-      </div>
+      {showStatus && isAvailable && debouncedSlug.length >= 2 && (
+        <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-100">
+          <p className="font-medium">Lien de connexion qui sera envoyé à l'admin :</p>
+          <p className="mt-1 font-mono break-all">{tenantUrl(debouncedSlug)}</p>
+          <p className="mt-2 text-blue-700 dark:text-blue-300">
+            Les utilisateurs cliquent ce lien (WhatsApp, email) et arrivent directement
+            sur la page de connexion de leur établissement.
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/super-admin/tenants-new/WizardShell.tsx
+++ b/components/super-admin/tenants-new/WizardShell.tsx
@@ -51,7 +51,7 @@ export function WizardShell() {
     return (
       <ProvisioningProgress
         status={mutation.isPending ? "pending" : mutation.isSuccess ? "success" : "error"}
-        result={mutation.data ? { tenant_slug: mutation.data.tenant_slug, url: mutation.data.url } : undefined}
+        result={mutation.data ? { tenant_slug: mutation.data.tenant_slug } : undefined}
         errorMessage={mutation.isError ? (mutation.error as Error).message : undefined}
       />
     )

--- a/components/super-admin/tenants/TenantDetail.tsx
+++ b/components/super-admin/tenants/TenantDetail.tsx
@@ -1,10 +1,12 @@
 "use client"
 
+import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 import { ExternalLink } from "lucide-react"
 import { useTenant } from "@/lib/hooks/super-admin/useTenants"
+import { isSystemTenant, tenantUrl } from "@/lib/super-admin/tenant-display"
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -55,18 +57,23 @@ export function TenantDetail({ slug }: { slug: string }) {
             {data.school_settings?.school_name ?? data.slug}
           </h1>
           <a
-            href={data.url}
+            href={tenantUrl(data.slug)}
             target="_blank"
             rel="noopener noreferrer"
             className="mt-1 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground hover:underline"
           >
-            {data.url}
+            {tenantUrl(data.slug)}
             <ExternalLink className="h-3 w-3" />
           </a>
         </div>
         <div className="text-right text-xs text-muted-foreground">
-          <p>
+          <p className="flex items-center justify-end gap-2">
             Slug : <span className="font-mono">{data.slug}</span>
+            {isSystemTenant(data.slug) && (
+              <Badge variant="secondary" className="text-[10px] uppercase">
+                système
+              </Badge>
+            )}
           </p>
           <p>
             Migration : <span className="font-mono">{data.alembic_head ?? "—"}</span>

--- a/components/super-admin/tenants/TenantsTable.tsx
+++ b/components/super-admin/tenants/TenantsTable.tsx
@@ -14,17 +14,8 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useTenantsList } from "@/lib/hooks/super-admin/useTenants"
+import { isSystemTenant, tenantUrl } from "@/lib/super-admin/tenant-display"
 import { ExternalLink } from "lucide-react"
-
-function isSystemTenant(slug: string): boolean {
-  return slug === "local"
-}
-
-function tenantUrl(slug: string): string {
-  return isSystemTenant(slug)
-    ? "https://college.klassci.com"
-    : `https://${slug}.college.klassci.com`
-}
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -16,10 +16,26 @@ function getBaseUrl(): string {
 export type { LoginResponse, RefreshResponse }
 
 export const authApi = {
-  login: async (email: string, password: string): Promise<LoginResponse> => {
+  /**
+   * Authenticate against the BE.
+   *
+   * ``tenantSlug`` is forwarded as ``X-Tenant-Slug`` header so the BE
+   * TenantMiddleware knows which tenant DB to query for the user
+   * (the JWT does not exist yet at this stage). Without it, the BE
+   * falls back to LOCAL_TENANT_ID — fine for super-admin login on
+   * ``college.klassci.com``, but client tenant login MUST pass it.
+   */
+  login: async (
+    email: string,
+    password: string,
+    tenantSlug?: string,
+  ): Promise<LoginResponse> => {
+    const headers: Record<string, string> = { "Content-Type": "application/json" }
+    if (tenantSlug) headers["X-Tenant-Slug"] = tenantSlug
+
     const res = await fetch(`${getBaseUrl()}/auth/login`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify({ email, password }),
     })
     if (!res.ok) {

--- a/lib/super-admin/tenant-display.ts
+++ b/lib/super-admin/tenant-display.ts
@@ -1,0 +1,26 @@
+/**
+ * Helpers d'affichage pour les URLs tenant côté super-admin et wizard.
+ *
+ * Pattern actuel (B-Lean single-domain) : un client se connecte via
+ * ``https://college.klassci.com/login?c=<slug>``. Le slug voyage dans le
+ * paramètre de query, est forwardé au BE par le LoginForm via le header
+ * ``X-Tenant-Slug``, puis persisté en cookie ``tenant_code`` pour les
+ * visites suivantes.
+ *
+ * Pour basculer plus tard vers un pattern par sous-domaine
+ * (``https://<slug>.college.klassci.com/login``) : flipper la valeur de
+ * ``settings.PUBLIC_LOGIN_URL_TEMPLATE`` côté BE et le template constant
+ * ci-dessous — pas de refactor de composants nécessaire.
+ */
+
+const PUBLIC_LOGIN_URL_TEMPLATE = "https://college.klassci.com/login?c={slug}"
+const SYSTEM_TENANT_URL = "https://college.klassci.com"
+
+export function isSystemTenant(slug: string): boolean {
+  return slug === "local"
+}
+
+export function tenantUrl(slug: string): string {
+  if (isSystemTenant(slug)) return SYSTEM_TENANT_URL
+  return PUBLIC_LOGIN_URL_TEMPLATE.replace("{slug}", slug)
+}


### PR DESCRIPTION
## Summary

FE half of Plan Ultimate B-Lean (multi-tenant client login). Sister BE PR : `African-DC/klassci-college-backend` PR for issue #136.

Two commits :

1. **refactor(super-admin)** — shared `tenantUrl()` / `isSystemTenant()` helpers in `lib/super-admin/tenant-display.ts`. Fixes a latent bug in `TenantDetail` and `ProvisioningProgress` that rendered `data.url` from the BE (`https://local.college.klassci.com` for the system tenant). All consumers now derive the URL client-side from the slug. Wizard `StepSchool` re-introduces the login URL preview (hidden in PR #182 while arch was undecided) with helper text advising short memorable slugs.

2. **feat(auth)** — Client tenant login wiring :
   - `lib/api/auth.ts` : `authApi.login(email, password, tenantSlug?)` forwards `tenantSlug` as `X-Tenant-Slug` header to BE.
   - `auth.ts` : NextAuth `CredentialsProvider` accepts `tenant_code` field, passes to `authApi.login()`.
   - `components/forms/LoginForm.tsx` : reads `?c=<slug>` from URL or `tenant_code` cookie, shows the establishment slug as a small badge above the form, persists the slug in a 1-year SameSite=Lax cookie on successful login.

User flow :
- WhatsApp link `https://college.klassci.com/login?c=lycee-x` → form shows 'Établissement : lycee-x' → user types email+password → JWT issued for `lycee-x` DB.
- Revisit `/login` (no `?c=`) → cookie is read → same flow.
- Super-admin on `https://college.klassci.com/login` (no slug) → falls back to LOCAL_TENANT_ID, unchanged behavior.

## Test plan

- [x] TypeScript strict passes : `npx tsc --noEmit`.
- [ ] Smoke test : visit `/login?c=local` → badge shows 'local' → login with `admin@klassci.com` → admin portal loads.
- [ ] Smoke test : create a new tenant via wizard → welcome email link works → user lands on /login with slug pre-filled.
- [ ] E2E with 2 tenants seeded : deferred — requires a 2nd seeded tenant in test env, will be added in a follow-up once provisioning fixtures support it.

## Forward-compat note

Cookie is host-scoped (no `Domain` attribute), so super-admin sessions on `college.klassci.com` are isolated from any future `<tenant>.college.klassci.com` subdomain sessions. Subdomain rollout later is : flip BE `PUBLIC_LOGIN_URL_TEMPLATE` env var, set up Let's Encrypt DNS-01 wildcard cert. Zero code change.

Closes #183