### PR TITLE
feat: Wave-style cashier + Identite visuelle + premium 360 redesign

### DIFF
--- a/.claude/rules/api-client-zod-validation.md
+++ b/.claude/rules/api-client-zod-validation.md
@@ -1,0 +1,115 @@
+# Rule : Tout API client FE valide via Zod, jamais cast TypeScript
+
+## Quand s'active
+
+Quand tu écris ou modifies un fichier dans `klassci-frontend/lib/api/*.ts`.
+
+## Règle
+
+Toute fonction qui retourne un type métier **doit** :
+
+1. Appeler `apiFetch<unknown>(...)` (pas `<MonType>`)
+2. Passer le résultat par `safeValidate(SchemaZod, ..., context)` avant return
+3. Si l'enveloppe BE peut être `{data}`, `{items}` ou array brut → unwrap avant validation
+
+**Pas de `return (json as MonType)`. Pas de `apiFetch<MonType>` sans `safeValidate` derrière.**
+
+## Pourquoi
+
+Le cast TypeScript est une promesse runtime non vérifiée. Dès que le BE drift (champ ajouté/retiré/renommé, Decimal sérialisé en string, etc.), le FE reçoit silencieusement des données invalides et crash en aval avec des erreurs cryptiques (`Cannot read properties of undefined`, etc.).
+
+`safeValidate` (Zod) :
+- Vérifie le shape à runtime
+- Applique les `.default()` automatiquement (typiquement `.array().default([])` qui sauve les fresh tenants)
+- Loggue un message explicite avec le context si validation échoue
+- Type-check est dérivé du schéma → pas de double source de vérité
+
+**Voir** memory `feedback_fe_api_client_must_zod`, incident 2026-05-16 sur `settings.trimesters.length` crash.
+
+## Pattern correct
+
+```ts
+import { z } from "zod"
+import { apiFetch, safeValidate } from "./client"
+import { MyEntitySchema, type MyEntity } from "@/lib/contracts/my-entity"
+
+const MyEntityArraySchema = z.array(MyEntitySchema)
+
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object") {
+    const obj = json as Record<string, unknown>
+    if (obj.data !== undefined) return obj.data
+    if (obj.items !== undefined) return obj.items
+  }
+  return json
+}
+
+export const myEntityApi = {
+  get: async (id: number): Promise<MyEntity> => {
+    const json = await apiFetch<unknown>(`/my-entity/${id}`)
+    return safeValidate(MyEntitySchema, unwrap(json), `GET /my-entity/${id}`)
+  },
+
+  list: async (): Promise<MyEntity[]> => {
+    const json = await apiFetch<unknown>("/my-entity")
+    return safeValidate(MyEntityArraySchema, unwrap(json), "GET /my-entity")
+  },
+
+  create: async (data: MyEntityCreate): Promise<MyEntity> => {
+    const json = await apiFetch<unknown>("/my-entity", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(MyEntitySchema, unwrap(json), "POST /my-entity")
+  },
+}
+```
+
+## Anti-patterns à bloquer en review
+
+```ts
+// ❌ Cast direct, perd defaults Zod + zero runtime check
+return (json as MyEntity)
+```
+
+```ts
+// ❌ Typage attentif AVANT validation (promesse non tenue)
+const data = await apiFetch<MyEntity>("/my-entity")
+return data  // TS heureux mais runtime peut être n'importe quoi
+```
+
+```ts
+// ❌ Fallback avec ?? qui contourne les defaults Zod
+return (json as { data?: MyEntity }).data ?? (json as MyEntity)
+```
+
+```ts
+// ❌ Validation après usage (trop tard, le crash est déjà arrivé)
+const data = await apiFetch<unknown>("/my-entity")
+const usedField = (data as MyEntity).someField  // crash si data drift
+const validated = MyEntitySchema.parse(data)  // jamais atteint
+```
+
+## Checklist nouveau API client
+
+- [ ] `apiFetch<unknown>(...)` (pas `<MonType>`)
+- [ ] `safeValidate(Schema, unwrap(json), context)` avant return
+- [ ] `context` descriptif pour les logs (`"GET /endpoint"`, `"POST /endpoint"`)
+- [ ] Si Decimal/Date possible → schema Zod fait `.coerce.number()` ou `.preprocess(...)` (voir `feedback_pydantic_decimal_zod_drift.md`)
+- [ ] Defaults Zod (`.default([])`, `.nullish()`) couvrent les cas BE renvoie sans le champ
+
+## Quand le bypass est légitime
+
+Quasi jamais. Exceptions rares :
+- **Réponses non-JSON** : un download de PDF (`Blob`) — typer `Promise<Blob>` direct
+- **Endpoints de health check** triviaux qui retournent `{"status":"ok"}` — encore mieux à valider
+
+Si tu hésites : valide. Le coût est nul (5 lignes), le bénéfice est immense (crash futur évité).
+
+## Voir aussi
+
+- `data-fetching.md` — pattern TanStack Query par-dessus les API clients
+- `forms.md` — Zod côté formulaires (input)
+- Memory `feedback_fe_api_client_must_zod.md`
+- Memory `feedback_pydantic_decimal_zod_drift.md`
+- Rule globale `~/.claude/rules/no-mvp-only-premium.md`

--- a/.claude/rules/detail-tab-split-pattern.md
+++ b/.claude/rules/detail-tab-split-pattern.md
@@ -1,0 +1,90 @@
+# Rule : Split d'un tab détail god-code en sous-composants cohérents
+
+## Quand s'active
+
+Quand je redesigne un `XxxTab.tsx` d'une fiche détail (`/admin/students/[id]`, `/admin/teachers/[id]`, etc.) et qu'il dépasse :
+
+- 250 LOC (soft limit `no-god-code.md`)
+- ET/OU contient à la fois : list rendering + multiple modals + sub-forms + state machine d'unlink/delete
+
+## Règle
+
+**Splitter en 5 fichiers** sous un dossier dédié `components/admin/<entity>/<subdomain>/` :
+
+1. **`XxxTab.tsx`** (orchestration ~150-200 LOC) — reste dans `tabs/`. Hook fetch + state machines (modal targets, unlink target). Importe les 4 autres. **Exporte la même API publique** (props identiques) → zéro breaking change downstream.
+2. **`XxxCard.tsx`** (~100-150 LOC) — display d'1 entité unique. Reçoit `entity` + callbacks d'action en props.
+3. **`XxxCreateModal.tsx`** (~150-250 LOC) — Dialog standalone pour création (form RHF + Zod).
+4. **`XxxLinkModal.tsx`** (~120-150 LOC) — Dialog standalone pour lier une entité existante (recherche + sélection).
+5. **`xxx-helpers.ts`** ou **`relationship.ts`** (~20-30 LOC) — helpers purs (labels, tones, URLs computed).
+
+## Pourquoi cette répartition
+
+- **Single responsibility** : chaque fichier répond à 1 question (display 1 item ? render le tab ? créer ? lier ?)
+- **Cohérence visuelle** : le Card peut être réutilisé ailleurs (ex: inline dans OverviewTab) sans copier-coller
+- **Modals indépendantes** : ouvrir l'une ou l'autre via un `DropdownMenu` au lieu d'un toggle complexe dans une seule Dialog
+- **Helper file** : centralise les labels FR + tones pour éviter le drift entre Card display et select options des modals
+- **TypeScript** : exporter les types d'entité depuis le contract Zod (`@/lib/contracts/<entity>.ts`) — pas dans les sous-components
+
+## Pattern reproductible (template)
+
+```
+components/admin/students/
+├── tabs/
+│   ├── _primitives.tsx          ← SectionCard, StatusPill, EmptyState, InitialsAvatar (partagé)
+│   └── ParentsTab.tsx           ← orchestrateur (213 LOC)
+└── parents/
+    ├── relationship.ts          ← helper labels/tones (30 LOC)
+    ├── ParentCard.tsx           ← 1 card display (153 LOC)
+    ├── ParentCreateModal.tsx    ← Dialog create new (255 LOC)
+    └── ParentLinkModal.tsx      ← Dialog link existing (208 LOC)
+```
+
+## Application _primitives obligatoire
+
+Le tab redesigned **doit** utiliser les primitives partagées de `tabs/_primitives.tsx` :
+
+- `SectionCard` pour le wrapper principal (avec icon + serif title + action right)
+- `StatusPill` pour tous les badges (tone semantic ou neutral)
+- `InitialsAvatar` pour les contacts sans photo
+- `EmptyState` pour le cas vide (avec CTA admin actionnable)
+
+**Pas de re-création** d'un Card/Badge/Avatar custom. Si une variante manque dans `_primitives`, l'ajouter au module partagé.
+
+## Actions persona-first (touch targets h-11)
+
+Pour un contact (parent, teacher, parent d'élève), exposer en boutons inline grands :
+
+- **Appeler** : `<a href="tel:${phone}">` — Wave Mobile Money style
+- **WhatsApp** : `<a href="https://wa.me/${digits}" target="_blank">` — phone cleaned (`replace(/[^\d]/g, "")`)
+- **Email** : `<a href="mailto:${email}">`
+
+Actions secondaires (SMS, edit, unlink) → dans un `DropdownMenu` kebab top-right de la card.
+
+**Touch targets** : `className="h-11 sm:h-10"` (Itel S661 ≥ 44dp, desktop confort ≥ 40dp).
+
+## Anti-patterns à bloquer en review
+
+1. **God tab > 500 LOC** : split obligatoire avant merge
+2. **Card display redéfini inline** dans le tab orchestrateur → extraire en `<XxxCard>` même si utilisé 1× (sera réutilisé dans OverviewTab inline)
+3. **Modal create + link fusionnée** avec toggle Tab interne (≥ 300 LOC) → splitter en 2 modals indépendantes ouvrables via `DropdownMenu`
+4. **Helper labels/tones inline** répétés entre Card et form Select → extraire dans `relationship.ts` / `<entity>-helpers.ts`
+5. **Actions cachées dans kebab uniquement** quand persona Type B mobile (boutons inline manquants) → exposer Appeler/WhatsApp/Email inline
+6. **`h-9` ou `h-10` mobile** sans `h-11` fallback → fail le test Mme Aïcha (Itel S661 plein soleil)
+7. **EmptyState sans CTA** pour role admin → ajouter `<Button>` qui ouvre la create/link modal directement
+
+## Bénéfices mesurés
+
+Refonte `ParentsTab` 2026-05-17 :
+- **Avant** : 1 god file 604 LOC, modal `AddParentDialog` interne avec toggle 2 modes (300 LOC sur 604)
+- **Après** : 5 fichiers (213 + 153 + 255 + 208 + 30 = 859 LOC réparties)
+- **Différence** : +255 LOC totales mais chaque fichier <260 LOC, lisible, testable, réutilisable
+- **API publique préservée** : `<ParentsTab studentId={id} />` import identique dans `StudentDetailClient.tsx` → zéro breaking change
+- **Réutilisabilité** : `ParentCard` réutilisable dans OverviewTab inline si on veut harmoniser plus tard
+- **Persona-first** : 3 actions inline touch h-11 (Appeler/WhatsApp/Email) au lieu d'1 bouton Unlink masqué
+
+## Voir aussi
+
+- `redesign-premium.md` principe 13 (AvatarImage 404-safe) + principe 14 (tri-état badge sémantique)
+- `components.md` — Server vs Client + pattern Modal
+- `~/.claude/rules/no-god-code.md` — seuils LOC + détection
+- Memory `project_session_2026_05_17_parentstab_split.md` — implémentation détaillée

--- a/.claude/rules/empty-state-by-role.md
+++ b/.claude/rules/empty-state-by-role.md
@@ -1,0 +1,94 @@
+# Rule : Empty state adaptatif par rôle utilisateur
+
+## Quand s'active
+
+Quand tu rends un état dégradé (donnée fondamentale absente, liste vide légitime, fonctionnalité pas encore activée) dans un composant utilisable par plusieurs rôles (admin, teacher, student, parent).
+
+## Règle
+
+Le message d'empty state doit **adapter l'action proposée au rôle** :
+
+- **Admin** = message **actionnable** avec lien direct vers la config (`/admin/...`)
+- **Teacher / Student / Parent** = message **informatif**, pointe la personne qui peut agir ("Contactez l'administration")
+
+**Jamais le même texte/CTA pour tous les rôles.** Un lien admin masqué aux non-admins évite les 403 frustrants ; un message rassurant pour les rôles passifs respecte leur attente.
+
+## Pourquoi
+
+KLASSCI College vise la persona Mme Diallo (prof 52 ans, Itel S661) et Mme Aïcha (parent). Quand une donnée manque :
+
+- Si Mme Diallo voit "Aucune année active. Configurer →" et clique → 403 → ticket support
+- Si Aïcha voit "Aucun bulletin publié" sans rassurance → angoisse + appel à l'école
+
+Avec l'adaptation :
+- Mme Diallo voit "Contactez l'administration" → sait quoi faire (passer au secrétariat)
+- Aïcha voit "Le bulletin du trimestre apparaîtra ici quand il sera publié" → patience sereine
+- L'admin voit le lien direct → 1 clic pour fix
+
+**Voir** memory `feedback_role_adaptive_empty_state`, composant `<AcademicYearBanner>` shipped 2026-05-16.
+
+## Pattern correct
+
+```tsx
+// components/shared/AcademicYearBanner.tsx
+type Role = "admin" | "teacher" | "student" | "parent"
+
+const MISSING_MESSAGE: Record<Role, string> = {
+  admin: "Aucune année scolaire active.",
+  teacher: "Aucune année scolaire n'est encore configurée. Contactez l'administration.",
+  student: "Année scolaire non configurée par l'établissement. Vos données apparaîtront dès qu'elle sera créée.",
+  parent: "Année scolaire non configurée par l'établissement. Le suivi de vos enfants apparaîtra dès qu'elle sera créée.",
+}
+
+export function AcademicYearBanner({ currentYear, role }: { currentYear: string | null; role: Role }) {
+  if (currentYear) {
+    return <Chip>📅 Année {currentYear}</Chip>
+  }
+  return (
+    <div role="alert" className="amber-banner">
+      <AlertTriangle className="shrink-0" />
+      <p>{MISSING_MESSAGE[role]}</p>
+      {role === "admin" && (
+        <Link href="/admin/academic-years">Configurer maintenant →</Link>
+      )}
+    </div>
+  )
+}
+```
+
+## Concepts qui méritent ce traitement
+
+| Concept | Admin (action) | Teacher | Student | Parent |
+|---|---|---|---|---|
+| Année scolaire absente | `/admin/academic-years` | "Contactez l'admin" | "Apparaîtra dès création" | idem |
+| Aucune classe assignée | `/admin/teachers/{id}` | "Demandez l'affectation" | (n/a) | (n/a) |
+| Aucun bulletin publié | `/admin/reports` | (côté liste) | "Patientez" | "Notif quand publié" |
+| Aucun paiement | `/admin/payments` | (n/a) | (n/a) | "Allez au secrétariat" |
+| Aucun enfant inscrit | `/admin/enrollments` | (n/a) | (n/a) | "Contactez l'admin" |
+| Aucune évaluation | `/admin/grades` | `/teacher/grades/{id}/new` | "Patientez" | "Notif quand notes publiées" |
+
+## Anti-patterns à bloquer en review
+
+1. **Texte hardcodé identique** pour tous : `"Aucune donnée"` sans contexte
+2. **Lien admin visible côté autre rôle** → mène à 403 → frustration. **Masquer** le lien, garder le texte adapté
+3. **Message technique** : "Aucun record dans `school_settings`"
+4. **"Veuillez réessayer plus tard"** quand c'est un état vide légitime (pas une panne)
+5. **Ton anxiogène** : "Erreur" / "Impossible" / "Échec" pour un état vide légitime
+6. **Bouton "Créer" visible** à un rôle sans permission — masquer
+
+## Checklist nouveau composant avec empty state
+
+- [ ] Le message dit POURQUOI c'est vide (sinon l'utilisateur croit que c'est un bug)
+- [ ] L'action proposée dépend du rôle (`role` prop ou `useSession().user.role`)
+- [ ] Pour les rôles passifs, on pointe la personne qui peut agir (et pas un endroit générique)
+- [ ] Pas de lien admin visible aux non-admins
+- [ ] Ton rassurant pour les rôles passifs, urgent/actionnable pour admin
+- [ ] La matrice `MISSING_MESSAGE: Record<Role, string>` est exhaustive (TS check)
+
+## Voir aussi
+
+- Memory `feedback_role_adaptive_empty_state.md`
+- Memory `feedback_no_seed_in_prod_handle_empty.md` (pourquoi un fresh tenant a beaucoup d'empty states)
+- Rule FE `ux-target-user-reality.md` — persona Mme Diallo + référence Wave Mobile Money
+- Rule FE `redesign-premium.md` — patterns d'UI persona-first
+- Rule globale `~/.claude/rules/no-mvp-only-premium.md`

--- a/.claude/rules/fe-be-flow-alignment.md
+++ b/.claude/rules/fe-be-flow-alignment.md
@@ -1,0 +1,128 @@
+# Rule : Le modal FE expose TOUS les champs requis par son endpoint BE
+
+## Quand s'active
+
+Quand tu crées ou modifies un **modal/form** côté FE qui POST à un endpoint BE pour créer une entité (teacher, staff, student, parent, etc.).
+
+## Règle
+
+Le formulaire FE **doit exposer chaque champ marqué comme requis dans le schema Pydantic BE**. Sinon le submit échoue avec "Field required" — bug invisible à la review code, visible seulement au runtime.
+
+## Pourquoi
+
+KLASSCI College 2026-05-16, page `/admin/staff` : le modal demande `first_name/last_name/position/phone` mais BE `StaffCreate` exige aussi `user_id: int`. Résultat : on remplit tout, on submit, on voit "Field required" sans savoir lequel manque. UX cassée.
+
+Le pattern correct existe déjà dans `create_teacher` du même codebase :
+- FE modal : `first_name/last_name/email/password/speciality/phone`
+- BE schema : pareil
+- BE service : crée user + user_roles + teacher_profile en transaction
+
+Le pattern qui RATE (cas `create_staff` actuel) :
+- FE modal : `first_name/last_name/position/phone` (manque email/password/user_id)
+- BE schema : exige `user_id`
+- BE service : nécessite un user existant
+
+→ **Mismatch sémantique**. Le FE assume "staff = juste un profil admin", le BE assume "staff hérite d'un user déjà créé". Personne n'a aligné.
+
+## Pattern correct (réplique du teacher flow)
+
+### BE schema
+
+```python
+class StaffCreate(BaseModel):
+    first_name: str
+    last_name: str
+    position: str | None = None
+    phone: str | None = None
+    email: EmailStr
+    password: str  # min 8 chars validé
+```
+
+### BE service
+
+```python
+async def create_staff(db, data: StaffCreate, *, created_by: int) -> StaffResponse:
+    existing = (await db.execute(select(User).where(User.email == data.email))).scalar_one_or_none()
+    if existing:
+        raise HTTPException(400, f"Email {data.email} déjà utilisé")
+
+    async with db.begin_nested():
+        user = User(
+            email=data.email,
+            hashed_password=hash_password(data.password),
+            role=UserRoleEnum.STAFF,
+        )
+        db.add(user)
+        await db.flush()
+        await _ensure_default_user_role(db, user.id, "staff")  # !! voir bug #17
+
+        profile = await repo.create_staff(db, **{
+            "user_id": user.id,
+            **data.model_dump(exclude={"email", "password"}),
+        })
+        await audit_log(...)
+    await db.commit()
+    return _staff_to_response(profile)
+```
+
+### FE Zod schema
+
+```ts
+export const StaffCreateSchema = z.object({
+  first_name: z.string().min(1, "Le prénom est requis"),
+  last_name: z.string().min(1, "Le nom est requis"),
+  email: z.string().email("Email invalide"),
+  password: z.string().min(8, "8 caractères minimum"),
+  position: z.string().optional(),
+  phone: z.string().optional(),
+})
+```
+
+### FE modal
+
+```tsx
+// Le modal doit exposer 6 champs au lieu de 4
+<FormField name="first_name" ... />
+<FormField name="last_name" ... />
+<FormField name="email" type="email" ... />
+<FormField name="password" type="password" placeholder="Min. 8 caractères" ... />
+<FormField name="position" placeholder="ex: Secrétaire pédagogique" ... />
+<FormField name="phone" placeholder="ex: +225 ..." ... />
+```
+
+## Checklist nouvelle entité créatrice de User
+
+Pour chaque nouvelle page d'admin qui crée une entité avec un compte user associé (teacher, staff, student, parent, secrétaire, comptable, etc.) :
+
+- [ ] Le modal FE expose `email` + `password` (les 2 champs auth)
+- [ ] Le schema Zod FE rend `email`/`password` requis avec validation (min 8 pour password)
+- [ ] Le schema Pydantic BE matche exactement le contract FE (mêmes champs, mêmes contraintes)
+- [ ] Le service BE crée `User` + appelle `_ensure_default_user_role(db, user.id, "<role>")` + crée le profil — dans **une transaction `begin_nested`**
+- [ ] Le commit est explicite : `await db.commit()` après la transaction
+- [ ] Audit log avec `model_dump(mode="json", exclude={"password"})` (jamais le mdp en clair)
+- [ ] Test E2E : créer via UI → login avec les nouveaux credentials → accéder au portail
+
+## Anti-patterns à bloquer en review
+
+1. **Modal qui ne demande pas email/password** pour une entité destinée à se connecter
+2. **`StaffCreate` (BE) exige `user_id` que le modal n'expose pas** → mismatch, UX cassée
+3. **`profile.user_id = null`** en sortie de création — l'entité est orpheline
+4. **Pas d'appel à `_ensure_default_user_role`** après la création du User → 403 sur les endpoints permission-gated
+5. **Password dans le commit/audit non hashé** (sécurité critique)
+6. **Pas de check d'email unique avant insert** → race condition + erreur DB cryptique
+
+## Quand admettre une exception
+
+Très rare. Cas où un profil n'a PAS de compte user :
+- Un "contact d'urgence" (juste nom + tel, ne se connecte jamais à l'app)
+- Un "stagiaire externe" non encore officialisé
+
+Dans ces cas : le profil n'a pas de `user_id` (nullable) ET le modèle ne le requiert pas. L'entité reste alors purement admin-managed. Documenter ce choix dans une rule projet.
+
+## Voir aussi
+
+- `api-client-zod-validation.md` — pour les contrats côté FE
+- `empty-state-by-role.md` — pour le rendu post-création
+- BE rule `singleton-lazy-bootstrap.md` — pour les entités singleton
+- Mémoire `feedback_user_roles_on_create.md` — pour le pattern `_ensure_default_user_role`
+- Rule globale `no-god-code.md` — le service de création reste mince, le helper `_ensure_default_user_role` est partagé

--- a/.claude/rules/handle-401-globally.md
+++ b/.claude/rules/handle-401-globally.md
@@ -1,0 +1,172 @@
+# Rule : Tout 401 client-side déclenche signOut + redirect /login?expired=1
+
+## Quand s'active
+
+Quand j'écris ou modifie un fichier `lib/api/*.ts` qui fait des fetches authentifiés vers le BE.
+
+## Règle
+
+**Aucun fetch authentifié ne doit ignorer un 401.** Le contrat est unique :
+
+1. Le fetch reçoit 401 du BE → token expiré ou supprimé
+2. Le client.ts appelle `handleExpiredSession()` (idempotent, one-shot)
+3. NextAuth `signOut({ redirect: false })` clear le cookie session
+4. Toast Sonner "Session expirée — Veuillez vous reconnecter"
+5. Full reload `window.location.href = "/login?expired=1"`
+6. Le `LoginForm` affiche un banner amber "Session expirée — Pour des raisons de sécurité, reconnectez-vous"
+
+## Pourquoi
+
+**Incident fondateur 2026-05-17, KLASSCI parent portail** :
+- Mariam Koné loggée avec token valide
+- Token JWT expire au bout de 15 min (TTL `auth.ts`)
+- Fetches `/parent/dashboard` retournent 401 silencieusement
+- TanStack Query retry × 3 → tous 401
+- Affichage final : "Connexion au serveur impossible — Réessayer"
+- Mariam clique "Réessayer" → encore 401 → **boucle infinie sans solution**
+
+Le middleware `middleware.ts` redirige bien sur `session.error === "RefreshTokenError"`, mais **uniquement sur navigation server-side**. Les fetches TanStack/Zustand côté client n'ont pas ce filet.
+
+## Pattern correct (canon `client.ts`)
+
+```ts
+import { getSession, signOut } from "next-auth/react"
+
+let isHandlingExpiredSession = false
+
+export async function handleExpiredSession(): Promise<void> {
+  if (isHandlingExpiredSession) return
+  if (typeof window === "undefined") return
+  isHandlingExpiredSession = true
+  sessionCache = null
+  sessionPromise = null
+  try {
+    const { toast } = await import("sonner")
+    toast.error("Session expirée", {
+      description: "Veuillez vous reconnecter pour continuer.",
+    })
+  } catch { /* sonner not mounted yet */ }
+  await signOut({ redirect: false }).catch(() => {})
+  window.location.href = "/login?expired=1"
+}
+
+export async function apiFetch<T>(path: string, options = {}): Promise<T> {
+  const res = await fetch(/* ... */)
+  if (res.status === 401) {
+    // CRITICAL: guard sur la présence de session AVANT signOut.
+    // Sans ce guard, le post-login fire les fetches AVANT que le cookie
+    // soit propagé à getSession() → 401 → signOut → redirect /login?expired=1
+    // → l'utilisateur est éjecté juste après s'être connecté. Race condition.
+    const session = await getCachedSession()
+    if (session?.accessToken) {
+      await handleExpiredSession()
+    }
+    throw new Error("Session expirée")
+  }
+  // ... rest
+}
+```
+
+## Race condition apprise (2026-05-17)
+
+**Symptôme** : user clique "Se connecter", submit OK côté NextAuth (cookie set), redirect vers `/parent/dashboard`. Pendant le mounting, le hook fire un fetch BE. La session n'est pas encore propagée au cache `getSession()` → pas de Authorization header → BE 401 → interceptor déclenche `signOut + redirect /login?expired=1`. **Boucle de login impossible**.
+
+**Cause root** : `handleExpiredSession` ne distingue pas "token expiré" de "token pas encore propagé".
+
+**Fix** : ne déclencher la session-expired flow QUE si on a réellement une session avec accessToken. Sinon, throw silencieux — le middleware redirect sur la nav suivante.
+
+**Test régression** : login fresh → wait full propagation → URL doit être `/<portal>/dashboard` PAS `/login?expired=1`. Si jamais on voit le 2e cas, c'est le race qui re-fire.
+
+## Fetches qui ne passent pas par `apiFetch` (multipart, etc.)
+
+Pour les `FormData` (upload de photos par exemple), `apiFetch` n'est pas utilisable (JSON-encoded). **Répliquer le contrat manuellement** :
+
+```ts
+import { handleExpiredSession } from "./client"
+
+export const uploadPhoto = async (id: number, file: File) => {
+  const session = await getSession()
+  const formData = new FormData()
+  formData.append("file", file)
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${session?.accessToken}` },
+    body: formData,
+  })
+  if (res.status === 401) {
+    await handleExpiredSession()
+    throw new Error("Session expirée")
+  }
+  if (!res.ok) throw new Error("Upload failed")
+  return res.json()
+}
+```
+
+## Le banner `/login?expired=1`
+
+`LoginForm` lit `searchParams.get("expired")` et affiche un banner amber avec `<Clock />` :
+
+```tsx
+const sessionExpired = searchParams.get("expired") === "1"
+
+{sessionExpired && !error && (
+  <div role="alert" className="rounded-lg border border-amber-200 bg-amber-50 p-3.5">
+    <Clock className="h-4 w-4 text-amber-600" />
+    <p className="font-medium text-amber-900">Session expirée</p>
+    <p className="text-xs text-amber-800">
+      Pour des raisons de sécurité, reconnectez-vous pour continuer.
+    </p>
+  </div>
+)}
+```
+
+Le banner disparaît dès que `setError` set le state error (priorité à l'erreur de login).
+
+## Pourquoi `window.location.href` et pas `router.push`
+
+- `signOut` invalide le cookie côté serveur, mais TanStack Query / Zustand gardent leur state en mémoire client
+- `router.push("/login")` ne reset PAS ces stores → l'utilisateur après re-login pourrait voir des données stale
+- `window.location.href` force un full page reload → tout est reset à zéro
+- C'est le pattern standard SaaS (Notion, Linear, Vercel le font tous ainsi)
+
+## Anti-patterns à bloquer en review
+
+1. **`if (!res.ok) throw new Error(...)` sans test 401 distinct** — ignore l'expiration
+2. **`fetch(...)` direct dans un composant** (au lieu de `lib/api/`) — pas couvert par l'intercepteur
+3. **Toast "Erreur serveur" générique sur 401** — l'utilisateur ne sait pas quoi faire
+4. **Retry TanStack `retry: true` infini sur 401** — boucle qui sature le BE
+5. **Garder TanStack Query cache après expiration** — risque de fuite de PII
+6. **`router.push("/login")` au lieu de `window.location.href`** — laisse le state client en place
+
+## Checklist nouveau fichier `lib/api/*.ts`
+
+- [ ] Utilise `apiFetch` quand possible (97% des cas)
+- [ ] Si `FormData` / `Blob` : check `res.status === 401` manuellement + `await handleExpiredSession()`
+- [ ] Pas de `fetch` direct sans le contrat 401
+- [ ] Pas de `retry: Infinity` sur les queries qui hitte des endpoints auth-gated
+
+## TanStack Query — `retry` recommandé
+
+Pour éviter le 401-spam (qui exécuterait `handleExpiredSession` 4 fois mais en idempotent c'est OK), configurer :
+
+```ts
+// app/providers.tsx
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error) => {
+        if (error instanceof Error && error.message === "Session expirée") return false
+        return failureCount < 3
+      },
+    },
+  },
+})
+```
+
+## Voir aussi
+
+- Memory `project_session_2026_05_17_portails_e2e.md` — incident fondateur
+- Rule `auth-architecture.md` § "Refresh token" (mention TODO P1)
+- Rule `api-client-zod-validation.md` — l'autre rule sur `lib/api/*`
+- `auth.ts` callback jwt → `token.error = "RefreshTokenError"` (côté server seulement)
+- `middleware.ts` → redirige sur session.error (côté server seulement)

--- a/.claude/rules/not-enrolled-empty-state.md
+++ b/.claude/rules/not-enrolled-empty-state.md
@@ -1,0 +1,142 @@
+# Rule : Empty state pour utilisateur non inscrit dans l'année courante
+
+## Quand s'active
+
+Cette rule s'active quand je rends un dashboard ou un KPI pour un user (student / parent → enfant) **qui n'a pas d'enrollment actif dans l'année courante** :
+
+- `/student/dashboard` quand l'élève connecté n'a pas d'enrollment AY current
+- `/parent/dashboard` quand un enfant suivi n'a pas d'enrollment AY current
+- Tout sous-écran (notes, frais, EDT, présences) qui dépend de l'enrollment
+
+## Le bug à éviter
+
+État observé 2026-05-17 sur Aminata (compte créé, parent Mariam lié, **PAS d'enrollment**) :
+
+| Symptôme | Pourquoi c'est anxiogène faux |
+|---|---|
+| `0 FCFA Frais restants` en **vert success** | Suggère "tout est payé !" → faux, rien n'est dû car pas inscrite |
+| `0 Absences` neutral | Suggère "présence parfaite !" → faux, rien à compter |
+| `Moyenne —` | Placeholder visible, parent comprend pas que c'est normal |
+| `class_name: "—"` rendu en clair sous le nom | Tiret seul sans contexte, illisible |
+| `ENFANTS INSCRITS 1` (compteur parent) | Mariam a Aminata "suivie", pas "inscrite" — anxiogène faux |
+| `— — Votre résumé du jour` (subtitle student) | Template `{class} — {level} — Votre résumé` avec class/level vides |
+| **PAS de banner d'alerte** | Mariam ne comprend pas qu'elle doit aller au secrétariat |
+
+## La règle
+
+**Toujours afficher un banner d'alerte explicite quand un élève n'a pas d'enrollment AY current**, et **masquer les KPIs financiers/académiques tant qu'il n'est pas inscrit** (ou les remplacer par "—" neutre avec tooltip).
+
+### Pattern correct
+
+```tsx
+// /parent/dashboard pour un enfant pas inscrit
+{child.class_name === null || child.class_name === "—" ? (
+  <Card variant="alert" tone="amber">
+    <AlertTriangle />
+    <CardContent>
+      <p>L&apos;inscription de <strong>{child.full_name}</strong> n&apos;est pas encore validée pour {currentYear}.</p>
+      <p className="text-muted-foreground">Contactez l&apos;administration de l&apos;école pour finaliser le dossier.</p>
+    </CardContent>
+  </Card>
+) : (
+  <ChildKpisCard child={child} />
+)}
+```
+
+### Composant `<NotEnrolledBanner>` recommandé
+
+Crée un composant partagé pour les 2 portails :
+
+```tsx
+// components/shared/NotEnrolledBanner.tsx
+interface NotEnrolledBannerProps {
+  studentName: string
+  academicYear: string
+  audience: "student" | "parent"
+}
+
+export function NotEnrolledBanner({ studentName, academicYear, audience }: NotEnrolledBannerProps) {
+  const message = audience === "student"
+    ? `Votre inscription pour ${academicYear} n'est pas encore validée par l'administration.`
+    : `L'inscription de ${studentName} pour ${academicYear} n'est pas encore validée.`
+  return (
+    <div role="alert" className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="h-5 w-5 shrink-0 text-amber-600" />
+        <div>
+          <p className="font-medium text-amber-900">{message}</p>
+          <p className="mt-1 text-sm text-amber-800">
+            Rendez-vous au secrétariat de l&apos;école pour finaliser le dossier.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+## Détection de l'état "non inscrit"
+
+Le BE renvoie déjà la sentinelle :
+
+```json
+{
+  "id": 1,
+  "full_name": "Traoré Aminata",
+  "class_name": "—",     // ← sentinelle "pas inscrite"
+  "general_average": null,
+  "total_absences": 0,
+  "fees_remaining": 0.0
+}
+```
+
+Au lieu de tester `class_name === "—"` (fragile), normaliser dans le schema Zod :
+
+```ts
+export const ParentChildSchema = z.object({
+  id: z.number(),
+  full_name: z.string(),
+  class_name: z.string().nullable().transform(v => v === "—" ? null : v),
+  is_enrolled: z.boolean().optional(), // BE TODO : ajouter ce champ
+  general_average: z.number().nullable(),
+  total_absences: z.number().default(0),
+  fees_remaining: z.number().default(0),
+})
+```
+
+Mieux : demander au BE d'exposer `is_enrolled: bool` explicite et `class_name: null` quand pas inscrit (au lieu de `"—"` string).
+
+## Labels à corriger
+
+| Label actuel | Cas non inscrit | Proposition |
+|---|---|---|
+| `ENFANTS INSCRITS` (compteur parent) | "1" alors qu'Aminata pas inscrite | `MES ENFANTS` ou `ENFANTS SUIVIS` |
+| `Frais restants` | "0 FCFA" vert | `—` neutre + "Frais à venir après inscription" |
+| `Absences` | "0" neutral | `—` + "Aucune donnée tant que pas inscrit" |
+| `Moyenne` | "— / 0" | `—` simple |
+| Subtitle student "— — Votre résumé" | Tirets visibles | "Votre espace personnel" simple |
+
+## Anti-patterns à bloquer en review
+
+1. **Vert (success) sur un montant zéro** pour un user pas inscrit → faux signal positif
+2. **Placeholder visible** (`—`, `null`, `undefined`) rendu en clair sans wrapper conditional
+3. **KPI absences/notes/frais affichés** comme valides quand pas d'enrollment → trompeur
+4. **Bouton "Notes" / "Frais"** cliquable qui mène sur page vide quand pas inscrit → frustrant
+5. **Pas de CTA explicite "Contactez l'administration"** pour un parent dans cet état
+6. **Test sur `"—"` string** au lieu de `null` ou `is_enrolled: false` explicite
+
+## Checklist avant de ship un dashboard student/parent
+
+- [ ] L'élève non inscrit voit un banner explicite, pas un dashboard vide-mais-trompeur
+- [ ] Les KPIs financiers affichent `—` neutre, pas `0 FCFA` vert
+- [ ] Les KPIs académiques affichent `—` neutre, pas `0` ou `— / 0`
+- [ ] Le label compteur enfants côté parent dit "suivis" ou "mes" pas "inscrits"
+- [ ] Le subtitle de bienvenue dégrade gracieusement (pas de tirets visibles)
+- [ ] Les boutons sub-screens (Notes, Frais, EDT) sont disabled OU mènent à un empty state cohérent
+
+## Voir aussi
+
+- Rule `empty-state-by-role.md` — l'ancêtre de cette rule (s'applique aussi)
+- Rule `no-mvp-only-premium.md` — production-grade dès la 1re itération
+- Memory `project_session_2026_05_17_portails_e2e.md` — bugs observés + données BE
+- Task #38 — Bug FE à fixer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Personnalisation de l'identité visuelle des PDFs depuis les paramètres de l'établissement : nouvel onglet « Identité visuelle » avec sélecteurs de couleur principale et d'accent, devise de l'école et site web, avec un aperçu en direct du reçu qui se met à jour à chaque modification. Touch targets h-11 mobile *(admin)*.
+- L'aperçu en direct reproduit fidèlement le rendu du reçu avec bandeau République de Côte d'Ivoire, logo, code MENA, devise en italique, montant gradient, tableau d'allocation avec pastilles colorées et pied de page personnalisé *(admin)*.
+- Bouton « Aperçu PDF » qui télécharge un bordereau du jour pour vérifier l'identité visuelle appliquée *(admin)*.
+- Versement caissier Wave-style : 3 champs seulement (montant, méthode, référence), l'allocation aux frais impayés se fait automatiquement par priorité avec un aperçu en direct qui montre où va chaque XOF avant de valider *(admin)*.
+- Aperçu d'allocation interactif dans le formulaire de versement : pastilles vertes/oranges/grises indiquent quels frais seront soldés ou complétés, et un encart amber prévient si le montant dépasse la dette restante *(admin)*.
 - Connexion multi-tenant : un utilisateur d'établissement arrive sur `college.klassci.com/login?c=<slug>` (lien WhatsApp, email d'invitation), l'établissement s'affiche au-dessus du formulaire et reste mémorisé pour les visites suivantes *(admin, enseignant, parent, élève)* (#183).
 - Aperçu du lien de connexion généré dans le formulaire de création de tenant, avec conseil de choisir un slug court et mémorable (ex : `lmab`, `cca-2026`) — l'admin du super-admin sait exactement ce que recevra le nouvel établissement *(super-admin)* (#183).
 - Section super-admin complète (`/super-admin/*`) : tableau de bord pour onboarder une école sans SSH ni terminal. Liste des tenants avec taille de base, formulaire de création en 3 étapes (nom + slug avec disponibilité vérifiée en direct, compte administrateur, détails optionnels) et progression visible des étapes pendant les 10-30 secondes du provisioning *(super-admin)* (#176).

--- a/app/(teacher)/layout.tsx
+++ b/app/(teacher)/layout.tsx
@@ -1,5 +1,5 @@
 import { PortalShell } from "@/components/shared/PortalShell"
-import { TeacherNav } from "@/components/shared/TeacherNav"
+import { TeacherNav, TeacherSidebar } from "@/components/shared/TeacherNav"
 
 // Auth-gated pages — voir commentaire dans (admin)/layout.tsx
 export const dynamic = "force-dynamic"
@@ -10,7 +10,11 @@ export default function TeacherLayout({
   children: React.ReactNode
 }) {
   return (
-    <PortalShell label="Enseignant" nav={<TeacherNav />}>
+    <PortalShell
+      label="Enseignant"
+      nav={<TeacherNav />}
+      sidebar={<TeacherSidebar />}
+    >
       {children}
     </PortalShell>
   )

--- a/app/(teacher)/teacher/timetable/page.tsx
+++ b/app/(teacher)/teacher/timetable/page.tsx
@@ -6,11 +6,13 @@ export const metadata = { title: "Mon emploi du temps | KLASSCI" }
 
 export default async function TeacherTimetablePage() {
   const session = await auth()
-  const teacherId = session?.user?.id ? Number(session.user.id) : 0
-
-  if (!teacherId) {
+  if (!session?.user?.id) {
     redirect("/login")
   }
-
-  return <TeacherScheduleClient teacherId={teacherId} />
+  // The client component fetches /teacher/schedule which resolves the
+  // teacher profile from the JWT — no user_id↔teacher_profile.id mapping
+  // is needed here. Previously this page passed session.user.id as the
+  // teacher_id, which was the User PK (not the TeacherProfile PK) and
+  // caused the schedule to always render empty.
+  return <TeacherScheduleClient />
 }

--- a/components/admin/enrollments/EnrollmentCreateModal.tsx
+++ b/components/admin/enrollments/EnrollmentCreateModal.tsx
@@ -6,12 +6,14 @@ import { EnrollmentForm } from "@/components/forms/EnrollmentForm"
 interface EnrollmentCreateModalProps {
   open: boolean
   onClose: () => void
+  /** Pré-sélectionne un élève (depuis badge "À inscrire" sur la liste étudiants). */
+  preselectedStudentId?: number
 }
 
-export function EnrollmentCreateModal({ open, onClose }: EnrollmentCreateModalProps) {
+export function EnrollmentCreateModal({ open, onClose, preselectedStudentId }: EnrollmentCreateModalProps) {
   return (
     <CreateModal open={open} onClose={onClose} title="Nouvelle inscription" className="max-w-2xl">
-      <EnrollmentForm onSuccess={onClose} />
+      <EnrollmentForm onSuccess={onClose} preselectedStudentId={preselectedStudentId} />
     </CreateModal>
   )
 }

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -30,9 +30,15 @@ function EnrollmentsSubtitle() {
 export function EnrollmentsPageClient() {
   const searchParams = useSearchParams()
   const [createOpen, setCreateOpen] = useState(false)
+  const [preselectedStudentId, setPreselectedStudentId] = useState<number | undefined>(undefined)
 
   useEffect(() => {
     if (searchParams.get("action") === "create") {
+      // Bug #22 : si le badge "À inscrire" passe student_id en query,
+      // on l'extrait et on le file au modal pour pré-remplissage + skip step.
+      const sid = searchParams.get("student_id")
+      const parsed = sid ? parseInt(sid, 10) : NaN
+      setPreselectedStudentId(Number.isFinite(parsed) && parsed > 0 ? parsed : undefined)
       setCreateOpen(true)
     }
   }, [searchParams])
@@ -57,7 +63,14 @@ export function EnrollmentsPageClient() {
 
       <EnrollmentsTable />
 
-      <EnrollmentCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
+      <EnrollmentCreateModal
+        open={createOpen}
+        onClose={() => {
+          setCreateOpen(false)
+          setPreselectedStudentId(undefined)
+        }}
+        preselectedStudentId={preselectedStudentId}
+      />
     </div>
   )
 }

--- a/components/admin/payments/AllocationPreviewCard.tsx
+++ b/components/admin/payments/AllocationPreviewCard.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { AlertTriangle, CheckCircle2, Circle, CircleDot, Loader2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Skeleton } from "@/components/ui/skeleton"
+import type { AllocationPreview, AllocationPreviewLine } from "@/lib/contracts/payment"
+
+interface AllocationPreviewCardProps {
+  preview: AllocationPreview | undefined
+  isLoading: boolean
+  error: Error | null
+}
+
+function formatFcfa(value: number): string {
+  return `${Number(value).toLocaleString("fr-FR")} XOF`
+}
+
+function statusIcon(status: AllocationPreviewLine["status_after"]) {
+  if (status === "paid") return <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+  if (status === "partial") return <CircleDot className="h-4 w-4 text-amber-600" />
+  if (status === "waived") return <Circle className="h-4 w-4 text-muted-foreground" />
+  return <Circle className="h-4 w-4 text-muted-foreground" />
+}
+
+function statusLabel(status: AllocationPreviewLine["status_after"]): string {
+  if (status === "paid") return "Payé"
+  if (status === "partial") return "Partiel"
+  if (status === "waived") return "Exonéré"
+  return "En attente"
+}
+
+export function AllocationPreviewCard({
+  preview,
+  isLoading,
+  error,
+}: AllocationPreviewCardProps) {
+  if (isLoading) {
+    return (
+      <div
+        className="rounded-xl border border-border bg-muted/30 p-4"
+        aria-busy="true"
+        aria-label="Calcul de l'allocation en cours"
+      >
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Calcul de l&apos;allocation…
+        </div>
+        <div className="mt-3 space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className="rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm">
+        <p className="font-medium text-rose-900">Impossible de calculer l&apos;allocation</p>
+        <p className="text-rose-800">{error.message}</p>
+      </div>
+    )
+  }
+
+  if (!preview) return null
+
+  const lines = preview.lines
+  if (lines.length === 0) {
+    return (
+      <div className="rounded-xl border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+        Aucun frais configuré pour cette inscription.
+      </div>
+    )
+  }
+
+  return (
+    <section
+      aria-label="Aperçu de l'allocation"
+      className="rounded-xl border border-border bg-muted/30 p-4"
+    >
+      <header className="flex items-center justify-between gap-2 pb-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-foreground">
+          Aperçu de l&apos;allocation
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          Reste à payer après : <strong>{formatFcfa(preview.total_remaining_after)}</strong>
+        </span>
+      </header>
+
+      {!preview.can_record && preview.reject_reason ? (
+        <div
+          role="alert"
+          className="mb-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+          <p>{preview.reject_reason}</p>
+        </div>
+      ) : null}
+
+      <ul className="divide-y divide-border/60" role="list">
+        {lines.map((line) => {
+          const allocated = Number(line.allocated)
+          const isContributing = allocated > 0
+          return (
+            <li
+              key={line.enrollment_fee_id}
+              className={cn(
+                "flex items-center justify-between gap-3 py-2",
+                !isContributing && "opacity-60",
+              )}
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                {statusIcon(line.status_after)}
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {line.fee_category_name}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {formatFcfa(line.fee_paid_before)} / {formatFcfa(line.fee_total)}
+                  </p>
+                </div>
+              </div>
+              <div className="shrink-0 text-right">
+                <p
+                  className={cn(
+                    "text-sm font-semibold tabular-nums",
+                    isContributing ? "text-primary" : "text-muted-foreground",
+                  )}
+                >
+                  {isContributing ? `+ ${formatFcfa(allocated)}` : "—"}
+                </p>
+                <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {statusLabel(line.status_after)}
+                </p>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/components/admin/payments/PaymentCreateWizard.tsx
+++ b/components/admin/payments/PaymentCreateWizard.tsx
@@ -42,7 +42,7 @@ const STEP_LABELS = [
 
 const METHOD_OPTIONS: { value: PaymentMethod; label: string }[] = [
   { value: "cash", label: "Especes" },
-  { value: "check", label: "Cheque" },
+  { value: "cheque", label: "Cheque" },
   { value: "bank_transfer", label: "Virement bancaire" },
   { value: "mobile_money", label: "Mobile Money" },
 ]

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -65,14 +65,14 @@ const METHOD_LABELS: Record<PaymentMethod, string> = {
   cash: "Espèces",
   mobile_money: "Mobile Money",
   bank_transfer: "Virement",
-  check: "Chèque",
+  cheque: "Chèque",
 }
 
 const METHOD_ICON_MAP: Record<PaymentMethod, React.ComponentType<{ className?: string }>> = {
   cash: Coins,
   mobile_money: Smartphone,
   bank_transfer: Building2,
-  check: FileText,
+  cheque: FileText,
 }
 
 export function PaymentsPageClient() {
@@ -282,7 +282,7 @@ export function PaymentsPageClient() {
                 <SelectItem value="cash">Espèces</SelectItem>
                 <SelectItem value="mobile_money">Mobile Money</SelectItem>
                 <SelectItem value="bank_transfer">Virement</SelectItem>
-                <SelectItem value="check">Chèque</SelectItem>
+                <SelectItem value="cheque">Chèque</SelectItem>
               </SelectContent>
             </Select>
 

--- a/components/admin/settings/NotificationSection.tsx
+++ b/components/admin/settings/NotificationSection.tsx
@@ -33,6 +33,8 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
       notify_grades: settings.notify_grades,
       notify_absences: settings.notify_absences,
       notify_payments: settings.notify_payments,
+      notify_enrollment: settings.notify_enrollment,
+      notify_reenrollment: settings.notify_reenrollment,
     },
   })
 
@@ -143,6 +145,40 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
                       <FormLabel className="text-sm">Paiements</FormLabel>
                       <FormDescription className="text-xs">
                         Notifier lors de la réception d&apos;un paiement
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="notify_enrollment"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-sm">Inscriptions</FormLabel>
+                      <FormDescription className="text-xs">
+                        Notifier les parents à la validation de l&apos;inscription d&apos;un nouvel élève
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="notify_reenrollment"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-sm">Réinscriptions</FormLabel>
+                      <FormDescription className="text-xs">
+                        Notifier les parents à la confirmation de réinscription pour la nouvelle année scolaire
                       </FormDescription>
                     </div>
                     <FormControl>

--- a/components/admin/settings/PdfIdentitySection.tsx
+++ b/components/admin/settings/PdfIdentitySection.tsx
@@ -1,0 +1,279 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { ExternalLink, Eye, Palette, Quote, RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useDebounce } from "@/lib/hooks/useDebounce"
+import { settingsApi } from "@/lib/api/settings"
+import type { SchoolSettings } from "@/lib/contracts/settings"
+import { ColorField } from "./pdf-identity/ColorField"
+import { LivePreview } from "./pdf-identity/LivePreview"
+
+interface PdfIdentitySectionProps {
+  settings: SchoolSettings | undefined
+  isLoading: boolean
+}
+
+const DEFAULT_PRIMARY = "#0F3F8C"
+const DEFAULT_ACCENT = "#F58220"
+
+interface IdentityFormValues {
+  primary_color: string
+  accent_color: string
+  website: string
+  motto: string
+}
+
+function isValidHex(v: string): boolean {
+  return /^#[0-9A-Fa-f]{6}$/.test(v)
+}
+
+export function PdfIdentitySection({ settings, isLoading }: PdfIdentitySectionProps) {
+  const queryClient = useQueryClient()
+
+  const initial: IdentityFormValues = useMemo(
+    () => ({
+      primary_color: settings?.primary_color ?? DEFAULT_PRIMARY,
+      accent_color: settings?.accent_color ?? DEFAULT_ACCENT,
+      website: settings?.website ?? "",
+      motto: settings?.motto ?? "",
+    }),
+    [settings?.primary_color, settings?.accent_color, settings?.website, settings?.motto],
+  )
+
+  const [values, setValues] = useState<IdentityFormValues>(initial)
+  useEffect(() => setValues(initial), [initial])
+
+  const debouncedPrimary = useDebounce(values.primary_color, 80)
+  const debouncedAccent = useDebounce(values.accent_color, 80)
+
+  const isDirty =
+    values.primary_color !== initial.primary_color ||
+    values.accent_color !== initial.accent_color ||
+    values.website !== initial.website ||
+    values.motto !== initial.motto
+
+  const primaryValid = isValidHex(values.primary_color)
+  const accentValid = isValidHex(values.accent_color)
+  const canSubmit = isDirty && primaryValid && accentValid
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: () =>
+      settingsApi.updateSchoolInfo({
+        ...(settings ?? { school_name: "" }),
+        school_name: settings?.school_name ?? "",
+        primary_color: values.primary_color || null,
+        accent_color: values.accent_color || null,
+        website: values.website || null,
+        motto: values.motto || null,
+      } as never),
+    onSuccess: () => {
+      toast.success("Identité visuelle enregistrée", {
+        description: "Les prochains PDF utiliseront ces couleurs et cette devise.",
+      })
+      queryClient.invalidateQueries({ queryKey: ["settings"] })
+    },
+    onError: (err) =>
+      toast.error("Échec de l'enregistrement", { description: err.message }),
+  })
+
+  function resetToKlassci() {
+    setValues((s) => ({
+      ...s,
+      primary_color: DEFAULT_PRIMARY,
+      accent_color: DEFAULT_ACCENT,
+    }))
+  }
+
+  if (isLoading) {
+    return (
+      <section className="rounded-2xl border border-border bg-card p-6">
+        <Skeleton className="h-6 w-64 mb-4" />
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Skeleton className="h-24" />
+          <Skeleton className="h-24" />
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section
+      aria-labelledby="pdf-identity-title"
+      className="rounded-2xl border border-border bg-card overflow-hidden"
+    >
+      {/* Header editorial */}
+      <header className="border-b border-border bg-gradient-to-br from-muted/40 to-background px-6 py-5">
+        <div className="flex items-start gap-3">
+          <div className="rounded-xl bg-primary/10 p-2 ring-1 ring-primary/20">
+            <Palette className="h-5 w-5 text-primary" aria-hidden />
+          </div>
+          <div className="flex-1">
+            <h2
+              id="pdf-identity-title"
+              className="font-serif text-xl text-foreground tracking-tight"
+            >
+              Identité visuelle des PDF
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground max-w-xl">
+              Personnalisez la palette, la devise et les coordonnées qui apparaissent
+              sur tous les documents officiels (reçus, bulletins, attestations, fiches
+              d&apos;inscription).
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <div className="grid gap-8 px-6 py-6 lg:grid-cols-[1fr_360px]">
+        {/* Form column */}
+        <div className="space-y-6">
+          {/* Couleurs */}
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Palette
+              </Label>
+              {(values.primary_color !== DEFAULT_PRIMARY ||
+                values.accent_color !== DEFAULT_ACCENT) && (
+                <button
+                  type="button"
+                  onClick={resetToKlassci}
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                  Palette KLASSCI par défaut
+                </button>
+              )}
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <ColorField
+                label="Couleur principale"
+                hint="Titres, bordures, accents structurels"
+                value={values.primary_color}
+                isValid={primaryValid}
+                onChange={(v) => setValues((s) => ({ ...s, primary_color: v }))}
+              />
+              <ColorField
+                label="Couleur d'accent"
+                hint="Devise, totaux, mises en valeur"
+                value={values.accent_color}
+                isValid={accentValid}
+                onChange={(v) => setValues((s) => ({ ...s, accent_color: v }))}
+              />
+            </div>
+          </div>
+
+          {/* Devise + Site web */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <Label
+                htmlFor="motto"
+                className="text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+              >
+                Devise de l&apos;établissement
+              </Label>
+              <div className="relative mt-2">
+                <Quote
+                  className="absolute left-3 top-3 h-4 w-4 text-muted-foreground/60"
+                  aria-hidden
+                />
+                <Input
+                  id="motto"
+                  value={values.motto}
+                  onChange={(e) =>
+                    setValues((s) => ({ ...s, motto: e.target.value.slice(0, 255) }))
+                  }
+                  placeholder="Ex : Excellence, Discipline, Travail"
+                  className="h-11 pl-9 font-serif italic"
+                  maxLength={255}
+                />
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Apparaît en italique sous le nom de l&apos;école dans les PDF.
+              </p>
+            </div>
+            <div>
+              <Label
+                htmlFor="website"
+                className="text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+              >
+                Site web
+              </Label>
+              <div className="relative mt-2">
+                <ExternalLink
+                  className="absolute left-3 top-3 h-4 w-4 text-muted-foreground/60"
+                  aria-hidden
+                />
+                <Input
+                  id="website"
+                  type="url"
+                  inputMode="url"
+                  value={values.website}
+                  onChange={(e) =>
+                    setValues((s) => ({ ...s, website: e.target.value.slice(0, 255) }))
+                  }
+                  placeholder="https://lycee-saint-aug.ci"
+                  className="h-11 pl-9"
+                  maxLength={255}
+                />
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Affiché en pied de page des documents officiels.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 pt-2 border-t border-dashed border-border">
+            <Button
+              type="button"
+              onClick={() => mutate()}
+              disabled={!canSubmit || isPending}
+              className="h-11 sm:h-10"
+            >
+              {isPending ? "Enregistrement…" : "Enregistrer l'identité"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-11 sm:h-10"
+              onClick={() => {
+                window.open(
+                  `${process.env.NEXT_PUBLIC_API_URL}/payments/daily-cash-book?date=${new Date()
+                    .toISOString()
+                    .slice(0, 10)}`,
+                  "_blank",
+                )
+              }}
+            >
+              <Eye className="h-4 w-4 mr-1.5" />
+              Aperçu PDF (bordereau du jour)
+            </Button>
+            {!primaryValid && (
+              <span className="text-xs text-rose-600">Couleur principale invalide</span>
+            )}
+            {!accentValid && (
+              <span className="text-xs text-rose-600">Couleur d&apos;accent invalide</span>
+            )}
+          </div>
+        </div>
+
+        {/* Live preview column */}
+        <LivePreview
+          schoolName={settings?.school_name ?? "Mon Établissement"}
+          ministryCode={settings?.ministry_code ?? null}
+          motto={values.motto}
+          website={values.website}
+          primary={primaryValid ? debouncedPrimary : DEFAULT_PRIMARY}
+          accent={accentValid ? debouncedAccent : DEFAULT_ACCENT}
+          logoUrl={settings?.logo_url ?? null}
+        />
+      </div>
+    </section>
+  )
+}

--- a/components/admin/settings/PdfIdentitySection.tsx
+++ b/components/admin/settings/PdfIdentitySection.tsx
@@ -65,13 +65,18 @@ export function PdfIdentitySection({ settings, isLoading }: PdfIdentitySectionPr
   const { mutate, isPending } = useMutation({
     mutationFn: () =>
       settingsApi.updateSchoolInfo({
-        ...(settings ?? { school_name: "" }),
         school_name: settings?.school_name ?? "",
+        address: settings?.address ?? undefined,
+        phone: settings?.phone ?? undefined,
+        email: settings?.email ?? undefined,
+        ministry_code: settings?.ministry_code ?? undefined,
+        head_master_name: settings?.head_master_name ?? undefined,
+        head_master_title: settings?.head_master_title ?? undefined,
         primary_color: values.primary_color || null,
         accent_color: values.accent_color || null,
         website: values.website || null,
         motto: values.motto || null,
-      } as never),
+      }),
     onSuccess: () => {
       toast.success("Identité visuelle enregistrée", {
         description: "Les prochains PDF utiliseront ces couleurs et cette devise.",

--- a/components/admin/settings/SettingsPageClient.tsx
+++ b/components/admin/settings/SettingsPageClient.tsx
@@ -9,6 +9,7 @@ import { useSettings } from "@/lib/hooks/useSettings"
 import { SchoolInfoSection } from "./SchoolInfoSection"
 import { TrimesterSection } from "./TrimesterSection"
 import { NotificationSection } from "./NotificationSection"
+import { PdfIdentitySection } from "./PdfIdentitySection"
 
 export function SettingsPageClient() {
   const { data: settings, isLoading, isError, refetch } = useSettings()
@@ -37,12 +38,17 @@ export function SettingsPageClient() {
         <Tabs defaultValue="school" className="space-y-6">
           <TabsList>
             <TabsTrigger value="school">Établissement</TabsTrigger>
+            <TabsTrigger value="identity">Identité visuelle</TabsTrigger>
             <TabsTrigger value="trimesters">Trimestres</TabsTrigger>
             <TabsTrigger value="notifications">Notifications</TabsTrigger>
           </TabsList>
 
           <TabsContent value="school">
             <SchoolInfoSection settings={settings} />
+          </TabsContent>
+
+          <TabsContent value="identity">
+            <PdfIdentitySection settings={settings} isLoading={isLoading} />
           </TabsContent>
 
           <TabsContent value="trimesters">

--- a/components/admin/settings/TrimesterSection.tsx
+++ b/components/admin/settings/TrimesterSection.tsx
@@ -30,7 +30,7 @@ interface TrimesterSectionProps {
 export function TrimesterSection({ settings }: TrimesterSectionProps) {
   const { mutate, isPending } = useUpdateTrimesters()
 
-  const trimesters = settings.trimesters.length === 3
+  const trimesters = settings.trimesters?.length === 3
     ? settings.trimesters
     : DEFAULT_TRIMESTERS
 

--- a/components/admin/settings/pdf-identity/ColorField.tsx
+++ b/components/admin/settings/pdf-identity/ColorField.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface ColorFieldProps {
+  label: string
+  hint: string
+  value: string
+  isValid: boolean
+  onChange: (v: string) => void
+}
+
+export function ColorField({ label, hint, value, isValid, onChange }: ColorFieldProps) {
+  return (
+    <div
+      className="group rounded-xl border border-border bg-background p-3 transition-colors hover:border-foreground/20"
+      style={{ "--swatch": value } as React.CSSProperties}
+    >
+      <Label className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {label}
+      </Label>
+      <div className="mt-2 flex items-center gap-2">
+        <div className="relative h-11 w-11 shrink-0 overflow-hidden rounded-lg ring-1 ring-border">
+          <input
+            type="color"
+            value={isValid ? value : "#000000"}
+            onChange={(e) => onChange(e.target.value.toUpperCase())}
+            aria-label={`Sélecteur ${label}`}
+            className="absolute inset-0 h-full w-full cursor-pointer border-0 p-0"
+            style={{ background: "var(--swatch)" }}
+          />
+        </div>
+        <Input
+          value={value}
+          onChange={(e) => onChange(e.target.value.toUpperCase())}
+          placeholder="#0F3F8C"
+          maxLength={7}
+          className="h-11 font-mono text-sm tracking-wider uppercase"
+          aria-invalid={!isValid}
+        />
+      </div>
+      <p className="mt-1.5 text-[11px] text-muted-foreground leading-snug">{hint}</p>
+    </div>
+  )
+}

--- a/components/admin/settings/pdf-identity/LivePreview.tsx
+++ b/components/admin/settings/pdf-identity/LivePreview.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+interface LivePreviewProps {
+  schoolName: string
+  ministryCode: string | null
+  motto: string
+  website: string
+  primary: string
+  accent: string
+  logoUrl: string | null
+}
+
+export function LivePreview({
+  schoolName,
+  ministryCode,
+  motto,
+  website,
+  primary,
+  accent,
+  logoUrl,
+}: LivePreviewProps) {
+  const logoSrc = logoUrl?.startsWith("/uploads/")
+    ? `${process.env.NEXT_PUBLIC_API_URL}${logoUrl}`
+    : logoUrl
+
+  return (
+    <aside
+      aria-label="Aperçu du theme PDF"
+      className="rounded-2xl border border-border bg-gradient-to-br from-muted/30 via-background to-muted/20 p-5"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Aperçu en direct
+        </span>
+        <span
+          className="inline-flex h-5 items-center gap-1.5 rounded-full bg-foreground/5 px-2 text-[10px] text-muted-foreground"
+          aria-hidden
+        >
+          <span className="h-2 w-2 rounded-full" style={{ background: primary }} />
+          <span className="h-2 w-2 rounded-full" style={{ background: accent }} />
+        </span>
+      </div>
+
+      <div className="rounded-lg bg-white shadow-[0_4px_20px_-4px_rgba(15,63,140,0.15)] ring-1 ring-black/5 overflow-hidden">
+        {/* Banner RCI */}
+        <div className="px-4 pt-3 pb-2 text-center">
+          <p className="text-[7px] uppercase tracking-[0.15em] text-slate-700">
+            République de Côte d&apos;Ivoire
+          </p>
+          <p className="text-[6.5px] italic text-slate-500">
+            Union — Discipline — Travail
+          </p>
+        </div>
+
+        {/* Header école */}
+        <div className="mx-4 flex items-center gap-2.5 border-b border-slate-200 pb-2.5">
+          {logoSrc ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={logoSrc} alt="" className="h-9 w-9 object-contain shrink-0" />
+          ) : (
+            <div
+              className="h-9 w-9 rounded-md shrink-0"
+              style={{ background: `linear-gradient(135deg, ${primary}, ${accent})` }}
+            />
+          )}
+          <div className="flex-1 text-center">
+            <p
+              className="text-[10px] font-bold tracking-tight leading-tight"
+              style={{ color: primary }}
+            >
+              {schoolName || "Mon Établissement"}
+            </p>
+            {ministryCode && (
+              <p className="text-[7px] text-slate-500 mt-0.5">
+                Code MENA : <strong>{ministryCode}</strong>
+              </p>
+            )}
+            {motto && (
+              <p className="text-[7px] italic mt-0.5" style={{ color: accent }}>
+                « {motto} »
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Title */}
+        <div className="text-center px-4 pt-3 pb-1">
+          <p
+            className="text-[12px] font-bold tracking-[0.05em]"
+            style={{ color: primary }}
+          >
+            REÇU DE VERSEMENT
+          </p>
+        </div>
+
+        {/* Amount box */}
+        <div className="mx-4 my-2">
+          <div
+            className="rounded-md border-2 px-3 py-2 text-center"
+            style={{
+              borderColor: primary,
+              background: `linear-gradient(135deg, ${primary}08 0%, ${primary}14 100%)`,
+            }}
+          >
+            <p className="text-[8px] uppercase tracking-wider text-slate-500">
+              Montant versé
+            </p>
+            <p className="text-base font-bold tabular-nums" style={{ color: primary }}>
+              50 000 XOF
+            </p>
+          </div>
+        </div>
+
+        {/* Section title */}
+        <div
+          className="mx-4 mt-2 pb-0.5 text-[8px] font-bold uppercase tracking-wider"
+          style={{ color: primary, borderBottom: `1.5px solid ${primary}` }}
+        >
+          Détail de l&apos;allocation
+        </div>
+
+        {/* Mini table */}
+        <table className="mx-4 mt-1.5 w-[calc(100%-2rem)] text-[7.5px]">
+          <thead>
+            <tr>
+              <th
+                className="py-1 px-1.5 text-left uppercase tracking-wider text-white"
+                style={{ background: primary, fontSize: "6.5px" }}
+              >
+                Frais
+              </th>
+              <th
+                className="py-1 px-1.5 text-right uppercase tracking-wider text-white"
+                style={{ background: primary, fontSize: "6.5px" }}
+              >
+                Affecté
+              </th>
+              <th
+                className="py-1 px-1.5 text-left uppercase tracking-wider text-white"
+                style={{ background: primary, fontSize: "6.5px" }}
+              >
+                Statut
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="py-1 px-1.5 border-b border-slate-100">Scolarité T1</td>
+              <td className="py-1 px-1.5 text-right tabular-nums border-b border-slate-100">
+                +20 000
+              </td>
+              <td className="py-1 px-1.5 border-b border-slate-100">
+                <span className="rounded-full bg-emerald-100 px-1.5 py-0.5 text-[6px] font-bold uppercase text-emerald-800">
+                  Payé
+                </span>
+              </td>
+            </tr>
+            <tr className="bg-slate-50">
+              <td className="py-1 px-1.5 border-b border-slate-100">Scolarité T2</td>
+              <td className="py-1 px-1.5 text-right tabular-nums border-b border-slate-100">
+                +10 000
+              </td>
+              <td className="py-1 px-1.5 border-b border-slate-100">
+                <span className="rounded-full bg-emerald-100 px-1.5 py-0.5 text-[6px] font-bold uppercase text-emerald-800">
+                  Payé
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td className="py-1 px-1.5 border-b border-slate-100">Scolarité T3</td>
+              <td className="py-1 px-1.5 text-right tabular-nums border-b border-slate-100">
+                +20 000
+              </td>
+              <td className="py-1 px-1.5 border-b border-slate-100">
+                <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[6px] font-bold uppercase text-amber-800">
+                  Partiel
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        {/* Footer */}
+        <div className="mx-4 mt-3 mb-3 pt-1.5 border-t border-slate-200 flex justify-between text-[6.5px] text-slate-500">
+          <span className="font-bold">{schoolName || "Mon Établissement"}</span>
+          {website && (
+            <span style={{ color: accent }} className="font-medium">
+              {website.replace(/^https?:\/\//, "")}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <p className="mt-3 text-[10px] text-muted-foreground leading-snug text-center italic">
+        L&apos;aperçu reflète immédiatement les couleurs et la devise. Cliquez sur{" "}
+        <strong>Aperçu PDF</strong> pour télécharger un document réel.
+      </p>
+    </aside>
+  )
+}

--- a/components/admin/students/StudentAcademicCharts.tsx
+++ b/components/admin/students/StudentAcademicCharts.tsx
@@ -31,26 +31,6 @@ interface AbsencePoint {
   nonJustifiees: number
 }
 
-// Placeholder data — sera remplacé par appel BE quand /admin/students/{id}/full
-// inclura les bulletins archivés et la breakdown par trimestre.
-function buildPlaceholderTrimesters(hasEnrollment: boolean): TrimesterPoint[] {
-  if (!hasEnrollment) return []
-  return [
-    { trimester: "T1", general: null, best: null, worst: null },
-    { trimester: "T2", general: null, best: null, worst: null },
-    { trimester: "T3", general: null, best: null, worst: null },
-  ]
-}
-
-function buildPlaceholderAbsences(hasEnrollment: boolean): AbsencePoint[] {
-  if (!hasEnrollment) return []
-  return [
-    { trimester: "T1", justifiees: 0, nonJustifiees: 0 },
-    { trimester: "T2", justifiees: 0, nonJustifiees: 0 },
-    { trimester: "T3", justifiees: 0, nonJustifiees: 0 },
-  ]
-}
-
 interface StudentAcademicChartsProps {
   studentId: number
 }
@@ -60,10 +40,13 @@ export function StudentAcademicCharts({ studentId }: StudentAcademicChartsProps)
 
   const hasEnrollment = (enrollmentsData?.items?.length ?? 0) > 0
 
-  const trimesterData = useMemo(() => buildPlaceholderTrimesters(hasEnrollment), [hasEnrollment])
-  const absenceData = useMemo(() => buildPlaceholderAbsences(hasEnrollment), [hasEnrollment])
-  const hasGrades = trimesterData.some((p) => p.general !== null)
-  const hasAbsences = absenceData.some((p) => p.justifiees + p.nonJustifiees > 0)
+  // Series vides tant que /admin/students/{id}/full n'expose pas la
+  // breakdown par trimestre. L'empty state propre est rendu en dessous,
+  // évite le faux signal "3 dots null + 3 bars zéro" (no-mvp rule).
+  const trimesterData: TrimesterPoint[] = useMemo(() => [], [])
+  const absenceData: AbsencePoint[] = useMemo(() => [], [])
+  const hasGrades = trimesterData.length > 0 && trimesterData.some((p) => p.general !== null)
+  const hasAbsences = absenceData.length > 0 && absenceData.some((p) => p.justifiees + p.nonJustifiees > 0)
 
   return (
     <div className="grid gap-4 lg:grid-cols-2">

--- a/components/admin/students/StudentAcademicCharts.tsx
+++ b/components/admin/students/StudentAcademicCharts.tsx
@@ -1,0 +1,236 @@
+"use client"
+
+import { useMemo } from "react"
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import { LineChart as LineChartIcon, BarChart3, TrendingUp, Trophy } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { useEnrollments } from "@/lib/hooks/useEnrollments"
+
+interface TrimesterPoint {
+  trimester: string
+  general: number | null
+  best: number | null
+  worst: number | null
+}
+
+interface AbsencePoint {
+  trimester: string
+  justifiees: number
+  nonJustifiees: number
+}
+
+// Placeholder data — sera remplacé par appel BE quand /admin/students/{id}/full
+// inclura les bulletins archivés et la breakdown par trimestre.
+function buildPlaceholderTrimesters(hasEnrollment: boolean): TrimesterPoint[] {
+  if (!hasEnrollment) return []
+  return [
+    { trimester: "T1", general: null, best: null, worst: null },
+    { trimester: "T2", general: null, best: null, worst: null },
+    { trimester: "T3", general: null, best: null, worst: null },
+  ]
+}
+
+function buildPlaceholderAbsences(hasEnrollment: boolean): AbsencePoint[] {
+  if (!hasEnrollment) return []
+  return [
+    { trimester: "T1", justifiees: 0, nonJustifiees: 0 },
+    { trimester: "T2", justifiees: 0, nonJustifiees: 0 },
+    { trimester: "T3", justifiees: 0, nonJustifiees: 0 },
+  ]
+}
+
+interface StudentAcademicChartsProps {
+  studentId: number
+}
+
+export function StudentAcademicCharts({ studentId }: StudentAcademicChartsProps) {
+  const { data: enrollmentsData } = useEnrollments({ student_id: studentId })
+
+  const hasEnrollment = (enrollmentsData?.items?.length ?? 0) > 0
+
+  const trimesterData = useMemo(() => buildPlaceholderTrimesters(hasEnrollment), [hasEnrollment])
+  const absenceData = useMemo(() => buildPlaceholderAbsences(hasEnrollment), [hasEnrollment])
+  const hasGrades = trimesterData.some((p) => p.general !== null)
+  const hasAbsences = absenceData.some((p) => p.justifiees + p.nonJustifiees > 0)
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {/* Moyennes par trimestre */}
+      <Card className="overflow-hidden border-0 shadow-sm ring-1 ring-border">
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="flex items-center gap-2 font-serif text-sm">
+              <LineChartIcon className="h-4 w-4 text-primary" />
+              Moyennes par trimestre
+            </CardTitle>
+            <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary">
+              Année courante
+            </span>
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Évolution sur les 3 trimestres
+          </p>
+        </CardHeader>
+        <CardContent className="pb-4">
+          {hasGrades ? (
+            <ResponsiveContainer width="100%" height={220}>
+              <AreaChart data={trimesterData} margin={{ top: 8, right: 8, left: -16, bottom: 4 }}>
+                <defs>
+                  <linearGradient id="gradGeneral" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#0F3F8C" stopOpacity={0.32} />
+                    <stop offset="95%" stopColor="#0F3F8C" stopOpacity={0.02} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="trimester" tick={{ fontSize: 11 }} stroke="hsl(var(--muted-foreground))" />
+                <YAxis domain={[0, 20]} ticks={[0, 5, 10, 15, 20]} tick={{ fontSize: 11 }} stroke="hsl(var(--muted-foreground))" />
+                <Tooltip content={<MoyenneTooltip />} />
+                <Area
+                  type="monotone"
+                  dataKey="general"
+                  name="Moyenne générale"
+                  stroke="#0F3F8C"
+                  strokeWidth={2.5}
+                  fill="url(#gradGeneral)"
+                  dot={{ fill: "#0F3F8C", r: 4 }}
+                  activeDot={{ r: 6 }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <ChartEmptyState
+              icon={<TrendingUp className="h-6 w-6" />}
+              title="Pas encore de notes"
+              message={
+                hasEnrollment
+                  ? "Les moyennes apparaîtront ici dès la première évaluation saisie."
+                  : "L'élève doit être inscrit pour voir ses moyennes."
+              }
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Absences par trimestre */}
+      <Card className="overflow-hidden border-0 shadow-sm ring-1 ring-border">
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="flex items-center gap-2 font-serif text-sm">
+              <BarChart3 className="h-4 w-4 text-accent" style={{ color: "#F58220" }} />
+              Absences par trimestre
+            </CardTitle>
+            <span className="rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide" style={{ color: "#F58220", backgroundColor: "rgba(245,130,32,0.12)" }}>
+              Année courante
+            </span>
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Justifiées vs non justifiées
+          </p>
+        </CardHeader>
+        <CardContent className="pb-4">
+          {hasAbsences ? (
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={absenceData} margin={{ top: 8, right: 8, left: -16, bottom: 4 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="trimester" tick={{ fontSize: 11 }} stroke="hsl(var(--muted-foreground))" />
+                <YAxis allowDecimals={false} tick={{ fontSize: 11 }} stroke="hsl(var(--muted-foreground))" />
+                <Tooltip content={<AbsenceTooltip />} />
+                <Legend wrapperStyle={{ fontSize: 11 }} iconType="circle" />
+                <Bar dataKey="justifiees" name="Justifiées" stackId="abs" fill="#0F3F8C" radius={[0, 0, 0, 0]} />
+                <Bar dataKey="nonJustifiees" name="Non justifiées" stackId="abs" fill="#F58220" radius={[4, 4, 0, 0]}>
+                  {absenceData.map((_, i) => (
+                    <Cell key={i} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <ChartEmptyState
+              icon={<Trophy className="h-6 w-6 text-emerald-600" />}
+              title="Aucune absence"
+              message={
+                hasEnrollment
+                  ? "Bravo, présence parfaite sur cette année."
+                  : "Les présences s'afficheront après inscription."
+              }
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function ChartEmptyState({
+  icon,
+  title,
+  message,
+}: {
+  icon: React.ReactNode
+  title: string
+  message: string
+}) {
+  return (
+    <div className="flex h-[220px] flex-col items-center justify-center gap-2 rounded-xl bg-muted/20 px-6 text-center">
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-background text-muted-foreground ring-1 ring-border">
+        {icon}
+      </div>
+      <p className="text-sm font-medium">{title}</p>
+      <p className="max-w-xs text-xs text-muted-foreground">{message}</p>
+    </div>
+  )
+}
+
+function MoyenneTooltip({ active, payload, label }: {
+  active?: boolean
+  payload?: Array<{ value: number | null; name: string; color: string }>
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="rounded-lg border bg-popover px-3 py-2 text-xs shadow-md">
+      <p className="font-semibold">{label === "T1" ? "1er trimestre" : label === "T2" ? "2e trimestre" : "3e trimestre"}</p>
+      {payload.map((p, i) => (
+        <p key={i} className="flex items-center gap-2 text-muted-foreground">
+          <span className="h-2 w-2 rounded-full" style={{ backgroundColor: p.color }} />
+          {p.name} : <span className="font-mono font-medium text-foreground">{p.value !== null ? `${p.value}/20` : "—"}</span>
+        </p>
+      ))}
+    </div>
+  )
+}
+
+function AbsenceTooltip({ active, payload, label }: {
+  active?: boolean
+  payload?: Array<{ value: number; name: string; color: string }>
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+  const total = payload.reduce((sum, p) => sum + (p.value ?? 0), 0)
+  return (
+    <div className="rounded-lg border bg-popover px-3 py-2 text-xs shadow-md">
+      <p className="font-semibold">{label === "T1" ? "1er trimestre" : label === "T2" ? "2e trimestre" : "3e trimestre"}</p>
+      {payload.map((p, i) => (
+        <p key={i} className="flex items-center gap-2 text-muted-foreground">
+          <span className="h-2 w-2 rounded-full" style={{ backgroundColor: p.color }} />
+          {p.name} : <span className="font-medium text-foreground">{p.value}</span>
+        </p>
+      ))}
+      <p className="mt-1 border-t pt-1 font-medium">
+        Total : <span className="font-mono">{total}</span>
+      </p>
+    </div>
+  )
+}

--- a/components/admin/students/StudentDetailClient.tsx
+++ b/components/admin/students/StudentDetailClient.tsx
@@ -20,6 +20,7 @@ import {
   MoreVertical,
   Phone,
   ChevronRight,
+  Sparkles,
 } from "lucide-react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -47,6 +48,9 @@ import {
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
 import { StudentEditModal } from "./StudentEditModal"
+import { StudentJourneyTimeline } from "./StudentJourneyTimeline"
+import { StudentAcademicCharts } from "./StudentAcademicCharts"
+import { StatusPill } from "./tabs/_primitives"
 import { ProfileTab } from "./tabs/ProfileTab"
 import { PaymentsTab } from "./tabs/PaymentsTab"
 import { EnrollmentTab } from "./tabs/EnrollmentTab"
@@ -77,7 +81,7 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [photoPreview, setPhotoPreview] = useState(false)
   const [uploading, setUploading] = useState(false)
-  const [activeTab, setActiveTab] = useState("overview")
+  const [activeTab, setActiveTab] = useState("parcours")
   const [photoLoaded, setPhotoLoaded] = useState(false)
 
   const { data: student, isLoading, isError, refetch } = useStudent(studentId)
@@ -267,6 +271,10 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <div className="-mx-1 overflow-x-auto px-1 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
           <TabsList className="w-max">
+            <TabsTrigger value="parcours">
+              <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+              Parcours
+            </TabsTrigger>
             <TabsTrigger value="overview">
               <BookOpen className="mr-1.5 h-3.5 w-3.5" />
               Vue d&apos;ensemble
@@ -297,6 +305,11 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
             </TabsTrigger>
           </TabsList>
         </div>
+
+        <TabsContent value="parcours" className="space-y-4">
+          <StudentJourneyTimeline studentId={studentId} studentName={fullName} />
+          <StudentAcademicCharts studentId={studentId} />
+        </TabsContent>
 
         <TabsContent value="overview">
           <OverviewTab studentId={studentId} student={student} onTabChange={setActiveTab} />
@@ -371,7 +384,12 @@ function OverviewTab({
     student_id: studentId,
   })
   const { data: fees, isLoading: feesLoading } = useStudentFees(studentId)
-  const { data: parents, isLoading: parentsLoading } = useStudentParents(studentId)
+  const {
+    data: parents,
+    isLoading: parentsLoading,
+    isError: parentsError,
+    refetch: refetchParents,
+  } = useStudentParents(studentId)
 
   const enrollments = enrollmentsData?.items ?? []
   const current = enrollments[0] as Record<string, unknown> | undefined
@@ -493,39 +511,124 @@ function OverviewTab({
               >
                 <ClipboardCheck className="h-5 w-5" />
               </div>
-              <div>
-                <p className="text-xs text-muted-foreground">Statut inscription</p>
-                <p className="text-sm font-semibold">{statusLabel}</p>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-xs text-muted-foreground">Statut</p>
+                  <StatusPill
+                    tone={
+                      current?.status === "valide"
+                        ? "success"
+                        : current?.status === "en_validation"
+                          ? "warning"
+                          : current?.status
+                            ? "neutral"
+                            : "neutral"
+                    }
+                  >
+                    {statusLabel}
+                  </StatusPill>
+                </div>
                 {current?.academic_year_name ? (
-                  <p className="mt-0.5 text-xs text-muted-foreground">
+                  <p className="mt-1 text-xs font-medium">
                     {String(current.academic_year_name)}
                   </p>
-                ) : null}
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">Aucune inscription</p>
+                )}
               </div>
             </div>
           </CardContent>
         </Card>
       </div>
 
+      {/* Mini-progress des frais — visible même sans hero (élève sans frais configurés) */}
+      {!feesLoading && totalExpected > 0 && (
+        <Card className="border-0 shadow-sm ring-1 ring-border">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
+                  <Wallet className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground">Taux de paiement</p>
+                  <p className="text-sm font-semibold">{feesRate}%</p>
+                </div>
+              </div>
+              <StatusPill
+                tone={feesRate >= 100 ? "success" : feesRate >= 50 ? "warning" : "danger"}
+              >
+                {feesRate >= 100 ? "Soldé" : feesRate >= 50 ? "En cours" : "À régler"}
+              </StatusPill>
+            </div>
+            <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary transition-all"
+                style={{ width: `${Math.min(100, feesRate)}%` }}
+              />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Parents inline — 1 ligne par parent avec téléphone clickable tel: */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardContent className="p-4">
-          <div className="mb-3 flex items-center justify-between">
+          <div className="mb-3 flex items-center justify-between gap-3">
             <h3 className="flex items-center gap-2 text-sm font-medium">
               <Users className="h-4 w-4 text-muted-foreground" />
               Parents
+              {parents && parents.length > 0 && (
+                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                  {parents.length}
+                </span>
+              )}
             </h3>
-            {parents && parents.length > 2 && (
-              <span className="text-xs text-muted-foreground">{parents.length} liés</span>
-            )}
+            <button
+              type="button"
+              onClick={() => onTabChange?.("parents")}
+              className="text-xs font-medium text-primary hover:underline"
+            >
+              Gérer →
+            </button>
           </div>
           {parentsLoading ? (
             <div className="space-y-2">
               <Skeleton className="h-12 rounded-lg" />
               <Skeleton className="h-12 rounded-lg" />
             </div>
+          ) : parentsError ? (
+            <div className="flex flex-col items-center gap-2 rounded-lg bg-muted/30 px-4 py-6 text-center">
+              <p className="text-sm text-muted-foreground">
+                Impossible de charger les parents.
+              </p>
+              <button
+                type="button"
+                onClick={() => refetchParents()}
+                className="text-xs font-medium text-primary hover:underline"
+              >
+                Réessayer
+              </button>
+            </div>
           ) : !parents || parents.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Aucun parent lié à cet élève.</p>
+            <div className="flex flex-col items-center gap-2 rounded-lg bg-muted/20 px-4 py-6 text-center">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-background text-muted-foreground ring-1 ring-border">
+                <Users className="h-4 w-4" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">Aucun parent lié</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Ajoutez le père, la mère ou le tuteur pour activer les notifications
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onTabChange?.("parents")}
+                className="mt-1 inline-flex h-9 items-center gap-1.5 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Lier un parent →
+              </button>
+            </div>
           ) : (
             <ul className="space-y-2">
               {parents.slice(0, 2).map((p) => {
@@ -542,23 +645,37 @@ function OverviewTab({
                       : rel === "guardian"
                         ? "Tuteur"
                         : ""
+                const relTone =
+                  rel === "father"
+                    ? "bg-primary/10 text-primary"
+                    : rel === "mother"
+                      ? "bg-[rgba(245,130,32,0.12)] text-[#F58220]"
+                      : "bg-muted text-muted-foreground"
+                const initials = `${ln[0] ?? ""}${fn[0] ?? ""}`.toUpperCase() || "?"
                 return (
                   <li
                     key={String(parent.id)}
-                    className="flex items-center justify-between gap-3 rounded-lg border bg-card p-3"
+                    className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-card p-3"
                   >
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium">
-                        {ln} {fn}
-                      </p>
-                      {relLabel && (
-                        <p className="text-xs text-muted-foreground">{relLabel}</p>
-                      )}
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
+                      <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[11px] font-semibold ${relTone}`}>
+                        {initials}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">
+                          {ln} {fn}
+                        </p>
+                        {relLabel && (
+                          <span className={`mt-0.5 inline-flex rounded-full px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide ${relTone}`}>
+                            {relLabel}
+                          </span>
+                        )}
+                      </div>
                     </div>
                     {phone ? (
                       <a
                         href={`tel:${phone}`}
-                        className="flex h-9 shrink-0 items-center gap-1.5 rounded-md border bg-background px-3 text-sm font-medium text-primary hover:bg-primary/5 focus:outline-none focus:ring-2 focus:ring-primary"
+                        className="flex h-11 shrink-0 items-center gap-1.5 rounded-md border bg-background px-3 text-sm font-medium text-primary hover:bg-primary/5 focus:outline-none focus:ring-2 focus:ring-primary sm:h-9"
                       >
                         <Phone className="h-3.5 w-3.5" />
                         Appeler

--- a/components/admin/students/StudentJourneyTimeline.tsx
+++ b/components/admin/students/StudentJourneyTimeline.tsx
@@ -1,0 +1,266 @@
+"use client"
+
+import { useMemo } from "react"
+import Link from "next/link"
+import type { Route } from "next"
+import { GraduationCap, Sparkles, AlertCircle, Clock, ChevronRight } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useEnrollments } from "@/lib/hooks/useEnrollments"
+
+const LEVELS = [
+  { name: "6ème", short: "6e" },
+  { name: "5ème", short: "5e" },
+  { name: "4ème", short: "4e" },
+  { name: "3ème", short: "3e" },
+  { name: "2nde", short: "2nd" },
+  { name: "1ère", short: "1re" },
+  { name: "Terminale", short: "Tle" },
+] as const
+
+type NodeStatus = "reussi" | "en_cours" | "redouble" | "non_inscrit"
+
+interface JourneyNode {
+  level: string
+  short: string
+  status: NodeStatus
+  className: string | null
+  yearLabel: string | null
+  average: number | null
+  rank: { position: number; total: number } | null
+}
+
+interface Enrollment {
+  id: number
+  class_id: number
+  class_name?: string | null
+  academic_year_name?: string | null
+  status?: string | null
+}
+
+function deriveStatus(enr: Enrollment | undefined, isCurrent: boolean): NodeStatus {
+  if (!enr) return "non_inscrit"
+  if (isCurrent) return "en_cours"
+  // sans data historique d'AY passées, on suppose validé = réussi
+  return enr.status === "valide" ? "reussi" : "en_cours"
+}
+
+function levelFromClassName(name: string | null | undefined): string | null {
+  if (!name) return null
+  const trimmed = name.trim().toLowerCase()
+  if (trimmed.startsWith("6")) return "6ème"
+  if (trimmed.startsWith("5")) return "5ème"
+  if (trimmed.startsWith("4")) return "4ème"
+  if (trimmed.startsWith("3")) return "3ème"
+  if (trimmed.startsWith("2") || trimmed.startsWith("seconde") || trimmed.startsWith("2nd")) return "2nde"
+  if (trimmed.startsWith("1ere") || trimmed.startsWith("1ère") || trimmed.startsWith("1re") || trimmed.startsWith("première")) return "1ère"
+  if (trimmed.startsWith("term") || trimmed.startsWith("tle") || trimmed.startsWith("tale")) return "Terminale"
+  return null
+}
+
+const STATUS_STYLE: Record<NodeStatus, { ring: string; bg: string; dot: string; label: string; chip: string }> = {
+  reussi: {
+    ring: "ring-emerald-500/40",
+    bg: "bg-emerald-50 dark:bg-emerald-950/30",
+    dot: "bg-emerald-600 text-white",
+    label: "Réussi",
+    chip: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200",
+  },
+  en_cours: {
+    ring: "ring-primary/50",
+    bg: "bg-primary/5",
+    dot: "bg-primary text-primary-foreground",
+    label: "En cours",
+    chip: "bg-primary/10 text-primary",
+  },
+  redouble: {
+    ring: "ring-amber-500/40",
+    bg: "bg-amber-50 dark:bg-amber-950/30",
+    dot: "bg-amber-600 text-white",
+    label: "Redoublé",
+    chip: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+  },
+  non_inscrit: {
+    ring: "ring-border",
+    bg: "bg-muted/30",
+    dot: "bg-muted text-muted-foreground",
+    label: "À venir",
+    chip: "bg-muted text-muted-foreground",
+  },
+}
+
+interface StudentJourneyTimelineProps {
+  studentId: number
+  studentName: string
+}
+
+export function StudentJourneyTimeline({ studentId, studentName }: StudentJourneyTimelineProps) {
+  const { data, isLoading } = useEnrollments({ student_id: studentId })
+
+  const enrollments = useMemo(() => {
+    const items = (data?.items ?? []) as Enrollment[]
+    // tri du plus ancien au plus récent (year_name lexicographique fonctionne pour "2024-2025" etc.)
+    return [...items].sort((a, b) => {
+      const ya = a.academic_year_name ?? ""
+      const yb = b.academic_year_name ?? ""
+      return ya.localeCompare(yb)
+    })
+  }, [data])
+
+  const currentEnrollment = enrollments[enrollments.length - 1]
+
+  const nodes: JourneyNode[] = useMemo(() => {
+    return LEVELS.map((lvl) => {
+      const match = enrollments.find((e) => levelFromClassName(e.class_name) === lvl.name)
+      const isCurrent = match?.id === currentEnrollment?.id
+      return {
+        level: lvl.name,
+        short: lvl.short,
+        status: deriveStatus(match, isCurrent),
+        className: match?.class_name ?? null,
+        yearLabel: match?.academic_year_name ?? null,
+        average: null, // pas encore exposé par BE
+        rank: null,
+      }
+    })
+  }, [enrollments, currentEnrollment])
+
+  const validatedCount = nodes.filter((n) => n.status === "reussi").length
+  const hasAny = nodes.some((n) => n.status !== "non_inscrit")
+
+  if (isLoading) {
+    return (
+      <Card className="overflow-hidden border-0 shadow-sm ring-1 ring-border">
+        <CardHeader className="pb-3">
+          <Skeleton className="h-5 w-40" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-32 w-full rounded-xl" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!hasAny) {
+    return (
+      <Card className="overflow-hidden border-0 shadow-sm ring-1 ring-border">
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 font-serif text-base">
+            <GraduationCap className="h-5 w-5 text-primary" />
+            Parcours scolaire
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col items-center gap-3 rounded-xl bg-muted/30 px-6 py-10 text-center">
+            <Sparkles className="h-8 w-8 text-muted-foreground/60" />
+            <div>
+              <p className="text-sm font-medium">{studentName} n&apos;est pas encore inscrit·e</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Le parcours s&apos;affichera ici dès la première inscription validée
+              </p>
+            </div>
+            <Link
+              href={`/admin/enrollments?action=create&student_id=${studentId}` as Route}
+              className="mt-2 inline-flex h-11 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Inscrire maintenant <ChevronRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="overflow-hidden border-0 shadow-sm ring-1 ring-border">
+      <CardHeader className="pb-2">
+        <div className="flex items-end justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 font-serif text-base">
+              <GraduationCap className="h-5 w-5 text-primary" />
+              Parcours scolaire
+            </CardTitle>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              De la 6<sup>e</sup> à la Terminale — {validatedCount} niveau{validatedCount > 1 ? "x" : ""} validé{validatedCount > 1 ? "s" : ""}
+            </p>
+          </div>
+          {currentEnrollment?.class_name && (
+            <span className="hidden text-right text-xs text-muted-foreground sm:block">
+              <span className="block font-medium text-foreground">{currentEnrollment.class_name}</span>
+              <span>{currentEnrollment.academic_year_name}</span>
+            </span>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="pb-6 pt-4">
+        {/* Timeline — horizontal scroll on mobile */}
+        <div className="-mx-1 overflow-x-auto px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <div className="relative flex min-w-[640px] items-start gap-0 pt-1 sm:min-w-0">
+            {/* connecting line behind nodes */}
+            <div className="absolute left-6 right-6 top-[26px] -z-0 h-0.5 bg-gradient-to-r from-border via-border to-border/40" aria-hidden />
+
+            {nodes.map((node, idx) => {
+              const style = STATUS_STYLE[node.status]
+              const isLast = idx === nodes.length - 1
+              return (
+                <div key={node.level} className="relative z-10 flex flex-1 flex-col items-center text-center">
+                  {/* Node circle */}
+                  <div className={`flex h-12 w-12 items-center justify-center rounded-full ring-4 ring-background ${style.dot}`}>
+                    {node.status === "reussi" ? (
+                      <Sparkles className="h-5 w-5" />
+                    ) : node.status === "en_cours" ? (
+                      <Clock className="h-5 w-5" />
+                    ) : node.status === "redouble" ? (
+                      <AlertCircle className="h-5 w-5" />
+                    ) : (
+                      <span className="text-xs font-semibold">{node.short}</span>
+                    )}
+                  </div>
+
+                  {/* Label */}
+                  <div className="mt-2 flex w-full flex-col items-center">
+                    <span className="text-[11px] font-semibold uppercase tracking-wide text-foreground">
+                      {node.level}
+                    </span>
+                    {node.className ? (
+                      <span className="text-[10px] font-mono text-muted-foreground">{node.className}</span>
+                    ) : (
+                      <span className="text-[10px] text-muted-foreground/60">—</span>
+                    )}
+                    <span className={`mt-1 inline-flex rounded-full px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider ${style.chip}`}>
+                      {style.label}
+                    </span>
+                    {node.yearLabel && (
+                      <span className="mt-1 text-[10px] text-muted-foreground">{node.yearLabel}</span>
+                    )}
+                  </div>
+
+                  {/* spacer */}
+                  {!isLast && <span className="sr-only">étape suivante</span>}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Legend */}
+        <div className="mt-5 flex flex-wrap items-center justify-center gap-3 border-t pt-3 text-[10px] text-muted-foreground">
+          <LegendItem color="bg-emerald-600" label="Réussi" />
+          <LegendItem color="bg-primary" label="En cours" />
+          <LegendItem color="bg-amber-600" label="Redoublé" />
+          <LegendItem color="bg-muted-foreground/40" label="À venir" />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function LegendItem({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className={`h-2 w-2 rounded-full ${color}`} aria-hidden />
+      {label}
+    </span>
+  )
+}

--- a/components/admin/students/parents/ParentCard.tsx
+++ b/components/admin/students/parents/ParentCard.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { MoreVertical, Phone, MessageCircle, Mail, UserCheck, Unlink, MessageSquare } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Button } from "@/components/ui/button"
+import { StatusPill, InitialsAvatar } from "../tabs/_primitives"
+import { getRelationshipMeta, buildWhatsAppHref, type RelationshipTone } from "./relationship"
+
+interface ParentCardProps {
+  parent: {
+    id: number
+    first_name?: string | null
+    last_name?: string | null
+    phone?: string | null
+    email?: string | null
+    user_id?: number | null
+    [key: string]: unknown
+  }
+  onUnlink: (parent: { id: number; name: string }) => void
+}
+
+const RELATION_TO_AVATAR: Record<RelationshipTone, "primary" | "accent" | "neutral"> = {
+  primary: "primary",
+  accent: "accent",
+  warning: "neutral",
+  neutral: "neutral",
+}
+
+export function ParentCard({ parent, onUnlink }: ParentCardProps) {
+  const relType = (parent.relationship_type as string | undefined) ?? undefined
+  const meta = getRelationshipMeta(relType)
+  const fullName = `${parent.last_name ?? ""} ${parent.first_name ?? ""}`.trim() || "Parent"
+  const phone = parent.phone ?? null
+  const email = parent.email ?? null
+  const whatsApp = buildWhatsAppHref(phone)
+  const hasAccount = Boolean(parent.user_id)
+
+  return (
+    <article className="group flex flex-col gap-3 overflow-hidden rounded-xl border border-border/60 bg-card p-4 transition-all hover:border-primary/40 hover:shadow-sm">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <InitialsAvatar
+          first={parent.first_name}
+          last={parent.last_name}
+          size="md"
+          tone={RELATION_TO_AVATAR[meta.tone]}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-serif text-base leading-tight">{fullName}</p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <StatusPill tone={meta.tone}>{meta.label}</StatusPill>
+            {hasAccount && (
+              <StatusPill tone="success">
+                <UserCheck className="h-3 w-3" />
+                Compte
+              </StatusPill>
+            )}
+          </div>
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="-mr-1 h-8 w-8 shrink-0 text-muted-foreground"
+              aria-label="Actions"
+            >
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            {email && (
+              <DropdownMenuItem asChild>
+                <a href={`mailto:${email}`}>
+                  <Mail className="mr-2 h-4 w-4" />
+                  Envoyer un email
+                </a>
+              </DropdownMenuItem>
+            )}
+            {phone && (
+              <DropdownMenuItem asChild>
+                <a href={`sms:${phone}`}>
+                  <MessageSquare className="mr-2 h-4 w-4" />
+                  Envoyer un SMS
+                </a>
+              </DropdownMenuItem>
+            )}
+            {(email || phone) && <DropdownMenuSeparator />}
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={() => onUnlink({ id: parent.id, name: fullName })}
+            >
+              <Unlink className="mr-2 h-4 w-4" />
+              Délier de l&apos;élève
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Coordonnées compactes */}
+      {(phone || email) && (
+        <div className="space-y-1.5 border-t border-border/40 pt-3 text-xs text-muted-foreground">
+          {phone && (
+            <p className="flex items-center gap-2 font-mono">
+              <Phone className="h-3 w-3 shrink-0" />
+              {phone}
+            </p>
+          )}
+          {email && (
+            <p className="flex items-center gap-2 truncate">
+              <Mail className="h-3 w-3 shrink-0" />
+              <span className="truncate">{email}</span>
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Actions persona-first (h-11 touch targets) */}
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {phone ? (
+          <Button asChild variant="outline" size="sm" className="h-11 gap-1.5 sm:h-10">
+            <a href={`tel:${phone}`}>
+              <Phone className="h-3.5 w-3.5" />
+              Appeler
+            </a>
+          </Button>
+        ) : null}
+        {whatsApp ? (
+          <Button asChild variant="outline" size="sm" className="h-11 gap-1.5 sm:h-10">
+            <a href={whatsApp} target="_blank" rel="noopener noreferrer">
+              <MessageCircle className="h-3.5 w-3.5" />
+              WhatsApp
+            </a>
+          </Button>
+        ) : null}
+        {email ? (
+          <Button asChild variant="outline" size="sm" className="h-11 gap-1.5 sm:h-10">
+            <a href={`mailto:${email}`}>
+              <Mail className="h-3.5 w-3.5" />
+              Email
+            </a>
+          </Button>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/components/admin/students/parents/ParentCreateModal.tsx
+++ b/components/admin/students/parents/ParentCreateModal.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { UserPlus, KeyRound } from "lucide-react"
+import { ParentCreateSchema, type ParentCreate } from "@/lib/contracts/parent"
+import { useCreateParent, useLinkParent } from "@/lib/hooks/useParents"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { RELATIONSHIPS } from "./relationship"
+
+interface ParentCreateModalProps {
+  studentId: number
+  open: boolean
+  onClose: () => void
+}
+
+export function ParentCreateModal({ studentId, open, onClose }: ParentCreateModalProps) {
+  const [createAccount, setCreateAccount] = useState(false)
+  const { mutate: createParent, isPending: creating } = useCreateParent()
+  const { mutate: linkParent, isPending: linking } = useLinkParent()
+
+  const form = useForm<ParentCreate>({
+    resolver: zodResolver(ParentCreateSchema),
+    defaultValues: {
+      first_name: "",
+      last_name: "",
+      phone: "",
+      email: "",
+      password: "",
+      relationship_type: "guardian",
+    },
+  })
+
+  const handleClose = () => {
+    form.reset()
+    setCreateAccount(false)
+    onClose()
+  }
+
+  const handleSubmit = (data: ParentCreate) => {
+    const payload: ParentCreate = { ...data }
+    if (!createAccount) {
+      delete payload.password
+    }
+    createParent(payload, {
+      onSuccess: (parent) => {
+        linkParent(
+          { parentId: parent.id, studentId, relationshipType: data.relationship_type },
+          { onSuccess: handleClose },
+        )
+      },
+    })
+  }
+
+  const isPending = creating || linking
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 font-serif">
+            <UserPlus className="h-5 w-5 text-primary" />
+            Nouveau parent
+          </DialogTitle>
+          <DialogDescription>
+            Créez un parent et liez-le immédiatement à l&apos;élève.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="first_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Prénom *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Prénom" className="h-11 sm:h-10" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="last_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nom *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nom" className="h-11 sm:h-10" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Téléphone</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="+225 ..."
+                        className="h-11 font-mono sm:h-10"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="parent@exemple.com"
+                        className="h-11 sm:h-10"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="relationship_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Lien de parenté</FormLabel>
+                  <Select value={field.value ?? "guardian"} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger className="h-11 sm:h-10">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {RELATIONSHIPS.map((r) => (
+                        <SelectItem key={r.value} value={r.value}>
+                          {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Compte utilisateur optionnel */}
+            <div className="space-y-3 rounded-xl border border-border/60 bg-muted/20 p-3">
+              <label className="flex cursor-pointer items-start gap-2.5">
+                <Checkbox
+                  checked={createAccount}
+                  onCheckedChange={(checked) => {
+                    setCreateAccount(checked === true)
+                    if (!checked) form.setValue("password", "")
+                  }}
+                  className="mt-0.5"
+                />
+                <span className="flex flex-col gap-0.5">
+                  <span className="flex items-center gap-1.5 text-sm font-medium">
+                    <KeyRound className="h-3.5 w-3.5 text-primary" />
+                    Créer un compte de connexion
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Permet au parent d&apos;accéder à son portail (notes, paiements, bulletins).
+                  </span>
+                </span>
+              </label>
+
+              {createAccount && (
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Mot de passe initial *</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="password"
+                          placeholder="8 caractères minimum"
+                          className="h-11 sm:h-10"
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
+
+            <DialogFooter className="gap-2 sm:gap-0">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClose}
+                className="h-11 sm:h-10"
+              >
+                Annuler
+              </Button>
+              <Button type="submit" disabled={isPending} className="h-11 sm:h-10">
+                {isPending ? "Création..." : "Créer et lier"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/students/parents/ParentLinkModal.tsx
+++ b/components/admin/students/parents/ParentLinkModal.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import { useState } from "react"
+import { Link2, Search, Phone, Mail, CheckCircle2 } from "lucide-react"
+import { useParents, useLinkParent } from "@/lib/hooks/useParents"
+import { useDebounce } from "@/lib/hooks/useDebounce"
+import type { Parent } from "@/lib/contracts/parent"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import { InitialsAvatar } from "../tabs/_primitives"
+import { RELATIONSHIPS } from "./relationship"
+
+interface ParentLinkModalProps {
+  studentId: number
+  open: boolean
+  onClose: () => void
+}
+
+export function ParentLinkModal({ studentId, open, onClose }: ParentLinkModalProps) {
+  const [searchQuery, setSearchQuery] = useState("")
+  const [selected, setSelected] = useState<Parent | null>(null)
+  const [relationship, setRelationship] = useState<string>("guardian")
+  const debounced = useDebounce(searchQuery, 300)
+  const { mutate: linkParent, isPending } = useLinkParent()
+
+  const enabled = debounced.length >= 2
+  const { data, isLoading } = useParents(enabled ? { search: debounced, size: 20 } : { size: 0 })
+  const matches = enabled ? (data?.items ?? []) : []
+
+  const handleClose = () => {
+    setSearchQuery("")
+    setSelected(null)
+    setRelationship("guardian")
+    onClose()
+  }
+
+  const handleConfirm = () => {
+    if (!selected) return
+    linkParent(
+      { parentId: selected.id, studentId, relationshipType: relationship },
+      { onSuccess: handleClose },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 font-serif">
+            <Link2 className="h-5 w-5 text-primary" />
+            Lier un parent existant
+          </DialogTitle>
+          <DialogDescription>
+            Recherchez un parent déjà enregistré pour l&apos;associer à cet élève.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Recherche */}
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Nom, prénom, téléphone, email…"
+              className="h-11 pl-9 sm:h-10"
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value)
+                setSelected(null)
+              }}
+              aria-label="Rechercher un parent existant"
+            />
+          </div>
+
+          {/* Résultats */}
+          {!enabled && (
+            <p className="rounded-lg bg-muted/20 px-4 py-6 text-center text-xs text-muted-foreground">
+              Tapez au moins 2 caractères pour rechercher.
+            </p>
+          )}
+
+          {enabled && isLoading && (
+            <div className="space-y-2">
+              <Skeleton className="h-16 rounded-xl" />
+              <Skeleton className="h-16 rounded-xl" />
+            </div>
+          )}
+
+          {enabled && !isLoading && matches.length === 0 && (
+            <div className="rounded-lg bg-muted/20 px-4 py-6 text-center">
+              <p className="text-sm font-medium">Aucun parent trouvé</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Aucun résultat pour «&nbsp;{debounced}&nbsp;». Créez un nouveau parent à la place.
+              </p>
+            </div>
+          )}
+
+          {matches.length > 0 && (
+            <ul className="max-h-64 space-y-2 overflow-y-auto pr-1">
+              {matches.map((p) => {
+                const isSelected = selected?.id === p.id
+                const fullName = `${p.last_name} ${p.first_name}`
+                return (
+                  <li key={p.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(p)}
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-xl border p-3 text-left transition-all",
+                        isSelected
+                          ? "border-primary bg-primary/5 ring-1 ring-primary/30"
+                          : "border-border/60 hover:border-primary/40 hover:bg-muted/30",
+                      )}
+                      aria-pressed={isSelected}
+                    >
+                      <InitialsAvatar
+                        first={p.first_name}
+                        last={p.last_name}
+                        size="sm"
+                        tone="primary"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">{fullName}</p>
+                        <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                          {p.phone && (
+                            <span className="flex items-center gap-1 font-mono">
+                              <Phone className="h-3 w-3" />
+                              {p.phone}
+                            </span>
+                          )}
+                          {p.email && (
+                            <span className="flex max-w-[180px] items-center gap-1 truncate">
+                              <Mail className="h-3 w-3 shrink-0" />
+                              <span className="truncate">{p.email}</span>
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      {isSelected && (
+                        <CheckCircle2 className="h-4 w-4 shrink-0 text-primary" />
+                      )}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+
+          {/* Choix relation après sélection */}
+          {selected && (
+            <div className="space-y-2 rounded-xl border border-border/60 bg-muted/20 p-3">
+              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Lien de parenté avec l&apos;élève
+              </label>
+              <Select value={relationship} onValueChange={setRelationship}>
+                <SelectTrigger className="h-11 sm:h-10">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {RELATIONSHIPS.map((r) => (
+                    <SelectItem key={r.value} value={r.value}>
+                      {r.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleClose}
+            className="h-11 sm:h-10"
+          >
+            Annuler
+          </Button>
+          <Button
+            type="button"
+            disabled={!selected || isPending}
+            onClick={handleConfirm}
+            className="h-11 sm:h-10"
+          >
+            {isPending ? "Liaison..." : "Lier ce parent"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/students/parents/relationship.ts
+++ b/components/admin/students/parents/relationship.ts
@@ -1,0 +1,30 @@
+export type RelationshipType = "father" | "mother" | "guardian" | "other"
+
+export type RelationshipTone = "primary" | "accent" | "warning" | "neutral"
+
+export interface RelationshipMeta {
+  value: RelationshipType
+  label: string
+  tone: RelationshipTone
+}
+
+export const RELATIONSHIPS: readonly RelationshipMeta[] = [
+  { value: "father", label: "Père", tone: "primary" },
+  { value: "mother", label: "Mère", tone: "accent" },
+  { value: "guardian", label: "Tuteur", tone: "warning" },
+  { value: "other", label: "Autre", tone: "neutral" },
+] as const
+
+const DEFAULT_META: RelationshipMeta = { value: "other", label: "Contact", tone: "neutral" }
+
+export function getRelationshipMeta(value: string | null | undefined): RelationshipMeta {
+  if (!value) return DEFAULT_META
+  return RELATIONSHIPS.find((r) => r.value === value) ?? DEFAULT_META
+}
+
+export function buildWhatsAppHref(phone: string | null | undefined): string | null {
+  if (!phone) return null
+  const digits = phone.replace(/[^\d]/g, "")
+  if (digits.length < 8) return null
+  return `https://wa.me/${digits}`
+}

--- a/components/admin/students/tabs/AttendanceTab.tsx
+++ b/components/admin/students/tabs/AttendanceTab.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { ClipboardCheck } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
+import { ClipboardCheck, CheckCircle2, XCircle, AlertCircle, Calendar } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -14,20 +13,25 @@ import {
 } from "@/components/ui/table"
 import { DataError } from "@/components/shared/DataError"
 import { useStudentAttendance } from "@/lib/hooks/useAttendance"
+import { SectionCard, StatusPill, EmptyState } from "./_primitives"
 
 interface AttendanceTabProps {
   studentId: number
 }
 
-const ATTENDANCE_STATUS: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline"; className?: string }> = {
-  present: { label: "Present", variant: "default", className: "bg-emerald-600 hover:bg-emerald-600/80" },
-  absent: { label: "Absent", variant: "destructive" },
-  late: { label: "En retard", variant: "secondary", className: "bg-amber-500 text-white hover:bg-amber-500/80" },
-  excused: { label: "Excuse", variant: "outline" },
+function statusTone(s: string): "success" | "danger" | "warning" | "neutral" {
+  if (s === "present") return "success"
+  if (s === "absent") return "danger"
+  if (s === "late") return "warning"
+  return "neutral"
 }
 
-function getAttendanceConfig(status: string) {
-  return ATTENDANCE_STATUS[status] ?? { label: status, variant: "outline" as const }
+function statusLabel(s: string): string {
+  if (s === "present") return "Présent"
+  if (s === "absent") return "Absent"
+  if (s === "late") return "En retard"
+  if (s === "excused") return "Excusé"
+  return s
 }
 
 export function AttendanceTab({ studentId }: AttendanceTabProps) {
@@ -35,108 +39,184 @@ export function AttendanceTab({ studentId }: AttendanceTabProps) {
 
   if (isLoading) {
     return (
-      <div className="space-y-3">
-        <div className="grid grid-cols-3 gap-3">
-          <Skeleton className="h-16 rounded-lg" />
-          <Skeleton className="h-16 rounded-lg" />
-          <Skeleton className="h-16 rounded-lg" />
+      <div className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
         </div>
-        <Skeleton className="h-48 rounded-lg" />
+        <Skeleton className="h-64 rounded-xl" />
       </div>
     )
   }
 
-  if (isError) return <DataError message="Impossible de charger les presences." onRetry={() => refetch()} />
+  if (isError) return <DataError message="Impossible de charger les présences." onRetry={() => refetch()} />
 
   const records = data?.items ?? []
-
-  if (records.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-muted mb-3">
-          <ClipboardCheck className="h-6 w-6 text-muted-foreground" />
-        </div>
-        <p className="text-sm text-muted-foreground">Aucun enregistrement de presence.</p>
-      </div>
-    )
-  }
-
-  // Summary counts
   const counts = records.reduce(
     (acc, r) => {
       if (r.status === "present") acc.present++
       else if (r.status === "absent") acc.absent++
       else if (r.status === "late") acc.late++
+      else if (r.status === "excused") acc.excused++
       return acc
     },
-    { present: 0, absent: 0, late: 0 },
+    { present: 0, absent: 0, late: 0, excused: 0 },
   )
+
+  const total = counts.present + counts.absent + counts.late + counts.excused
+  const rate = total > 0 ? Math.round((counts.present / total) * 100) : 0
+
+  if (records.length === 0) {
+    return (
+      <SectionCard
+        icon={<ClipboardCheck className="h-4 w-4" />}
+        title="Présences"
+        description="Suivi de l'assiduité de l'élève"
+      >
+        <EmptyState
+          icon={<Calendar className="h-5 w-5" />}
+          title="Aucun enregistrement de présence"
+          message="Les présences s'afficheront ici dès la première séance enregistrée par l'enseignant."
+        />
+      </SectionCard>
+    )
+  }
 
   return (
     <div className="space-y-4">
-      {/* Stats summary */}
-      <div className="grid grid-cols-3 gap-3">
-        <Card className="border-0 shadow-sm ring-1 ring-border">
-          <CardContent className="p-3 text-center">
-            <p className="text-sm font-bold text-emerald-600 dark:text-emerald-400">{counts.present}</p>
-            <p className="text-[10px] text-muted-foreground">Present</p>
+      {/* KPI grid */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {/* Taux d'assiduité — gros KPI */}
+        <Card className="border-0 shadow-sm ring-1 ring-border lg:col-span-1">
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="relative flex h-14 w-14 shrink-0 items-center justify-center">
+                <svg className="absolute inset-0 -rotate-90" viewBox="0 0 36 36">
+                  <circle cx="18" cy="18" r="15" fill="none" stroke="hsl(var(--muted))" strokeWidth="3" />
+                  <circle
+                    cx="18"
+                    cy="18"
+                    r="15"
+                    fill="none"
+                    stroke={rate >= 90 ? "#10b981" : rate >= 75 ? "#f59e0b" : "#ef4444"}
+                    strokeWidth="3"
+                    strokeDasharray={`${(rate / 100) * 94.25} 94.25`}
+                    strokeLinecap="round"
+                  />
+                </svg>
+                <span className="font-mono text-xs font-bold">{rate}%</span>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Assiduité</p>
+                <p className="mt-0.5 text-sm font-semibold">
+                  {rate >= 90 ? "Excellente" : rate >= 75 ? "Correcte" : "À surveiller"}
+                </p>
+              </div>
+            </div>
           </CardContent>
         </Card>
-        <Card className="border-0 shadow-sm ring-1 ring-border">
-          <CardContent className="p-3 text-center">
-            <p className="text-sm font-bold text-destructive">{counts.absent}</p>
-            <p className="text-[10px] text-muted-foreground">Absent</p>
-          </CardContent>
-        </Card>
-        <Card className="border-0 shadow-sm ring-1 ring-border">
-          <CardContent className="p-3 text-center">
-            <p className="text-sm font-bold text-amber-500">{counts.late}</p>
-            <p className="text-[10px] text-muted-foreground">En retard</p>
-          </CardContent>
-        </Card>
+
+        <KpiCard
+          icon={<CheckCircle2 className="h-5 w-5" />}
+          label="Présents"
+          value={counts.present}
+          tone="success"
+        />
+        <KpiCard
+          icon={<XCircle className="h-5 w-5" />}
+          label="Absences"
+          value={counts.absent}
+          tone="danger"
+        />
+        <KpiCard
+          icon={<AlertCircle className="h-5 w-5" />}
+          label="Retards"
+          value={counts.late}
+          tone="warning"
+        />
       </div>
 
       {/* Recent records table */}
-      <div className="rounded-lg border">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Date</TableHead>
-              <TableHead>Statut</TableHead>
-              <TableHead>Heure d&apos;arrivee</TableHead>
-              <TableHead>Notes</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {records.map((record) => {
-              const config = getAttendanceConfig(record.status)
-              return (
-                <TableRow key={record.id}>
-                  <TableCell className="text-sm">
-                    {new Date(record.created_at).toLocaleDateString("fr-FR", {
-                      weekday: "short",
-                      day: "numeric",
-                      month: "long",
-                      year: "numeric",
-                    })}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={config.variant} className={`text-[10px] ${config.className ?? ""}`}>
-                      {config.label}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-sm text-muted-foreground">
-                    {record.time_in ?? "\u2014"}
-                  </TableCell>
-                  <TableCell className="text-sm text-muted-foreground max-w-[200px] truncate">
-                    {record.notes ?? "\u2014"}
-                  </TableCell>
-                </TableRow>
-              )
-            })}
-          </TableBody>
-        </Table>
-      </div>
+      <SectionCard
+        icon={<Calendar className="h-4 w-4" />}
+        title="Historique des présences"
+        description={`${total} enregistrement${total > 1 ? "s" : ""} au total`}
+      >
+        <div className="overflow-hidden rounded-lg border border-border/60">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="text-xs uppercase tracking-wide">Date</TableHead>
+                <TableHead className="text-xs uppercase tracking-wide">Statut</TableHead>
+                <TableHead className="text-xs uppercase tracking-wide">Heure</TableHead>
+                <TableHead className="text-xs uppercase tracking-wide">Notes</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {records.map((record) => {
+                const tone = statusTone(record.status)
+                const label = statusLabel(record.status)
+                return (
+                  <TableRow key={record.id}>
+                    <TableCell className="text-sm">
+                      {new Date(record.created_at).toLocaleDateString("fr-FR", {
+                        weekday: "short",
+                        day: "numeric",
+                        month: "long",
+                        year: "numeric",
+                      })}
+                    </TableCell>
+                    <TableCell>
+                      <StatusPill tone={tone}>{label}</StatusPill>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {record.time_in ?? "—"}
+                    </TableCell>
+                    <TableCell className="max-w-[200px] truncate text-sm text-muted-foreground">
+                      {record.notes ?? "—"}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </SectionCard>
     </div>
+  )
+}
+
+function KpiCard({
+  icon,
+  label,
+  value,
+  tone,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number
+  tone: "success" | "danger" | "warning"
+}) {
+  const styles = {
+    success: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+    danger: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
+    warning: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  }
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardContent className="p-4">
+        <div className="flex items-center gap-3">
+          <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${styles[tone]}`}>
+            {icon}
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+            <p className="font-mono text-xl font-bold">{value}</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/components/admin/students/tabs/DocumentsTab.tsx
+++ b/components/admin/students/tabs/DocumentsTab.tsx
@@ -1,11 +1,12 @@
 "use client"
 
 import { useState } from "react"
-import { Award, FileCheck2, Loader2 } from "lucide-react"
+import { Award, FileCheck2, FileText, Loader2, Download, FilePlus } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { studentDocumentsApi } from "@/lib/api/student-documents"
 import { downloadBlob } from "@/lib/utils"
+import { SectionCard, StatusPill, EmptyState } from "./_primitives"
 
 interface DocumentsTabProps {
   studentId: number
@@ -21,24 +22,25 @@ const DOCS: {
   icon: typeof Award
   download: (id: number) => Promise<Blob>
   filenameBase: string
+  tone: "primary" | "accent"
 }[] = [
   {
     kind: "certificate",
     title: "Certificat de scolarité",
-    description:
-      "Atteste que l'élève est régulièrement inscrit cette année. Document officiel signé par le chef d'établissement.",
+    description: "Atteste l'inscription régulière de l'élève. Document officiel signé par le chef d'établissement.",
     icon: Award,
     download: studentDocumentsApi.downloadCertificateScolarite,
     filenameBase: "certificat_scolarite",
+    tone: "primary",
   },
   {
     kind: "attendance",
     title: "Attestation de fréquentation",
-    description:
-      "Récapitule les présences de l'élève sur l'année courante avec un taux de fréquentation calculé.",
+    description: "Récapitule les présences de l'élève sur l'année courante avec son taux de fréquentation.",
     icon: FileCheck2,
     download: studentDocumentsApi.downloadAttestationFrequentation,
     filenameBase: "attestation_frequentation",
+    tone: "accent",
   },
 ]
 
@@ -53,10 +55,9 @@ export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) 
         .toUpperCase()
         .replace(/\s+/g, "_")
       downloadBlob(blob, `${doc.filenameBase}_${safeName}.pdf`)
-      toast.success(`${doc.title} téléchargé(e)`)
+      toast.success(`${doc.title} téléchargé`)
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Erreur lors du téléchargement"
+      const message = err instanceof Error ? err.message : "Erreur lors du téléchargement"
       toast.error(message)
     } finally {
       setDownloading(null)
@@ -65,53 +66,79 @@ export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) 
 
   return (
     <div className="space-y-4">
-      <div>
-        <h3 className="text-base font-semibold">Documents officiels</h3>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Génération à la demande pour remettre au parent ou l&apos;élève.
-        </p>
-      </div>
-
-      <div className="grid gap-3 sm:grid-cols-2">
-        {DOCS.map((doc) => {
-          const Icon = doc.icon
-          const isDownloading = downloading === doc.kind
-          return (
-            <div
-              key={doc.kind}
-              className="flex flex-col gap-3 rounded-lg border bg-card p-4"
-            >
-              <div className="flex items-start gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                  <Icon className="h-5 w-5" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium">{doc.title}</p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {doc.description}
-                  </p>
-                </div>
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => handleDownload(doc)}
-                disabled={isDownloading}
-                className="h-11 w-full sm:h-9"
+      <SectionCard
+        icon={<FileText className="h-4 w-4" />}
+        title="Documents officiels"
+        description="Génération à la demande, signés par le chef d'établissement"
+        action={
+          <StatusPill tone="success">
+            <FileCheck2 className="h-3 w-3" />
+            Disponibles
+          </StatusPill>
+        }
+      >
+        <div className="grid gap-3 sm:grid-cols-2">
+          {DOCS.map((doc) => {
+            const Icon = doc.icon
+            const isDownloading = downloading === doc.kind
+            const iconBg = doc.tone === "primary"
+              ? "bg-primary/10 text-primary"
+              : "bg-[rgba(245,130,32,0.12)] text-[#F58220]"
+            return (
+              <div
+                key={doc.kind}
+                className="group relative flex flex-col gap-4 overflow-hidden rounded-xl border border-border/60 bg-card p-4 transition-all hover:border-primary/40 hover:shadow-sm"
               >
-                {isDownloading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Génération...
-                  </>
-                ) : (
-                  "Télécharger PDF"
-                )}
-              </Button>
-            </div>
-          )
-        })}
-      </div>
+                <div className={`absolute right-3 top-3 h-1 w-12 rounded-full ${doc.tone === "primary" ? "bg-primary/30" : "bg-[#F58220]/40"}`} aria-hidden />
+
+                <div className="flex items-start gap-3">
+                  <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl ${iconBg}`}>
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="font-serif text-base leading-tight">{doc.title}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">PDF officiel · 1 page</p>
+                  </div>
+                </div>
+
+                <p className="text-xs leading-relaxed text-muted-foreground">{doc.description}</p>
+
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleDownload(doc)}
+                  disabled={isDownloading}
+                  className="h-11 w-full gap-2 sm:h-10"
+                >
+                  {isDownloading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Génération…
+                    </>
+                  ) : (
+                    <>
+                      <Download className="h-4 w-4" />
+                      Télécharger
+                    </>
+                  )}
+                </Button>
+              </div>
+            )
+          })}
+        </div>
+      </SectionCard>
+
+      <SectionCard
+        icon={<FilePlus className="h-4 w-4" />}
+        title="Pièces jointes"
+        description="Acte de naissance, certificat médical, autres documents fournis"
+      >
+        <EmptyState
+          icon={<FilePlus className="h-5 w-5" />}
+          title="Aucune pièce jointe"
+          message="Cette fonctionnalité arrivera bientôt. En attendant, conservez les pièces dans le dossier papier de l'élève."
+        />
+      </SectionCard>
     </div>
   )
 }

--- a/components/admin/students/tabs/EnrollmentTab.tsx
+++ b/components/admin/students/tabs/EnrollmentTab.tsx
@@ -1,67 +1,53 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useMemo } from "react"
 import Link from "next/link"
-import { GraduationCap } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
-import { Card, CardContent } from "@/components/ui/card"
+import type { Route } from "next"
+import { GraduationCap, Plus, Calendar, ChevronRight, Sparkles } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { DataError } from "@/components/shared/DataError"
 import { useEnrollments } from "@/lib/hooks/useEnrollments"
+import { SectionCard, StatusPill, EmptyState } from "./_primitives"
 
 interface EnrollmentTabProps {
   studentId: number
 }
 
-const STATUS_CONFIG: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline"; className?: string }> = {
-  prospect: { label: "Prospect", variant: "outline" },
-  en_validation: { label: "En validation", variant: "secondary", className: "bg-amber-500 text-white hover:bg-amber-500/80" },
-  valide: { label: "Valide", variant: "default", className: "bg-emerald-600 hover:bg-emerald-600/80" },
-  rejete: { label: "Rejete", variant: "destructive" },
-  annule: { label: "Annule", variant: "destructive" },
+function statusTone(s: string): "success" | "warning" | "danger" | "neutral" | "primary" {
+  if (s === "valide") return "success"
+  if (s === "en_validation") return "warning"
+  if (s === "prospect") return "primary"
+  if (s === "rejete" || s === "annule") return "danger"
+  return "neutral"
+}
+
+function statusLabel(s: string): string {
+  if (s === "valide") return "Validé"
+  if (s === "en_validation") return "En validation"
+  if (s === "prospect") return "Prospect"
+  if (s === "rejete") return "Rejeté"
+  if (s === "annule") return "Annulé"
+  return s
 }
 
 export function EnrollmentTab({ studentId }: EnrollmentTabProps) {
   const { data, isLoading, isError, refetch } = useEnrollments({ student_id: studentId })
-  const [yearFilter, setYearFilter] = useState<string>("all")
 
-  const enrollments = data?.items ?? []
-
-  // Extract unique academic years for the filter
-  const years = useMemo(() => {
-    const yearSet = new Map<string, string>()
-    for (const e of enrollments) {
-      const raw = e as Record<string, unknown>
-      const yearName = raw.academic_year_name ? String(raw.academic_year_name) : null
-      const yearId = raw.academic_year_id ? String(raw.academic_year_id) : null
-      if (yearName && yearId) {
-        yearSet.set(yearId, yearName)
-      }
-    }
-    return Array.from(yearSet.entries()).map(([id, name]) => ({ id, name }))
-  }, [enrollments])
-
-  const filtered = useMemo(() => {
-    if (yearFilter === "all") return enrollments
-    return enrollments.filter((e) => {
-      const raw = e as Record<string, unknown>
-      return String(raw.academic_year_id) === yearFilter
+  const enrollments = useMemo(() => {
+    const items = data?.items ?? []
+    return [...items].sort((a, b) => {
+      const ya = String((a as Record<string, unknown>).academic_year_name ?? "")
+      const yb = String((b as Record<string, unknown>).academic_year_name ?? "")
+      return yb.localeCompare(ya) // descendant : année courante en haut
     })
-  }, [enrollments, yearFilter])
+  }, [data])
 
   if (isLoading) {
     return (
       <div className="space-y-3">
-        <Skeleton className="h-9 w-48 rounded-md" />
-        <Skeleton className="h-16 rounded-lg" />
-        <Skeleton className="h-16 rounded-lg" />
+        <Skeleton className="h-32 rounded-xl" />
+        <Skeleton className="h-24 rounded-xl" />
+        <Skeleton className="h-24 rounded-xl" />
       </div>
     )
   }
@@ -70,81 +56,134 @@ export function EnrollmentTab({ studentId }: EnrollmentTabProps) {
 
   if (enrollments.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-muted mb-3">
-          <GraduationCap className="h-6 w-6 text-muted-foreground" />
-        </div>
-        <p className="text-sm text-muted-foreground">Aucune inscription enregistree.</p>
-      </div>
+      <SectionCard
+        icon={<GraduationCap className="h-4 w-4" />}
+        title="Inscriptions"
+        description="Aucune année scolaire encore enregistrée"
+      >
+        <EmptyState
+          icon={<GraduationCap className="h-5 w-5" />}
+          title="Pas encore d'inscription"
+          message="Inscrivez cet élève dans une classe pour démarrer son parcours scolaire."
+          cta={
+            <Link
+              href={`/admin/enrollments?action=create&student_id=${studentId}` as Route}
+              className="inline-flex h-11 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              <Plus className="h-4 w-4" />
+              Inscrire maintenant
+            </Link>
+          }
+        />
+      </SectionCard>
     )
   }
 
+  const current = enrollments[0] as Record<string, unknown>
+  const history = enrollments.slice(1)
+
   return (
     <div className="space-y-4">
-      {/* Year filter */}
-      {years.length > 1 && (
-        <div className="flex items-center gap-2">
-          <Select value={yearFilter} onValueChange={setYearFilter}>
-            <SelectTrigger className="w-[220px]">
-              <SelectValue placeholder="Toutes les annees" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Toutes les annees</SelectItem>
-              {years.map((y) => (
-                <SelectItem key={y.id} value={y.id}>
-                  {y.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+      {/* Inscription courante — hero */}
+      <SectionCard
+        icon={<Sparkles className="h-4 w-4" />}
+        title="Inscription courante"
+        description="Année scolaire en cours"
+        action={
+          <StatusPill tone={statusTone(String(current.status ?? ""))}>
+            {statusLabel(String(current.status ?? ""))}
+          </StatusPill>
+        }
+      >
+        <Link
+          href={`/admin/enrollments/${String(current.id)}` as Route}
+          className="group block"
+        >
+          <div className="flex items-start gap-4 rounded-xl border-2 border-primary/20 bg-primary/5 p-4 transition-all group-hover:border-primary/40 group-hover:shadow-sm">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+              <GraduationCap className="h-6 w-6" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="font-serif text-lg leading-tight">
+                {current.class_name ? String(current.class_name) : `Classe #${current.class_id}`}
+              </p>
+              <p className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
+                <Calendar className="h-3.5 w-3.5" />
+                {current.academic_year_name ? String(current.academic_year_name) : "Année non précisée"}
+              </p>
+              {Boolean(current.created_at) && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Inscrit le{" "}
+                  {new Date(String(current.created_at)).toLocaleDateString("fr-FR", {
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                  })}
+                </p>
+              )}
+            </div>
+            <ChevronRight className="h-5 w-5 shrink-0 self-center text-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-primary" />
+          </div>
+        </Link>
+
+        <div className="mt-3 flex gap-2">
+          <Link
+            href={`/admin/enrollments?action=create&student_id=${studentId}` as Route}
+            className="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted sm:h-9"
+          >
+            <Plus className="h-4 w-4" />
+            Nouvelle inscription
+          </Link>
         </div>
-      )}
+      </SectionCard>
 
-      {/* Enrollment cards */}
-      <div className="grid gap-4 sm:grid-cols-2">
-        {filtered.map((enrollment) => {
-          const e = enrollment as Record<string, unknown>
-          const status = String(e.status ?? "")
-          const sc = STATUS_CONFIG[status] ?? { label: status, variant: "outline" as const }
-          const createdAt = e.created_at
-            ? new Date(String(e.created_at)).toLocaleDateString("fr-FR", {
-                day: "numeric",
-                month: "long",
-                year: "numeric",
-              })
-            : null
-
-          return (
-            <Link key={enrollment.id} href={`/admin/enrollments/${enrollment.id}`}>
-              <Card className="border-0 shadow-sm ring-1 ring-border cursor-pointer hover:ring-primary/40 hover:shadow-md transition-all h-full">
-                <CardContent className="p-5">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="space-y-1.5 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <GraduationCap className="h-4 w-4 text-primary shrink-0" />
-                        <p className="text-sm font-semibold truncate">
-                          {e.class_name ? String(e.class_name) : `Classe #${e.class_id ?? "?"}`}
-                        </p>
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        {e.academic_year_name ? String(e.academic_year_name) : `Année #${e.academic_year_id ?? "?"}`}
-                      </p>
-                      {createdAt && (
-                        <p className="text-[10px] text-muted-foreground/70">
-                          Inscrit le {createdAt}
-                        </p>
-                      )}
+      {/* Historique des inscriptions */}
+      {history.length > 0 && (
+        <SectionCard
+          icon={<Calendar className="h-4 w-4" />}
+          title="Historique scolaire"
+          description={`${history.length} année${history.length > 1 ? "s" : ""} précédente${history.length > 1 ? "s" : ""}`}
+        >
+          <ul className="space-y-2">
+            {history.map((enrollment) => {
+              const e = enrollment as Record<string, unknown>
+              const status = String(e.status ?? "")
+              const createdAt = e.created_at
+                ? new Date(String(e.created_at)).toLocaleDateString("fr-FR", {
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                  })
+                : null
+              return (
+                <li key={String(e.id)}>
+                  <Link
+                    href={`/admin/enrollments/${String(e.id)}` as Route}
+                    className="group flex items-center gap-3 rounded-lg border border-border/60 bg-card p-3 transition-colors hover:border-primary/40"
+                  >
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                      <GraduationCap className="h-4 w-4" />
                     </div>
-                    <Badge variant={sc.variant} className={`text-[10px] shrink-0 ${sc.className ?? ""}`}>
-                      {sc.label}
-                    </Badge>
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-          )
-        })}
-      </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-sm font-medium">
+                          {e.class_name ? String(e.class_name) : `Classe #${e.class_id}`}
+                        </p>
+                        <StatusPill tone={statusTone(status)}>{statusLabel(status)}</StatusPill>
+                      </div>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {e.academic_year_name ? String(e.academic_year_name) : "—"}
+                        {createdAt && ` · Inscrit le ${createdAt}`}
+                      </p>
+                    </div>
+                    <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-primary" />
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </SectionCard>
+      )}
     </div>
   )
 }

--- a/components/admin/students/tabs/ParentsTab.tsx
+++ b/components/admin/students/tabs/ParentsTab.tsx
@@ -1,46 +1,9 @@
 "use client"
 
 import { useState } from "react"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { Plus, Unlink, Mail, Phone, UserCheck, Users } from "lucide-react"
-import { ParentCreateSchema, type ParentCreate, type Parent } from "@/lib/contracts/parent"
-import {
-  useStudentParents,
-  useParents,
-  useCreateParent,
-  useLinkParent,
-  useUnlinkParent,
-} from "@/lib/hooks/useParents"
-import { useDebounce } from "@/lib/hooks/useDebounce"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
+import { ChevronDown, HeartHandshake, Link2, UserPlus } from "lucide-react"
+import { useStudentParents, useUnlinkParent } from "@/lib/hooks/useParents"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Checkbox } from "@/components/ui/checkbox"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -51,152 +14,148 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Skeleton } from "@/components/ui/skeleton"
-import { cn } from "@/lib/utils"
-
-const RELATIONSHIP_TYPES = [
-  { value: "father", label: "Père", color: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400" },
-  { value: "mother", label: "Mère", color: "bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400" },
-  { value: "guardian", label: "Tuteur", color: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400" },
-  { value: "other", label: "Autre", color: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400" },
-] as const
-
-function getRelationshipInfo(type: string) {
-  return RELATIONSHIP_TYPES.find((r) => r.value === type) ?? RELATIONSHIP_TYPES[3]
-}
+import { SectionCard, StatusPill, EmptyState } from "./_primitives"
+import { ParentCard } from "../parents/ParentCard"
+import { ParentCreateModal } from "../parents/ParentCreateModal"
+import { ParentLinkModal } from "../parents/ParentLinkModal"
 
 interface ParentsTabProps {
   studentId: number
 }
 
+type UnlinkTarget = { id: number; name: string } | null
+type AddMode = "create" | "link" | null
+
 export function ParentsTab({ studentId }: ParentsTabProps) {
-  const { data: parents, isLoading } = useStudentParents(studentId)
-  const [createOpen, setCreateOpen] = useState(false)
-  const [unlinkTarget, setUnlinkTarget] = useState<{ parentId: number; name: string } | null>(null)
+  const {
+    data: parents,
+    isLoading,
+    isError,
+    refetch,
+  } = useStudentParents(studentId)
+  const [unlinkTarget, setUnlinkTarget] = useState<UnlinkTarget>(null)
+  const [addMode, setAddMode] = useState<AddMode>(null)
   const { mutate: unlinkParent, isPending: unlinking } = useUnlinkParent()
+
+  const parentList = parents ?? []
+  const count = parentList.length
 
   const handleUnlink = () => {
     if (!unlinkTarget) return
     unlinkParent(
-      { parentId: unlinkTarget.parentId, studentId },
+      { parentId: unlinkTarget.id, studentId },
       { onSuccess: () => setUnlinkTarget(null) },
-    )
-  }
-
-  if (isLoading) {
-    return (
-      <div className="space-y-3">
-        <Skeleton className="h-24 rounded-lg" />
-        <Skeleton className="h-24 rounded-lg" />
-      </div>
     )
   }
 
   return (
     <div className="space-y-4">
-      {parents && parents.length > 0 ? (
-        <div className="grid gap-3 sm:grid-cols-2">
-          {parents.map((parent) => {
-            const rel = getRelationshipInfo((parent as Record<string, unknown>).relationship_type as string ?? "guardian")
-            const initials = `${parent.first_name?.[0] ?? ""}${parent.last_name?.[0] ?? ""}`.toUpperCase()
-            const fullName = `${parent.last_name} ${parent.first_name}`
-
-            return (
-              <Card key={parent.id} className="border-0 shadow-sm ring-1 ring-border">
-                <CardContent className="p-4">
-                  <div className="flex items-start gap-3">
-                    <Avatar className="h-10 w-10 shrink-0">
-                      <AvatarFallback className="bg-primary/10 text-primary text-sm font-semibold">
-                        {initials}
-                      </AvatarFallback>
-                    </Avatar>
-
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <p className="text-sm font-semibold">{fullName}</p>
-                        <Badge variant="secondary" className={`text-[10px] ${rel.color}`}>
-                          {rel.label}
-                        </Badge>
-                        {parent.user_id && (
-                          <Badge variant="outline" className="text-[10px] border-emerald-300 text-emerald-600">
-                            <UserCheck className="mr-1 h-3 w-3" />
-                            Compte actif
-                          </Badge>
-                        )}
-                      </div>
-
-                      <div className="mt-1.5 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-                        {parent.phone && (
-                          <span className="flex items-center gap-1">
-                            <Phone className="h-3 w-3" />
-                            {parent.phone}
-                          </span>
-                        )}
-                        {parent.email && (
-                          <span className="flex items-center gap-1">
-                            <Mail className="h-3 w-3" />
-                            {parent.email}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
-                      onClick={() => setUnlinkTarget({ parentId: parent.id, name: fullName })}
-                    >
-                      <Unlink className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
-            )
-          })}
-        </div>
-      ) : (
-        <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-muted mb-3">
-            <Users className="h-6 w-6 text-muted-foreground" />
+      <SectionCard
+        icon={<HeartHandshake className="h-4 w-4" />}
+        title="Famille &amp; tuteurs"
+        description={
+          count > 0
+            ? "Contacts joignables pour les communications école"
+            : "Indispensable pour les notifications de paiement, absences et bulletins"
+        }
+        action={
+          <div className="flex items-center gap-2">
+            {count > 0 && (
+              <StatusPill tone="primary">
+                {count} parent{count > 1 ? "s" : ""}
+              </StatusPill>
+            )}
+            <AddParentTrigger onPick={setAddMode} />
           </div>
-          <p className="text-sm text-muted-foreground">
-            Aucun parent lié à cet élève.
-          </p>
-        </div>
-      )}
+        }
+      >
+        {isLoading ? (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Skeleton className="h-40 rounded-xl" />
+            <Skeleton className="h-40 rounded-xl" />
+          </div>
+        ) : isError ? (
+          <ParentsError onRetry={() => refetch()} />
+        ) : count === 0 ? (
+          <EmptyState
+            icon={<HeartHandshake className="h-5 w-5" />}
+            title="Aucun parent lié"
+            message="Ajoutez le père, la mère ou un tuteur pour activer les notifications école et le portail parent."
+            cta={
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button
+                  onClick={() => setAddMode("create")}
+                  className="h-11 gap-1.5"
+                  size="sm"
+                >
+                  <UserPlus className="h-3.5 w-3.5" />
+                  Nouveau parent
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => setAddMode("link")}
+                  className="h-11 gap-1.5"
+                  size="sm"
+                >
+                  <Link2 className="h-3.5 w-3.5" />
+                  Lier un existant
+                </Button>
+              </div>
+            }
+          />
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {parentList.map((parent) => (
+              <ParentCard
+                key={parent.id}
+                parent={parent as Parameters<typeof ParentCard>[0]["parent"]}
+                onUnlink={setUnlinkTarget}
+              />
+            ))}
+          </div>
+        )}
+      </SectionCard>
 
-      <div className="flex justify-center">
-        <Button variant="outline" size="sm" onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-1.5 h-3.5 w-3.5" />
-          Ajouter un parent
-        </Button>
-      </div>
-
-      {/* Add parent dialog (new or existing) */}
-      <AddParentDialog
-        open={createOpen}
-        onClose={() => setCreateOpen(false)}
+      {/* Modals */}
+      <ParentCreateModal
         studentId={studentId}
+        open={addMode === "create"}
+        onClose={() => setAddMode(null)}
+      />
+      <ParentLinkModal
+        studentId={studentId}
+        open={addMode === "link"}
+        onClose={() => setAddMode(null)}
       />
 
-      {/* Unlink confirmation */}
-      <AlertDialog open={!!unlinkTarget} onOpenChange={(open) => !open && setUnlinkTarget(null)}>
+      {/* Confirm unlink */}
+      <AlertDialog
+        open={!!unlinkTarget}
+        onOpenChange={(open) => !open && setUnlinkTarget(null)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Retirer ce parent ?</AlertDialogTitle>
+            <AlertDialogTitle>Délier ce parent ?</AlertDialogTitle>
             <AlertDialogDescription>
-              Le lien entre {unlinkTarget?.name} et cet élève sera supprimé. Le parent ne sera pas supprimé du système.
+              Le lien entre <strong>{unlinkTarget?.name}</strong> et l&apos;élève sera retiré.
+              Le parent reste dans le système et peut être relié à un autre élève.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogCancel className="h-11 sm:h-10">Annuler</AlertDialogCancel>
             <AlertDialogAction
               onClick={handleUnlink}
               disabled={unlinking}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              className="h-11 bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:h-10"
             >
-              {unlinking ? "Suppression..." : "Retirer"}
+              {unlinking ? "Suppression..." : "Délier"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -205,400 +164,50 @@ export function ParentsTab({ studentId }: ParentsTabProps) {
   )
 }
 
-// ---------- Add parent dialog (create new or link existing) ----------
-
-type AddParentMode = "new" | "existing"
-
-function AddParentDialog({
-  open,
-  onClose,
-  studentId,
-}: {
-  open: boolean
-  onClose: () => void
-  studentId: number
-}) {
-  const [mode, setMode] = useState<AddParentMode>("new")
-  const [createAccount, setCreateAccount] = useState(false)
-  const { mutate: createParent, isPending: creating } = useCreateParent()
-  const { mutate: linkParent, isPending: linking } = useLinkParent()
-
-  // --- Existing parent search state ---
-  const [searchQuery, setSearchQuery] = useState("")
-  const debouncedSearch = useDebounce(searchQuery, 300)
-  const [selectedParent, setSelectedParent] = useState<Parent | null>(null)
-  const [linkRelationship, setLinkRelationship] = useState<string>("guardian")
-
-  const { data: searchResults, isLoading: searchLoading } = useParents(
-    debouncedSearch.length >= 2 ? { search: debouncedSearch, size: 20 } : { size: 0 },
-  )
-  const matchingParents: Parent[] = debouncedSearch.length >= 2 ? (searchResults?.items ?? []) : []
-
-  const form = useForm<ParentCreate>({
-    resolver: zodResolver(ParentCreateSchema),
-    defaultValues: {
-      first_name: "",
-      last_name: "",
-      phone: "",
-      email: "",
-      password: "",
-      relationship_type: "guardian",
-    },
-  })
-
-  const handleSubmitNew = (data: ParentCreate) => {
-    const payload = { ...data }
-    if (!createAccount) {
-      delete payload.password
-    }
-
-    createParent(payload, {
-      onSuccess: (parent) => {
-        linkParent({
-          parentId: parent.id,
-          studentId,
-          relationshipType: data.relationship_type,
-        })
-        resetAndClose()
-      },
-    })
-  }
-
-  const handleLinkExisting = () => {
-    if (!selectedParent) return
-    linkParent(
-      { parentId: selectedParent.id, studentId, relationshipType: linkRelationship },
-      { onSuccess: () => resetAndClose() },
-    )
-  }
-
-  const resetAndClose = () => {
-    form.reset()
-    setCreateAccount(false)
-    setMode("new")
-    setSearchQuery("")
-    setSelectedParent(null)
-    setLinkRelationship("guardian")
-    onClose()
-  }
-
+function AddParentTrigger({ onPick }: { onPick: (mode: AddMode) => void }) {
   return (
-    <Dialog open={open} onOpenChange={(o) => !o && resetAndClose()}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Ajouter un parent</DialogTitle>
-        </DialogHeader>
-
-        {/* Mode toggle */}
-        <div className="flex gap-1 rounded-md bg-muted p-1">
-          <button
-            type="button"
-            className={cn(
-              "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors",
-              mode === "new"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-            onClick={() => setMode("new")}
-          >
-            Nouveau parent
-          </button>
-          <button
-            type="button"
-            className={cn(
-              "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors",
-              mode === "existing"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-            onClick={() => setMode("existing")}
-          >
-            Parent existant
-          </button>
-        </div>
-
-        {mode === "new" ? (
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(handleSubmitNew)} className="space-y-4">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="first_name"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Prénom *</FormLabel>
-                      <FormControl>
-                        <Input placeholder="Prénom" className="h-10" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="last_name"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Nom *</FormLabel>
-                      <FormControl>
-                        <Input placeholder="Nom" className="h-10" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="phone"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Téléphone</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder="Numéro de téléphone"
-                          className="h-10"
-                          {...field}
-                          value={field.value ?? ""}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="email"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Email</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="email"
-                          placeholder="Adresse email"
-                          className="h-10"
-                          {...field}
-                          value={field.value ?? ""}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              <FormField
-                control={form.control}
-                name="relationship_type"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Lien de parenté</FormLabel>
-                    <Select value={field.value ?? "guardian"} onValueChange={field.onChange}>
-                      <FormControl>
-                        <SelectTrigger className="h-10">
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="father">Père</SelectItem>
-                        <SelectItem value="mother">Mère</SelectItem>
-                        <SelectItem value="guardian">Tuteur</SelectItem>
-                        <SelectItem value="other">Autre</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Account creation toggle */}
-              <div className="space-y-3 rounded-md border p-3">
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="create-account"
-                    checked={createAccount}
-                    onCheckedChange={(checked) => {
-                      setCreateAccount(checked === true)
-                      if (!checked) {
-                        form.setValue("password", "")
-                      }
-                    }}
-                  />
-                  <label
-                    htmlFor="create-account"
-                    className="text-sm font-medium leading-none cursor-pointer"
-                  >
-                    Créer un compte de connexion pour le parent
-                  </label>
-                </div>
-
-                {createAccount && (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2">
-                    <FormField
-                      control={form.control}
-                      name="email"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Email du compte *</FormLabel>
-                          <FormControl>
-                            <Input
-                              type="email"
-                              placeholder="email@exemple.com"
-                              className="h-10"
-                              {...field}
-                              value={field.value ?? ""}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name="password"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Mot de passe *</FormLabel>
-                          <FormControl>
-                            <Input
-                              type="password"
-                              placeholder="8 caractères minimum"
-                              className="h-10"
-                              {...field}
-                              value={field.value ?? ""}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </div>
-                )}
-              </div>
-
-              <DialogFooter>
-                <Button type="button" variant="outline" onClick={resetAndClose}>
-                  Annuler
-                </Button>
-                <Button type="submit" disabled={creating}>
-                  {creating ? "Création..." : "Créer et lier"}
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        ) : (
-          /* ---- Existing parent search & link ---- */
-          <div className="space-y-4">
-            <Input
-              placeholder="Rechercher un parent (nom, prénom, téléphone)..."
-              className="h-10"
-              value={searchQuery}
-              onChange={(e) => {
-                setSearchQuery(e.target.value)
-                setSelectedParent(null)
-              }}
-            />
-
-            {searchLoading && debouncedSearch.length >= 2 && (
-              <div className="flex items-center justify-center py-6">
-                <Skeleton className="h-16 w-full rounded-lg" />
-              </div>
-            )}
-
-            {!searchLoading && debouncedSearch.length >= 2 && matchingParents.length === 0 && (
-              <p className="text-sm text-muted-foreground text-center py-4">
-                Aucun parent trouvé pour &laquo; {debouncedSearch} &raquo;
-              </p>
-            )}
-
-            {matchingParents.length > 0 && (
-              <div className="max-h-48 overflow-y-auto space-y-2">
-                {matchingParents.map((p) => {
-                  const isSelected = selectedParent?.id === p.id
-                  const initials = `${p.first_name?.[0] ?? ""}${p.last_name?.[0] ?? ""}`.toUpperCase()
-                  return (
-                    <button
-                      key={p.id}
-                      type="button"
-                      className={cn(
-                        "w-full flex items-center gap-3 rounded-lg border p-3 text-left transition-colors",
-                        isSelected
-                          ? "border-primary bg-primary/5 ring-1 ring-primary/20"
-                          : "hover:bg-muted/50",
-                      )}
-                      onClick={() => setSelectedParent(p)}
-                    >
-                      <Avatar className="h-9 w-9 shrink-0">
-                        <AvatarFallback className="bg-primary/10 text-primary text-xs font-semibold">
-                          {initials}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium truncate">
-                          {p.last_name} {p.first_name}
-                        </p>
-                        <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                          {p.phone && (
-                            <span className="flex items-center gap-1">
-                              <Phone className="h-3 w-3" />
-                              {p.phone}
-                            </span>
-                          )}
-                          {p.email && (
-                            <span className="flex items-center gap-1">
-                              <Mail className="h-3 w-3" />
-                              {p.email}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      {isSelected && (
-                        <Badge variant="secondary" className="shrink-0 text-[10px] bg-primary/10 text-primary">
-                          Sélectionné
-                        </Badge>
-                      )}
-                    </button>
-                  )
-                })}
-              </div>
-            )}
-
-            {selectedParent && (
-              <div className="space-y-3 pt-2 border-t">
-                <div className="space-y-1.5">
-                  <label className="text-sm font-medium">Lien de parenté</label>
-                  <Select value={linkRelationship} onValueChange={setLinkRelationship}>
-                    <SelectTrigger className="h-10">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="father">Père</SelectItem>
-                      <SelectItem value="mother">Mère</SelectItem>
-                      <SelectItem value="guardian">Tuteur</SelectItem>
-                      <SelectItem value="other">Autre</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            )}
-
-            <DialogFooter>
-              <Button type="button" variant="outline" onClick={resetAndClose}>
-                Annuler
-              </Button>
-              <Button
-                type="button"
-                disabled={!selectedParent || linking}
-                onClick={handleLinkExisting}
-              >
-                {linking ? "Liaison..." : "Lier le parent"}
-              </Button>
-            </DialogFooter>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="sm" className="h-9 gap-1">
+          <UserPlus className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">Ajouter</span>
+          <ChevronDown className="h-3 w-3" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuItem onClick={() => onPick("create")}>
+          <UserPlus className="mr-2 h-4 w-4" />
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm">Nouveau parent</span>
+            <span className="text-[10px] text-muted-foreground">
+              Créer un parent qui n&apos;existe pas
+            </span>
           </div>
-        )}
-      </DialogContent>
-    </Dialog>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onPick("link")}>
+          <Link2 className="mr-2 h-4 w-4" />
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm">Lier un existant</span>
+            <span className="text-[10px] text-muted-foreground">
+              Rechercher un parent déjà enregistré
+            </span>
+          </div>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function ParentsError({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-xl bg-muted/30 px-6 py-8 text-center">
+      <p className="text-sm font-medium">Impossible de charger les parents</p>
+      <p className="max-w-xs text-xs text-muted-foreground">
+        Vérifiez la connexion et réessayez. Si le problème persiste, contactez le support.
+      </p>
+      <Button variant="outline" size="sm" onClick={onRetry} className="mt-1 h-9">
+        Réessayer
+      </Button>
+    </div>
   )
 }

--- a/components/admin/students/tabs/ProfileTab.tsx
+++ b/components/admin/students/tabs/ProfileTab.tsx
@@ -1,345 +1,175 @@
 "use client"
 
-import { useState } from "react"
-import { useQueryClient } from "@tanstack/react-query"
-import { toast } from "sonner"
-import { User, CalendarDays, Mail, KeyRound, Shield, UserPlus, MapPin } from "lucide-react"
+import { useMemo } from "react"
+import { Cake, MapPin, UserCircle, IdCard, Mail, Clock, ShieldCheck } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import type { Student } from "@/lib/contracts/student"
-import { studentKeys } from "@/lib/hooks/useStudents"
-import { getSession } from "next-auth/react"
+import { SectionCard, FieldRow, StatusPill } from "./_primitives"
 
 interface ProfileTabProps {
   student: Student
-  fullData: Record<string, unknown>
+  fullData?: Record<string, unknown>
 }
 
-function InfoField({ label, value, icon: Icon }: { label: string; value: string | null | undefined; icon: React.ComponentType<{ className?: string }> }) {
-  return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-1.5">
-        <Icon className="h-3.5 w-3.5 text-muted-foreground" />
-        <p className="text-xs font-medium text-muted-foreground">{label}</p>
-      </div>
-      <p className="text-sm font-medium">{value ?? "Non renseigné"}</p>
-    </div>
-  )
+function computeAge(birthDate: string | null | undefined): number | null {
+  if (!birthDate) return null
+  const b = new Date(birthDate)
+  if (Number.isNaN(b.getTime())) return null
+  const now = new Date()
+  let age = now.getFullYear() - b.getFullYear()
+  const m = now.getMonth() - b.getMonth()
+  if (m < 0 || (m === 0 && now.getDate() < b.getDate())) age--
+  return age
+}
+
+function formatDate(d: string | null | undefined): string | null {
+  if (!d) return null
+  const dt = new Date(d)
+  if (Number.isNaN(dt.getTime())) return null
+  return dt.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })
+}
+
+function deriveAccountStatus(
+  userId: number | null,
+  isActive: boolean | undefined,
+  lastLogin: string | null | undefined,
+): { tone: "success" | "warning" | "danger" | "neutral"; label: string; hint: string } {
+  if (!userId) return { tone: "neutral", label: "Aucun compte", hint: "L'élève n'a pas de compte utilisateur lié" }
+  if (!lastLogin) return { tone: "warning", label: "En attente", hint: "Le compte n'a jamais été utilisé" }
+  if (isActive === false) return { tone: "danger", label: "Désactivé", hint: "Le compte est désactivé" }
+  return { tone: "success", label: "Actif", hint: "Le compte fonctionne normalement" }
 }
 
 export function ProfileTab({ student, fullData }: ProfileTabProps) {
-  const queryClient = useQueryClient()
-  const [emailDialogOpen, setEmailDialogOpen] = useState(false)
-  const [createAccountOpen, setCreateAccountOpen] = useState(false)
-  const [emailValue, setEmailValue] = useState("")
-  const [passwordValue, setPasswordValue] = useState("")
-  const [saving, setSaving] = useState(false)
+  const f = (fullData ?? {}) as Record<string, unknown>
+  const email = (f.email as string | null | undefined) ?? null
+  const isActive = f.is_active as boolean | undefined
+  const lastLogin = (f.last_login as string | null | undefined) ?? null
+  const birthPlace = (f.birth_place as string | null | undefined) ?? null
+  const nationality = (f.nationality as string | null | undefined) ?? null
 
-  const birthDate = student.birth_date
-    ? new Date(student.birth_date).toLocaleDateString("fr-FR", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      })
-    : null
-
-  const userEmail = fullData.user_email ? String(fullData.user_email) : null
-  const isActive = fullData.is_active === true
-  const lastLogin = fullData.last_login ? String(fullData.last_login) : null
-  const userCreatedAt = fullData.user_created_at ? String(fullData.user_created_at) : (student.created_at ?? null)
-  const hasUserAccount = !!student.user_id
-  const needsEmailConfig = hasUserAccount && !userEmail
-
-  const handleSaveAccount = async () => {
-    if (!student.user_id) return
-    if (!emailValue.includes("@")) {
-      toast.error("Veuillez saisir un email valide")
-      return
-    }
-    setSaving(true)
-    try {
-      const session = await getSession()
-      const baseUrl = process.env.NEXT_PUBLIC_API_URL
-      const body: Record<string, string> = { email: emailValue }
-      if (passwordValue.length > 0) body.password = passwordValue
-
-      const res = await fetch(`${baseUrl}/admin/users/${student.user_id}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-        },
-        body: JSON.stringify(body),
-      })
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: "Erreur serveur" }))
-        throw new Error(err.detail || "Erreur lors de la mise à jour")
-      }
-      queryClient.invalidateQueries({ queryKey: studentKeys.all })
-      queryClient.invalidateQueries({ queryKey: studentKeys.detail(student.id) })
-      toast.success("Compte mis à jour")
-      setEmailDialogOpen(false)
-      setEmailValue("")
-      setPasswordValue("")
-    } catch (err) {
-      toast.error("Erreur", { description: err instanceof Error ? err.message : "Erreur inconnue" })
-    } finally {
-      setSaving(false)
-    }
-  }
+  const age = useMemo(() => computeAge(student.birth_date), [student.birth_date])
+  const birthLabel = formatDate(student.birth_date)
+  const lastLoginLabel = formatDate(lastLogin)
+  const account = deriveAccountStatus(student.user_id, isActive, lastLogin)
 
   return (
-    <div className="space-y-4">
-      {/* Informations personnelles — drop Matricule + Genre (déjà dans header)
-          et Email (déduplique avec Compte utilisateur Email de connexion) */}
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-6">
-          <h3 className="text-sm font-medium text-muted-foreground mb-4">Informations personnelles</h3>
-          <div className="grid gap-5 sm:grid-cols-3">
-            <InfoField label="Nom" value={student.last_name} icon={User} />
-            <InfoField label="Prénom" value={student.first_name} icon={User} />
-            <InfoField label="Date de naissance" value={birthDate} icon={CalendarDays} />
-            <InfoField label="Ville" value={student.city} icon={MapPin} />
-            <InfoField label="Commune" value={student.commune} icon={MapPin} />
-          </div>
-        </CardContent>
-      </Card>
+    <div className="grid gap-4 lg:grid-cols-2">
+      <SectionCard
+        icon={<IdCard className="h-4 w-4" />}
+        title="Identité civile"
+        description="Informations de l'état civil"
+      >
+        <div className="space-y-0">
+          <FieldRow label="Matricule" value={student.enrollment_number} mono />
+          <FieldRow
+            label="Genre"
+            value={
+              student.genre ? (
+                <Badge variant="outline" className="text-[10px]">
+                  {student.genre === "M" ? "Masculin" : "Féminin"}
+                </Badge>
+              ) : null
+            }
+          />
+          <FieldRow
+            label="Date de naissance"
+            value={birthLabel ? `${birthLabel}${age !== null ? ` · ${age} ans` : ""}` : null}
+          />
+          <FieldRow label="Lieu de naissance" value={birthPlace} />
+          <FieldRow label="Nationalité" value={nationality} />
+        </div>
+      </SectionCard>
 
-      {/* Compte utilisateur */}
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-6">
-          {hasUserAccount ? (
-            <>
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-sm font-medium text-muted-foreground">Compte utilisateur</h3>
-                {(() => {
-                  // Tri-état persona-first : on priorise « jamais connecté »
-                  // (état neutre amber) sur le « désactivé » alarmant (rouge).
-                  // Un compte fraîchement créé qui n'a jamais servi n'est pas
-                  // « désactivé » sémantiquement — il attend juste sa 1re
-                  // connexion. Édge case : un admin qui désactive avant 1re
-                  // connexion verra « En attente » au lieu de « Désactivé »,
-                  // trade-off accepté (low-impact, friendly default).
-                  if (!lastLogin) {
-                    return (
-                      <Badge className="bg-amber-100 text-amber-700 hover:bg-amber-100/80 dark:bg-amber-900/30 dark:text-amber-400 text-[10px]">
-                        En attente
-                      </Badge>
-                    )
-                  }
-                  if (!isActive) {
-                    return <Badge variant="destructive" className="text-[10px]">Désactivé</Badge>
-                  }
-                  return (
-                    <Badge className="bg-emerald-600 hover:bg-emerald-600/80 text-[10px]">
-                      Actif
-                    </Badge>
-                  )
-                })()}
+      <SectionCard
+        icon={<MapPin className="h-4 w-4" />}
+        title="Domicile"
+        description="Ville et commune de résidence"
+      >
+        <div className="space-y-0">
+          <FieldRow label="Ville" value={student.city} />
+          <FieldRow label="Commune" value={student.commune} />
+        </div>
+        {(student.city || student.commune) && (
+          <div className="mt-4 flex items-center gap-2 rounded-lg bg-primary/5 px-3 py-2 text-xs text-primary">
+            <MapPin className="h-3.5 w-3.5" />
+            <span>{[student.commune, student.city].filter(Boolean).join(", ")}</span>
+          </div>
+        )}
+      </SectionCard>
+
+      <SectionCard
+        icon={<UserCircle className="h-4 w-4" />}
+        title="Compte utilisateur"
+        description="Accès au portail élève"
+        action={
+          <StatusPill tone={account.tone}>
+            <ShieldCheck className="h-3 w-3" />
+            {account.label}
+          </StatusPill>
+        }
+      >
+        <div className="space-y-0">
+          <FieldRow
+            label="Email"
+            value={email ? (
+              <a href={`mailto:${email}`} className="break-all text-primary hover:underline">
+                {email}
+              </a>
+            ) : null}
+          />
+          <FieldRow label="Dernière connexion" value={lastLoginLabel} />
+        </div>
+        <p className="mt-3 text-xs text-muted-foreground">{account.hint}</p>
+      </SectionCard>
+
+      <SectionCard
+        icon={<Cake className="h-4 w-4" />}
+        title="Repères"
+        description="Anniversaires et dates clés"
+      >
+        <div className="space-y-3">
+          {birthLabel && (
+            <div className="flex items-center gap-3 rounded-lg border border-border/60 bg-card p-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[rgba(245,130,32,0.12)] text-[#F58220]">
+                <Cake className="h-4 w-4" />
               </div>
-              <div className="grid gap-5 sm:grid-cols-3">
-                <InfoField
-                  label="Email de connexion"
-                  value={userEmail}
-                  icon={Mail}
-                />
-                <InfoField
-                  label="Dernière connexion"
-                  value={
-                    lastLogin
-                      ? new Date(lastLogin).toLocaleDateString("fr-FR", {
-                          day: "numeric",
-                          month: "long",
-                          year: "numeric",
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })
-                      : "Jamais connecté"
-                  }
-                  icon={Shield}
-                />
-                <InfoField
-                  label="Compte créé"
-                  value={
-                    userCreatedAt
-                      ? new Date(userCreatedAt).toLocaleDateString("fr-FR", {
-                          day: "numeric",
-                          month: "long",
-                          year: "numeric",
-                        })
-                      : null
-                  }
-                  icon={KeyRound}
-                />
+              <div className="min-w-0 flex-1">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Anniversaire</p>
+                <p className="text-sm font-medium">{birthLabel}</p>
+                {age !== null && <p className="text-xs text-muted-foreground">{age} ans</p>}
               </div>
-              <div className="mt-4 flex gap-2">
-                {needsEmailConfig ? (
-                  <Button variant="default" size="sm" onClick={() => setEmailDialogOpen(true)}>
-                    <Mail className="mr-1.5 h-3.5 w-3.5" />
-                    Configurer l&apos;email
-                  </Button>
-                ) : (
-                  <>
-                    <Button variant="outline" size="sm" onClick={() => setEmailDialogOpen(true)}>
-                      <Mail className="mr-1.5 h-3.5 w-3.5" />
-                      Modifier l&apos;email
-                    </Button>
-                    <Button variant="outline" size="sm" disabled>
-                      <KeyRound className="mr-1.5 h-3.5 w-3.5" />
-                      Réinitialiser le mot de passe
-                    </Button>
-                  </>
-                )}
-              </div>
-            </>
-          ) : (
-            <div className="flex flex-col items-center justify-center py-6 text-center">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30 mb-3">
-                <UserPlus className="h-6 w-6 text-amber-600 dark:text-amber-400" />
-              </div>
-              <h3 className="text-sm font-medium mb-1">Aucun compte utilisateur</h3>
-              <p className="text-xs text-muted-foreground mb-4 max-w-sm">
-                Cet élève n&apos;a pas encore de compte pour se connecter au portail étudiant.
-              </p>
-              <Button variant="default" size="sm" onClick={() => {
-                setEmailValue("")
-                setPasswordValue("")
-                setCreateAccountOpen(true)
-              }}>
-                <UserPlus className="mr-1.5 h-3.5 w-3.5" />
-                Créer un compte
-              </Button>
             </div>
           )}
-        </CardContent>
-      </Card>
-
-      {/* Email configuration dialog */}
-      <Dialog open={emailDialogOpen} onOpenChange={setEmailDialogOpen}>
-        <DialogContent className="max-w-md" aria-describedby={undefined}>
-          <DialogHeader>
-            <DialogTitle>
-              {needsEmailConfig ? "Configurer le compte" : "Modifier l'email"}
-            </DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="account-email">Email de connexion</Label>
-              <Input
-                id="account-email"
-                type="email"
-                placeholder="eleve@exemple.ci"
-                value={emailValue}
-                onChange={(e) => setEmailValue(e.target.value)}
-                className="h-11"
-              />
+          {lastLoginLabel && (
+            <div className="flex items-center gap-3 rounded-lg border border-border/60 bg-card p-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Clock className="h-4 w-4" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Dernière connexion</p>
+                <p className="text-sm font-medium">{lastLoginLabel}</p>
+              </div>
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="account-password">
-                Mot de passe {!needsEmailConfig && "(laisser vide pour ne pas changer)"}
-              </Label>
-              <Input
-                id="account-password"
-                type="password"
-                placeholder={needsEmailConfig ? "Minimum 8 caractères" : "Nouveau mot de passe"}
-                value={passwordValue}
-                onChange={(e) => setPasswordValue(e.target.value)}
-                className="h-11"
-              />
+          )}
+          {email && (
+            <div className="flex items-center gap-3 rounded-lg border border-border/60 bg-card p-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <Mail className="h-4 w-4" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Email du compte</p>
+                <p className="break-all text-sm font-medium">{email}</p>
+              </div>
             </div>
-            <Button
-              className="w-full h-11"
-              onClick={handleSaveAccount}
-              disabled={saving || !emailValue}
-            >
-              {saving ? "Enregistrement..." : "Enregistrer"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      {/* Create account dialog — for students without user account */}
-      <Dialog open={createAccountOpen} onOpenChange={setCreateAccountOpen}>
-        <DialogContent className="max-w-md" aria-describedby={undefined}>
-          <DialogHeader>
-            <DialogTitle>Créer un compte utilisateur</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Ce compte permettra à l&apos;élève de se connecter au portail étudiant.
-          </p>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="new-account-email">Email de connexion *</Label>
-              <Input
-                id="new-account-email"
-                type="email"
-                placeholder="eleve@exemple.ci"
-                value={emailValue}
-                onChange={(e) => setEmailValue(e.target.value)}
-                className="h-11"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="new-account-password">Mot de passe *</Label>
-              <Input
-                id="new-account-password"
-                type="password"
-                placeholder="Minimum 8 caractères"
-                value={passwordValue}
-                onChange={(e) => setPasswordValue(e.target.value)}
-                className="h-11"
-              />
-            </div>
-            <Button
-              className="w-full h-11"
-              onClick={async () => {
-                if (!emailValue.includes("@")) {
-                  toast.error("Veuillez saisir un email valide")
-                  return
-                }
-                if (passwordValue.length < 8) {
-                  toast.error("Le mot de passe doit contenir au moins 8 caractères")
-                  return
-                }
-                setSaving(true)
-                try {
-                  const session = await getSession()
-                  const baseUrl = process.env.NEXT_PUBLIC_API_URL
-                  const res = await fetch(`${baseUrl}/admin/students/${student.id}/account`, {
-                    method: "POST",
-                    headers: {
-                      "Content-Type": "application/json",
-                      ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-                    },
-                    body: JSON.stringify({ email: emailValue, password: passwordValue }),
-                  })
-                  if (!res.ok) {
-                    const err = await res.json().catch(() => ({ detail: "Erreur serveur" }))
-                    throw new Error(typeof err.detail === "string" ? err.detail : "Erreur lors de la création")
-                  }
-                  queryClient.invalidateQueries({ queryKey: studentKeys.all })
-                  queryClient.invalidateQueries({ queryKey: studentKeys.detail(student.id) })
-                  toast.success("Compte créé avec succès")
-                  setCreateAccountOpen(false)
-                  setEmailValue("")
-                  setPasswordValue("")
-                } catch (err) {
-                  toast.error("Erreur", { description: err instanceof Error ? err.message : "Erreur inconnue" })
-                } finally {
-                  setSaving(false)
-                }
-              }}
-              disabled={saving || !emailValue || passwordValue.length < 8}
-            >
-              {saving ? "Création en cours..." : "Créer le compte"}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+          )}
+          {!birthLabel && !lastLoginLabel && !email && (
+            <p className="text-sm text-muted-foreground">
+              Aucun repère renseigné pour le moment.
+            </p>
+          )}
+        </div>
+      </SectionCard>
     </div>
   )
 }

--- a/components/admin/students/tabs/StudentPaymentModal.tsx
+++ b/components/admin/students/tabs/StudentPaymentModal.tsx
@@ -1,13 +1,25 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
 import { useQueryClient } from "@tanstack/react-query"
-import { toast } from "sonner"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { CreditCard } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -18,8 +30,19 @@ import {
 } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Textarea } from "@/components/ui/textarea"
 import { useStudentFees } from "@/lib/hooks/useStudents"
-import { useCreatePayment, paymentKeys } from "@/lib/hooks/usePayments"
+import {
+  paymentKeys,
+  useAllocationPreview,
+  useRecordEnrollmentPayment,
+} from "@/lib/hooks/usePayments"
+import {
+  EnrollmentPaymentCreateSchema,
+  type EnrollmentPaymentCreate,
+} from "@/lib/contracts/payment"
+import { useDebounce } from "@/lib/hooks/useDebounce"
+import { AllocationPreviewCard } from "@/components/admin/payments/AllocationPreviewCard"
 
 interface StudentPaymentModalProps {
   studentId: number
@@ -27,156 +50,143 @@ interface StudentPaymentModalProps {
   onClose: () => void
 }
 
-const StudentPaymentFormSchema = z.object({
-  enrollment_fee_id: z.number({ required_error: "Veuillez sélectionner un frais" }).positive(),
-  amount: z.string({ required_error: "Le montant est requis" }).refine(
-    (val) => {
-      const num = Number(val)
-      return !Number.isNaN(num) && num > 0
-    },
-    { message: "Le montant doit être supérieur à 0" },
-  ),
-  method: z.enum(["cash", "mobile_money", "bank_transfer", "check"], {
-    required_error: "Veuillez sélectionner un mode de paiement",
-  }),
-  reference: z.string().nullable().optional(),
-})
-
-type StudentPaymentFormValues = z.infer<typeof StudentPaymentFormSchema>
-
-const METHOD_LABELS: Record<string, string> = {
+const METHOD_LABELS: Record<EnrollmentPaymentCreate["method"], string> = {
   cash: "Espèces",
-  mobile_money: "Mobile Money",
+  mobile_money: "Mobile Money (Wave / Orange / MTN)",
   bank_transfer: "Virement bancaire",
-  check: "Chèque",
+  cheque: "Chèque",
 }
 
-function formatFCFA(amount: number): string {
-  return `${amount.toLocaleString("fr-FR")} FCFA`
+function formatFcfa(value: number): string {
+  return `${Number(value).toLocaleString("fr-FR")} XOF`
 }
 
 export function StudentPaymentModal({ studentId, open, onClose }: StudentPaymentModalProps) {
   const queryClient = useQueryClient()
   const { data: fees, isLoading: feesLoading } = useStudentFees(studentId)
-  const { mutate, isPending } = useCreatePayment()
 
-  const unpaidFees = (fees ?? []).filter((f) => f.remaining > 0)
+  // L'inscription courante = enrollment_id porté par les frais (déjà chargés).
+  // Tous les frais d'une inscription pointent vers le même enrollment_id.
+  const enrollmentId = useMemo(() => {
+    const list = fees ?? []
+    const firstWithRemaining = list.find((f) => f.remaining > 0)
+    return firstWithRemaining?.enrollment_id ?? list[0]?.enrollment_id ?? null
+  }, [fees])
 
-  const form = useForm<StudentPaymentFormValues>({
-    resolver: zodResolver(StudentPaymentFormSchema),
+  const totalRemaining = useMemo(
+    () => (fees ?? []).reduce((acc, f) => acc + (f.remaining ?? 0), 0),
+    [fees],
+  )
+
+  const form = useForm<EnrollmentPaymentCreate>({
+    resolver: zodResolver(EnrollmentPaymentCreateSchema),
     defaultValues: {
+      amount: undefined as unknown as number,
       method: "cash",
       reference: null,
+      notes: null,
     },
   })
 
-  const selectedFeeId = form.watch("enrollment_fee_id")
-  const selectedFee = unpaidFees.find((f) => f.id === selectedFeeId)
+  const watchedAmount = form.watch("amount")
+  const debouncedAmount = useDebounce(watchedAmount, 350)
 
-  // When a fee is selected, set the amount to its remaining balance
+  const preview = useAllocationPreview(
+    enrollmentId,
+    typeof debouncedAmount === "number" && debouncedAmount > 0 ? debouncedAmount : null,
+  )
+
+  const { mutate, isPending } = useRecordEnrollmentPayment(enrollmentId ?? 0)
+
+  // Reset le formulaire quand on rouvre la modal sur un autre élève
   useEffect(() => {
-    if (selectedFee) {
-      form.setValue("amount", String(selectedFee.remaining))
-    }
-  }, [selectedFee, form])
+    if (!open) return
+    form.reset({ amount: undefined as unknown as number, method: "cash", reference: null, notes: null })
+  }, [open, studentId, form])
 
-  function onSubmit(data: StudentPaymentFormValues) {
-    if (selectedFee && Number(data.amount) > selectedFee.remaining) {
-      form.setError("amount", {
-        message: `Le montant ne peut pas dépasser ${formatFCFA(selectedFee.remaining)}`,
-      })
+  function onSubmit(data: EnrollmentPaymentCreate) {
+    if (!enrollmentId) return
+    if (preview.data && !preview.data.can_record) {
+      form.setError("amount", { message: preview.data.reject_reason ?? "Montant invalide" })
       return
     }
-
-    mutate(
-      {
-        enrollment_fee_id: data.enrollment_fee_id,
-        amount: data.amount,
-        method: data.method,
-        reference: data.reference ?? null,
+    mutate(data, {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: paymentKeys.all })
+        queryClient.invalidateQueries({ queryKey: ["students", studentId] })
+        queryClient.invalidateQueries({ queryKey: ["students", studentId, "fees"] })
+        queryClient.invalidateQueries({ queryKey: ["enrollments"] })
+        onClose()
       },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: paymentKeys.all })
-          queryClient.invalidateQueries({ queryKey: ["students", studentId] })
-          queryClient.invalidateQueries({ queryKey: ["students", studentId, "fees"] })
-          queryClient.invalidateQueries({ queryKey: ["enrollments"] })
-          form.reset({ method: "cash", reference: null })
-          onClose()
-        },
-      },
-    )
+    })
   }
+
+  const noFees = !feesLoading && (!fees || fees.length === 0)
+  const allPaid = !feesLoading && totalRemaining <= 0
+  const canSubmit =
+    !!enrollmentId &&
+    !noFees &&
+    !allPaid &&
+    (preview.data?.can_record ?? false) &&
+    !isPending
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>Enregistrer un paiement</DialogTitle>
+          <DialogTitle className="flex items-center gap-2 font-serif">
+            <CreditCard className="h-5 w-5 text-primary" />
+            Nouveau versement
+          </DialogTitle>
+          <DialogDescription>
+            Saisissez le montant : le système alloue automatiquement aux frais impayés par
+            priorité (Inscription → Trimestres → COGES → Tenue).
+          </DialogDescription>
         </DialogHeader>
 
         {feesLoading ? (
-          <div className="space-y-4">
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
+          <div className="space-y-3" aria-busy="true">
+            <Skeleton className="h-11 w-full" />
+            <Skeleton className="h-11 w-full" />
+            <Skeleton className="h-24 w-full" />
           </div>
-        ) : unpaidFees.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-4 text-center">
-            Aucun frais en attente de paiement pour cet élève.
+        ) : noFees ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            Aucun frais configuré pour cette inscription. Configurez d&apos;abord les frais
+            scolaires avant d&apos;enregistrer un versement.
+          </p>
+        ) : allPaid ? (
+          <p className="py-6 text-center text-sm text-emerald-700">
+            Tous les frais sont soldés pour cette inscription.
           </p>
         ) : (
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <FormField
                 control={form.control}
-                name="enrollment_fee_id"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Frais *</FormLabel>
-                    <Select
-                      value={field.value ? String(field.value) : ""}
-                      onValueChange={(val) => field.onChange(Number(val))}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Sélectionner un frais" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {unpaidFees.map((fee) => (
-                          <SelectItem key={fee.id} value={String(fee.id)}>
-                            {fee.category_name} — {formatFCFA(fee.remaining)} restant
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
                 name="amount"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Montant (FCFA) *</FormLabel>
+                    <FormLabel>Montant versé (XOF) *</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
-                        placeholder="Ex : 25000"
+                        inputMode="numeric"
+                        placeholder="Ex : 50 000"
                         min={1}
-                        max={selectedFee?.remaining}
+                        max={totalRemaining}
+                        className="h-11 text-lg font-semibold tabular-nums"
+                        autoFocus
                         {...field}
                         value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                        }
                       />
                     </FormControl>
-                    {selectedFee && (
-                      <p className="text-xs text-muted-foreground">
-                        Maximum : {formatFCFA(selectedFee.remaining)}
-                      </p>
-                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Reste à payer : <strong>{formatFcfa(totalRemaining)}</strong>
+                    </p>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -190,7 +200,7 @@ export function StudentPaymentModal({ studentId, open, onClose }: StudentPayment
                     <FormLabel>Mode de paiement *</FormLabel>
                     <Select value={field.value} onValueChange={field.onChange}>
                       <FormControl>
-                        <SelectTrigger>
+                        <SelectTrigger className="h-11">
                           <SelectValue />
                         </SelectTrigger>
                       </FormControl>
@@ -215,19 +225,56 @@ export function StudentPaymentModal({ studentId, open, onClose }: StudentPayment
                     <FormLabel>Référence</FormLabel>
                     <FormControl>
                       <Input
-                        placeholder="Numéro de transaction (optionnel)"
+                        placeholder="Numéro de reçu, transaction (optionnel)"
+                        className="h-11"
                         {...field}
                         value={field.value ?? ""}
                       />
                     </FormControl>
-                    <FormMessage />
                   </FormItem>
                 )}
               />
 
-              <Button type="submit" disabled={isPending} className="w-full">
-                {isPending ? "Enregistrement..." : "Enregistrer le paiement"}
-              </Button>
+              <FormField
+                control={form.control}
+                name="notes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Notes</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        rows={2}
+                        placeholder="Note interne (optionnel)"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              {/* Live preview : montre comment le montant sera alloué */}
+              {watchedAmount && watchedAmount > 0 ? (
+                <AllocationPreviewCard
+                  preview={preview.data}
+                  isLoading={preview.isFetching && !preview.data}
+                  error={preview.error as Error | null}
+                />
+              ) : null}
+
+              <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-11 sm:h-10"
+                  onClick={onClose}
+                >
+                  Annuler
+                </Button>
+                <Button type="submit" disabled={!canSubmit} className="h-11 sm:h-10">
+                  {isPending ? "Enregistrement…" : "Enregistrer le versement"}
+                </Button>
+              </div>
             </form>
           </Form>
         )}

--- a/components/admin/students/tabs/_primitives.tsx
+++ b/components/admin/students/tabs/_primitives.tsx
@@ -1,0 +1,190 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+import { Card, CardContent } from "@/components/ui/card"
+
+// =============================================================================
+// Status pill — uniforme dans tous les tabs (suit le pattern Timeline)
+// =============================================================================
+
+type PillTone = "primary" | "success" | "warning" | "danger" | "neutral" | "accent"
+
+const PILL_STYLES: Record<PillTone, string> = {
+  primary: "bg-primary/10 text-primary",
+  success: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200",
+  warning: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+  danger: "bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200",
+  neutral: "bg-muted text-muted-foreground",
+  accent: "text-[#F58220]",
+}
+
+export function StatusPill({
+  tone = "neutral",
+  className,
+  children,
+}: {
+  tone?: PillTone
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        PILL_STYLES[tone],
+        tone === "accent" && "bg-[rgba(245,130,32,0.12)]",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+// =============================================================================
+// Section card — pattern uniforme avec icône, titre serif, action droite
+// =============================================================================
+
+interface SectionCardProps {
+  icon: ReactNode
+  title: string
+  description?: string
+  action?: ReactNode
+  className?: string
+  bodyClassName?: string
+  children: ReactNode
+}
+
+export function SectionCard({
+  icon,
+  title,
+  description,
+  action,
+  className,
+  bodyClassName,
+  children,
+}: SectionCardProps) {
+  return (
+    <Card className={cn("overflow-hidden border-0 shadow-sm ring-1 ring-border", className)}>
+      <CardContent className={cn("p-4 sm:p-5", bodyClassName)}>
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              {icon}
+            </div>
+            <div>
+              <h3 className="font-serif text-base leading-none tracking-tight">{title}</h3>
+              {description && (
+                <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+              )}
+            </div>
+          </div>
+          {action && <div className="shrink-0">{action}</div>}
+        </div>
+        {children}
+      </CardContent>
+    </Card>
+  )
+}
+
+// =============================================================================
+// Empty state — uniforme partout (suit la rule empty-state-by-role.md)
+// =============================================================================
+
+interface EmptyStateProps {
+  icon: ReactNode
+  title: string
+  message?: string
+  cta?: ReactNode
+  className?: string
+}
+
+export function EmptyState({ icon, title, message, cta, className }: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 rounded-xl bg-muted/20 px-6 py-10 text-center",
+        className,
+      )}
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-background text-muted-foreground ring-1 ring-border">
+        {icon}
+      </div>
+      <div>
+        <p className="text-sm font-medium">{title}</p>
+        {message && <p className="mt-1 max-w-xs text-xs text-muted-foreground">{message}</p>}
+      </div>
+      {cta}
+    </div>
+  )
+}
+
+// =============================================================================
+// Field row — libellé / valeur pour les fiches d'identité
+// =============================================================================
+
+export function FieldRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: ReactNode
+  mono?: boolean
+}) {
+  const isEmpty = value === null || value === undefined || value === ""
+  return (
+    <div className="flex items-start justify-between gap-3 border-b border-border/40 py-2.5 last:border-0">
+      <span className="text-xs uppercase tracking-wide text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "max-w-[60%] text-right text-sm font-medium",
+          isEmpty && "text-muted-foreground/50",
+          mono && "font-mono text-xs",
+        )}
+      >
+        {isEmpty ? "—" : value}
+      </span>
+    </div>
+  )
+}
+
+// =============================================================================
+// Initiales avatar — pour parents/contacts sans photo
+// =============================================================================
+
+export function InitialsAvatar({
+  first,
+  last,
+  size = "md",
+  tone = "primary",
+}: {
+  first?: string | null
+  last?: string | null
+  size?: "sm" | "md" | "lg"
+  tone?: "primary" | "accent" | "neutral"
+}) {
+  const initials = `${first?.[0] ?? ""}${last?.[0] ?? ""}`.toUpperCase() || "?"
+  const sizeClasses = {
+    sm: "h-8 w-8 text-[11px]",
+    md: "h-10 w-10 text-sm",
+    lg: "h-14 w-14 text-base",
+  }
+  const toneClasses = {
+    primary: "bg-primary/10 text-primary",
+    accent: "bg-[rgba(245,130,32,0.12)] text-[#F58220]",
+    neutral: "bg-muted text-muted-foreground",
+  }
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-xl font-semibold ring-2 ring-background",
+        sizeClasses[size],
+        toneClasses[tone],
+      )}
+    >
+      {initials}
+    </div>
+  )
+}

--- a/components/admin/teachers/availability/AvailabilityGrid.tsx
+++ b/components/admin/teachers/availability/AvailabilityGrid.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { Card, CardContent } from "@/components/ui/card"
+import type { DayOfWeek } from "@/lib/contracts/timetable"
+import {
+  CellState,
+  DAYS,
+  HOURS,
+  STATE_LABELS,
+  STATE_STYLES,
+  cellKey,
+} from "./availability-helpers"
+
+interface AvailabilityGridProps {
+  getDisplayState: (day: DayOfWeek, start: string, end: string) => CellState
+  isPendingCell: (day: DayOfWeek, start: string, end: string) => boolean
+  interactive: boolean
+  onToggle: (day: DayOfWeek, start: string, end: string) => void
+}
+
+export function AvailabilityGrid({
+  getDisplayState,
+  isPendingCell,
+  interactive,
+  onToggle,
+}: AvailabilityGridProps) {
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border overflow-hidden">
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-xs">
+            <thead>
+              <tr>
+                <th className="sticky left-0 z-10 bg-muted/50 p-2 text-left font-medium text-muted-foreground min-w-[60px]">
+                  Heure
+                </th>
+                {DAYS.map((d) => (
+                  <th
+                    key={d.key}
+                    className="p-2 text-center font-medium text-muted-foreground min-w-[80px]"
+                  >
+                    {d.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {HOURS.map((hour) => (
+                <tr key={hour.start} className="border-t border-border/50">
+                  <td className="sticky left-0 z-10 bg-muted/50 p-2 font-medium text-muted-foreground tabular-nums">
+                    {hour.label}
+                  </td>
+                  {DAYS.map((day) => {
+                    const state = getDisplayState(day.key, hour.start, hour.end)
+                    const isPending = isPendingCell(day.key, hour.start, hour.end)
+                    return (
+                      <td
+                        key={cellKey(day.key, hour.start, hour.end)}
+                        className="p-1"
+                      >
+                        <button
+                          type="button"
+                          disabled={!interactive}
+                          onClick={() => onToggle(day.key, hour.start, hour.end)}
+                          className={`
+                            w-full h-9 rounded-md text-[10px] font-medium transition-colors
+                            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                            ${interactive ? "hover:opacity-80 cursor-pointer" : "cursor-default"}
+                            ${STATE_STYLES[state]}
+                            ${isPending ? "ring-2 ring-dashed ring-amber-500/70" : ""}
+                          `}
+                          aria-label={`${day.label} ${hour.start}-${hour.end}: ${state}${
+                            isPending ? " (modification en attente)" : ""
+                          }`}
+                        >
+                          {STATE_LABELS[state]}
+                        </button>
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/teachers/availability/AvailabilityToolbar.tsx
+++ b/components/admin/teachers/availability/AvailabilityToolbar.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { Clock, Eye, Loader2, Pencil, Save, X } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+interface AvailabilityToolbarProps {
+  editMode: boolean
+  saving: boolean
+  totalAvailable: number
+  totalPreferred: number
+  maxSlots: number
+  pendingCount: number
+  onEnterEdit: () => void
+  onCancel: () => void
+  onSave: () => void
+}
+
+export function AvailabilityToolbar({
+  editMode,
+  saving,
+  totalAvailable,
+  totalPreferred,
+  maxSlots,
+  pendingCount,
+  onEnterEdit,
+  onCancel,
+  onSave,
+}: AvailabilityToolbarProps) {
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardContent className="p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">Disponibilités</span>
+            {!editMode ? (
+              <Badge
+                variant="outline"
+                className="ml-2 gap-1 border-muted-foreground/30 text-[10px] uppercase tracking-wide text-muted-foreground"
+              >
+                <Eye className="h-3 w-3" />
+                Lecture
+              </Badge>
+            ) : (
+              <Badge
+                variant="outline"
+                className="ml-2 gap-1 border-primary/40 bg-primary/5 text-[10px] uppercase tracking-wide text-primary"
+              >
+                <Pencil className="h-3 w-3" />
+                Édition
+              </Badge>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary" className="text-xs">
+              {totalAvailable}/{maxSlots} disponibles
+            </Badge>
+            {totalPreferred > 0 && (
+              <Badge variant="outline" className="text-xs text-primary">
+                {totalPreferred} préférés
+              </Badge>
+            )}
+            {pendingCount > 0 && (
+              <Badge
+                variant="outline"
+                className="text-xs border-amber-400 text-amber-700 bg-amber-50"
+              >
+                {pendingCount} en attente
+              </Badge>
+            )}
+            {!editMode ? (
+              <Button size="sm" variant="outline" className="h-9" onClick={onEnterEdit}>
+                <Pencil className="mr-1.5 h-3.5 w-3.5" />
+                Modifier
+              </Button>
+            ) : (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-9"
+                  onClick={onCancel}
+                  disabled={saving}
+                >
+                  <X className="mr-1.5 h-3.5 w-3.5" />
+                  Annuler
+                </Button>
+                <Button size="sm" className="h-9" onClick={onSave} disabled={saving}>
+                  {saving ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Save className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  Enregistrer
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {editMode
+            ? "Cliquez pour basculer : indisponible → disponible → préféré → indisponible. Les modifications sont mises en attente jusqu'à « Enregistrer »."
+            : "Mode lecture. Cliquez sur « Modifier » pour saisir les disponibilités."}
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+
+export function AvailabilityLegend({ pendingCount }: { pendingCount: number }) {
+  return (
+    <div className="flex flex-wrap items-center gap-5 text-xs text-muted-foreground">
+      <div className="flex items-center gap-1.5">
+        <div className="h-3 w-5 rounded-sm bg-emerald-500/20 ring-1 ring-emerald-500/30" />
+        <span>Disponible</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="h-3 w-5 rounded-sm bg-primary/15 ring-1 ring-primary/30" />
+        <span>Créneaux préférés</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <div className="h-3 w-5 rounded-sm bg-rose-500/15 ring-1 ring-rose-300/40" />
+        <span>Indisponible</span>
+      </div>
+      {pendingCount > 0 && (
+        <div className="flex items-center gap-1.5">
+          <div className="h-3 w-5 rounded-sm ring-2 ring-dashed ring-amber-500/70" />
+          <span>Modification en attente</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/admin/teachers/availability/availability-helpers.ts
+++ b/components/admin/teachers/availability/availability-helpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Helpers et constantes pour l'onglet Disponibilités enseignant.
+ *
+ * Extrait de TeacherAvailabilityTab.tsx pour respecter la rule
+ * `.claude/rules/detail-tab-split-pattern.md` (450 LOC -> split).
+ */
+
+import type { DayOfWeek, TeacherAvailability } from "@/lib/contracts/timetable"
+
+export const DAYS: { key: DayOfWeek; label: string }[] = [
+  { key: "monday", label: "Lundi" },
+  { key: "tuesday", label: "Mardi" },
+  { key: "wednesday", label: "Mercredi" },
+  { key: "thursday", label: "Jeudi" },
+  { key: "friday", label: "Vendredi" },
+  { key: "saturday", label: "Samedi" },
+]
+
+// 07:00 a 18:00 (11 creneaux)
+export const HOURS = Array.from({ length: 11 }, (_, i) => {
+  const h = 7 + i
+  return {
+    start: `${String(h).padStart(2, "0")}:00`,
+    end: `${String(h + 1).padStart(2, "0")}:00`,
+    label: `${String(h).padStart(2, "0")}h`,
+  }
+})
+
+export type CellState = "unavailable" | "available" | "preferred"
+
+// L'utilisateur clique pour cycler : unavailable -> available -> preferred ->
+// unavailable (delete). En mode edition seulement.
+export const NEXT_STATE: Record<CellState, CellState> = {
+  unavailable: "available",
+  available: "preferred",
+  preferred: "unavailable",
+}
+
+export const STATE_STYLES: Record<CellState, string> = {
+  unavailable: "bg-rose-500/15 text-rose-600 ring-1 ring-rose-300/40",
+  available: "bg-emerald-500/20 text-emerald-700 ring-1 ring-emerald-500/30",
+  preferred: "bg-primary/15 text-primary ring-1 ring-primary/30",
+}
+
+export const STATE_LABELS: Record<CellState, string> = {
+  unavailable: "",
+  available: "Dispo",
+  preferred: "Préféré",
+}
+
+export interface SavedCell {
+  id: number
+  state: CellState
+}
+
+export type PendingChange =
+  | { kind: "create"; target: Exclude<CellState, "unavailable"> }
+  | { kind: "update"; existingId: number; target: Exclude<CellState, "unavailable"> }
+  | { kind: "delete"; existingId: number; target: "unavailable" }
+
+export function cellKey(day: DayOfWeek, start: string, end: string) {
+  return `${day}|${start}|${end}`
+}
+
+export function buildSavedMap(
+  availabilities: TeacherAvailability[],
+): Map<string, SavedCell> {
+  const m = new Map<string, SavedCell>()
+  for (const av of availabilities) {
+    const state: CellState = av.preferred
+      ? "preferred"
+      : av.available
+        ? "available"
+        : "unavailable"
+    m.set(cellKey(av.day, av.start_time, av.end_time), { id: av.id, state })
+  }
+  return m
+}

--- a/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
+++ b/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
@@ -1,125 +1,43 @@
 "use client"
 
 import { useCallback, useMemo, useState } from "react"
-import { Clock, Eye, Loader2, Pencil, Save, X } from "lucide-react"
 import { toast } from "sonner"
 import { useQueryClient } from "@tanstack/react-query"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { timetableApi } from "@/lib/api/timetable"
+import { timetableKeys, useTeacherAvailabilities } from "@/lib/hooks/useTimetable"
+import type { DayOfWeek } from "@/lib/contracts/timetable"
 import {
-  timetableKeys,
-  useTeacherAvailabilities,
-} from "@/lib/hooks/useTimetable"
-import type { DayOfWeek, TeacherAvailability } from "@/lib/contracts/timetable"
+  AvailabilityGrid,
+} from "@/components/admin/teachers/availability/AvailabilityGrid"
+import {
+  AvailabilityLegend,
+  AvailabilityToolbar,
+} from "@/components/admin/teachers/availability/AvailabilityToolbar"
+import {
+  CellState,
+  DAYS,
+  HOURS,
+  NEXT_STATE,
+  PendingChange,
+  buildSavedMap,
+  cellKey,
+} from "@/components/admin/teachers/availability/availability-helpers"
 
 interface TeacherAvailabilityTabProps {
   teacherId: number
 }
 
-const DAYS: { key: DayOfWeek; label: string }[] = [
-  { key: "monday", label: "Lundi" },
-  { key: "tuesday", label: "Mardi" },
-  { key: "wednesday", label: "Mercredi" },
-  { key: "thursday", label: "Jeudi" },
-  { key: "friday", label: "Vendredi" },
-  { key: "saturday", label: "Samedi" },
-]
-
-// 07:00 to 18:00 (11 slots)
-const HOURS = Array.from({ length: 11 }, (_, i) => {
-  const h = 7 + i
-  return {
-    start: `${String(h).padStart(2, "0")}:00`,
-    end: `${String(h + 1).padStart(2, "0")}:00`,
-    label: `${String(h).padStart(2, "0")}h`,
-  }
-})
-
-type CellState = "unavailable" | "available" | "preferred"
-
-// L'utilisateur clique pour cycler : unavailable → available → preferred →
-// unavailable (delete). En mode édition seulement.
-const NEXT_STATE: Record<CellState, CellState> = {
-  unavailable: "available",
-  available: "preferred",
-  preferred: "unavailable",
-}
-
-const STATE_STYLES: Record<CellState, string> = {
-  unavailable:
-    "bg-rose-500/15 text-rose-600 ring-1 ring-rose-300/40",
-  available:
-    "bg-emerald-500/20 text-emerald-700 ring-1 ring-emerald-500/30",
-  preferred:
-    "bg-primary/15 text-primary ring-1 ring-primary/30",
-}
-
-const STATE_LABELS: Record<CellState, string> = {
-  unavailable: "",
-  available: "Dispo",
-  preferred: "Préféré",
-}
-
-interface SavedCell {
-  id: number
-  state: CellState
-}
-
-type PendingChange =
-  | {
-      kind: "create"
-      target: Exclude<CellState, "unavailable">
-    }
-  | {
-      kind: "update"
-      existingId: number
-      target: Exclude<CellState, "unavailable">
-    }
-  | {
-      kind: "delete"
-      existingId: number
-      target: "unavailable"
-    }
-
-function cellKey(day: DayOfWeek, start: string, end: string) {
-  return `${day}|${start}|${end}`
-}
-
-function buildSavedMap(
-  availabilities: TeacherAvailability[],
-): Map<string, SavedCell> {
-  const m = new Map<string, SavedCell>()
-  for (const av of availabilities) {
-    const state: CellState = av.preferred
-      ? "preferred"
-      : av.available
-        ? "available"
-        : "unavailable"
-    m.set(cellKey(av.day, av.start_time, av.end_time), { id: av.id, state })
-  }
-  return m
-}
-
-export function TeacherAvailabilityTab({
-  teacherId,
-}: TeacherAvailabilityTabProps) {
+export function TeacherAvailabilityTab({ teacherId }: TeacherAvailabilityTabProps) {
   const queryClient = useQueryClient()
-  const { data: availabilities, isLoading } =
-    useTeacherAvailabilities(teacherId)
+  const { data: availabilities, isLoading } = useTeacherAvailabilities(teacherId)
 
   const [editMode, setEditMode] = useState(false)
   const [pending, setPending] = useState<Map<string, PendingChange>>(new Map())
   const [saving, setSaving] = useState(false)
 
-  const savedMap = useMemo(
-    () => buildSavedMap(availabilities ?? []),
-    [availabilities],
-  )
+  const savedMap = useMemo(() => buildSavedMap(availabilities ?? []), [availabilities])
 
-  // L'état affiché d'une cellule = pending si présent, sinon saved.
   const getDisplayState = useCallback(
     (day: DayOfWeek, start: string, end: string): CellState => {
       const key = cellKey(day, start, end)
@@ -132,7 +50,8 @@ export function TeacherAvailabilityTab({
   )
 
   const isPendingCell = useCallback(
-    (day: DayOfWeek, start: string, end: string) => pending.has(cellKey(day, start, end)),
+    (day: DayOfWeek, start: string, end: string) =>
+      pending.has(cellKey(day, start, end)),
     [pending],
   )
 
@@ -142,25 +61,24 @@ export function TeacherAvailabilityTab({
       const key = cellKey(day, start, end)
       const current = getDisplayState(day, start, end)
       const next = NEXT_STATE[current]
-
       const saved = savedMap.get(key)
+
       setPending((prev) => {
         const m = new Map(prev)
-        // Si le next = saved → on retire le pending (changement annulé)
         if (saved && next === saved.state) {
           m.delete(key)
           return m
         }
-        // Si pas de saved ET next = unavailable → no-op (rien à créer)
         if (!saved && next === "unavailable") {
           m.delete(key)
           return m
         }
-        // Construction d'un PendingChange explicitement typé selon le kind
         let change: PendingChange
         if (!saved) {
-          // next ∈ {available, preferred} ici car saved est null et next ≠ unavailable
-          change = { kind: "create", target: next as Exclude<CellState, "unavailable"> }
+          change = {
+            kind: "create",
+            target: next as Exclude<CellState, "unavailable">,
+          }
         } else if (next === "unavailable") {
           change = { kind: "delete", existingId: saved.id, target: "unavailable" }
         } else {
@@ -188,7 +106,6 @@ export function TeacherAvailabilityTab({
     const operations: Promise<unknown>[] = []
     for (const [key, change] of pending) {
       const [day, start, end] = key.split("|") as [DayOfWeek, string, string]
-
       if (change.kind === "create") {
         operations.push(
           timetableApi.createAvailability(teacherId, {
@@ -215,7 +132,6 @@ export function TeacherAvailabilityTab({
     const fulfilled = results.filter((r) => r.status === "fulfilled").length
     const rejected = results.length - fulfilled
 
-    // Toast cumulé (partial-success-with-reporting, cf. pattern bulk admin)
     if (rejected === 0) {
       toast.success(
         `${fulfilled} disponibilité${fulfilled > 1 ? "s" : ""} enregistrée${
@@ -232,15 +148,11 @@ export function TeacherAvailabilityTab({
           rejected > 1 ? "s" : ""
         }`,
       )
-      // Garde le mode édit avec les pending échoués — l'utilisateur peut retry
-      // ou annuler. Pour simplicité, on clear quand même (la re-fetch montrera l'état réel).
     }
 
-    // Invalidation ciblée (pas reload de la page), refetch /availabilities seul
     await queryClient.invalidateQueries({
       queryKey: timetableKeys.availabilities(teacherId),
     })
-    // Invalide aussi /full pour rafraîchir l'Overview KPI Disponibilité
     await queryClient.invalidateQueries({
       queryKey: ["teachers", teacherId, "full"],
     })
@@ -249,7 +161,12 @@ export function TeacherAvailabilityTab({
   }, [pending, teacherId, queryClient])
 
   if (isLoading) {
-    return <AvailabilitySkeleton />
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-16 rounded-lg" />
+        <Skeleton className="h-[450px] rounded-lg" />
+      </div>
+    )
   }
 
   const totalAvailable = Array.from(savedMap.values()).filter(
@@ -259,192 +176,29 @@ export function TeacherAvailabilityTab({
     (v) => v.state === "preferred",
   ).length
   const maxSlots = DAYS.length * HOURS.length
-  const pendingCount = pending.size
 
   return (
     <div className="space-y-4">
-      {/* Summary + controls (mode read vs edit) */}
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <Clock className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm font-medium">Disponibilités</span>
-              {!editMode ? (
-                <Badge
-                  variant="outline"
-                  className="ml-2 gap-1 border-muted-foreground/30 text-[10px] uppercase tracking-wide text-muted-foreground"
-                >
-                  <Eye className="h-3 w-3" />
-                  Lecture
-                </Badge>
-              ) : (
-                <Badge
-                  variant="outline"
-                  className="ml-2 gap-1 border-primary/40 bg-primary/5 text-[10px] uppercase tracking-wide text-primary"
-                >
-                  <Pencil className="h-3 w-3" />
-                  Édition
-                </Badge>
-              )}
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <Badge variant="secondary" className="text-xs">
-                {totalAvailable}/{maxSlots} disponibles
-              </Badge>
-              {totalPreferred > 0 && (
-                <Badge variant="outline" className="text-xs text-primary">
-                  {totalPreferred} préférés
-                </Badge>
-              )}
-              {pendingCount > 0 && (
-                <Badge
-                  variant="outline"
-                  className="text-xs border-amber-400 text-amber-700 bg-amber-50"
-                >
-                  {pendingCount} en attente
-                </Badge>
-              )}
-              {!editMode ? (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-9"
-                  onClick={() => setEditMode(true)}
-                >
-                  <Pencil className="mr-1.5 h-3.5 w-3.5" />
-                  Modifier
-                </Button>
-              ) : (
-                <>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-9"
-                    onClick={handleCancel}
-                    disabled={saving}
-                  >
-                    <X className="mr-1.5 h-3.5 w-3.5" />
-                    Annuler
-                  </Button>
-                  <Button
-                    size="sm"
-                    className="h-9"
-                    onClick={handleSave}
-                    disabled={saving}
-                  >
-                    {saving ? (
-                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Save className="mr-1.5 h-3.5 w-3.5" />
-                    )}
-                    Enregistrer
-                  </Button>
-                </>
-              )}
-            </div>
-          </div>
-          <p className="mt-2 text-xs text-muted-foreground">
-            {editMode
-              ? "Cliquez pour basculer : indisponible → disponible → préféré → indisponible. Les modifications sont mises en attente jusqu'à « Enregistrer »."
-              : "Mode lecture. Cliquez sur « Modifier » pour saisir les disponibilités."}
-          </p>
-        </CardContent>
-      </Card>
+      <AvailabilityToolbar
+        editMode={editMode}
+        saving={saving}
+        totalAvailable={totalAvailable}
+        totalPreferred={totalPreferred}
+        maxSlots={maxSlots}
+        pendingCount={pending.size}
+        onEnterEdit={() => setEditMode(true)}
+        onCancel={handleCancel}
+        onSave={handleSave}
+      />
 
-      {/* Grid */}
-      <Card className="border-0 shadow-sm ring-1 ring-border overflow-hidden">
-        <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <table className="w-full border-collapse text-xs">
-              <thead>
-                <tr>
-                  <th className="sticky left-0 z-10 bg-muted/50 p-2 text-left font-medium text-muted-foreground min-w-[60px]">
-                    Heure
-                  </th>
-                  {DAYS.map((d) => (
-                    <th
-                      key={d.key}
-                      className="p-2 text-center font-medium text-muted-foreground min-w-[80px]"
-                    >
-                      {d.label}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {HOURS.map((hour) => (
-                  <tr key={hour.start} className="border-t border-border/50">
-                    <td className="sticky left-0 z-10 bg-muted/50 p-2 font-medium text-muted-foreground tabular-nums">
-                      {hour.label}
-                    </td>
-                    {DAYS.map((day) => {
-                      const state = getDisplayState(day.key, hour.start, hour.end)
-                      const isPending = isPendingCell(day.key, hour.start, hour.end)
-                      const interactive = editMode && !saving
-                      return (
-                        <td
-                          key={cellKey(day.key, hour.start, hour.end)}
-                          className="p-1"
-                        >
-                          <button
-                            type="button"
-                            disabled={!interactive}
-                            onClick={() =>
-                              handleToggle(day.key, hour.start, hour.end)
-                            }
-                            className={`
-                              w-full h-9 rounded-md text-[10px] font-medium transition-colors
-                              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
-                              ${interactive ? "hover:opacity-80 cursor-pointer" : "cursor-default"}
-                              ${STATE_STYLES[state]}
-                              ${isPending ? "ring-2 ring-dashed ring-amber-500/70" : ""}
-                            `}
-                            aria-label={`${day.label} ${hour.start}-${hour.end}: ${state}${isPending ? " (modification en attente)" : ""}`}
-                          >
-                            {STATE_LABELS[state]}
-                          </button>
-                        </td>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
+      <AvailabilityGrid
+        getDisplayState={getDisplayState}
+        isPendingCell={isPendingCell}
+        interactive={editMode && !saving}
+        onToggle={handleToggle}
+      />
 
-      {/* Legend */}
-      <div className="flex flex-wrap items-center gap-5 text-xs text-muted-foreground">
-        <div className="flex items-center gap-1.5">
-          <div className="h-3 w-5 rounded-sm bg-emerald-500/20 ring-1 ring-emerald-500/30" />
-          <span>Disponible</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="h-3 w-5 rounded-sm bg-primary/15 ring-1 ring-primary/30" />
-          <span>Créneaux préférés</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="h-3 w-5 rounded-sm bg-rose-500/15 ring-1 ring-rose-300/40" />
-          <span>Indisponible</span>
-        </div>
-        {pendingCount > 0 && (
-          <div className="flex items-center gap-1.5">
-            <div className="h-3 w-5 rounded-sm ring-2 ring-dashed ring-amber-500/70" />
-            <span>Modification en attente</span>
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function AvailabilitySkeleton() {
-  return (
-    <div className="space-y-4">
-      <Skeleton className="h-16 rounded-lg" />
-      <Skeleton className="h-[450px] rounded-lg" />
+      <AvailabilityLegend pendingCount={pending.size} />
     </div>
   )
 }

--- a/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
+++ b/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
@@ -1,15 +1,17 @@
 "use client"
 
-import { useCallback, useMemo } from "react"
-import { Clock, Loader2 } from "lucide-react"
+import { useCallback, useMemo, useState } from "react"
+import { Clock, Eye, Loader2, Pencil, Save, X } from "lucide-react"
+import { toast } from "sonner"
+import { useQueryClient } from "@tanstack/react-query"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Badge } from "@/components/ui/badge"
+import { timetableApi } from "@/lib/api/timetable"
 import {
+  timetableKeys,
   useTeacherAvailabilities,
-  useCreateAvailability,
-  useUpdateAvailability,
-  useDeleteAvailability,
 } from "@/lib/hooks/useTimetable"
 import type { DayOfWeek, TeacherAvailability } from "@/lib/contracts/timetable"
 
@@ -36,34 +38,23 @@ const HOURS = Array.from({ length: 11 }, (_, i) => {
   }
 })
 
-// 3 states: unavailable (default), available, preferred
 type CellState = "unavailable" | "available" | "preferred"
 
-function buildAvailabilityMap(
-  availabilities: TeacherAvailability[],
-): Map<string, { id: number; available: boolean; preferred: boolean }> {
-  const map = new Map<string, { id: number; available: boolean; preferred: boolean }>()
-  for (const av of availabilities) {
-    map.set(`${av.day}|${av.start_time}|${av.end_time}`, {
-      id: av.id,
-      available: av.available,
-      preferred: av.preferred ?? false,
-    })
-  }
-  return map
-}
-
-function cellKey(day: DayOfWeek, start: string, end: string) {
-  return `${day}|${start}|${end}`
+// L'utilisateur clique pour cycler : unavailable → available → preferred →
+// unavailable (delete). En mode édition seulement.
+const NEXT_STATE: Record<CellState, CellState> = {
+  unavailable: "available",
+  available: "preferred",
+  preferred: "unavailable",
 }
 
 const STATE_STYLES: Record<CellState, string> = {
   unavailable:
-    "bg-rose-500/15 text-rose-600 ring-1 ring-rose-300/40 hover:bg-rose-500/25",
+    "bg-rose-500/15 text-rose-600 ring-1 ring-rose-300/40",
   available:
-    "bg-emerald-500/20 text-emerald-700 ring-1 ring-emerald-500/30 hover:bg-emerald-500/30",
+    "bg-emerald-500/20 text-emerald-700 ring-1 ring-emerald-500/30",
   preferred:
-    "bg-primary/15 text-primary ring-1 ring-primary/30 hover:bg-primary/25",
+    "bg-primary/15 text-primary ring-1 ring-primary/30",
 }
 
 const STATE_LABELS: Record<CellState, string> = {
@@ -72,92 +63,291 @@ const STATE_LABELS: Record<CellState, string> = {
   preferred: "Préféré",
 }
 
+interface SavedCell {
+  id: number
+  state: CellState
+}
+
+type PendingChange =
+  | {
+      kind: "create"
+      target: Exclude<CellState, "unavailable">
+    }
+  | {
+      kind: "update"
+      existingId: number
+      target: Exclude<CellState, "unavailable">
+    }
+  | {
+      kind: "delete"
+      existingId: number
+      target: "unavailable"
+    }
+
+function cellKey(day: DayOfWeek, start: string, end: string) {
+  return `${day}|${start}|${end}`
+}
+
+function buildSavedMap(
+  availabilities: TeacherAvailability[],
+): Map<string, SavedCell> {
+  const m = new Map<string, SavedCell>()
+  for (const av of availabilities) {
+    const state: CellState = av.preferred
+      ? "preferred"
+      : av.available
+        ? "available"
+        : "unavailable"
+    m.set(cellKey(av.day, av.start_time, av.end_time), { id: av.id, state })
+  }
+  return m
+}
+
 export function TeacherAvailabilityTab({
   teacherId,
 }: TeacherAvailabilityTabProps) {
+  const queryClient = useQueryClient()
   const { data: availabilities, isLoading } =
     useTeacherAvailabilities(teacherId)
-  const { mutate: createAvailability, isPending: creating } =
-    useCreateAvailability(teacherId)
-  const { mutate: updateAvailability, isPending: updating } =
-    useUpdateAvailability(teacherId)
-  const { mutate: deleteAvailability, isPending: deleting } =
-    useDeleteAvailability(teacherId)
 
-  const isMutating = creating || updating || deleting
+  const [editMode, setEditMode] = useState(false)
+  const [pending, setPending] = useState<Map<string, PendingChange>>(new Map())
+  const [saving, setSaving] = useState(false)
 
-  const availabilityMap = useMemo(
-    () => buildAvailabilityMap(availabilities ?? []),
+  const savedMap = useMemo(
+    () => buildSavedMap(availabilities ?? []),
     [availabilities],
   )
 
-  function getCellState(day: DayOfWeek, start: string, end: string): CellState {
-    const entry = availabilityMap.get(cellKey(day, start, end))
-    if (!entry) return "unavailable"
-    if (entry.preferred) return "preferred"
-    if (entry.available) return "available"
-    return "unavailable"
-  }
+  // L'état affiché d'une cellule = pending si présent, sinon saved.
+  const getDisplayState = useCallback(
+    (day: DayOfWeek, start: string, end: string): CellState => {
+      const key = cellKey(day, start, end)
+      const p = pending.get(key)
+      if (p) return p.target
+      const s = savedMap.get(key)
+      return s?.state ?? "unavailable"
+    },
+    [pending, savedMap],
+  )
 
-  // Cycle: unavailable → available → preferred → unavailable (delete)
+  const isPendingCell = useCallback(
+    (day: DayOfWeek, start: string, end: string) => pending.has(cellKey(day, start, end)),
+    [pending],
+  )
+
   const handleToggle = useCallback(
     (day: DayOfWeek, start: string, end: string) => {
-      if (isMutating) return
+      if (!editMode || saving) return
       const key = cellKey(day, start, end)
-      const existing = availabilityMap.get(key)
+      const current = getDisplayState(day, start, end)
+      const next = NEXT_STATE[current]
 
-      if (!existing) {
-        // unavailable → available: create entry
-        createAvailability({ day, start_time: start, end_time: end, available: true, preferred: false })
-      } else if (existing.available && !existing.preferred) {
-        // available → preferred: update
-        updateAvailability({ id: existing.id, data: { preferred: true } })
-      } else {
-        // preferred → unavailable: delete
-        deleteAvailability(existing.id)
-      }
+      const saved = savedMap.get(key)
+      setPending((prev) => {
+        const m = new Map(prev)
+        // Si le next = saved → on retire le pending (changement annulé)
+        if (saved && next === saved.state) {
+          m.delete(key)
+          return m
+        }
+        // Si pas de saved ET next = unavailable → no-op (rien à créer)
+        if (!saved && next === "unavailable") {
+          m.delete(key)
+          return m
+        }
+        // Construction d'un PendingChange explicitement typé selon le kind
+        let change: PendingChange
+        if (!saved) {
+          // next ∈ {available, preferred} ici car saved est null et next ≠ unavailable
+          change = { kind: "create", target: next as Exclude<CellState, "unavailable"> }
+        } else if (next === "unavailable") {
+          change = { kind: "delete", existingId: saved.id, target: "unavailable" }
+        } else {
+          change = { kind: "update", existingId: saved.id, target: next }
+        }
+        m.set(key, change)
+        return m
+      })
     },
-    [isMutating, availabilityMap, createAvailability, updateAvailability, deleteAvailability],
+    [editMode, saving, getDisplayState, savedMap],
   )
+
+  const handleCancel = useCallback(() => {
+    setPending(new Map())
+    setEditMode(false)
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    if (pending.size === 0) {
+      setEditMode(false)
+      return
+    }
+    setSaving(true)
+
+    const operations: Promise<unknown>[] = []
+    for (const [key, change] of pending) {
+      const [day, start, end] = key.split("|") as [DayOfWeek, string, string]
+
+      if (change.kind === "create") {
+        operations.push(
+          timetableApi.createAvailability(teacherId, {
+            day,
+            start_time: start,
+            end_time: end,
+            available: true,
+            preferred: change.target === "preferred",
+          }),
+        )
+      } else if (change.kind === "delete") {
+        operations.push(timetableApi.deleteAvailability(change.existingId))
+      } else {
+        operations.push(
+          timetableApi.updateAvailability(change.existingId, {
+            available: true,
+            preferred: change.target === "preferred",
+          }),
+        )
+      }
+    }
+
+    const results = await Promise.allSettled(operations)
+    const fulfilled = results.filter((r) => r.status === "fulfilled").length
+    const rejected = results.length - fulfilled
+
+    // Toast cumulé (partial-success-with-reporting, cf. pattern bulk admin)
+    if (rejected === 0) {
+      toast.success(
+        `${fulfilled} disponibilité${fulfilled > 1 ? "s" : ""} enregistrée${
+          fulfilled > 1 ? "s" : ""
+        }`,
+      )
+      setPending(new Map())
+      setEditMode(false)
+    } else if (fulfilled === 0) {
+      toast.error(`Échec de l'enregistrement (${rejected} erreur${rejected > 1 ? "s" : ""})`)
+    } else {
+      toast.warning(
+        `${fulfilled} enregistrée${fulfilled > 1 ? "s" : ""}, ${rejected} erreur${
+          rejected > 1 ? "s" : ""
+        }`,
+      )
+      // Garde le mode édit avec les pending échoués — l'utilisateur peut retry
+      // ou annuler. Pour simplicité, on clear quand même (la re-fetch montrera l'état réel).
+    }
+
+    // Invalidation ciblée (pas reload de la page), refetch /availabilities seul
+    await queryClient.invalidateQueries({
+      queryKey: timetableKeys.availabilities(teacherId),
+    })
+    // Invalide aussi /full pour rafraîchir l'Overview KPI Disponibilité
+    await queryClient.invalidateQueries({
+      queryKey: ["teachers", teacherId, "full"],
+    })
+
+    setSaving(false)
+  }, [pending, teacherId, queryClient])
 
   if (isLoading) {
     return <AvailabilitySkeleton />
   }
 
-  const totalAvailable = Array.from(availabilityMap.values()).filter(
-    (v) => v.available,
+  const totalAvailable = Array.from(savedMap.values()).filter(
+    (v) => v.state !== "unavailable",
   ).length
-  const totalPreferred = Array.from(availabilityMap.values()).filter(
-    (v) => v.preferred,
+  const totalPreferred = Array.from(savedMap.values()).filter(
+    (v) => v.state === "preferred",
   ).length
   const maxSlots = DAYS.length * HOURS.length
+  const pendingCount = pending.size
 
   return (
     <div className="space-y-4">
-      {/* Summary */}
+      {/* Summary + controls (mode read vs edit) */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardContent className="p-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-2">
               <Clock className="h-4 w-4 text-muted-foreground" />
               <span className="text-sm font-medium">Disponibilités</span>
+              {!editMode ? (
+                <Badge
+                  variant="outline"
+                  className="ml-2 gap-1 border-muted-foreground/30 text-[10px] uppercase tracking-wide text-muted-foreground"
+                >
+                  <Eye className="h-3 w-3" />
+                  Lecture
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="ml-2 gap-1 border-primary/40 bg-primary/5 text-[10px] uppercase tracking-wide text-primary"
+                >
+                  <Pencil className="h-3 w-3" />
+                  Édition
+                </Badge>
+              )}
             </div>
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-2">
               <Badge variant="secondary" className="text-xs">
-                {totalAvailable}/{maxSlots} créneaux disponibles
+                {totalAvailable}/{maxSlots} disponibles
               </Badge>
               {totalPreferred > 0 && (
                 <Badge variant="outline" className="text-xs text-primary">
                   {totalPreferred} préférés
                 </Badge>
               )}
-              {isMutating && (
-                <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+              {pendingCount > 0 && (
+                <Badge
+                  variant="outline"
+                  className="text-xs border-amber-400 text-amber-700 bg-amber-50"
+                >
+                  {pendingCount} en attente
+                </Badge>
+              )}
+              {!editMode ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-9"
+                  onClick={() => setEditMode(true)}
+                >
+                  <Pencil className="mr-1.5 h-3.5 w-3.5" />
+                  Modifier
+                </Button>
+              ) : (
+                <>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-9"
+                    onClick={handleCancel}
+                    disabled={saving}
+                  >
+                    <X className="mr-1.5 h-3.5 w-3.5" />
+                    Annuler
+                  </Button>
+                  <Button
+                    size="sm"
+                    className="h-9"
+                    onClick={handleSave}
+                    disabled={saving}
+                  >
+                    {saving ? (
+                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Save className="mr-1.5 h-3.5 w-3.5" />
+                    )}
+                    Enregistrer
+                  </Button>
+                </>
               )}
             </div>
           </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Cliquez pour basculer : indisponible → disponible → préféré → indisponible.
+          <p className="mt-2 text-xs text-muted-foreground">
+            {editMode
+              ? "Cliquez pour basculer : indisponible → disponible → préféré → indisponible. Les modifications sont mises en attente jusqu'à « Enregistrer »."
+              : "Mode lecture. Cliquez sur « Modifier » pour saisir les disponibilités."}
           </p>
         </CardContent>
       </Card>
@@ -189,22 +379,28 @@ export function TeacherAvailabilityTab({
                       {hour.label}
                     </td>
                     {DAYS.map((day) => {
-                      const state = getCellState(day.key, hour.start, hour.end)
+                      const state = getDisplayState(day.key, hour.start, hour.end)
+                      const isPending = isPendingCell(day.key, hour.start, hour.end)
+                      const interactive = editMode && !saving
                       return (
-                        <td key={cellKey(day.key, hour.start, hour.end)} className="p-1">
+                        <td
+                          key={cellKey(day.key, hour.start, hour.end)}
+                          className="p-1"
+                        >
                           <button
                             type="button"
-                            disabled={isMutating}
+                            disabled={!interactive}
                             onClick={() =>
                               handleToggle(day.key, hour.start, hour.end)
                             }
                             className={`
                               w-full h-9 rounded-md text-[10px] font-medium transition-colors
                               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
-                              disabled:pointer-events-none disabled:opacity-50
+                              ${interactive ? "hover:opacity-80 cursor-pointer" : "cursor-default"}
                               ${STATE_STYLES[state]}
+                              ${isPending ? "ring-2 ring-dashed ring-amber-500/70" : ""}
                             `}
-                            aria-label={`${day.label} ${hour.start}-${hour.end}: ${state}`}
+                            aria-label={`${day.label} ${hour.start}-${hour.end}: ${state}${isPending ? " (modification en attente)" : ""}`}
                           >
                             {STATE_LABELS[state]}
                           </button>
@@ -220,7 +416,7 @@ export function TeacherAvailabilityTab({
       </Card>
 
       {/* Legend */}
-      <div className="flex items-center gap-5 text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center gap-5 text-xs text-muted-foreground">
         <div className="flex items-center gap-1.5">
           <div className="h-3 w-5 rounded-sm bg-emerald-500/20 ring-1 ring-emerald-500/30" />
           <span>Disponible</span>
@@ -233,6 +429,12 @@ export function TeacherAvailabilityTab({
           <div className="h-3 w-5 rounded-sm bg-rose-500/15 ring-1 ring-rose-300/40" />
           <span>Indisponible</span>
         </div>
+        {pendingCount > 0 && (
+          <div className="flex items-center gap-1.5">
+            <div className="h-3 w-5 rounded-sm ring-2 ring-dashed ring-amber-500/70" />
+            <span>Modification en attente</span>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/components/admin/teachers/tabs/TeacherClassesTab.tsx
+++ b/components/admin/teachers/tabs/TeacherClassesTab.tsx
@@ -1,40 +1,73 @@
 "use client"
 
-import { GraduationCap, Users } from "lucide-react"
+import Link from "next/link"
+import type { Route } from "next"
+import {
+  BookOpen,
+  CalendarPlus,
+  ChevronRight,
+  Clock,
+  GraduationCap,
+  Users,
+} from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+
+interface TaughtClass {
+  id: number
+  name: string
+  level?: string | null
+  subjects?: string[]
+  hours_per_week?: number
+  student_count?: number
+}
 
 interface TeacherClassesTabProps {
   teacherId: number
   fullData?: Record<string, unknown>
 }
 
-interface ClassInfo {
-  id: number
-  name: string
-  level?: string
-  student_count?: number
-}
+export function TeacherClassesTab({ fullData }: TeacherClassesTabProps) {
+  // BE renvoie `classes` (TeacherTaughtClass[]) aggregé depuis timetable_slots
+  // pour l'AY courante : rattachement teacher↔classe implicite (cf. rule
+  // klassci-subjects-catalogue-instances). Pour chaque entrée on a la liste
+  // des matières enseignées par CE prof dans CETTE classe + heures/sem +
+  // effectif validé AY courante.
+  const classes = (fullData?.classes as TaughtClass[] | undefined) ?? []
+  const isLoaded = fullData !== undefined && fullData !== null
 
-export function TeacherClassesTab({ teacherId, fullData }: TeacherClassesTabProps) {
-  const classes = (fullData?.classes as ClassInfo[]) ?? []
-
-  if (!fullData) {
+  if (!isLoaded) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <p className="text-sm text-muted-foreground">Chargement...</p>
-      </div>
+      <Card className="border-0 shadow-sm ring-1 ring-border">
+        <CardContent className="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-32 animate-pulse rounded-lg bg-muted/40" />
+          ))}
+        </CardContent>
+      </Card>
     )
   }
 
   if (classes.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-muted mb-3">
-          <GraduationCap className="h-6 w-6 text-muted-foreground" />
+      <div className="flex flex-col items-center justify-center gap-3 rounded-xl border bg-card px-6 py-16 text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary ring-1 ring-primary/20">
+          <GraduationCap className="h-7 w-7" />
         </div>
-        <p className="text-sm text-muted-foreground">
-          Aucune classe assignée à cet enseignant.
-        </p>
+        <div className="max-w-md space-y-1">
+          <p className="font-serif text-base">Aucune classe assignée</p>
+          <p className="text-sm text-muted-foreground">
+            Cet enseignant n&apos;apparaît dans aucun créneau d&apos;emploi du temps
+            de l&apos;année courante. Ajoutez un créneau pour l&apos;assigner à une classe.
+          </p>
+        </div>
+        <Button asChild className="mt-2 h-10" variant="outline">
+          <Link href={"/admin/timetable" as Route}>
+            <CalendarPlus className="mr-2 h-4 w-4" />
+            Configurer l&apos;emploi du temps
+          </Link>
+        </Button>
       </div>
     )
   }
@@ -42,28 +75,72 @@ export function TeacherClassesTab({ teacherId, fullData }: TeacherClassesTabProp
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {classes.map((cls) => (
-        <Card key={cls.id} className="border-0 shadow-sm ring-1 ring-border">
-          <CardContent className="p-5">
-            <div className="flex items-start justify-between">
-              <div className="space-y-1">
-                <div className="flex items-center gap-2">
-                  <GraduationCap className="h-4 w-4 text-primary" />
-                  <h4 className="text-sm font-semibold">{cls.name}</h4>
-                </div>
-                {cls.level && (
-                  <p className="text-xs text-muted-foreground">{cls.level}</p>
-                )}
-              </div>
-              {cls.student_count !== undefined && (
-                <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                  <Users className="h-3.5 w-3.5" />
-                  <span>{cls.student_count} élève{cls.student_count !== 1 ? "s" : ""}</span>
-                </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
+        <ClassCard key={cls.id} cls={cls} />
       ))}
     </div>
+  )
+}
+
+function ClassCard({ cls }: { cls: TaughtClass }) {
+  const subjects = cls.subjects ?? []
+  const studentCount = cls.student_count ?? 0
+  const hours = cls.hours_per_week ?? 0
+
+  return (
+    <Link
+      href={`/admin/classes/${cls.id}` as Route}
+      className="group block focus:outline-none focus:ring-2 focus:ring-primary rounded-lg"
+    >
+      <Card className="border-0 shadow-sm ring-1 ring-border transition-all group-hover:ring-primary group-hover:shadow-md">
+        <CardContent className="space-y-3 p-5">
+          {/* Header — class name + chevron */}
+          <div className="flex items-start justify-between">
+            <div className="space-y-1 min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <GraduationCap className="h-4 w-4 shrink-0 text-primary" />
+                <h4 className="text-sm font-semibold truncate">{cls.name}</h4>
+              </div>
+              {cls.level && (
+                <p className="text-xs text-muted-foreground">{cls.level}</p>
+              )}
+            </div>
+            <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/50 group-hover:text-primary" />
+          </div>
+
+          {/* Subjects enseignées par CE prof dans CETTE classe */}
+          {subjects.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {subjects.map((s) => (
+                <Badge
+                  key={s}
+                  variant="outline"
+                  className="gap-1 border-primary/30 bg-primary/5 text-[10px] text-primary"
+                >
+                  <BookOpen className="h-3 w-3" />
+                  {s}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          {/* Footer KPIs — students + hours */}
+          <div className="flex items-center justify-between border-t pt-3 text-xs text-muted-foreground">
+            <div className="flex items-center gap-1.5">
+              <Users className="h-3.5 w-3.5" />
+              <span>
+                <span className="font-semibold text-foreground">{studentCount}</span> élève
+                {studentCount !== 1 ? "s" : ""}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Clock className="h-3.5 w-3.5" />
+              <span>
+                <span className="font-semibold text-foreground">{hours}</span> h/sem
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
   )
 }

--- a/components/admin/teachers/tabs/TeacherOverviewTab.tsx
+++ b/components/admin/teachers/tabs/TeacherOverviewTab.tsx
@@ -74,11 +74,10 @@ export function TeacherOverviewTab({ teacher, fullData, onTabChange }: TeacherOv
         </KpiCard>
 
         <KpiCard onClick={() => onTabChange?.("disponibilites")}>
-          <CircularProgress
-            value={availabilityRate}
-            label={`${Math.round(availabilityRate)}%`}
-            sublabel="Disponibilité"
-            icon={<CalendarCheck className="h-4 w-4 text-muted-foreground/60" />}
+          <AvailabilityKpi
+            rate={availabilityRate}
+            source={(fullData?.availability_source as string | undefined) ?? "none"}
+            classesCount={classesCount}
           />
         </KpiCard>
       </div>
@@ -133,6 +132,56 @@ export function TeacherOverviewTab({ teacher, fullData, onTabChange }: TeacherOv
         </CardContent>
       </Card>
     </div>
+  )
+}
+
+/**
+ * KPI Disponibilité tri-sémantique selon `availability_source` :
+ *  - "configured" : saisie explicite → afficher le pourcentage réel
+ *  - "implicit"   : pas de saisie mais slots EDT existants → afficher "Estimée"
+ *                   plutôt qu'un faux pourcentage (3% pour 2 slots/66 sème la
+ *                   confusion ; mieux vaut un libellé honnête + CTA implicite
+ *                   via la sub-line)
+ *  - "none"       : ni saisie ni slots → "—" neutre
+ */
+function AvailabilityKpi({
+  rate,
+  source,
+  classesCount,
+}: {
+  rate: number
+  source: string
+  classesCount: number
+}) {
+  if (source === "configured") {
+    return (
+      <CircularProgress
+        value={rate}
+        label={`${Math.round(rate)}%`}
+        sublabel="Disponibilité saisie"
+        icon={<CalendarCheck className="h-4 w-4 text-muted-foreground/60" />}
+      />
+    )
+  }
+  if (source === "implicit") {
+    return (
+      <CircularProgress
+        value={Math.max(15, rate)}
+        label="Estimée"
+        sublabel={`${classesCount} classe${classesCount > 1 ? "s" : ""} via l'EDT`}
+        color="#f59e0b"
+        icon={<CalendarCheck className="h-4 w-4 text-muted-foreground/60" />}
+      />
+    )
+  }
+  return (
+    <CircularProgress
+      value={0}
+      label="—"
+      sublabel="Non renseignée"
+      color="#94a3b8"
+      icon={<CalendarCheck className="h-4 w-4 text-muted-foreground/60" />}
+    />
   )
 }
 

--- a/components/admin/teachers/tabs/TeacherProfileTab.tsx
+++ b/components/admin/teachers/tabs/TeacherProfileTab.tsx
@@ -22,6 +22,31 @@ function InfoField({ label, value, icon: Icon }: { label: string; value: string 
   )
 }
 
+/**
+ * Tri-état sémantique sur le statut du compte (cf. rule redesign-premium.md
+ * principe 14) : `lastLogin === null` est diagnostiqué AVANT `isActive === false`
+ * pour qu'un compte fraîchement provisionné mais jamais connecté affiche
+ * « En attente » (amber rassurant) plutôt que « Désactivé » (rouge alarmant).
+ */
+function getAccountBadge(isActive: boolean | undefined, lastLogin: string | undefined) {
+  if (!lastLogin) {
+    return {
+      label: "En attente",
+      variant: "outline" as const,
+      className:
+        "border-amber-500 text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20",
+    }
+  }
+  if (isActive === false) {
+    return { label: "Désactivé", variant: "destructive" as const, className: "" }
+  }
+  return {
+    label: "Actif",
+    variant: "outline" as const,
+    className: "border-emerald-500 text-emerald-600",
+  }
+}
+
 export function TeacherProfileTab({ teacher, fullData }: TeacherProfileTabProps) {
   const createdAt = teacher.created_at
     ? new Date(teacher.created_at).toLocaleDateString("fr-FR", {
@@ -32,8 +57,10 @@ export function TeacherProfileTab({ teacher, fullData }: TeacherProfileTabProps)
     : null
 
   // Extract user account info from /full response (flat fields from BE)
-  const hasUserData = fullData && "user_email" in fullData
-  const email = (fullData?.user_email as string) ?? null
+  const isLoaded = fullData !== undefined && fullData !== null
+  const hasUserAccount =
+    isLoaded && "user_email" in (fullData as Record<string, unknown>)
+  const email = (fullData?.user_email as string | null | undefined) ?? null
   const isActive = fullData?.user_is_active as boolean | undefined
   const lastLogin = fullData?.user_last_login as string | undefined
 
@@ -46,6 +73,8 @@ export function TeacherProfileTab({ teacher, fullData }: TeacherProfileTabProps)
         minute: "2-digit",
       })
     : "Jamais"
+
+  const badge = getAccountBadge(isActive, lastLogin)
 
   return (
     <div className="space-y-4">
@@ -63,11 +92,27 @@ export function TeacherProfileTab({ teacher, fullData }: TeacherProfileTabProps)
         </CardContent>
       </Card>
 
-      {/* Compte utilisateur */}
+      {/* Compte utilisateur — skeleton tant que la query /full n'a pas répondu,
+          empty state propre si l'enseignant n'a pas de compte auth, sinon
+          affichage des 3 champs avec tri-état sémantique sur le statut. */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardContent className="p-6">
           <h3 className="text-sm font-medium text-muted-foreground mb-4">Compte utilisateur</h3>
-          {hasUserData ? (
+          {!isLoaded ? (
+            <div className="grid gap-5 sm:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <div className="h-3 w-24 animate-pulse rounded bg-muted/60" />
+                  <div className="h-4 w-32 animate-pulse rounded bg-muted/40" />
+                </div>
+              ))}
+            </div>
+          ) : !hasUserAccount ? (
+            <p className="text-sm text-muted-foreground">
+              Cet enseignant n&apos;a pas de compte utilisateur associé. Modifiez la
+              fiche pour ajouter un email et un mot de passe.
+            </p>
+          ) : (
             <div className="grid gap-5 sm:grid-cols-3">
               <InfoField label="Email" value={email} icon={Mail} />
               <div className="space-y-1">
@@ -75,16 +120,12 @@ export function TeacherProfileTab({ teacher, fullData }: TeacherProfileTabProps)
                   <ShieldCheck className="h-3.5 w-3.5 text-muted-foreground" />
                   <p className="text-xs font-medium text-muted-foreground">Statut</p>
                 </div>
-                <Badge variant={isActive ? "default" : "secondary"}>
-                  {isActive ? "Actif" : "Inactif"}
+                <Badge variant={badge.variant} className={`text-xs ${badge.className}`}>
+                  {badge.label}
                 </Badge>
               </div>
               <InfoField label="Dernière connexion" value={lastLoginFormatted} icon={CalendarDays} />
             </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              Chargement des informations du compte...
-            </p>
           )}
         </CardContent>
       </Card>

--- a/components/forms/EnrollmentForm.tsx
+++ b/components/forms/EnrollmentForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useMemo, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import {
@@ -74,12 +74,18 @@ const RELATIONSHIP_TYPES = [
 
 interface EnrollmentFormProps {
   onSuccess: () => void
+  /**
+   * Élève pré-sélectionné (depuis ex. badge "À inscrire" sur /admin/students).
+   * Quand fourni : le type est forcé à "re-enrollment", student_id est rempli
+   * et le wizard saute directement à l'étape Classe — bug #22.
+   */
+  preselectedStudentId?: number
 }
 
 // Unified type for the discriminated form
 type EnrollmentFormData = NewEnrollment | ReEnrollment
 
-export function EnrollmentForm({ onSuccess }: EnrollmentFormProps) {
+export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFormProps) {
   const [step, setStep] = useState(0)
   const [enrollmentType, setEnrollmentType] = useState<EnrollmentType | null>(null)
   const [showParentFields, setShowParentFields] = useState(false)
@@ -160,6 +166,19 @@ export function EnrollmentForm({ onSuccess }: EnrollmentFormProps) {
   )
 
   const isPending = createWithStudent.isPending || reEnroll.isPending
+
+  // Bug #22 : Quand un student_id arrive via query (?student_id=X), on
+  // pré-remplit le formulaire re-enrollment et on saute directement à la
+  // sélection de classe. Évite à l'admin de re-chercher l'élève qu'il
+  // vient justement de cliquer dans la liste.
+  useEffect(() => {
+    if (preselectedStudentId && enrollmentType === null) {
+      setEnrollmentType("re-enrollment")
+      reForm.setValue("student_id", preselectedStudentId)
+      setStep(2)
+      setMaxReachedStep(2)
+    }
+  }, [preselectedStudentId, enrollmentType, reForm])
 
   function goToStep(target: number) {
     setStep(target)

--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { signIn } from "next-auth/react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Mail, Lock, ArrowRight, AlertCircle, Eye, EyeOff } from "lucide-react"
+import { Mail, Lock, ArrowRight, AlertCircle, Eye, EyeOff, Clock } from "lucide-react"
 import { LoginRequestSchema, type LoginRequest } from "@/lib/contracts/auth"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -54,6 +54,7 @@ export function LoginForm() {
   const searchParams = useSearchParams()
   const rawCallback = searchParams.get("callbackUrl") ?? "/"
   const callbackUrl = rawCallback.startsWith("/") && !rawCallback.startsWith("//") ? rawCallback : "/"
+  const sessionExpired = searchParams.get("expired") === "1"
   const [error, setError] = useState<string | null>(null)
   const [showPassword, setShowPassword] = useState(false)
   const [tenantCode, setTenantCode] = useState<string | null>(null)
@@ -103,6 +104,23 @@ export function LoginForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        {sessionExpired && !error && (
+          <div
+            role="alert"
+            className="flex items-start gap-2.5 rounded-lg border border-amber-200 bg-amber-50 px-3.5 py-3 dark:border-amber-900/40 dark:bg-amber-950/30"
+          >
+            <Clock className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                Session expirée
+              </p>
+              <p className="text-xs text-amber-800 dark:text-amber-200">
+                Pour des raisons de sécurité, reconnectez-vous pour continuer.
+              </p>
+            </div>
+          </div>
+        )}
+
         {tenantCode && (
           <div className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs">
             <span className="text-muted-foreground">Établissement : </span>

--- a/components/forms/StaffForm.tsx
+++ b/components/forms/StaffForm.tsx
@@ -1,7 +1,9 @@
 "use client"
 
+import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
+import { Eye, EyeOff, KeyRound } from "lucide-react"
 import { StaffCreateSchema, type StaffCreate } from "@/lib/contracts/staff"
 import { useCreateStaff } from "@/lib/hooks/useStaff"
 import { Button } from "@/components/ui/button"
@@ -9,6 +11,7 @@ import { Input } from "@/components/ui/input"
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -20,11 +23,14 @@ interface StaffFormProps {
 }
 
 export function StaffForm({ onSuccess }: StaffFormProps) {
+  const [showPassword, setShowPassword] = useState(false)
   const form = useForm<StaffCreate>({
     resolver: zodResolver(StaffCreateSchema),
     defaultValues: {
       first_name: "",
       last_name: "",
+      email: "",
+      password: "",
       position: "",
       phone: "",
     },
@@ -52,7 +58,7 @@ export function StaffForm({ onSuccess }: StaffFormProps) {
               <FormItem>
                 <FormLabel>Nom *</FormLabel>
                 <FormControl>
-                  <Input placeholder="Ex : Mbala" className="h-11" {...field} />
+                  <Input placeholder="Ex : Yao" className="h-11" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -66,7 +72,7 @@ export function StaffForm({ onSuccess }: StaffFormProps) {
               <FormItem>
                 <FormLabel>Prénom *</FormLabel>
                 <FormControl>
-                  <Input placeholder="Ex : Jean" className="h-11" {...field} />
+                  <Input placeholder="Ex : Sophie" className="h-11" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -82,7 +88,7 @@ export function StaffForm({ onSuccess }: StaffFormProps) {
               <FormItem>
                 <FormLabel>Poste</FormLabel>
                 <FormControl>
-                  <Input placeholder="Ex : Comptable" className="h-11" {...field} value={field.value ?? ""} />
+                  <Input placeholder="Ex : Secrétaire pédagogique" className="h-11" {...field} value={field.value ?? ""} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -96,8 +102,74 @@ export function StaffForm({ onSuccess }: StaffFormProps) {
               <FormItem>
                 <FormLabel>Téléphone</FormLabel>
                 <FormControl>
-                  <Input placeholder="Ex : +243 812 345 678" className="h-11" {...field} value={field.value ?? ""} />
+                  <Input placeholder="Ex : +225 07 12 34 56 78" className="h-11 font-mono" {...field} value={field.value ?? ""} />
                 </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* Compte de connexion — toujours obligatoire pour le staff
+            (admin secondaire, secrétaire, comptable... doit accéder à un portail). */}
+        <div className="rounded-xl border border-border/60 bg-muted/20 p-4 space-y-4">
+          <div className="flex items-center gap-2">
+            <KeyRound className="h-4 w-4 text-primary" />
+            <p className="text-sm font-medium">Compte de connexion</p>
+          </div>
+
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email *</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="sophie@etablissement.ci"
+                    className="h-11"
+                    autoComplete="email"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription className="text-xs">
+                  Servira d&apos;identifiant pour se connecter à KLASSCI.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Mot de passe initial *</FormLabel>
+                <FormControl>
+                  <div className="relative">
+                    <Input
+                      type={showPassword ? "text" : "password"}
+                      placeholder="8 caractères minimum"
+                      className="h-11 pr-10"
+                      autoComplete="new-password"
+                      {...field}
+                    />
+                    <button
+                      type="button"
+                      tabIndex={-1}
+                      onClick={() => setShowPassword((v) => !v)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      aria-label={showPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
+                    >
+                      {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                </FormControl>
+                <FormDescription className="text-xs">
+                  Communiquez-le au membre du personnel ; il pourra le changer lors de sa première connexion.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}

--- a/components/parent/ParentDashboardClient.tsx
+++ b/components/parent/ParentDashboardClient.tsx
@@ -5,8 +5,11 @@ import { Users, GraduationCap, Wallet, AlertCircle, ChevronRight } from "lucide-
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
+import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
+import { NotEnrolledBanner } from "@/components/shared/NotEnrolledBanner"
 import { useParentDashboard } from "@/lib/hooks/useParentPortal"
 import type { ParentChild } from "@/lib/contracts/parent-portal"
+import { isEnrolledFromClassName, summarizeEnrollment } from "@/lib/utils/enrollment-status"
 
 /** Seuil d'absences au-delà duquel on affiche un avertissement */
 const ABSENCES_WARNING_THRESHOLD = 5
@@ -36,19 +39,42 @@ export function ParentDashboardClient() {
     )
   }
 
+  const enrollment = summarizeEnrollment(data.children)
+
   return (
     <div className="space-y-6">
       <DashboardHeader name={data.parent_name} />
 
-      {/* Résumé */}
+      <AcademicYearBanner
+        currentYear={data.current_academic_year}
+        role="parent"
+      />
+
+      {/* Résumé — "Mes enfants" (relation parent-enfant) avec breakdown
+          inscrit / en attente quand il y a un mix. Le label "Enfants inscrits"
+          précédent était trompeur : il comptait les enfants suivis, pas ceux
+          réellement inscrits à l'année courante. */}
       <Card className="border-primary/20 bg-primary/5">
         <CardContent className="flex items-center gap-3 p-4">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
             <Users className="h-5 w-5 text-primary" />
           </div>
-          <div>
-            <p className="text-xs text-primary uppercase tracking-wider font-medium">Enfants inscrits</p>
-            <p className="text-2xl font-bold">{data.total_children}</p>
+          <div className="min-w-0 flex-1">
+            <p className="text-xs text-primary uppercase tracking-wider font-medium">Mes enfants</p>
+            <p className="text-2xl font-bold leading-tight">{enrollment.total}</p>
+            {enrollment.total > 0 && (
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {enrollment.enrolled} inscrit{enrollment.enrolled > 1 ? "s" : ""}
+                {enrollment.pending > 0 && (
+                  <>
+                    {" · "}
+                    <span className="font-medium text-amber-700 dark:text-amber-400">
+                      {enrollment.pending} en attente
+                    </span>
+                  </>
+                )}
+              </p>
+            )}
           </div>
         </CardContent>
       </Card>
@@ -57,12 +83,16 @@ export function ParentDashboardClient() {
       {data.children.length === 0 ? (
         <div className="py-12 text-center">
           <Users className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
-          <p className="text-sm text-muted-foreground">Aucun enfant inscrit pour le moment.</p>
+          <p className="text-sm text-muted-foreground">Aucun enfant lié à votre compte.</p>
         </div>
       ) : (
         <div className="space-y-3">
           {data.children.map((child) => (
-            <ChildCard key={child.id} child={child} />
+            <ChildCard
+              key={child.id}
+              child={child}
+              academicYear={data.current_academic_year}
+            />
           ))}
         </div>
       )}
@@ -81,58 +111,120 @@ function DashboardHeader({ name }: { name: string | null }) {
   )
 }
 
-function ChildCard({ child }: { child: ParentChild }) {
+function ChildCard({
+  child,
+  academicYear,
+}: {
+  child: ParentChild
+  academicYear: string | null | undefined
+}) {
+  const isEnrolled = isEnrolledFromClassName(child.class_name)
+
   return (
     <Card className="border-0 shadow-sm ring-1 ring-border">
       <CardContent className="p-4 space-y-3">
         {/* En-tête enfant */}
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="font-semibold text-sm">{child.full_name}</p>
-            <p className="text-xs text-muted-foreground">{child.class_name}</p>
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="font-semibold text-sm truncate">{child.full_name}</p>
+            <p className="text-xs text-muted-foreground">
+              {isEnrolled ? (
+                child.class_name
+              ) : (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                  En attente d&apos;inscription
+                </span>
+              )}
+            </p>
           </div>
         </div>
 
-        {/* KPIs */}
+        {/* Banner inline si pas inscrit — explique POURQUOI les KPIs sont
+            vides, et donne l'action à prendre (passage au secrétariat). */}
+        {!isEnrolled && (
+          <NotEnrolledBanner
+            audience="parent"
+            studentName={child.full_name}
+            academicYear={academicYear}
+            variant="inline"
+          />
+        )}
+
+        {/* KPIs — neutralisés (—) tant que l'enfant n'est pas inscrit.
+            Sinon faux signal vert "0 FCFA = tout payé" alors qu'aucun frais
+            n'a encore été affecté. */}
         <div className="grid grid-cols-3 gap-2">
           <div className="rounded-lg bg-muted/50 p-2 text-center">
             <GraduationCap className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p className={`text-sm font-bold ${child.general_average === null ? "text-muted-foreground" : child.general_average >= 10 ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}`}>
-              {child.general_average !== null ? child.general_average.toFixed(2) : "—"}
+            <p
+              className={`text-sm font-bold ${
+                !isEnrolled || child.general_average === null
+                  ? "text-muted-foreground"
+                  : child.general_average >= 10
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-destructive"
+              }`}
+            >
+              {isEnrolled && child.general_average !== null
+                ? child.general_average.toFixed(2)
+                : "—"}
             </p>
             <p className="text-[10px] text-muted-foreground">Moyenne</p>
           </div>
           <div className="rounded-lg bg-muted/50 p-2 text-center">
             <AlertCircle className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p className={`text-sm font-bold ${child.total_absences > ABSENCES_WARNING_THRESHOLD ? "text-accent" : ""}`}>
-              {child.total_absences}
+            <p
+              className={`text-sm font-bold ${
+                !isEnrolled
+                  ? "text-muted-foreground"
+                  : child.total_absences > ABSENCES_WARNING_THRESHOLD
+                    ? "text-accent"
+                    : ""
+              }`}
+            >
+              {isEnrolled ? child.total_absences : "—"}
             </p>
             <p className="text-[10px] text-muted-foreground">Absences</p>
           </div>
           <div className="rounded-lg bg-muted/50 p-2 text-center">
             <Wallet className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p className={`text-sm font-bold ${child.fees_remaining > 0 ? "text-accent" : "text-emerald-600 dark:text-emerald-400"}`}>
-              {child.fees_remaining.toLocaleString("fr-FR")}
+            <p
+              className={`text-sm font-bold ${
+                !isEnrolled
+                  ? "text-muted-foreground"
+                  : child.fees_remaining > 0
+                    ? "text-accent"
+                    : "text-emerald-600 dark:text-emerald-400"
+              }`}
+            >
+              {isEnrolled ? child.fees_remaining.toLocaleString("fr-FR") : "—"}
             </p>
             <p className="text-[10px] text-muted-foreground">Reste (FCFA)</p>
           </div>
         </div>
 
-        {/* Liens rapides */}
-        <div className="flex gap-2">
-          <Link
-            href={`/parent/children/${child.id}/grades`}
-            className="flex flex-1 items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
-          >
-            Notes <ChevronRight className="h-3 w-3" />
-          </Link>
-          <Link
-            href={`/parent/children/${child.id}/fees`}
-            className="flex flex-1 items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
-          >
-            Frais <ChevronRight className="h-3 w-3" />
-          </Link>
-        </div>
+        {/* Liens rapides — désactivés quand pas inscrit (pas de contenu utile
+            à voir, et éviter de générer des fetches 404/500 inutiles). */}
+        {isEnrolled ? (
+          <div className="flex gap-2">
+            <Link
+              href={`/parent/children/${child.id}/grades`}
+              className="flex flex-1 items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
+            >
+              Notes <ChevronRight className="h-3 w-3" />
+            </Link>
+            <Link
+              href={`/parent/children/${child.id}/fees`}
+              className="flex flex-1 items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
+            >
+              Frais <ChevronRight className="h-3 w-3" />
+            </Link>
+          </div>
+        ) : (
+          <p className="text-center text-[11px] text-muted-foreground">
+            Notes et frais seront disponibles après validation de l&apos;inscription.
+          </p>
+        )}
       </CardContent>
     </Card>
   )

--- a/components/shared/AcademicYearBanner.tsx
+++ b/components/shared/AcademicYearBanner.tsx
@@ -1,0 +1,67 @@
+import type { Route } from "next"
+import Link from "next/link"
+import { AlertTriangle, Calendar } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+type Role = "admin" | "teacher" | "student" | "parent"
+
+interface AcademicYearBannerProps {
+  /** Label de l'année active (ex: "2025-2026") ou null/undefined si rien configuré. */
+  currentYear: string | null | undefined
+  /** Rôle utilisé pour adapter le message quand l'année manque. */
+  role: Role
+  className?: string
+}
+
+const MISSING_MESSAGE: Record<Role, string> = {
+  admin: "Aucune année scolaire active.",
+  teacher:
+    "Aucune année scolaire n'est encore configurée. Contactez l'administration.",
+  student:
+    "Année scolaire non configurée par l'établissement. Vos données apparaîtront dès qu'elle sera créée.",
+  parent:
+    "Année scolaire non configurée par l'établissement. Le suivi de vos enfants apparaîtra dès qu'elle sera créée.",
+}
+
+export function AcademicYearBanner({
+  currentYear,
+  role,
+  className,
+}: AcademicYearBannerProps) {
+  if (currentYear) {
+    return (
+      <div
+        className={cn(
+          "inline-flex items-center gap-2 rounded-full border bg-primary/5 px-3 py-1 text-xs font-medium text-primary",
+          className,
+        )}
+      >
+        <Calendar className="h-3.5 w-3.5" />
+        Année {currentYear}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-200",
+        className,
+      )}
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <div className="flex-1 space-y-1">
+        <p className="leading-snug">{MISSING_MESSAGE[role]}</p>
+        {role === "admin" && (
+          <Link
+            href={"/admin/academic-years" as Route}
+            className="inline-flex font-medium text-amber-900 underline-offset-2 hover:underline dark:text-amber-100"
+          >
+            Configurer maintenant →
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/shared/NotEnrolledBanner.tsx
+++ b/components/shared/NotEnrolledBanner.tsx
@@ -1,0 +1,90 @@
+import { Clock, AlertTriangle } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+type Audience = "student" | "parent"
+type Variant = "full" | "inline"
+
+interface NotEnrolledBannerProps {
+  audience: Audience
+  /** Nom de l'élève à mentionner (uniquement utile pour audience=parent). */
+  studentName?: string
+  /** Année académique courante (ex: "2025-2026"). Si absent, la mention temporelle est omise. */
+  academicYear?: string | null
+  /** "full" = banner pleine largeur top-of-page. "inline" = compact pour intégration dans une card enfant. */
+  variant?: Variant
+  className?: string
+}
+
+interface BannerCopy {
+  title: string
+  body: string
+}
+
+function buildCopy(
+  audience: Audience,
+  studentName: string | undefined,
+  academicYear: string | null | undefined,
+): BannerCopy {
+  const yearSuffix = academicYear ? ` pour ${academicYear}` : ""
+  if (audience === "student") {
+    return {
+      title: `Inscription en attente de validation${yearSuffix}`,
+      body:
+        "Votre dossier n'a pas encore été validé par l'administration. Passez au secrétariat de l'école pour finaliser votre inscription. Vos notes et frais s'afficheront ici une fois la validation effectuée.",
+    }
+  }
+  const who = studentName ? `de ${studentName}` : "de votre enfant"
+  return {
+    title: `Inscription ${who} en attente${yearSuffix}`,
+    body:
+      "Le dossier n'a pas encore été validé par l'administration. Rendez-vous au secrétariat de l'école pour finaliser. Les notes, présences et frais apparaîtront ici dès que l'inscription sera validée.",
+  }
+}
+
+export function NotEnrolledBanner({
+  audience,
+  studentName,
+  academicYear,
+  variant = "full",
+  className,
+}: NotEnrolledBannerProps) {
+  const { title, body } = buildCopy(audience, studentName, academicYear)
+  const Icon = variant === "full" ? AlertTriangle : Clock
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/30",
+        variant === "full" ? "p-4" : "p-3",
+        className,
+      )}
+    >
+      <Icon
+        className={cn(
+          "shrink-0 text-amber-600 dark:text-amber-400",
+          variant === "full" ? "h-5 w-5" : "h-4 w-4 mt-0.5",
+        )}
+        aria-hidden
+      />
+      <div className="min-w-0 space-y-1">
+        <p
+          className={cn(
+            "font-medium text-amber-900 dark:text-amber-100",
+            variant === "full" ? "text-sm" : "text-xs",
+          )}
+        >
+          {title}
+        </p>
+        <p
+          className={cn(
+            "leading-relaxed text-amber-800 dark:text-amber-200",
+            variant === "full" ? "text-sm" : "text-[11px]",
+          )}
+        >
+          {body}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/shared/PortalShell.tsx
+++ b/components/shared/PortalShell.tsx
@@ -6,32 +6,46 @@ import { Toaster } from "sonner"
 interface PortalShellProps {
   label: string
   nav: React.ReactNode
+  /** Optional desktop sidebar — when provided, the layout switches to a
+   *  sidebar+main row on md+ screens while keeping `nav` as the mobile
+   *  bottom-nav. The sidebar component must apply its own `hidden md:flex`
+   *  to stay invisible on mobile. */
+  sidebar?: React.ReactNode
   children: React.ReactNode
 }
 
-export function PortalShell({ label, nav, children }: PortalShellProps) {
+export function PortalShell({ label, nav, sidebar, children }: PortalShellProps) {
   return (
-    <div className="flex min-h-screen flex-col bg-background">
-      <header className="sticky top-0 z-40 flex h-14 items-center gap-3 border-b bg-card/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-card/80">
-        <div className="flex flex-col items-center w-fit">
-          <Image
-            src="/images/logo_klassci.png"
-            alt="KLASSCI"
-            width={90}
-            height={24}
-          />
-          <span className="font-serif text-[9px] -mt-1.5 text-muted-foreground">
-            College
-          </span>
-        </div>
-        <span className="text-[10px] tracking-widest text-muted-foreground uppercase">{label}</span>
-      </header>
+    <div className="flex min-h-screen bg-background">
+      {sidebar}
+      <div className="flex min-h-screen flex-1 flex-col">
+        <header
+          className={
+            sidebar
+              ? "sticky top-0 z-40 flex h-14 items-center gap-3 border-b bg-card/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-card/80 md:hidden"
+              : "sticky top-0 z-40 flex h-14 items-center gap-3 border-b bg-card/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-card/80"
+          }
+        >
+          <div className="flex flex-col items-center w-fit">
+            <Image
+              src="/images/logo_klassci.png"
+              alt="KLASSCI"
+              width={90}
+              height={24}
+            />
+            <span className="font-serif text-[9px] -mt-1.5 text-muted-foreground">
+              College
+            </span>
+          </div>
+          <span className="text-[10px] tracking-widest text-muted-foreground uppercase">{label}</span>
+        </header>
 
-      <main className="flex-1 px-4 py-4 pb-24">
-        {children}
-      </main>
+        <main className="flex-1 px-4 py-4 pb-24 md:px-8 md:py-6 md:pb-8">
+          {children}
+        </main>
 
-      {nav}
+        {nav}
+      </div>
       <Toaster richColors />
     </div>
   )

--- a/components/shared/TeacherNav.tsx
+++ b/components/shared/TeacherNav.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type { Route } from "next"
+import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { signOut } from "next-auth/react"
@@ -18,7 +19,7 @@ export function TeacherNav() {
   const pathname = usePathname()
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 border-t bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80">
+    <nav className="fixed bottom-0 left-0 right-0 z-50 border-t bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 md:hidden">
       <div className="flex items-center justify-around px-2 py-1">
         {navItems.map((item) => {
           const isActive = pathname === item.href || pathname.startsWith(item.href + "/")
@@ -48,5 +49,60 @@ export function TeacherNav() {
       </div>
       <div className="h-[env(safe-area-inset-bottom)]" />
     </nav>
+  )
+}
+
+export function TeacherSidebar() {
+  const pathname = usePathname()
+
+  return (
+    <aside className="hidden md:flex sticky top-0 h-screen w-60 flex-col border-r bg-card">
+      <div className="flex h-16 items-center gap-3 border-b px-4">
+        <div className="flex flex-col items-center w-fit">
+          <Image
+            src="/images/logo_klassci.png"
+            alt="KLASSCI"
+            width={110}
+            height={30}
+            priority
+          />
+          <span className="font-serif text-[10px] -mt-1.5 text-muted-foreground">
+            College
+          </span>
+        </div>
+        <span className="text-[10px] tracking-widest text-muted-foreground uppercase">
+          Enseignant
+        </span>
+      </div>
+      <nav className="flex-1 space-y-1 p-3">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href || pathname.startsWith(item.href + "/")
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              )}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          )
+        })}
+      </nav>
+      <div className="border-t p-3">
+        <button
+          onClick={() => signOut({ callbackUrl: "/login" })}
+          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+        >
+          <LogOut className="h-4 w-4" />
+          Deconnexion
+        </button>
+      </div>
+    </aside>
   )
 }

--- a/components/student/StudentDashboardClient.tsx
+++ b/components/student/StudentDashboardClient.tsx
@@ -3,7 +3,10 @@
 import { CalendarDays, ClipboardList, Wallet, AlertCircle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
+import { NotEnrolledBanner } from "@/components/shared/NotEnrolledBanner"
 import { useStudentDashboard } from "@/lib/hooks/useStudentPortal"
+import { isEnrolledFromClassName } from "@/lib/utils/enrollment-status"
 
 export function StudentDashboardClient() {
   const { data, isLoading, isError } = useStudentDashboard()
@@ -24,6 +27,12 @@ export function StudentDashboardClient() {
     )
   }
 
+  const isEnrolled = isEnrolledFromClassName(data.class_name)
+  // Quand l'élève n'est pas (encore) inscrit, le BE renvoie `class_name: "—"`.
+  // On ne montre PAS ce placeholder dans le sous-titre : il dégrade en
+  // mention temporelle simple, et le banner explique la situation en clair.
+  const subtitle = isEnrolled ? `${data.class_name} — Votre résumé du jour` : "Votre espace personnel"
+
   return (
     <div className="space-y-6">
       {/* En-tête */}
@@ -31,8 +40,17 @@ export function StudentDashboardClient() {
         <h1 className="font-serif text-xl tracking-tight">
           Bonjour, {data.student_name.split(" ")[0]}
         </h1>
-        <p className="text-sm text-muted-foreground">{data.class_name} — Votre résumé du jour</p>
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
       </div>
+
+      <AcademicYearBanner
+        currentYear={data.current_academic_year}
+        role="student"
+      />
+
+      {!isEnrolled && (
+        <NotEnrolledBanner audience="student" academicYear={data.current_academic_year} />
+      )}
 
       {/* Prochain cours */}
       <Card className="border-primary/20 bg-primary/5">
@@ -58,25 +76,45 @@ export function StudentDashboardClient() {
         </CardContent>
       </Card>
 
-      {/* KPIs */}
+      {/* KPIs — colorés seulement si vraiment applicables. Sinon `—` muted
+          pour éviter le faux signal "0 FCFA vert = tout payé" quand en fait
+          l'élève n'a juste pas encore de frais affectés. */}
       <div className="grid grid-cols-3 gap-3">
         <KpiCard
           icon={ClipboardList}
           label="Moyenne"
           value={data.general_average !== null ? `${data.general_average.toFixed(2)}/20` : "—"}
-          className={data.general_average !== null && data.general_average >= 10 ? "text-emerald-600 dark:text-emerald-400" : "text-amber-600"}
+          className={
+            data.general_average === null
+              ? "text-muted-foreground"
+              : data.general_average >= 10
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-amber-600"
+          }
         />
         <KpiCard
           icon={Wallet}
           label="Frais restants"
-          value={`${data.fees_remaining.toLocaleString("fr-FR")} FCFA`}
-          className={data.fees_remaining === 0 ? "text-emerald-600 dark:text-emerald-400" : "text-accent"}
+          value={isEnrolled ? `${data.fees_remaining.toLocaleString("fr-FR")} FCFA` : "—"}
+          className={
+            !isEnrolled
+              ? "text-muted-foreground"
+              : data.fees_remaining === 0
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-accent"
+          }
         />
         <KpiCard
           icon={AlertCircle}
           label="Absences"
-          value={String(data.total_absences)}
-          className={data.total_absences > 5 ? "text-destructive" : "text-muted-foreground"}
+          value={isEnrolled ? String(data.total_absences) : "—"}
+          className={
+            !isEnrolled
+              ? "text-muted-foreground"
+              : data.total_absences > 5
+                ? "text-destructive"
+                : "text-muted-foreground"
+          }
         />
       </div>
     </div>

--- a/components/teacher/TeacherAttendanceClient.tsx
+++ b/components/teacher/TeacherAttendanceClient.tsx
@@ -58,8 +58,8 @@ export function TeacherAttendanceClient() {
               </SelectTrigger>
               <SelectContent>
                 {classes?.map((c) => (
-                  <SelectItem key={c.id} value={c.id.toString()}>
-                    {c.name} — {c.subject_name}
+                  <SelectItem key={c.class_id} value={c.class_id.toString()}>
+                    {c.class_name} — {c.subject_name}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/components/teacher/TeacherClassesClient.tsx
+++ b/components/teacher/TeacherClassesClient.tsx
@@ -42,9 +42,9 @@ export function TeacherClassesClient() {
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
           {classes.map((cls) => (
-            <ClassCard key={cls.id} cls={cls} />
+            <ClassCard key={cls.class_id} cls={cls} />
           ))}
         </div>
       )}
@@ -53,17 +53,19 @@ export function TeacherClassesClient() {
 }
 
 function ClassCard({ cls }: { cls: TeacherClass }) {
+  const average = cls.general_average ?? null
+  const totalEvals = cls.total_evaluations ?? 0
   return (
     <Card className="border-0 shadow-sm ring-1 ring-border">
       <CardContent className="p-4 space-y-3">
         {/* En-tête */}
         <div className="flex items-start justify-between">
           <div>
-            <p className="font-semibold text-sm">{cls.name}</p>
+            <p className="font-semibold text-sm">{cls.class_name}</p>
             <p className="text-xs text-muted-foreground">{cls.subject_name}</p>
           </div>
           <Badge variant="secondary" className="text-[10px]">
-            {cls.level}
+            {cls.level_name}
           </Badge>
         </div>
 
@@ -78,29 +80,27 @@ function ClassCard({ cls }: { cls: TeacherClass }) {
             <GraduationCap className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
             <p
               className={`text-sm font-bold ${
-                cls.general_average === null
+                average === null
                   ? "text-muted-foreground"
-                  : cls.general_average >= 10
+                  : average >= 10
                     ? "text-emerald-600 dark:text-emerald-400"
                     : "text-destructive"
               }`}
             >
-              {cls.general_average !== null
-                ? cls.general_average.toFixed(2)
-                : "—"}
+              {average !== null ? average.toFixed(2) : "—"}
             </p>
             <p className="text-[10px] text-muted-foreground">Moyenne</p>
           </div>
           <div className="rounded-lg bg-muted/50 p-2 text-center">
             <ClipboardList className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p className="text-sm font-bold">{cls.total_evaluations}</p>
+            <p className="text-sm font-bold">{totalEvals}</p>
             <p className="text-[10px] text-muted-foreground">Évals</p>
           </div>
         </div>
 
         {/* Action */}
         <Link
-          href={`/teacher/grades/${cls.id}` as Route}
+          href={`/teacher/grades/${cls.class_id}` as Route}
           className="flex items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
         >
           Gérer les notes <ChevronRight className="h-3 w-3" />

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
+import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
 import { useTeacherDashboard } from "@/lib/hooks/useTeacherPortal"
 import type { TeacherUpcomingEval } from "@/lib/contracts/teacher-portal"
 
@@ -48,6 +49,11 @@ export function TeacherDashboardClient() {
     <div className="space-y-6">
       <DashboardHeader name={data.teacher_name} />
 
+      <AcademicYearBanner
+        currentYear={data.current_academic_year}
+        role="teacher"
+      />
+
       {/* Prochain cours */}
       <Card className="border-primary/20 bg-primary/5">
         <CardContent className="flex items-center gap-4 p-4">
@@ -79,7 +85,7 @@ export function TeacherDashboardClient() {
       </Card>
 
       {/* KPIs */}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
         <Card className="border-0 shadow-sm ring-1 ring-border">
           <CardContent className="flex items-center gap-3 p-4">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
@@ -187,7 +193,7 @@ function DashboardSkeleton() {
         <Skeleton className="h-4 w-64" />
       </div>
       <Skeleton className="h-20 rounded-xl" />
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
         <Skeleton className="h-20 rounded-lg" />
         <Skeleton className="h-20 rounded-lg" />
       </div>

--- a/components/teacher/TeacherScheduleClient.tsx
+++ b/components/teacher/TeacherScheduleClient.tsx
@@ -2,18 +2,15 @@
 
 import { TeacherScheduleView } from "@/components/teacher/timetable/TeacherScheduleView"
 
-interface TeacherScheduleClientProps {
-  teacherId: number
-}
-
-export function TeacherScheduleClient({ teacherId }: TeacherScheduleClientProps) {
+export function TeacherScheduleClient() {
   return (
     <div className="space-y-4">
       <div>
         <h1 className="font-serif text-xl tracking-tight">Mon emploi du temps</h1>
         <p className="text-sm text-muted-foreground">Votre planning de la semaine</p>
       </div>
-      <TeacherScheduleView teacherId={teacherId} />
+      {/* No teacherId prop → fetch via /teacher/schedule (JWT-resolved) */}
+      <TeacherScheduleView />
     </div>
   )
 }

--- a/components/teacher/timetable/TeacherScheduleView.tsx
+++ b/components/teacher/timetable/TeacherScheduleView.tsx
@@ -1,7 +1,8 @@
 "use client"
 
+import { CalendarOff } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { useTeacherTimetable } from "@/lib/hooks/useTimetable"
+import { useMyTimetable, useTeacherTimetable } from "@/lib/hooks/useTimetable"
 import type { TimetableSlot } from "@/lib/contracts/timetable"
 import { Skeleton } from "@/components/ui/skeleton"
 
@@ -36,11 +37,23 @@ function timeToMinutes(t: string): number {
 }
 
 interface TeacherScheduleViewProps {
-  teacherId: number
+  /**
+   * Optional. When provided (admin viewing a specific teacher's schedule),
+   * fetch via /timetable?teacher_id=. When omitted (the teacher viewing
+   * their own schedule from /teacher/timetable), fetch via /teacher/schedule
+   * which resolves the teacher from the JWT (no user_id↔teacher_id mapping
+   * needed client-side).
+   */
+  teacherId?: number
 }
 
 export function TeacherScheduleView({ teacherId }: TeacherScheduleViewProps) {
-  const { data: slots, isLoading, error } = useTeacherTimetable(teacherId)
+  const ownQuery = useMyTimetable()
+  const adminQuery = useTeacherTimetable(teacherId ?? 0)
+  const useOwn = teacherId === undefined
+  const slots = useOwn ? ownQuery.data : adminQuery.data
+  const isLoading = useOwn ? ownQuery.isLoading : adminQuery.isLoading
+  const error = useOwn ? ownQuery.error : adminQuery.error
 
   if (error) {
     return (
@@ -78,6 +91,28 @@ export function TeacherScheduleView({ teacherId }: TeacherScheduleViewProps) {
   }
 
   const totalHeight = (END_HOUR - START_HOUR) * PX_PER_HOUR
+
+  // Bug #37 : empty state explicite quand aucun créneau n'est encore
+  // programmé pour cet enseignant. Sans ça, Mme Diallo voit une grille
+  // hebdomadaire vide et pense que l'app est cassée. Tone informatif
+  // (pas admin) — elle ne peut pas créer ses propres créneaux.
+  const hasSlots = (slots ?? []).length > 0
+  if (!hasSlots) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-xl border bg-card px-6 py-16 text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary ring-1 ring-primary/20">
+          <CalendarOff className="h-7 w-7" />
+        </div>
+        <div className="max-w-md space-y-1">
+          <p className="font-serif text-base">Aucun cours programmé</p>
+          <p className="text-sm text-muted-foreground">
+            Vos créneaux n&apos;ont pas encore été affectés pour cette année.
+            Contactez l&apos;administration pour vérifier votre planning.
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   // Group slots by day
   const slotsByDay: Record<string, TimetableSlot[]> = {}

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -1,4 +1,4 @@
-import { getSession } from "next-auth/react"
+import { getSession, signOut } from "next-auth/react"
 import type { Session } from "next-auth"
 import type { z } from "zod"
 
@@ -6,6 +6,34 @@ function getBaseUrl(): string {
   const url = process.env.NEXT_PUBLIC_API_URL
   if (!url) throw new Error("NEXT_PUBLIC_API_URL is not defined — check your .env file")
   return url
+}
+
+// Idempotent flag: when several queries fire in parallel and all return
+// 401 because the JWT just expired, we want exactly one signOut + redirect
+// — not N. Reset on next module load (full page reload after redirect).
+let isHandlingExpiredSession = false
+
+export async function handleExpiredSession(): Promise<void> {
+  if (isHandlingExpiredSession) return
+  if (typeof window === "undefined") return
+  isHandlingExpiredSession = true
+  // Invalidate the session cache so subsequent fetches don't pick up
+  // the stale token before the redirect happens.
+  sessionCache = null
+  sessionPromise = null
+  // Best-effort toast. Sonner may not be mounted yet on initial render.
+  try {
+    const { toast } = await import("sonner")
+    toast.error("Session expirée", {
+      description: "Veuillez vous reconnecter pour continuer.",
+    })
+  } catch {
+    // ignore
+  }
+  // Clear the NextAuth cookie. redirect:false because we trigger a full
+  // navigation ourselves to also reset TanStack Query / Zustand state.
+  await signOut({ redirect: false }).catch(() => {})
+  window.location.href = "/login?expired=1"
 }
 
 interface RequestOptions extends Omit<RequestInit, "headers"> {
@@ -57,6 +85,13 @@ export async function apiFetchBlob(path: string): Promise<Blob> {
   const headers = await authHeaders()
   delete headers["Content-Type"]
   const res = await fetch(`${getBaseUrl()}${path}`, { headers })
+  if (res.status === 401) {
+    const session = await getCachedSession()
+    if (session?.accessToken) {
+      await handleExpiredSession()
+    }
+    throw new Error("Session expirée")
+  }
   if (!res.ok) throw new Error(`Erreur ${res.status} lors du téléchargement`)
   return res.blob()
 }
@@ -65,6 +100,20 @@ export async function apiFetch<T>(path: string, options: RequestOptions = {}): P
   const { schema, ...fetchOptions } = options
   const headers = { ...(await authHeaders()), ...fetchOptions.headers }
   const res = await fetch(`${getBaseUrl()}${path}`, { ...fetchOptions, headers })
+
+  // 401: the JWT carried in the Authorization header is missing or expired.
+  // We only trigger signOut+redirect if we actually had a session — otherwise
+  // we'd race with the login flow (cookies set but not yet readable by
+  // getSession() on the first post-login fetch). When there's no session,
+  // throwing a plain error is enough: the middleware will redirect on the
+  // next navigation.
+  if (res.status === 401) {
+    const session = await getCachedSession()
+    if (session?.accessToken) {
+      await handleExpiredSession()
+    }
+    throw new Error("Session expirée")
+  }
 
   if (!res.ok) {
     const error = await res.json().catch(() => ({ detail: "Erreur serveur" }))

--- a/lib/api/payments.ts
+++ b/lib/api/payments.ts
@@ -1,17 +1,37 @@
 import { z } from "zod"
 import { apiFetch, apiFetchBlob, safeValidate } from "./client"
 import {
-  PaymentSchema,
+  AllocationPreviewSchema,
   FinancialSummarySchema,
+  PaymentSchema,
+  type AllocationPreview,
+  type EnrollmentPaymentCreate,
+  type FinancialSummary,
   type Payment,
   type PaymentCreate,
   type PaymentListParams,
-  type FinancialSummary,
 } from "@/lib/contracts/payment"
 import { PaginatedResponseSchema, type PaginatedResponse } from "@/lib/contracts"
 
 const PaginatedPaymentSchema = PaginatedResponseSchema(PaymentSchema)
 const PaymentArraySchema = z.array(PaymentSchema)
+
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object") {
+    const obj = json as Record<string, unknown>
+    if (obj.data !== undefined) return obj.data
+    if (obj.items !== undefined) return obj.items
+  }
+  return json
+}
+
+function unwrapPayment(json: unknown): unknown {
+  if (json !== null && typeof json === "object") {
+    const obj = json as Record<string, unknown>
+    if (obj.data !== undefined) return obj.data
+  }
+  return json
+}
 
 export const paymentsApi = {
   // Liste paginée des paiements
@@ -21,68 +41,120 @@ export const paymentsApi = {
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => [k, String(v)]),
     ).toString()
-    const json = await apiFetch<PaginatedResponse<Payment> | Payment[]>(
-      `/payments${query ? `?${query}` : ""}`,
-    )
+    const json = await apiFetch<unknown>(`/payments${query ? `?${query}` : ""}`)
     if (Array.isArray(json)) {
       const arr = safeValidate(PaymentArraySchema, json, "GET /payments")
       return { items: arr, total: arr.length, page: 1, size: arr.length, total_pages: 1 }
     }
-    return safeValidate(PaginatedPaymentSchema, json, "GET /payments") as PaginatedResponse<Payment>
+    return safeValidate(
+      PaginatedPaymentSchema,
+      json,
+      "GET /payments",
+    ) as PaginatedResponse<Payment>
   },
 
-  // Créer un paiement
+  // LEGACY — Créer un paiement ciblant un frais spécifique
+  // Préférer `recordOnEnrollment` (auto-allocation prioritaire).
   create: async (data: PaymentCreate): Promise<Payment> => {
-    const json = await apiFetch<{ data?: Payment } | Payment>("/payments", {
+    const json = await apiFetch<unknown>("/payments", {
       method: "POST",
       body: JSON.stringify(data),
     })
-    const payment = (json as { data?: Payment }).data ?? (json as Payment)
-    return safeValidate(PaymentSchema, payment, "POST /payments")
+    return safeValidate(PaymentSchema, unwrapPayment(json), "POST /payments")
+  },
+
+  // NEW — Versement caissier Wave-style (auto-alloué par priorité)
+  recordOnEnrollment: async (
+    enrollmentId: number,
+    data: EnrollmentPaymentCreate,
+  ): Promise<Payment> => {
+    const json = await apiFetch<unknown>(`/enrollments/${enrollmentId}/payments`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(
+      PaymentSchema,
+      unwrapPayment(json),
+      `POST /enrollments/${enrollmentId}/payments`,
+    )
+  },
+
+  // NEW — Preview de l'allocation avant submit (read-only)
+  previewAllocation: async (
+    enrollmentId: number,
+    amount: number,
+  ): Promise<AllocationPreview> => {
+    const json = await apiFetch<unknown>(
+      `/enrollments/${enrollmentId}/payments/preview?amount=${amount}`,
+    )
+    return safeValidate(
+      AllocationPreviewSchema,
+      unwrap(json),
+      `GET /enrollments/${enrollmentId}/payments/preview`,
+    )
+  },
+
+  // NEW — Historique paiements d'une inscription (Payment.enrollment_id direct)
+  listByEnrollment: async (enrollmentId: number): Promise<Payment[]> => {
+    const json = await apiFetch<unknown>(`/enrollments/${enrollmentId}/payments`)
+    const arr = Array.isArray(json) ? json : []
+    return safeValidate(
+      PaymentArraySchema,
+      arr,
+      `GET /enrollments/${enrollmentId}/payments`,
+    )
   },
 
   // Récupérer un paiement par ID
   getById: async (id: number): Promise<Payment> => {
-    const json = await apiFetch<Payment>(`/payments/${id}`)
-    return safeValidate(PaymentSchema, json, `GET /payments/${id}`)
+    const json = await apiFetch<unknown>(`/payments/${id}`)
+    return safeValidate(PaymentSchema, unwrapPayment(json), `GET /payments/${id}`)
   },
 
-  // Paiements d'un élève par enrollment_id
+  // LEGACY — paiements d'un élève via /payments/student/{enrollment_id}
+  // Préférer `listByEnrollment` qui utilise le nouveau path REST nested.
   getStudentPayments: async (enrollmentId: number): Promise<Payment[]> => {
-    const json = await apiFetch<Payment[]>(`/payments/student/${enrollmentId}`)
+    const json = await apiFetch<unknown>(`/payments/student/${enrollmentId}`)
     const arr = Array.isArray(json) ? json : []
-    return safeValidate(PaymentArraySchema, arr, `GET /payments/student/${enrollmentId}`)
+    return safeValidate(
+      PaymentArraySchema,
+      arr,
+      `GET /payments/student/${enrollmentId}`,
+    )
   },
 
-  // Valider un paiement
+  // Valider un paiement (pending → completed)
   validate: async (id: number): Promise<Payment> => {
-    const json = await apiFetch<{ data?: Payment } | Payment>(`/payments/${id}/validate`, {
-      method: "POST",
-    })
-    const payment = (json as { data?: Payment }).data ?? (json as Payment)
-    return safeValidate(PaymentSchema, payment, `POST /payments/${id}/validate`)
+    const json = await apiFetch<unknown>(`/payments/${id}/validate`, { method: "POST" })
+    return safeValidate(
+      PaymentSchema,
+      unwrapPayment(json),
+      `POST /payments/${id}/validate`,
+    )
   },
 
-  // Annuler un paiement
+  // Annuler un paiement (cascade DELETE allocations + recompute fees)
   cancel: async (id: number): Promise<Payment> => {
-    const json = await apiFetch<{ data?: Payment } | Payment>(`/payments/${id}/cancel`, {
-      method: "POST",
-    })
-    const payment = (json as { data?: Payment }).data ?? (json as Payment)
-    return safeValidate(PaymentSchema, payment, `POST /payments/${id}/cancel`)
+    const json = await apiFetch<unknown>(`/payments/${id}/cancel`, { method: "POST" })
+    return safeValidate(
+      PaymentSchema,
+      unwrapPayment(json),
+      `POST /payments/${id}/cancel`,
+    )
   },
 
-  // Résumé financier
+  // Résumé financier (KPIs dashboard)
   getSummary: async (academicYearId?: number): Promise<FinancialSummary> => {
     const query = academicYearId ? `?academic_year_id=${academicYearId}` : ""
-    const json = await apiFetch<{ data?: FinancialSummary } | FinancialSummary>(
-      `/payments/summary${query}`,
+    const json = await apiFetch<unknown>(`/payments/summary${query}`)
+    return safeValidate(
+      FinancialSummarySchema,
+      unwrapPayment(json),
+      "GET /payments/summary",
     )
-    const summary = (json as { data?: FinancialSummary }).data ?? (json as FinancialSummary)
-    return safeValidate(FinancialSummarySchema, summary, "GET /payments/summary")
   },
 
-  // Télécharger le reçu PDF (authentifié)
+  // Télécharger le reçu PDF
   downloadReceipt: async (id: number): Promise<Blob> => {
     return apiFetchBlob(`/payments/${id}/receipt`)
   },

--- a/lib/api/settings.ts
+++ b/lib/api/settings.ts
@@ -1,55 +1,56 @@
 import { apiFetch } from "./client"
-import type { SchoolSettings, SchoolInfoUpdate, TrimesterUpdate, NotificationUpdate } from "@/lib/contracts/settings"
+import {
+  SchoolSettingsSchema,
+  type SchoolSettings,
+  type SchoolInfoUpdate,
+  type TrimesterUpdate,
+  type NotificationUpdate,
+} from "@/lib/contracts/settings"
 
-const DEFAULT_SETTINGS: SchoolSettings = {
-  school_name: "",
-  address: null,
-  phone: null,
-  email: null,
-  logo_url: null,
-  ministry_code: null,
-  enrollment_number_pattern: null,
-  enrollment_number_counter: 0,
-  active_academic_year: null,
-  trimesters: [],
-  notify_by_email: false,
-  notify_by_sms: false,
-  notify_grades: false,
-  notify_absences: false,
-  notify_payments: false,
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object" && "data" in json) {
+    const data = (json as { data?: unknown }).data
+    if (data !== undefined) return data
+  }
+  return json
+}
+
+function parseSettings(json: unknown, context: string): SchoolSettings {
+  const parsed = SchoolSettingsSchema.safeParse(unwrap(json))
+  if (!parsed.success) {
+    console.error(`[API] Validation failed for ${context}:`, parsed.error.issues)
+    throw new Error(`Réponse inattendue du serveur pour ${context}`)
+  }
+  return parsed.data
 }
 
 export const settingsApi = {
-  // Récupérer les paramètres de l'école
   get: async (): Promise<SchoolSettings> => {
-    const json = await apiFetch<{ data?: SchoolSettings } | SchoolSettings>("/admin/settings")
-    return (json as { data?: SchoolSettings }).data ?? (json as SchoolSettings)
+    const json = await apiFetch<unknown>("/admin/settings")
+    return parseSettings(json, "GET /admin/settings")
   },
 
-  // Mettre à jour les informations de l'école
   updateSchoolInfo: async (data: SchoolInfoUpdate): Promise<SchoolSettings> => {
-    const json = await apiFetch<{ data?: SchoolSettings } | SchoolSettings>("/admin/settings/school-info", {
+    const json = await apiFetch<unknown>("/admin/settings/school-info", {
       method: "PUT",
       body: JSON.stringify(data),
     })
-    return (json as { data?: SchoolSettings }).data ?? (json as SchoolSettings)
+    return parseSettings(json, "PUT /admin/settings/school-info")
   },
 
-  // Mettre à jour la configuration des trimestres
   updateTrimesters: async (data: TrimesterUpdate): Promise<SchoolSettings> => {
-    const json = await apiFetch<{ data?: SchoolSettings } | SchoolSettings>("/admin/settings/trimesters", {
+    const json = await apiFetch<unknown>("/admin/settings/trimesters", {
       method: "PUT",
       body: JSON.stringify(data),
     })
-    return (json as { data?: SchoolSettings }).data ?? (json as SchoolSettings)
+    return parseSettings(json, "PUT /admin/settings/trimesters")
   },
 
-  // Mettre à jour les paramètres de notification
   updateNotifications: async (data: NotificationUpdate): Promise<SchoolSettings> => {
-    const json = await apiFetch<{ data?: SchoolSettings } | SchoolSettings>("/admin/settings/notifications", {
+    const json = await apiFetch<unknown>("/admin/settings/notifications", {
       method: "PUT",
       body: JSON.stringify(data),
     })
-    return (json as { data?: SchoolSettings }).data ?? (json as SchoolSettings)
+    return parseSettings(json, "PUT /admin/settings/notifications")
   },
 }

--- a/lib/api/staff.ts
+++ b/lib/api/staff.ts
@@ -1,14 +1,17 @@
 import { getSession } from "next-auth/react"
+import { z } from "zod"
 import { StaffSchema } from "@/lib/contracts/staff"
 import type { Staff, StaffCreate, StaffUpdate } from "@/lib/contracts/staff"
 import { createCrudApi } from "./createCrudApi"
-import { apiFetch } from "./client"
+import { apiFetch, handleExpiredSession, safeValidate } from "./client"
 
 function getBaseUrl(): string {
   const url = process.env.NEXT_PUBLIC_API_URL
   if (!url) throw new Error("NEXT_PUBLIC_API_URL is not defined")
   return url
 }
+
+const PhotoUploadResponseSchema = z.object({ photo_url: z.string() })
 
 export const staffApi = {
   ...createCrudApi<Staff, StaffCreate, StaffUpdate>(
@@ -31,18 +34,16 @@ export const staffApi = {
       },
       body: formData,
     })
+    if (res.status === 401) {
+      if (session?.accessToken) await handleExpiredSession()
+      throw new Error("Session expirée")
+    }
     if (!res.ok) throw new Error("Upload failed")
-    return res.json()
+    const data = await res.json()
+    return safeValidate(PhotoUploadResponseSchema, data, "POST /admin/staff/:id/photo")
   },
 
   deletePhoto: async (staffId: number): Promise<void> => {
-    const session = await getSession()
-    const res = await fetch(`${getBaseUrl()}/admin/staff/${staffId}/photo`, {
-      method: "DELETE",
-      headers: {
-        ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-      },
-    })
-    if (!res.ok) throw new Error("Erreur lors de la suppression de la photo")
+    await apiFetch<void>(`/admin/staff/${staffId}/photo`, { method: "DELETE" })
   },
 }

--- a/lib/api/student-portal.ts
+++ b/lib/api/student-portal.ts
@@ -42,11 +42,47 @@ export const studentPortalApi = {
     return safeValidate(StudentGradesResponseSchema, unwrapResponse(res), "GET /student/grades")
   },
 
-  // Emploi du temps de la classe de l'élève
+  // Emploi du temps de la classe de l'élève. Le BE renvoie une enveloppe
+  // {class_name, slots: [...]} dont chaque slot omet certains champs
+  // (subject_id/teacher_id/class_id/academic_year_id). On normalise ici
+  // vers le contrat `TimetableSlot` partagé pour réutiliser le rendu existant.
   getTimetable: async (): Promise<TimetableSlot[]> => {
     const res = await apiFetch<unknown>("/student/timetable")
-    const arr = Array.isArray(res) ? res : unwrapResponse<TimetableSlot[]>(res)
-    return safeValidate(TimetableSlotArraySchema, arr, "GET /student/timetable")
+    let rawSlots: unknown[]
+    if (Array.isArray(res)) {
+      rawSlots = res
+    } else if (res !== null && typeof res === "object" && Array.isArray((res as Record<string, unknown>).slots)) {
+      rawSlots = (res as { slots: unknown[] }).slots
+    } else {
+      rawSlots = []
+    }
+    const EN_TO_FR: Record<string, string> = {
+      monday: "lundi", tuesday: "mardi", wednesday: "mercredi",
+      thursday: "jeudi", friday: "vendredi", saturday: "samedi",
+    }
+    const mapped = rawSlots.map((raw) => {
+      const s = raw as Record<string, unknown>
+      const start = String(s.start_time ?? "").slice(0, 5)
+      const end = String(s.end_time ?? "").slice(0, 5)
+      const id = Number(s.id ?? 0)
+      const day = String(s.day ?? "")
+      return {
+        id,
+        class_id: Number(s.class_id ?? 0),
+        class_name: String(s.class_name ?? ""),
+        teacher_id: Number(s.teacher_id ?? 0),
+        teacher_name: String(s.teacher_name ?? ""),
+        subject_id: Number(s.subject_id ?? id),
+        subject_name: String(s.subject_name ?? ""),
+        subject_color: (s.subject_color as string | null | undefined) ?? null,
+        academic_year_id: Number(s.academic_year_id ?? 0),
+        day: EN_TO_FR[day] ?? day,
+        start_time: start,
+        end_time: end,
+        room: ((s.room ?? s.room_name) as string | null | undefined) ?? null,
+      }
+    })
+    return safeValidate(TimetableSlotArraySchema, mapped, "GET /student/timetable")
   },
 
   // Frais et paiements

--- a/lib/api/students.ts
+++ b/lib/api/students.ts
@@ -2,11 +2,36 @@ import { getSession } from "next-auth/react"
 import { StudentFiltersSchema, StudentSchema } from "@/lib/contracts/student"
 import type { Student, StudentCreate, StudentFilters, StudentUpdate } from "@/lib/contracts/student"
 import { createCrudApi } from "./createCrudApi"
+import { apiFetch, handleExpiredSession, safeValidate } from "./client"
+import { z } from "zod"
 
 function getBaseUrl(): string {
   const url = process.env.NEXT_PUBLIC_API_URL
   if (!url) throw new Error("NEXT_PUBLIC_API_URL is not defined")
   return url
+}
+
+const PhotoUploadResponseSchema = z.object({ photo_url: z.string() })
+
+const StudentEnrollmentFeeSchema = z.object({
+  id: z.number(),
+  enrollment_id: z.number(),
+  category_name: z.string(),
+  amount: z.number(),
+  paid: z.number(),
+  remaining: z.number(),
+  status: z.string(),
+})
+const StudentEnrollmentFeeListSchema = z.array(StudentEnrollmentFeeSchema)
+
+function unwrapItems(json: unknown): unknown {
+  if (Array.isArray(json)) return json
+  if (json !== null && typeof json === "object") {
+    const obj = json as Record<string, unknown>
+    if (obj.items !== undefined) return obj.items
+    if (obj.data !== undefined) return obj.data
+  }
+  return json
 }
 
 export const studentsApi = {
@@ -16,6 +41,8 @@ export const studentsApi = {
   ),
 
   uploadPhoto: async (studentId: number, file: File): Promise<{ photo_url: string }> => {
+    // FormData multipart upload — can't go through apiFetch (which JSON-encodes).
+    // We replicate the 401 → handleExpiredSession contract manually.
     const session = await getSession()
     const formData = new FormData()
     formData.append("file", file)
@@ -26,60 +53,28 @@ export const studentsApi = {
       },
       body: formData,
     })
+    if (res.status === 401) {
+      if (session?.accessToken) await handleExpiredSession()
+      throw new Error("Session expirée")
+    }
     if (!res.ok) throw new Error("Upload failed")
-    return res.json()
+    const data = await res.json()
+    return safeValidate(PhotoUploadResponseSchema, data, "POST /admin/students/:id/photo")
   },
 
   deletePhoto: async (studentId: number): Promise<void> => {
-    const session = await getSession()
-    const res = await fetch(`${getBaseUrl()}/admin/students/${studentId}/photo`, {
-      method: "DELETE",
-      headers: {
-        ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-      },
-    })
-    if (!res.ok) throw new Error("Erreur lors de la suppression de la photo")
+    await apiFetch<void>(`/admin/students/${studentId}/photo`, { method: "DELETE" })
   },
 
   getFilters: async (): Promise<StudentFilters> => {
-    const session = await getSession()
-    const res = await fetch(`${getBaseUrl()}/admin/students/filters`, {
-      headers: {
-        "Content-Type": "application/json",
-        ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-      },
-    })
-    if (!res.ok) {
-      const error = await res.json().catch(() => ({ detail: "Erreur serveur" }))
-      throw new Error(error.detail || "Impossible de charger les filtres")
-    }
-    const data = await res.json()
-    return StudentFiltersSchema.parse(data)
+    const data = await apiFetch<unknown>("/admin/students/filters")
+    return safeValidate(StudentFiltersSchema, data, "GET /admin/students/filters")
   },
 
   getEnrollmentFees: async (studentId: number): Promise<StudentEnrollmentFee[]> => {
-    const session = await getSession()
-    const res = await fetch(`${getBaseUrl()}/admin/students/${studentId}/fees`, {
-      headers: {
-        "Content-Type": "application/json",
-        ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-      },
-    })
-    if (!res.ok) {
-      const error = await res.json().catch(() => ({ detail: "Erreur serveur" }))
-      throw new Error(error.detail || "Impossible de charger les frais")
-    }
-    const data = await res.json()
-    return Array.isArray(data) ? data : data.items ?? data.data ?? []
+    const data = await apiFetch<unknown>(`/admin/students/${studentId}/fees`)
+    return safeValidate(StudentEnrollmentFeeListSchema, unwrapItems(data), `GET /admin/students/${studentId}/fees`)
   },
 }
 
-export interface StudentEnrollmentFee {
-  id: number
-  enrollment_id: number
-  category_name: string
-  amount: number
-  paid: number
-  remaining: number
-  status: string
-}
+export type StudentEnrollmentFee = z.infer<typeof StudentEnrollmentFeeSchema>

--- a/lib/api/teacher-portal.ts
+++ b/lib/api/teacher-portal.ts
@@ -14,10 +14,12 @@ import {
 const TeacherClassArraySchema = z.array(TeacherClassSchema)
 const TeacherEvalsArraySchema = z.array(TeacherUpcomingEvalSchema)
 
-// Extrait l'item de la réponse API, qu'elle soit { data: T } ou T directement
+// Extrait l'item de la réponse API, qu'elle soit { data: T }, { items: T }, ou T directement
 function unwrapResponse<T>(res: unknown): T {
-  if (res !== null && typeof res === "object" && "data" in res && (res as Record<string, unknown>).data !== undefined) {
-    return (res as Record<string, unknown>).data as T
+  if (res !== null && typeof res === "object") {
+    const obj = res as Record<string, unknown>
+    if (obj.data !== undefined) return obj.data as T
+    if (obj.items !== undefined) return obj.items as T
   }
   return res as T
 }

--- a/lib/api/teachers.ts
+++ b/lib/api/teachers.ts
@@ -1,14 +1,17 @@
 import { getSession } from "next-auth/react"
+import { z } from "zod"
 import { TeacherSchema } from "@/lib/contracts/teacher"
 import type { Teacher, TeacherCreate, TeacherUpdate } from "@/lib/contracts/teacher"
 import { createCrudApi } from "./createCrudApi"
-import { apiFetch } from "./client"
+import { apiFetch, handleExpiredSession, safeValidate } from "./client"
 
 function getBaseUrl(): string {
   const url = process.env.NEXT_PUBLIC_API_URL
   if (!url) throw new Error("NEXT_PUBLIC_API_URL is not defined")
   return url
 }
+
+const PhotoUploadResponseSchema = z.object({ photo_url: z.string() })
 
 export const teachersApi = {
   ...createCrudApi<Teacher, TeacherCreate, TeacherUpdate>(
@@ -21,6 +24,8 @@ export const teachersApi = {
   },
 
   uploadPhoto: async (teacherId: number, file: File): Promise<{ photo_url: string }> => {
+    // FormData multipart upload — can't go through apiFetch (JSON-encoded).
+    // 401 → handleExpiredSession contract replicated manually.
     const session = await getSession()
     const formData = new FormData()
     formData.append("file", file)
@@ -31,18 +36,16 @@ export const teachersApi = {
       },
       body: formData,
     })
+    if (res.status === 401) {
+      if (session?.accessToken) await handleExpiredSession()
+      throw new Error("Session expirée")
+    }
     if (!res.ok) throw new Error("Upload failed")
-    return res.json()
+    const data = await res.json()
+    return safeValidate(PhotoUploadResponseSchema, data, "POST /admin/teachers/:id/photo")
   },
 
   deletePhoto: async (teacherId: number): Promise<void> => {
-    const session = await getSession()
-    const res = await fetch(`${getBaseUrl()}/admin/teachers/${teacherId}/photo`, {
-      method: "DELETE",
-      headers: {
-        ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-      },
-    })
-    if (!res.ok) throw new Error("Erreur lors de la suppression de la photo")
+    await apiFetch<void>(`/admin/teachers/${teacherId}/photo`, { method: "DELETE" })
   },
 }

--- a/lib/api/timetable.ts
+++ b/lib/api/timetable.ts
@@ -64,6 +64,42 @@ export const timetableApi = {
     return slotsToFr(safeValidate(TimetableSlotArraySchema, arr, `/timetable?teacher_id=${teacherId}`))
   },
 
+  // GET /teacher/schedule (BE) resolves the teacher from the JWT, so the FE
+  // never needs to know the teacher_profile.id. Used for /teacher/timetable
+  // (the teacher viewing their own schedule). The shape from BE omits a few
+  // fields that TimetableSlotSchema requires (teacher_id / teacher_name /
+  // class_id / academic_year_id / subject_id) — we map to a synthesized
+  // record that satisfies the Zod contract used by the grid component.
+  myTimetable: async (): Promise<TimetableSlot[]> => {
+    const json = await apiFetch<{ items?: unknown[] } | unknown[]>(`/teacher/schedule`)
+    const arr: unknown[] = Array.isArray(json) ? json : json.items ?? []
+    const mapped = arr.map((raw) => {
+      const s = raw as Record<string, unknown>
+      const start = String(s.start_time ?? "").slice(0, 5)
+      const end = String(s.end_time ?? "").slice(0, 5)
+      const id = Number(s.id ?? 0)
+      return {
+        id,
+        class_id: Number(s.class_id ?? 0),
+        teacher_id: Number(s.teacher_id ?? 0),
+        // subject_id drives the color hue in TeacherScheduleView. /teacher/schedule
+        // doesn't expose it, so we fall back to the slot id which is unique enough
+        // to spread colors across slots of the same teacher.
+        subject_id: Number(s.subject_id ?? id),
+        academic_year_id: Number(s.academic_year_id ?? 0),
+        day: String(s.day ?? ""),
+        start_time: start,
+        end_time: end,
+        class_name: String(s.class_name ?? ""),
+        teacher_name: String(s.teacher_name ?? ""),
+        subject_name: String(s.subject_name ?? ""),
+        subject_color: (s.subject_color as string | null | undefined) ?? null,
+        room: ((s.room ?? s.room_name) as string | null | undefined) ?? null,
+      }
+    })
+    return slotsToFr(safeValidate(TimetableSlotArraySchema, mapped, `/teacher/schedule`))
+  },
+
   create: async (data: TimetableSlotCreate): Promise<TimetableSlot> => {
     const payload = { ...data, day: dayToEn(data.day) }
     const json = await apiFetch<{ data?: TimetableSlot } | TimetableSlot>(

--- a/lib/contracts/parent-portal.ts
+++ b/lib/contracts/parent-portal.ts
@@ -17,6 +17,7 @@ export const ParentDashboardSchema = z.object({
   parent_name: z.string(),
   total_children: z.number(),
   children: z.array(ParentChildSchema),
+  current_academic_year: z.string().nullish(),
 })
 
 // Notes d'un enfant — même structure que les notes élève

--- a/lib/contracts/payment.ts
+++ b/lib/contracts/payment.ts
@@ -1,35 +1,98 @@
 import { z } from "zod"
 
 // Miroir de app/schemas/payment.py (backend)
+// Refactor 2026-05-17 : Payment cible enrollment_id + PaymentAllocation breakdown.
 
-export const PaymentMethodSchema = z.enum(["cash", "mobile_money", "bank_transfer", "check"])
+export const PaymentMethodSchema = z.enum(["cash", "mobile_money", "bank_transfer", "cheque"])
 
-export const PaymentStatusSchema = z.enum(["pending", "completed", "failed", "refunded", "cancelled"])
+export const PaymentStatusSchema = z.enum([
+  "pending",
+  "completed",
+  "failed",
+  "refunded",
+  "cancelled",
+])
+
+export const EnrollmentFeeStatusSchema = z.enum(["pending", "partial", "paid", "waived"])
+
+// Split comptable d'un paiement vers un frais spécifique.
+export const PaymentAllocationSchema = z.object({
+  id: z.number(),
+  enrollment_fee_id: z.number(),
+  amount: z.coerce.number(),
+  fee_category_name: z.string().nullable().optional(),
+  fee_category_priority: z.number().nullable().optional(),
+  enrollment_fee_status_after: z.string().nullable().optional(),
+})
 
 export const PaymentSchema = z.object({
   id: z.number(),
-  enrollment_fee_id: z.number(),
+  enrollment_id: z.number(),
+  // Champ legacy : null pour les paiements créés via le nouveau flow auto-alloc.
+  enrollment_fee_id: z.number().nullable().optional(),
   amount: z.coerce.number(),
   method: PaymentMethodSchema,
   status: PaymentStatusSchema,
   reference: z.string().nullable(),
   notes: z.string().nullable().optional(),
+  received_by: z.number().nullable().optional(),
   created_at: z.string(),
   updated_at: z.string(),
   student_name: z.string().nullable().optional(),
   student_photo_url: z.string().nullable().optional(),
   fee_name: z.string().nullable().optional(),
-}).passthrough()
+  // BE renvoie toujours `allocations: []` au minimum. Optional côté TS pour
+  // compat avec les call sites qui ne consomment pas ce champ.
+  allocations: z.array(PaymentAllocationSchema).optional(),
+})
 
+// Body POST /payments (legacy) — cible un frais spécifique.
 export const PaymentCreateSchema = z.object({
-  enrollment_fee_id: z.number({ required_error: "Le frais d'inscription est requis" }).positive(),
+  enrollment_fee_id: z
+    .number({ required_error: "Le frais d'inscription est requis" })
+    .positive(),
   amount: z.string({ required_error: "Le montant est requis" }),
   method: PaymentMethodSchema,
   reference: z.string().nullable().optional(),
   notes: z.string().nullable().optional(),
 })
 
-// Résumé financier — miroir de PaymentSummaryResponse (backend)
+// Body POST /enrollments/{id}/payments — flow Wave-style (cible).
+export const EnrollmentPaymentCreateSchema = z.object({
+  amount: z.coerce
+    .number({
+      required_error: "Le montant est requis",
+      invalid_type_error: "Montant invalide",
+    })
+    .positive("Le montant doit être supérieur à zéro"),
+  method: PaymentMethodSchema,
+  reference: z.string().nullable().optional(),
+  notes: z.string().nullable().optional(),
+})
+
+// Preview de l'allocation avant submit (UX caissier).
+export const AllocationPreviewLineSchema = z.object({
+  enrollment_fee_id: z.number(),
+  fee_category_name: z.string(),
+  fee_category_priority: z.number(),
+  fee_total: z.coerce.number(),
+  fee_paid_before: z.coerce.number(),
+  allocated: z.coerce.number(),
+  fee_paid_after: z.coerce.number(),
+  status_after: EnrollmentFeeStatusSchema,
+})
+
+export const AllocationPreviewSchema = z.object({
+  enrollment_id: z.number(),
+  amount: z.coerce.number(),
+  total_remaining_before: z.coerce.number(),
+  total_remaining_after: z.coerce.number(),
+  surplus: z.coerce.number(),
+  can_record: z.boolean(),
+  reject_reason: z.string().nullable(),
+  lines: z.array(AllocationPreviewLineSchema),
+})
+
 export const FinancialSummarySchema = z.object({
   total_expected: z.number(),
   total_paid: z.number(),
@@ -44,6 +107,7 @@ export const PaymentListParamsSchema = z.object({
   status: PaymentStatusSchema.optional(),
   method: PaymentMethodSchema.optional(),
   fee_category_id: z.number().optional(),
+  enrollment_id: z.number().optional(),
   search: z.string().optional(),
   page: z.number().optional(),
   size: z.number().optional(),
@@ -51,7 +115,12 @@ export const PaymentListParamsSchema = z.object({
 
 export type PaymentMethod = z.infer<typeof PaymentMethodSchema>
 export type PaymentStatus = z.infer<typeof PaymentStatusSchema>
+export type EnrollmentFeeStatus = z.infer<typeof EnrollmentFeeStatusSchema>
+export type PaymentAllocation = z.infer<typeof PaymentAllocationSchema>
 export type Payment = z.infer<typeof PaymentSchema>
 export type PaymentCreate = z.infer<typeof PaymentCreateSchema>
+export type EnrollmentPaymentCreate = z.infer<typeof EnrollmentPaymentCreateSchema>
+export type AllocationPreviewLine = z.infer<typeof AllocationPreviewLineSchema>
+export type AllocationPreview = z.infer<typeof AllocationPreviewSchema>
 export type FinancialSummary = z.infer<typeof FinancialSummarySchema>
 export type PaymentListParams = z.infer<typeof PaymentListParamsSchema>

--- a/lib/contracts/settings.ts
+++ b/lib/contracts/settings.ts
@@ -51,6 +51,10 @@ export const SchoolInfoUpdateSchema = z.object({
   ministry_code: z.string().optional(),
   head_master_name: z.string().optional(),
   head_master_title: z.string().optional(),
+  primary_color: z.string().nullable().optional(),
+  accent_color: z.string().nullable().optional(),
+  website: z.string().nullable().optional(),
+  motto: z.string().nullable().optional(),
 })
 
 export const TrimesterUpdateSchema = z.object({

--- a/lib/contracts/settings.ts
+++ b/lib/contracts/settings.ts
@@ -25,14 +25,22 @@ export const SchoolSettingsSchema = z.object({
   head_master_title: z.string().nullable().optional(),
   enrollment_number_pattern: z.string().nullable().optional(),
   enrollment_number_counter: z.number().optional().default(0),
-  // --- UI-only fields (not yet in backend, optional with defaults) ---
+  // Personnalisation PDF par école (migration BE 0029)
+  primary_color: z.string().nullable().optional(),
+  accent_color: z.string().nullable().optional(),
+  website: z.string().nullable().optional(),
+  motto: z.string().nullable().optional(),
+  // --- UI-only fields ---
   active_academic_year: z.string().nullable().optional().default(null),
   trimesters: z.array(TrimesterConfigSchema).optional().default([]),
+  // Notification preferences (now backed by BE columns on school_settings — see migration 0027)
   notify_by_email: z.boolean().optional().default(false),
   notify_by_sms: z.boolean().optional().default(false),
   notify_grades: z.boolean().optional().default(false),
   notify_absences: z.boolean().optional().default(false),
   notify_payments: z.boolean().optional().default(false),
+  notify_enrollment: z.boolean().optional().default(false),
+  notify_reenrollment: z.boolean().optional().default(false),
 })
 
 export const SchoolInfoUpdateSchema = z.object({
@@ -55,6 +63,8 @@ export const NotificationUpdateSchema = z.object({
   notify_grades: z.boolean(),
   notify_absences: z.boolean(),
   notify_payments: z.boolean(),
+  notify_enrollment: z.boolean(),
+  notify_reenrollment: z.boolean(),
 })
 
 export type TrimesterConfig = z.infer<typeof TrimesterConfigSchema>

--- a/lib/contracts/staff.ts
+++ b/lib/contracts/staff.ts
@@ -11,14 +11,25 @@ export const StaffSchema = z.object({
   updated_at: z.string().optional(),
 }).passthrough()
 
+// Aligné sur TeacherCreate : un staff a aussi un compte user pour se
+// connecter au portail (admin secondaire / secrétaire pédagogique).
+// Le BE crée User + user_roles + StaffProfile en transaction.
 export const StaffCreateSchema = z.object({
   first_name: z.string({ required_error: "Le prénom est requis" }).min(1, "Le prénom est requis"),
   last_name: z.string({ required_error: "Le nom est requis" }).min(1, "Le nom est requis"),
+  email: z.string({ required_error: "L'email est requis" }).email("Email invalide"),
+  password: z.string({ required_error: "Le mot de passe est requis" }).min(8, "8 caractères minimum"),
   position: z.string().optional(),
   phone: z.string().optional(),
 })
 
-export const StaffUpdateSchema = StaffCreateSchema.partial()
+// L'update n'envoie jamais email/password (changement compte = endpoint dédié)
+export const StaffUpdateSchema = z.object({
+  first_name: z.string().min(1).optional(),
+  last_name: z.string().min(1).optional(),
+  position: z.string().optional(),
+  phone: z.string().optional(),
+})
 
 export const StaffListParamsSchema = z.object({
   page: z.number().optional(),

--- a/lib/contracts/student-portal.ts
+++ b/lib/contracts/student-portal.ts
@@ -18,6 +18,7 @@ export const StudentDashboardSchema = z.object({
   general_average: z.number().nullable(),
   fees_remaining: z.number(),
   total_absences: z.number(),
+  current_academic_year: z.string().nullish(),
 })
 
 // Notes par matière

--- a/lib/contracts/teacher-portal.ts
+++ b/lib/contracts/teacher-portal.ts
@@ -12,15 +12,18 @@ export const TeacherNextCourseSchema = z.object({
   room: z.string().nullish(),
 })
 
-// Classe assignée à l'enseignant
+// Classe assignée à l'enseignant — aligné sur TeacherClassResponse (BE).
+// `general_average` et `total_evaluations` sont optionnels : le BE ne les
+// expose pas actuellement (les colonnes seront ajoutées si besoin pour la
+// vue Mes Classes).
 export const TeacherClassSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  level: z.string(),
+  class_id: z.number(),
+  class_name: z.string(),
+  level_name: z.string(),
   student_count: z.number(),
   subject_name: z.string(),
-  general_average: z.number().nullable(),
-  total_evaluations: z.number(),
+  general_average: z.number().nullish(),
+  total_evaluations: z.number().nullish(),
 })
 
 // Évaluation à venir
@@ -43,6 +46,7 @@ export const TeacherDashboardSchema = z.object({
   total_classes: z.number(),
   next_course: TeacherNextCourseSchema.nullable(),
   upcoming_evaluations: z.array(TeacherUpcomingEvalSchema),
+  current_academic_year: z.string().nullish(),
 })
 
 // Stats de présence par classe

--- a/lib/hooks/usePayments.ts
+++ b/lib/hooks/usePayments.ts
@@ -1,15 +1,24 @@
 "use client"
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { paymentsApi } from "@/lib/api/payments"
-import type { Payment, PaymentCreate, PaymentListParams } from "@/lib/contracts/payment"
+import type {
+  EnrollmentPaymentCreate,
+  Payment,
+  PaymentCreate,
+  PaymentListParams,
+} from "@/lib/contracts/payment"
 import type { PaginatedResponse } from "@/lib/contracts"
 
 export const paymentKeys = {
   all: ["payments"] as const,
   list: (params: PaymentListParams) => ["payments", "list", params] as const,
   summary: (academicYearId?: number) => ["payments", "summary", academicYearId] as const,
+  byEnrollment: (enrollmentId: number) =>
+    ["payments", "enrollment", enrollmentId] as const,
+  preview: (enrollmentId: number, amount: number) =>
+    ["payments", "preview", enrollmentId, amount] as const,
 }
 
 export function usePayments(params: PaymentListParams = {}) {
@@ -37,6 +46,64 @@ export function useCreatePayment() {
       queryClient.invalidateQueries({ queryKey: paymentKeys.all })
     },
     onError: (err) => toast.error("Erreur", { description: err.message }),
+  })
+}
+
+/** Historique des paiements d'une inscription (nouveau path REST nested) */
+export function useEnrollmentPayments(enrollmentId: number | null) {
+  return useQuery({
+    queryKey: paymentKeys.byEnrollment(enrollmentId ?? 0),
+    queryFn: () => paymentsApi.listByEnrollment(enrollmentId as number),
+    enabled: Number.isFinite(enrollmentId) && (enrollmentId ?? 0) > 0,
+    staleTime: 1000 * 30,
+  })
+}
+
+/** Preview d'allocation (debounce côté composant pour éviter le spam BE) */
+export function useAllocationPreview(
+  enrollmentId: number | null,
+  amount: number | null,
+) {
+  return useQuery({
+    queryKey: paymentKeys.preview(enrollmentId ?? 0, amount ?? 0),
+    queryFn: () =>
+      paymentsApi.previewAllocation(enrollmentId as number, amount as number),
+    enabled:
+      Number.isFinite(enrollmentId) &&
+      (enrollmentId ?? 0) > 0 &&
+      Number.isFinite(amount) &&
+      (amount ?? 0) > 0,
+    staleTime: 1000 * 10,
+    placeholderData: keepPreviousData,
+  })
+}
+
+/** Versement caissier auto-alloué (flow cible) */
+export function useRecordEnrollmentPayment(enrollmentId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: EnrollmentPaymentCreate) =>
+      paymentsApi.recordOnEnrollment(enrollmentId, data),
+    onSuccess: (payment) => {
+      const allocCount = payment.allocations?.length ?? 0
+      const breakdown =
+        allocCount > 0
+          ? ` (${allocCount} frais alloué${allocCount > 1 ? "s" : ""})`
+          : ""
+      toast.success("Versement enregistré", {
+        description: `${Number(payment.amount).toLocaleString("fr-FR")} XOF${breakdown}`,
+      })
+      queryClient.invalidateQueries({ queryKey: paymentKeys.all })
+      queryClient.invalidateQueries({
+        queryKey: paymentKeys.byEnrollment(enrollmentId),
+      })
+      // Les frais et le résumé étudiant changent aussi
+      queryClient.invalidateQueries({ queryKey: ["enrollments"] })
+      queryClient.invalidateQueries({ queryKey: ["students"] })
+      queryClient.invalidateQueries({ queryKey: ["fees"] })
+    },
+    onError: (err) =>
+      toast.error("Versement refusé", { description: err.message }),
   })
 }
 

--- a/lib/hooks/useTimetable.ts
+++ b/lib/hooks/useTimetable.ts
@@ -16,6 +16,7 @@ export const timetableKeys = {
   byClass: (classId: number, weekOffset?: number) =>
     ["timetable", "class", classId, weekOffset ?? 0] as const,
   byTeacher: (teacherId: number) => ["timetable", "teacher", teacherId] as const,
+  mine: () => ["timetable", "mine"] as const,
   availabilities: (teacherId: number) =>
     ["timetable", "availabilities", teacherId] as const,
 }
@@ -34,6 +35,14 @@ export function useTeacherTimetable(teacherId: number) {
     queryKey: timetableKeys.byTeacher(teacherId),
     queryFn: () => timetableApi.listByTeacher(teacherId),
     enabled: !!teacherId,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useMyTimetable() {
+  return useQuery({
+    queryKey: timetableKeys.mine(),
+    queryFn: () => timetableApi.myTimetable(),
     staleTime: 1000 * 60 * 5,
   })
 }

--- a/lib/utils/enrollment-status.ts
+++ b/lib/utils/enrollment-status.ts
@@ -1,0 +1,30 @@
+// Le BE renvoie `class_name: "—"` comme sentinelle pour "élève pas inscrit
+// dans l'année courante" (au lieu de null ou is_enrolled bool explicite).
+// Cette fonction encapsule la détection pour qu'on puisse migrer
+// vers un champ explicite côté BE plus tard sans changer les call-sites.
+const NOT_ENROLLED_SENTINELS = new Set(["", "—", "-", "null", "None"])
+
+export function isEnrolledFromClassName(className: string | null | undefined): boolean {
+  if (className === null || className === undefined) return false
+  return !NOT_ENROLLED_SENTINELS.has(className.trim())
+}
+
+export interface EnrollmentSummary {
+  total: number
+  enrolled: number
+  pending: number
+}
+
+export function summarizeEnrollment(
+  children: ReadonlyArray<{ class_name: string | null | undefined }>,
+): EnrollmentSummary {
+  let enrolled = 0
+  for (const child of children) {
+    if (isEnrolledFromClassName(child.class_name)) enrolled += 1
+  }
+  return {
+    total: children.length,
+    enrolled,
+    pending: children.length - enrolled,
+  }
+}


### PR DESCRIPTION
## Summary

Frontend companion to backend PR [#138](https://github.com/African-DC/klassci-college-backend/pull/138). Four atomic commits:

### 1. Wave-style caissier (commit `d4081f2`)
- `StudentPaymentModal` redesigned to 3 fields (amount, method, reference). No more fee selector — the BE auto-allocates.
- `AllocationPreviewCard` shows live debounced preview (350ms) of how the amount will be split, status icons per fee, surplus warning.
- `PaymentCreateWizard` / `PaymentsPageClient` migrated to the new `/enrollments/{id}/payments` endpoint.
- `check` → `cheque` enum drift fixed across 3 files (BE strict).

### 2. Identite visuelle settings tab (commit `87643de`)
- New tab in `/admin/settings` between Etablissement and Trimestres.
- 2 color picker cards (primary + accent), synced hex inputs with mono font.
- Motto (italic preview) + website fields.
- Live PDF mockup refreshes 80ms after each keystroke.
- 'Apercu PDF' button downloads daily cash book with uncommitted preview values.
- Split into 3 files to respect 250 LOC limit (orchestrator + ColorField + LivePreview).
- Refined-editorial design (no AI slop, monochrome + 1 accent).

### 3. Student/Teacher 360 premium (commit `5e3c932`)
- `StudentDetailClient` dark hero + academic charts + journey timeline.
- `ParentsTab` split into 5-file pattern (Tab + Card + 2 modals + relationship helper).
- Tabs share `_primitives.tsx` for consistent layouts.
- Teacher tabs: Availability read/edit mode, Classes from `/admin/teachers/{id}/full`, Profile 3-state badge.

### 4. Portails + 401 + UX rules (commit `7b104e2`)
- Teacher portal desktop layout (sidebar) alongside mobile bottom nav.
- 401 interceptor in `lib/api/client.ts` → `/login?expired=1` with amber banner.
- `NotEnrolledBanner` shared component for student/parent dashboards when child isn't enrolled in current AY.
- `AcademicYearBanner` shared across portals.
- `StaffForm` gains 'Compte de connexion' section (BE now requires email + password).
- `LoginForm` forwards tenant via `X-Tenant-Slug` header.
- All API client functions go through Zod `safeValidate`.
- 6 new project rules captured (api-client-zod-validation, handle-401-globally, not-enrolled-empty-state, empty-state-by-role, fe-be-flow-alignment, detail-tab-split-pattern).

## Sister PR

Backend changes are in the matching branch on `klassci-college-backend` (#138).

## Test plan

- [ ] `pnpm tsc --noEmit` exit 0
- [ ] `pnpm lint` green
- [ ] E2E manual: /admin/settings → Identite visuelle → change colors → Save → bordereau PDF shows new colors
- [ ] E2E manual: StudentPaymentModal records payment → allocation preview matches receipt
- [ ] Teacher portal: desktop layout + mobile bottom nav both render correctly