### PR TITLE
feat(teachers): tab Présences + bouton Me déclarer absent (Phase 7b finition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Suivi des présences enseignant sur la fiche `/admin/teachers/[id]` : nouvel onglet « Présences » avec taux de présence, absences, retards cumulés en minutes et compteur d'auto-déclarations à valider. L'admin saisit en un clic absence ou retard en choisissant la date, le créneau EDT concerné et un motif *(admin)*.
+- Auto-déclaration côté enseignant : bouton « Me déclarer absent » sur le tableau de bord prof pour signaler une absence ou un retard. La déclaration arrive en attente de validation côté admin avec un encart d'avertissement amber pour rappeler le contact secrétariat si urgent *(enseignant)*.
+- Validation en deux clics côté admin : panel amber « Auto-déclarations en attente » sur la fiche enseignant, boutons Valider (vert) et Rejeter (rose) avec un champ de notes administratives optionnel et un dialog de confirmation pour le rejet *(admin)*.
 - Personnalisation de l'identité visuelle des PDFs depuis les paramètres de l'établissement : nouvel onglet « Identité visuelle » avec sélecteurs de couleur principale et d'accent, devise de l'école et site web, avec un aperçu en direct du reçu qui se met à jour à chaque modification. Touch targets h-11 mobile *(admin)*.
 - L'aperçu en direct reproduit fidèlement le rendu du reçu avec bandeau République de Côte d'Ivoire, logo, code MENA, devise en italique, montant gradient, tableau d'allocation avec pastilles colorées et pied de page personnalisé *(admin)*.
 - Bouton « Aperçu PDF » qui télécharge un bordereau du jour pour vérifier l'identité visuelle appliquée *(admin)*.

--- a/components/admin/teachers/TeacherDetailClient.tsx
+++ b/components/admin/teachers/TeacherDetailClient.tsx
@@ -16,6 +16,7 @@ import {
   Phone,
   FileText,
   CalendarDays,
+  CalendarCheck,
   Clock,
   MoreVertical,
 } from "lucide-react"
@@ -50,6 +51,7 @@ import { TeacherClassesTab } from "./tabs/TeacherClassesTab"
 import { TeacherEvaluationsTab } from "./tabs/TeacherEvaluationsTab"
 import { TeacherTimetableTab } from "./tabs/TeacherTimetableTab"
 import { TeacherAvailabilityTab } from "./tabs/TeacherAvailabilityTab"
+import { TeacherAttendanceTab } from "./tabs/TeacherAttendanceTab"
 import { useTeacher, useTeacherFull, useDeleteTeacher, teacherKeys } from "@/lib/hooks/useTeachers"
 import { teachersApi } from "@/lib/api/teachers"
 import { getUploadUrl } from "@/lib/utils"
@@ -283,6 +285,10 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
             <Clock className="mr-1.5 h-3.5 w-3.5" />
             Disponibilités
           </TabsTrigger>
+          <TabsTrigger value="presences">
+            <CalendarCheck className="mr-1.5 h-3.5 w-3.5" />
+            Présences
+          </TabsTrigger>
         </TabsList>
         </div>
 
@@ -313,6 +319,10 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
 
         <TabsContent value="disponibilites">
           <TeacherAvailabilityTab teacherId={teacherId} />
+        </TabsContent>
+
+        <TabsContent value="presences">
+          <TeacherAttendanceTab teacherId={teacherId} />
         </TabsContent>
       </Tabs>
 

--- a/components/admin/teachers/attendance/AttendanceFormFields.tsx
+++ b/components/admin/teachers/attendance/AttendanceFormFields.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import type { UseFormReturn, FieldValues, Path } from "react-hook-form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { TimetableSlot } from "@/lib/contracts/timetable"
+import { STATUS_LABEL, formatSlotOption } from "./teacher-attendance-helpers"
+
+type Status = "present" | "absent_excused" | "absent_unexcused" | "late"
+
+interface AttendanceFormFieldsProps<TForm extends FieldValues> {
+  form: UseFormReturn<TForm>
+  /** Status options offered in the Statut/Motif select (order preserved). */
+  statusOptions: Status[]
+  /** Label of the status field — "Statut" (admin) or "Motif" (self-declare). */
+  statusLabel: string
+  /** Available timetable slots — pre-loaded by the parent. */
+  slots: TimetableSlot[]
+  slotsLoading: boolean
+  /** Label of the slot field — "Créneau concerné" (admin) or "Cours concerné" (self). */
+  slotLabel: string
+  /** Placeholder shown for the "no slot" option in the select. */
+  noSlotLabel: string
+  /** Optional helper text displayed below the slot select. */
+  slotDescription?: string
+  /** Label/placeholder for the notes textarea. */
+  notesLabel: string
+  notesPlaceholder: string
+}
+
+/**
+ * Renders the date+status grid, slot select, conditional late minutes,
+ * and notes textarea — shared by AttendanceRecordModal (admin) and
+ * SelfDeclareAbsenceModal (teacher). Touch targets h-11 for mobile.
+ */
+export function AttendanceFormFields<TForm extends FieldValues>({
+  form,
+  statusOptions,
+  statusLabel,
+  slots,
+  slotsLoading,
+  slotLabel,
+  noSlotLabel,
+  slotDescription,
+  notesLabel,
+  notesPlaceholder,
+}: AttendanceFormFieldsProps<TForm>) {
+  const status = form.watch("status" as Path<TForm>) as Status
+  const dateField = "date" as Path<TForm>
+  const statusField = "status" as Path<TForm>
+  const slotField = "slot_id" as Path<TForm>
+  const lateField = "late_minutes" as Path<TForm>
+  const notesField = "notes" as Path<TForm>
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-4">
+        <FormField
+          control={form.control}
+          name={dateField}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Date</FormLabel>
+              <FormControl>
+                <Input type="date" className="h-11" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={statusField}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{statusLabel}</FormLabel>
+              <Select
+                value={field.value as string}
+                onValueChange={(v) => field.onChange(v as Status)}
+              >
+                <FormControl>
+                  <SelectTrigger className="h-11">
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {statusOptions.map((opt) => (
+                    <SelectItem key={opt} value={opt}>
+                      {STATUS_LABEL[opt]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+
+      <FormField
+        control={form.control}
+        name={slotField}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{slotLabel}</FormLabel>
+            <Select
+              value={field.value ? String(field.value) : "none"}
+              onValueChange={(v) =>
+                field.onChange(v === "none" ? null : Number(v))
+              }
+              disabled={slotsLoading}
+            >
+              <FormControl>
+                <SelectTrigger className="h-11">
+                  <SelectValue
+                    placeholder={slotsLoading ? "Chargement..." : noSlotLabel}
+                  />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="none">{noSlotLabel}</SelectItem>
+                {slots.map((slot) => (
+                  <SelectItem key={slot.id} value={String(slot.id)}>
+                    {formatSlotOption(slot)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {slotDescription && (
+              <FormDescription className="text-xs">
+                {slotDescription}
+              </FormDescription>
+            )}
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {status === "late" && (
+        <FormField
+          control={form.control}
+          name={lateField}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Minutes de retard</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  min={1}
+                  max={480}
+                  step={5}
+                  className="h-11"
+                  value={(field.value as number | undefined) ?? 0}
+                  onChange={(e) =>
+                    field.onChange(Number(e.target.value) || 0)
+                  }
+                />
+              </FormControl>
+              <FormDescription className="text-xs">
+                Entre 1 et 480 (8h max).
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      )}
+
+      <FormField
+        control={form.control}
+        name={notesField}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{notesLabel}</FormLabel>
+            <FormControl>
+              <Textarea
+                rows={3}
+                placeholder={notesPlaceholder}
+                value={(field.value as string | null | undefined) ?? ""}
+                onChange={field.onChange}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  )
+}
+
+// Re-export Form to avoid duplicate imports in the modal files.
+export { Form }

--- a/components/admin/teachers/attendance/AttendanceHistoryList.tsx
+++ b/components/admin/teachers/attendance/AttendanceHistoryList.tsx
@@ -36,10 +36,9 @@ import type {
   TeacherAttendanceResponse,
   TeacherAttendanceStatus,
 } from "@/lib/contracts/teacher-attendance"
+import { AttendanceStatusChip } from "./AttendanceStatusChip"
 import {
-  STATUS_CHIP_CLASS,
   STATUS_LABEL,
-  formatLateMinutes,
   formatLongFrenchDate,
 } from "./teacher-attendance-helpers"
 
@@ -49,6 +48,13 @@ interface AttendanceHistoryListProps {
 }
 
 type StatusFilter = TeacherAttendanceStatus | "all"
+
+const STATUS_FILTER_OPTIONS: TeacherAttendanceStatus[] = [
+  "absent_unexcused",
+  "absent_excused",
+  "late",
+  "present",
+]
 
 export function AttendanceHistoryList({
   teacherId,
@@ -84,14 +90,11 @@ export function AttendanceHistoryList({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">Tous les statuts</SelectItem>
-              <SelectItem value="absent_unexcused">
-                {STATUS_LABEL.absent_unexcused}
-              </SelectItem>
-              <SelectItem value="absent_excused">
-                {STATUS_LABEL.absent_excused}
-              </SelectItem>
-              <SelectItem value="late">{STATUS_LABEL.late}</SelectItem>
-              <SelectItem value="present">{STATUS_LABEL.present}</SelectItem>
+              {STATUS_FILTER_OPTIONS.map((opt) => (
+                <SelectItem key={opt} value={opt}>
+                  {STATUS_LABEL[opt]}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -128,16 +131,10 @@ function AttendanceRow({ item }: { item: TeacherAttendanceResponse }) {
     <li className="flex items-start justify-between gap-3 rounded-lg border bg-card p-3">
       <div className="min-w-0 flex-1 space-y-1">
         <div className="flex flex-wrap items-center gap-2">
-          <span
-            className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${STATUS_CHIP_CLASS[item.status]}`}
-          >
-            {STATUS_LABEL[item.status]}
-            {item.status === "late" && item.late_minutes > 0 && (
-              <span className="ml-1 font-semibold">
-                · {formatLateMinutes(item.late_minutes)}
-              </span>
-            )}
-          </span>
+          <AttendanceStatusChip
+            status={item.status}
+            lateMinutes={item.late_minutes}
+          />
           <span className="text-sm font-medium">
             {formatLongFrenchDate(item.date)}
           </span>

--- a/components/admin/teachers/attendance/AttendanceHistoryList.tsx
+++ b/components/admin/teachers/attendance/AttendanceHistoryList.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import { useState } from "react"
+import { Trash2, MoreVertical, Calendar } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  useDeleteTeacherAttendance,
+  useTeacherAttendanceList,
+} from "@/lib/hooks/useTeacherAttendance"
+import type {
+  TeacherAttendanceResponse,
+  TeacherAttendanceStatus,
+} from "@/lib/contracts/teacher-attendance"
+import {
+  STATUS_CHIP_CLASS,
+  STATUS_LABEL,
+  formatLateMinutes,
+  formatLongFrenchDate,
+} from "./teacher-attendance-helpers"
+
+interface AttendanceHistoryListProps {
+  teacherId: number
+  academicYearId?: number
+}
+
+type StatusFilter = TeacherAttendanceStatus | "all"
+
+export function AttendanceHistoryList({
+  teacherId,
+  academicYearId,
+}: AttendanceHistoryListProps) {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
+
+  const { data, isLoading } = useTeacherAttendanceList(teacherId, {
+    academic_year_id: academicYearId,
+    status: statusFilter === "all" ? undefined : statusFilter,
+    per_page: 100,
+  })
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4 sm:p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <h3 className="font-serif text-base">Historique</h3>
+            {data && (
+              <span className="text-xs text-muted-foreground">
+                · {data.total} entrée{data.total > 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+          <Select
+            value={statusFilter}
+            onValueChange={(v) => setStatusFilter(v as StatusFilter)}
+          >
+            <SelectTrigger className="h-9 w-[200px]">
+              <SelectValue placeholder="Tous les statuts" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Tous les statuts</SelectItem>
+              <SelectItem value="absent_unexcused">
+                {STATUS_LABEL.absent_unexcused}
+              </SelectItem>
+              <SelectItem value="absent_excused">
+                {STATUS_LABEL.absent_excused}
+              </SelectItem>
+              <SelectItem value="late">{STATUS_LABEL.late}</SelectItem>
+              <SelectItem value="present">{STATUS_LABEL.present}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 rounded-lg" />
+            ))}
+          </div>
+        ) : !data || data.items.length === 0 ? (
+          <p className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-foreground">
+            {statusFilter === "all"
+              ? "Aucun pointage enregistré pour le moment."
+              : "Aucun pointage avec ce statut."}
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {data.items.map((item) => (
+              <AttendanceRow key={item.id} item={item} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function AttendanceRow({ item }: { item: TeacherAttendanceResponse }) {
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const { mutate: del, isPending } = useDeleteTeacherAttendance()
+
+  return (
+    <li className="flex items-start justify-between gap-3 rounded-lg border bg-card p-3">
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${STATUS_CHIP_CLASS[item.status]}`}
+          >
+            {STATUS_LABEL[item.status]}
+            {item.status === "late" && item.late_minutes > 0 && (
+              <span className="ml-1 font-semibold">
+                · {formatLateMinutes(item.late_minutes)}
+              </span>
+            )}
+          </span>
+          <span className="text-sm font-medium">
+            {formatLongFrenchDate(item.date)}
+          </span>
+          {!item.is_validated && (
+            <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800">
+              En attente
+            </span>
+          )}
+        </div>
+        {item.slot_summary && (
+          <p className="text-xs text-muted-foreground">{item.slot_summary}</p>
+        )}
+        {item.notes && (
+          <p className="text-xs italic text-muted-foreground">
+            « {item.notes} »
+          </p>
+        )}
+      </div>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-9 w-9 shrink-0">
+            <MoreVertical className="h-4 w-4" />
+            <span className="sr-only">Actions</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={() => setDeleteOpen(true)}
+            className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Supprimer
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Supprimer ce pointage ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Le pointage du {formatLongFrenchDate(item.date)} sera
+              définitivement supprimé. Cette action est irréversible.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() =>
+                del(item.id, { onSuccess: () => setDeleteOpen(false) })
+              }
+              disabled={isPending}
+              className="bg-destructive hover:bg-destructive/90"
+            >
+              {isPending ? "Suppression..." : "Supprimer"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </li>
+  )
+}

--- a/components/admin/teachers/attendance/AttendanceRecordModal.tsx
+++ b/components/admin/teachers/attendance/AttendanceRecordModal.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useTeacherTimetable } from "@/lib/hooks/useTimetable"
+import { useRecordTeacherAttendance } from "@/lib/hooks/useTeacherAttendance"
+import {
+  TeacherAttendanceCreateSchema,
+  type TeacherAttendanceCreate,
+} from "@/lib/contracts/teacher-attendance"
+import { STATUS_LABEL, todayIso } from "./teacher-attendance-helpers"
+
+interface AttendanceRecordModalProps {
+  teacherId: number
+  open: boolean
+  onClose: () => void
+}
+
+const FRENCH_DAY_LABEL: Record<string, string> = {
+  lundi: "Lundi",
+  mardi: "Mardi",
+  mercredi: "Mercredi",
+  jeudi: "Jeudi",
+  vendredi: "Vendredi",
+  samedi: "Samedi",
+  monday: "Lundi",
+  tuesday: "Mardi",
+  wednesday: "Mercredi",
+  thursday: "Jeudi",
+  friday: "Vendredi",
+  saturday: "Samedi",
+}
+
+export function AttendanceRecordModal({
+  teacherId,
+  open,
+  onClose,
+}: AttendanceRecordModalProps) {
+  const { data: slots = [], isLoading: slotsLoading } = useTeacherTimetable(teacherId)
+  const { mutate, isPending } = useRecordTeacherAttendance(teacherId)
+
+  const form = useForm<TeacherAttendanceCreate>({
+    resolver: zodResolver(TeacherAttendanceCreateSchema),
+    defaultValues: {
+      slot_id: null,
+      date: todayIso(),
+      status: "absent_unexcused",
+      late_minutes: 0,
+      notes: null,
+    },
+  })
+
+  const status = form.watch("status")
+
+  useEffect(() => {
+    if (status !== "late" && form.getValues("late_minutes") !== 0) {
+      form.setValue("late_minutes", 0, { shouldValidate: true })
+    }
+  }, [status, form])
+
+  useEffect(() => {
+    if (!open) form.reset()
+  }, [open, form])
+
+  function onSubmit(data: TeacherAttendanceCreate) {
+    const cleaned: TeacherAttendanceCreate = {
+      ...data,
+      late_minutes: data.status === "late" ? data.late_minutes : 0,
+      notes: data.notes?.trim() ? data.notes.trim() : null,
+      slot_id: data.slot_id ?? null,
+    }
+    mutate(cleaned, {
+      onSuccess: () => {
+        form.reset()
+        onClose()
+      },
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (!v ? onClose() : undefined)}>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Saisir une absence ou un retard</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date</FormLabel>
+                    <FormControl>
+                      <Input type="date" className="h-11" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Statut</FormLabel>
+                    <Select
+                      value={field.value}
+                      onValueChange={(v) =>
+                        field.onChange(v as TeacherAttendanceCreate["status"])
+                      }
+                    >
+                      <FormControl>
+                        <SelectTrigger className="h-11">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="absent_unexcused">
+                          {STATUS_LABEL.absent_unexcused}
+                        </SelectItem>
+                        <SelectItem value="absent_excused">
+                          {STATUS_LABEL.absent_excused}
+                        </SelectItem>
+                        <SelectItem value="late">
+                          {STATUS_LABEL.late}
+                        </SelectItem>
+                        <SelectItem value="present">
+                          {STATUS_LABEL.present}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="slot_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Créneau concerné (optionnel)</FormLabel>
+                  <Select
+                    value={field.value ? String(field.value) : "none"}
+                    onValueChange={(v) =>
+                      field.onChange(v === "none" ? null : Number(v))
+                    }
+                    disabled={slotsLoading}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="h-11">
+                        <SelectValue placeholder={slotsLoading ? "Chargement..." : "Aucun créneau (absence hors EDT)"} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="none">
+                        Aucun créneau (absence hors EDT)
+                      </SelectItem>
+                      {slots.map((slot) => {
+                        const dayLabel = FRENCH_DAY_LABEL[slot.day] ?? slot.day
+                        return (
+                          <SelectItem key={slot.id} value={String(slot.id)}>
+                            {dayLabel} {slot.start_time}–{slot.end_time} · {slot.subject_name} · {slot.class_name}
+                          </SelectItem>
+                        )
+                      })}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription className="text-xs">
+                    Lier au créneau pour un calcul d&apos;heures précis (DREN).
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {status === "late" && (
+              <FormField
+                control={form.control}
+                name="late_minutes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Minutes de retard</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={480}
+                        step={5}
+                        className="h-11"
+                        value={field.value}
+                        onChange={(e) =>
+                          field.onChange(Number(e.target.value) || 0)
+                        }
+                      />
+                    </FormControl>
+                    <FormDescription className="text-xs">
+                      Entre 1 et 480 (8h max).
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Notes (optionnel)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={3}
+                      placeholder="Justification, contexte, pièce jointe transmise..."
+                      value={field.value ?? ""}
+                      onChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" variant="outline" onClick={onClose} className="h-11">
+                Annuler
+              </Button>
+              <Button type="submit" disabled={isPending} className="h-11 font-semibold">
+                {isPending ? "Enregistrement..." : "Enregistrer"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/teachers/attendance/AttendanceRecordModal.tsx
+++ b/components/admin/teachers/attendance/AttendanceRecordModal.tsx
@@ -5,31 +5,14 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { useTeacherTimetable } from "@/lib/hooks/useTimetable"
 import { useRecordTeacherAttendance } from "@/lib/hooks/useTeacherAttendance"
 import {
   TeacherAttendanceCreateSchema,
   type TeacherAttendanceCreate,
 } from "@/lib/contracts/teacher-attendance"
-import { STATUS_LABEL, todayIso } from "./teacher-attendance-helpers"
+import { AttendanceFormFields, Form } from "./AttendanceFormFields"
+import { cleanNotes, todayIso } from "./teacher-attendance-helpers"
 
 interface AttendanceRecordModalProps {
   teacherId: number
@@ -37,20 +20,12 @@ interface AttendanceRecordModalProps {
   onClose: () => void
 }
 
-const FRENCH_DAY_LABEL: Record<string, string> = {
-  lundi: "Lundi",
-  mardi: "Mardi",
-  mercredi: "Mercredi",
-  jeudi: "Jeudi",
-  vendredi: "Vendredi",
-  samedi: "Samedi",
-  monday: "Lundi",
-  tuesday: "Mardi",
-  wednesday: "Mercredi",
-  thursday: "Jeudi",
-  friday: "Vendredi",
-  saturday: "Samedi",
-}
+const STATUS_OPTIONS: TeacherAttendanceCreate["status"][] = [
+  "absent_unexcused",
+  "absent_excused",
+  "late",
+  "present",
+]
 
 export function AttendanceRecordModal({
   teacherId,
@@ -84,18 +59,19 @@ export function AttendanceRecordModal({
   }, [open, form])
 
   function onSubmit(data: TeacherAttendanceCreate) {
-    const cleaned: TeacherAttendanceCreate = {
-      ...data,
-      late_minutes: data.status === "late" ? data.late_minutes : 0,
-      notes: data.notes?.trim() ? data.notes.trim() : null,
-      slot_id: data.slot_id ?? null,
-    }
-    mutate(cleaned, {
-      onSuccess: () => {
-        form.reset()
-        onClose()
+    mutate(
+      {
+        ...data,
+        notes: cleanNotes(data.notes),
+        slot_id: data.slot_id ?? null,
       },
-    })
+      {
+        onSuccess: () => {
+          form.reset()
+          onClose()
+        },
+      },
+    )
   }
 
   return (
@@ -106,144 +82,17 @@ export function AttendanceRecordModal({
         </DialogHeader>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
-            <div className="grid grid-cols-2 gap-4">
-              <FormField
-                control={form.control}
-                name="date"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Date</FormLabel>
-                    <FormControl>
-                      <Input type="date" className="h-11" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="status"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Statut</FormLabel>
-                    <Select
-                      value={field.value}
-                      onValueChange={(v) =>
-                        field.onChange(v as TeacherAttendanceCreate["status"])
-                      }
-                    >
-                      <FormControl>
-                        <SelectTrigger className="h-11">
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="absent_unexcused">
-                          {STATUS_LABEL.absent_unexcused}
-                        </SelectItem>
-                        <SelectItem value="absent_excused">
-                          {STATUS_LABEL.absent_excused}
-                        </SelectItem>
-                        <SelectItem value="late">
-                          {STATUS_LABEL.late}
-                        </SelectItem>
-                        <SelectItem value="present">
-                          {STATUS_LABEL.present}
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <FormField
-              control={form.control}
-              name="slot_id"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Créneau concerné (optionnel)</FormLabel>
-                  <Select
-                    value={field.value ? String(field.value) : "none"}
-                    onValueChange={(v) =>
-                      field.onChange(v === "none" ? null : Number(v))
-                    }
-                    disabled={slotsLoading}
-                  >
-                    <FormControl>
-                      <SelectTrigger className="h-11">
-                        <SelectValue placeholder={slotsLoading ? "Chargement..." : "Aucun créneau (absence hors EDT)"} />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="none">
-                        Aucun créneau (absence hors EDT)
-                      </SelectItem>
-                      {slots.map((slot) => {
-                        const dayLabel = FRENCH_DAY_LABEL[slot.day] ?? slot.day
-                        return (
-                          <SelectItem key={slot.id} value={String(slot.id)}>
-                            {dayLabel} {slot.start_time}–{slot.end_time} · {slot.subject_name} · {slot.class_name}
-                          </SelectItem>
-                        )
-                      })}
-                    </SelectContent>
-                  </Select>
-                  <FormDescription className="text-xs">
-                    Lier au créneau pour un calcul d&apos;heures précis (DREN).
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {status === "late" && (
-              <FormField
-                control={form.control}
-                name="late_minutes"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Minutes de retard</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        min={1}
-                        max={480}
-                        step={5}
-                        className="h-11"
-                        value={field.value}
-                        onChange={(e) =>
-                          field.onChange(Number(e.target.value) || 0)
-                        }
-                      />
-                    </FormControl>
-                    <FormDescription className="text-xs">
-                      Entre 1 et 480 (8h max).
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            )}
-
-            <FormField
-              control={form.control}
-              name="notes"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Notes (optionnel)</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      rows={3}
-                      placeholder="Justification, contexte, pièce jointe transmise..."
-                      value={field.value ?? ""}
-                      onChange={field.onChange}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+            <AttendanceFormFields
+              form={form}
+              statusOptions={STATUS_OPTIONS}
+              statusLabel="Statut"
+              slots={slots}
+              slotsLoading={slotsLoading}
+              slotLabel="Créneau concerné (optionnel)"
+              noSlotLabel="Aucun créneau (absence hors EDT)"
+              slotDescription="Lier au créneau pour un calcul d'heures précis (DREN)."
+              notesLabel="Notes (optionnel)"
+              notesPlaceholder="Justification, contexte, pièce jointe transmise..."
             />
 
             <div className="flex justify-end gap-2 pt-2">

--- a/components/admin/teachers/attendance/AttendanceStatsHero.tsx
+++ b/components/admin/teachers/attendance/AttendanceStatsHero.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AlertTriangle, CheckCircle2, Clock, XCircle } from "lucide-react"
 import type { TeacherAttendanceStats } from "@/lib/contracts/teacher-attendance"
-import { formatLateMinutes } from "./teacher-attendance-helpers"
+import { TONE_CLASSES, formatLateMinutes } from "./teacher-attendance-helpers"
 
 interface AttendanceStatsHeroProps {
   stats: TeacherAttendanceStats | undefined
@@ -33,7 +33,13 @@ export function AttendanceStatsHero({ stats, isLoading }: AttendanceStatsHeroPro
   }
 
   const rate = Math.round(stats.attendance_rate)
-  const totalAbsences = stats.sessions_absent_excused + stats.sessions_absent_unexcused
+  const totalAbsences =
+    stats.sessions_absent_excused + stats.sessions_absent_unexcused
+  const totalSessions =
+    stats.total_sessions ||
+    stats.sessions_present + totalAbsences + stats.sessions_late
+  const unexcusedPlural = stats.sessions_absent_unexcused > 1 ? "s" : ""
+  const hasPending = stats.pending_validation_count > 0
 
   return (
     <div className="space-y-3">
@@ -43,14 +49,14 @@ export function AttendanceStatsHero({ stats, isLoading }: AttendanceStatsHeroPro
           value={`${rate}%`}
           tone="emerald"
           icon={<CheckCircle2 className="h-4 w-4" />}
-          subtext={`${stats.sessions_present} / ${stats.total_sessions || stats.sessions_present + totalAbsences + stats.sessions_late} créneaux`}
+          subtext={`${stats.sessions_present} / ${totalSessions} créneaux`}
         />
         <Kpi
           label="Absences"
           value={String(totalAbsences)}
           tone="rose"
           icon={<XCircle className="h-4 w-4" />}
-          subtext={`${stats.sessions_absent_unexcused} non justifiée${stats.sessions_absent_unexcused > 1 ? "s" : ""}`}
+          subtext={`${stats.sessions_absent_unexcused} non justifiée${unexcusedPlural}`}
         />
         <Kpi
           label="Retards"
@@ -66,13 +72,9 @@ export function AttendanceStatsHero({ stats, isLoading }: AttendanceStatsHeroPro
         <Kpi
           label="En attente"
           value={String(stats.pending_validation_count)}
-          tone={stats.pending_validation_count > 0 ? "amber" : "neutral"}
+          tone={hasPending ? "amber" : "neutral"}
           icon={<AlertTriangle className="h-4 w-4" />}
-          subtext={
-            stats.pending_validation_count > 0
-              ? "À valider"
-              : "Aucune en attente"
-          }
+          subtext={hasPending ? "À valider" : "Aucune en attente"}
         />
       </div>
       <p className="text-xs text-muted-foreground">
@@ -90,28 +92,14 @@ interface KpiProps {
   subtext: string
 }
 
-const TONE_CLASSES: Record<KpiProps["tone"], { text: string; bg: string; ring: string }> = {
-  emerald: {
-    text: "text-emerald-700",
-    bg: "bg-emerald-50",
-    ring: "ring-emerald-100",
-  },
-  rose: { text: "text-rose-700", bg: "bg-rose-50", ring: "ring-rose-100" },
-  blue: { text: "text-blue-700", bg: "bg-blue-50", ring: "ring-blue-100" },
-  amber: { text: "text-amber-700", bg: "bg-amber-50", ring: "ring-amber-100" },
-  neutral: {
-    text: "text-muted-foreground",
-    bg: "bg-muted/40",
-    ring: "ring-muted-foreground/10",
-  },
-}
-
 function Kpi({ label, value, tone, icon, subtext }: KpiProps) {
   const c = TONE_CLASSES[tone]
   return (
     <Card className={`${c.bg} ring-1 ${c.ring} border-0`}>
       <CardContent className="p-3.5">
-        <div className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide ${c.text}`}>
+        <div
+          className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide ${c.text}`}
+        >
           {icon}
           {label}
         </div>

--- a/components/admin/teachers/attendance/AttendanceStatsHero.tsx
+++ b/components/admin/teachers/attendance/AttendanceStatsHero.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { AlertTriangle, CheckCircle2, Clock, XCircle } from "lucide-react"
+import type { TeacherAttendanceStats } from "@/lib/contracts/teacher-attendance"
+import { formatLateMinutes } from "./teacher-attendance-helpers"
+
+interface AttendanceStatsHeroProps {
+  stats: TeacherAttendanceStats | undefined
+  isLoading: boolean
+}
+
+export function AttendanceStatsHero({ stats, isLoading }: AttendanceStatsHeroProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-xl" />
+        ))}
+      </div>
+    )
+  }
+
+  if (!stats) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-center text-sm text-muted-foreground">
+          Statistiques indisponibles.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const rate = Math.round(stats.attendance_rate)
+  const totalAbsences = stats.sessions_absent_excused + stats.sessions_absent_unexcused
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Kpi
+          label="Taux de présence"
+          value={`${rate}%`}
+          tone="emerald"
+          icon={<CheckCircle2 className="h-4 w-4" />}
+          subtext={`${stats.sessions_present} / ${stats.total_sessions || stats.sessions_present + totalAbsences + stats.sessions_late} créneaux`}
+        />
+        <Kpi
+          label="Absences"
+          value={String(totalAbsences)}
+          tone="rose"
+          icon={<XCircle className="h-4 w-4" />}
+          subtext={`${stats.sessions_absent_unexcused} non justifiée${stats.sessions_absent_unexcused > 1 ? "s" : ""}`}
+        />
+        <Kpi
+          label="Retards"
+          value={String(stats.sessions_late)}
+          tone="blue"
+          icon={<Clock className="h-4 w-4" />}
+          subtext={
+            stats.total_late_minutes > 0
+              ? `${formatLateMinutes(stats.total_late_minutes)} cumulés`
+              : "Aucun retard cumulé"
+          }
+        />
+        <Kpi
+          label="En attente"
+          value={String(stats.pending_validation_count)}
+          tone={stats.pending_validation_count > 0 ? "amber" : "neutral"}
+          icon={<AlertTriangle className="h-4 w-4" />}
+          subtext={
+            stats.pending_validation_count > 0
+              ? "À valider"
+              : "Aucune en attente"
+          }
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Année {stats.academic_year_name}
+      </p>
+    </div>
+  )
+}
+
+interface KpiProps {
+  label: string
+  value: string
+  tone: "emerald" | "rose" | "blue" | "amber" | "neutral"
+  icon: React.ReactNode
+  subtext: string
+}
+
+const TONE_CLASSES: Record<KpiProps["tone"], { text: string; bg: string; ring: string }> = {
+  emerald: {
+    text: "text-emerald-700",
+    bg: "bg-emerald-50",
+    ring: "ring-emerald-100",
+  },
+  rose: { text: "text-rose-700", bg: "bg-rose-50", ring: "ring-rose-100" },
+  blue: { text: "text-blue-700", bg: "bg-blue-50", ring: "ring-blue-100" },
+  amber: { text: "text-amber-700", bg: "bg-amber-50", ring: "ring-amber-100" },
+  neutral: {
+    text: "text-muted-foreground",
+    bg: "bg-muted/40",
+    ring: "ring-muted-foreground/10",
+  },
+}
+
+function Kpi({ label, value, tone, icon, subtext }: KpiProps) {
+  const c = TONE_CLASSES[tone]
+  return (
+    <Card className={`${c.bg} ring-1 ${c.ring} border-0`}>
+      <CardContent className="p-3.5">
+        <div className={`flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide ${c.text}`}>
+          {icon}
+          {label}
+        </div>
+        <p className={`mt-1.5 text-2xl font-semibold ${c.text}`}>{value}</p>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">{subtext}</p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/teachers/attendance/AttendanceStatusChip.tsx
+++ b/components/admin/teachers/attendance/AttendanceStatusChip.tsx
@@ -1,0 +1,30 @@
+import type { TeacherAttendanceStatus } from "@/lib/contracts/teacher-attendance"
+import {
+  STATUS_CHIP_CLASS,
+  STATUS_LABEL,
+  formatLateMinutes,
+} from "./teacher-attendance-helpers"
+
+interface AttendanceStatusChipProps {
+  status: TeacherAttendanceStatus
+  lateMinutes: number
+}
+
+/** Rounded chip with semantic color + optional late-minutes suffix (e.g. "En retard · 15 min"). */
+export function AttendanceStatusChip({
+  status,
+  lateMinutes,
+}: AttendanceStatusChipProps) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${STATUS_CHIP_CLASS[status]}`}
+    >
+      {STATUS_LABEL[status]}
+      {status === "late" && lateMinutes > 0 && (
+        <span className="ml-1 font-semibold">
+          · {formatLateMinutes(lateMinutes)}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/components/admin/teachers/attendance/PendingValidationSection.tsx
+++ b/components/admin/teachers/attendance/PendingValidationSection.tsx
@@ -1,0 +1,237 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { AlertCircle, Check, X } from "lucide-react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  useTeacherAttendanceList,
+  useValidateTeacherAttendance,
+} from "@/lib/hooks/useTeacherAttendance"
+import type { TeacherAttendanceResponse } from "@/lib/contracts/teacher-attendance"
+import {
+  STATUS_CHIP_CLASS,
+  STATUS_LABEL,
+  formatLongFrenchDate,
+  formatLateMinutes,
+} from "./teacher-attendance-helpers"
+
+interface PendingValidationSectionProps {
+  teacherId: number
+  academicYearId?: number
+}
+
+export function PendingValidationSection({
+  teacherId,
+  academicYearId,
+}: PendingValidationSectionProps) {
+  // Fetch all unvalidated items: BE filter is_validated=false n'est pas exposé
+  // directement, mais le contrat list renvoie tout, on filtre côté FE pour
+  // le panel "En attente" (volume modéré : < 50 items typiques).
+  const { data, isLoading } = useTeacherAttendanceList(
+    teacherId,
+    {
+      academic_year_id: academicYearId,
+      per_page: 200,
+    },
+    { enabled: teacherId > 0 },
+  )
+
+  const pending = (data?.items ?? []).filter((item) => !item.is_validated)
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-sm text-muted-foreground">
+          Chargement des auto-déclarations...
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (pending.length === 0) return null
+
+  return (
+    <Card className="border-amber-200 bg-amber-50/40">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <AlertCircle className="h-4 w-4 text-amber-600" />
+          Auto-déclarations en attente
+          <span className="ml-1 rounded-full bg-amber-200 px-2 py-0.5 text-xs font-medium text-amber-900">
+            {pending.length}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 pt-0">
+        {pending.map((item) => (
+          <PendingRow key={item.id} item={item} />
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function PendingRow({ item }: { item: TeacherAttendanceResponse }) {
+  const [rejectOpen, setRejectOpen] = useState(false)
+  const [approveOpen, setApproveOpen] = useState(false)
+  const [adminNotes, setAdminNotes] = useState("")
+  const { mutate: validate, isPending } = useValidateTeacherAttendance()
+
+  const onApprove = () => {
+    validate(
+      {
+        attendanceId: item.id,
+        data: { approved: true, admin_notes: adminNotes.trim() || null },
+      },
+      {
+        onSuccess: () => {
+          setAdminNotes("")
+          setApproveOpen(false)
+        },
+      },
+    )
+  }
+
+  const onReject = () => {
+    validate(
+      {
+        attendanceId: item.id,
+        data: { approved: false, admin_notes: adminNotes.trim() || null },
+      },
+      {
+        onSuccess: () => {
+          setAdminNotes("")
+          setRejectOpen(false)
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="rounded-lg border border-amber-200 bg-white p-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${STATUS_CHIP_CLASS[item.status]}`}
+            >
+              {STATUS_LABEL[item.status]}
+              {item.status === "late" && item.late_minutes > 0 && (
+                <span className="ml-1 font-semibold">
+                  · {formatLateMinutes(item.late_minutes)}
+                </span>
+              )}
+            </span>
+            <span className="text-sm font-medium">
+              {formatLongFrenchDate(item.date)}
+            </span>
+          </div>
+          {item.slot_summary && (
+            <p className="text-xs text-muted-foreground">{item.slot_summary}</p>
+          )}
+          {item.notes && (
+            <p className="text-xs italic text-muted-foreground">
+              « {item.notes} »
+            </p>
+          )}
+          <p className="text-[11px] text-muted-foreground">
+            Déclaré par {item.declared_by_email ?? "l'enseignant"}
+          </p>
+        </div>
+        <div className="flex gap-2 sm:flex-col">
+          <Button
+            size="sm"
+            className="h-11 flex-1 bg-emerald-600 font-medium text-white hover:bg-emerald-700 sm:h-9 sm:flex-none"
+            disabled={isPending}
+            onClick={() => setApproveOpen(true)}
+          >
+            <Check className="mr-1.5 h-3.5 w-3.5" />
+            Valider
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-11 flex-1 border-rose-200 font-medium text-rose-700 hover:bg-rose-50 sm:h-9 sm:flex-none"
+            disabled={isPending}
+            onClick={() => setRejectOpen(true)}
+          >
+            <X className="mr-1.5 h-3.5 w-3.5" />
+            Rejeter
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={approveOpen} onOpenChange={setApproveOpen}>
+        <DialogContent className="max-w-md" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>Valider cette déclaration ?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            La déclaration sera marquée comme validée et comptabilisée dans
+            les statistiques de présence.
+          </p>
+          <Textarea
+            rows={3}
+            placeholder="Notes administratives (optionnel)"
+            value={adminNotes}
+            onChange={(e) => setAdminNotes(e.target.value)}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setApproveOpen(false)}>
+              Annuler
+            </Button>
+            <Button onClick={onApprove} disabled={isPending} className="bg-emerald-600 hover:bg-emerald-700">
+              {isPending ? "Validation..." : "Valider"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={rejectOpen} onOpenChange={setRejectOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rejeter cette déclaration ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              La déclaration sera conservée pour audit mais non comptabilisée.
+              Précisez la raison du rejet pour informer l&apos;enseignant.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Textarea
+            rows={3}
+            placeholder="Raison du rejet (recommandé)"
+            value={adminNotes}
+            onChange={(e) => setAdminNotes(e.target.value)}
+          />
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={onReject}
+              disabled={isPending}
+              className="bg-rose-600 hover:bg-rose-700"
+            >
+              {isPending ? "Rejet..." : "Rejeter"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/components/admin/teachers/attendance/PendingValidationSection.tsx
+++ b/components/admin/teachers/attendance/PendingValidationSection.tsx
@@ -27,11 +27,10 @@ import {
   useValidateTeacherAttendance,
 } from "@/lib/hooks/useTeacherAttendance"
 import type { TeacherAttendanceResponse } from "@/lib/contracts/teacher-attendance"
+import { AttendanceStatusChip } from "./AttendanceStatusChip"
 import {
-  STATUS_CHIP_CLASS,
-  STATUS_LABEL,
+  cleanNotes,
   formatLongFrenchDate,
-  formatLateMinutes,
 } from "./teacher-attendance-helpers"
 
 interface PendingValidationSectionProps {
@@ -43,9 +42,8 @@ export function PendingValidationSection({
   teacherId,
   academicYearId,
 }: PendingValidationSectionProps) {
-  // Fetch all unvalidated items: BE filter is_validated=false n'est pas exposé
-  // directement, mais le contrat list renvoie tout, on filtre côté FE pour
-  // le panel "En attente" (volume modéré : < 50 items typiques).
+  // BE filter is_validated=false n'est pas exposé directement, donc on récupère
+  // tout et filtre côté FE (volume modéré : < 50 items typiques).
   const { data, isLoading } = useTeacherAttendanceList(
     teacherId,
     {
@@ -95,31 +93,16 @@ function PendingRow({ item }: { item: TeacherAttendanceResponse }) {
   const [adminNotes, setAdminNotes] = useState("")
   const { mutate: validate, isPending } = useValidateTeacherAttendance()
 
-  const onApprove = () => {
+  function submit(approved: boolean, close: () => void) {
     validate(
       {
         attendanceId: item.id,
-        data: { approved: true, admin_notes: adminNotes.trim() || null },
+        data: { approved, admin_notes: cleanNotes(adminNotes) },
       },
       {
         onSuccess: () => {
           setAdminNotes("")
-          setApproveOpen(false)
-        },
-      },
-    )
-  }
-
-  const onReject = () => {
-    validate(
-      {
-        attendanceId: item.id,
-        data: { approved: false, admin_notes: adminNotes.trim() || null },
-      },
-      {
-        onSuccess: () => {
-          setAdminNotes("")
-          setRejectOpen(false)
+          close()
         },
       },
     )
@@ -130,16 +113,10 @@ function PendingRow({ item }: { item: TeacherAttendanceResponse }) {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1">
           <div className="flex flex-wrap items-center gap-2">
-            <span
-              className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${STATUS_CHIP_CLASS[item.status]}`}
-            >
-              {STATUS_LABEL[item.status]}
-              {item.status === "late" && item.late_minutes > 0 && (
-                <span className="ml-1 font-semibold">
-                  · {formatLateMinutes(item.late_minutes)}
-                </span>
-              )}
-            </span>
+            <AttendanceStatusChip
+              status={item.status}
+              lateMinutes={item.late_minutes}
+            />
             <span className="text-sm font-medium">
               {formatLongFrenchDate(item.date)}
             </span>
@@ -198,7 +175,11 @@ function PendingRow({ item }: { item: TeacherAttendanceResponse }) {
             <Button variant="outline" onClick={() => setApproveOpen(false)}>
               Annuler
             </Button>
-            <Button onClick={onApprove} disabled={isPending} className="bg-emerald-600 hover:bg-emerald-700">
+            <Button
+              onClick={() => submit(true, () => setApproveOpen(false))}
+              disabled={isPending}
+              className="bg-emerald-600 hover:bg-emerald-700"
+            >
               {isPending ? "Validation..." : "Valider"}
             </Button>
           </DialogFooter>
@@ -223,7 +204,7 @@ function PendingRow({ item }: { item: TeacherAttendanceResponse }) {
           <AlertDialogFooter>
             <AlertDialogCancel>Annuler</AlertDialogCancel>
             <AlertDialogAction
-              onClick={onReject}
+              onClick={() => submit(false, () => setRejectOpen(false))}
               disabled={isPending}
               className="bg-rose-600 hover:bg-rose-700"
             >

--- a/components/admin/teachers/attendance/teacher-attendance-helpers.ts
+++ b/components/admin/teachers/attendance/teacher-attendance-helpers.ts
@@ -1,3 +1,4 @@
+import type { TimetableSlot } from "@/lib/contracts/timetable"
 import type { TeacherAttendanceStatus } from "@/lib/contracts/teacher-attendance"
 
 export const STATUS_LABEL: Record<TeacherAttendanceStatus, string> = {
@@ -21,6 +22,33 @@ export const STATUS_CHIP_CLASS: Record<TeacherAttendanceStatus, string> = {
   absent_excused: "bg-amber-50 text-amber-700 border-amber-200",
   absent_unexcused: "bg-rose-50 text-rose-700 border-rose-200",
   late: "bg-blue-50 text-blue-700 border-blue-200",
+}
+
+export const TONE_CLASSES: Record<Tone, { text: string; bg: string; ring: string }> = {
+  emerald: { text: "text-emerald-700", bg: "bg-emerald-50", ring: "ring-emerald-100" },
+  rose: { text: "text-rose-700", bg: "bg-rose-50", ring: "ring-rose-100" },
+  blue: { text: "text-blue-700", bg: "bg-blue-50", ring: "ring-blue-100" },
+  amber: { text: "text-amber-700", bg: "bg-amber-50", ring: "ring-amber-100" },
+  neutral: {
+    text: "text-muted-foreground",
+    bg: "bg-muted/40",
+    ring: "ring-muted-foreground/10",
+  },
+}
+
+export const FRENCH_DAY_LABEL: Record<string, string> = {
+  lundi: "Lundi",
+  mardi: "Mardi",
+  mercredi: "Mercredi",
+  jeudi: "Jeudi",
+  vendredi: "Vendredi",
+  samedi: "Samedi",
+  monday: "Lundi",
+  tuesday: "Mardi",
+  wednesday: "Mercredi",
+  thursday: "Jeudi",
+  friday: "Vendredi",
+  saturday: "Samedi",
 }
 
 const FRENCH_MONTHS = [
@@ -91,4 +119,15 @@ export function formatLateMinutes(minutes: number): string {
   const h = Math.floor(minutes / 60)
   const m = minutes % 60
   return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, "0")}`
+}
+
+/** Builds the option label for a timetable slot select item. */
+export function formatSlotOption(slot: TimetableSlot): string {
+  const dayLabel = FRENCH_DAY_LABEL[slot.day] ?? slot.day
+  return `${dayLabel} ${slot.start_time}–${slot.end_time} · ${slot.subject_name} · ${slot.class_name}`
+}
+
+/** Trims notes and returns null if empty (BE expects null over empty string). */
+export function cleanNotes(notes: string | null | undefined): string | null {
+  return notes?.trim() || null
 }

--- a/components/admin/teachers/attendance/teacher-attendance-helpers.ts
+++ b/components/admin/teachers/attendance/teacher-attendance-helpers.ts
@@ -1,0 +1,94 @@
+import type { TeacherAttendanceStatus } from "@/lib/contracts/teacher-attendance"
+
+export const STATUS_LABEL: Record<TeacherAttendanceStatus, string> = {
+  present: "Présent",
+  absent_excused: "Absence justifiée",
+  absent_unexcused: "Absence non justifiée",
+  late: "En retard",
+}
+
+type Tone = "emerald" | "amber" | "rose" | "blue" | "neutral"
+
+export const STATUS_TONE: Record<TeacherAttendanceStatus, Tone> = {
+  present: "emerald",
+  absent_excused: "amber",
+  absent_unexcused: "rose",
+  late: "blue",
+}
+
+export const STATUS_CHIP_CLASS: Record<TeacherAttendanceStatus, string> = {
+  present: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  absent_excused: "bg-amber-50 text-amber-700 border-amber-200",
+  absent_unexcused: "bg-rose-50 text-rose-700 border-rose-200",
+  late: "bg-blue-50 text-blue-700 border-blue-200",
+}
+
+const FRENCH_MONTHS = [
+  "janvier",
+  "février",
+  "mars",
+  "avril",
+  "mai",
+  "juin",
+  "juillet",
+  "août",
+  "septembre",
+  "octobre",
+  "novembre",
+  "décembre",
+]
+
+const FRENCH_DAYS = [
+  "dimanche",
+  "lundi",
+  "mardi",
+  "mercredi",
+  "jeudi",
+  "vendredi",
+  "samedi",
+]
+
+export function formatLongFrenchDate(isoDate: string): string {
+  const [y, m, d] = isoDate.split("-").map(Number)
+  const date = new Date(Date.UTC(y, m - 1, d))
+  const day = FRENCH_DAYS[date.getUTCDay()]
+  const dayNum = date.getUTCDate()
+  const month = FRENCH_MONTHS[date.getUTCMonth()]
+  return `${day} ${dayNum} ${month} ${y}`
+}
+
+export function formatShortFrenchDate(isoDate: string): string {
+  const [y, m, d] = isoDate.split("-").map(Number)
+  return `${String(d).padStart(2, "0")}/${String(m).padStart(2, "0")}/${y}`
+}
+
+export function formatRelativeFromNow(isoDate: string): string {
+  const [y, m, d] = isoDate.split("-").map(Number)
+  const target = new Date(Date.UTC(y, m - 1, d))
+  const today = new Date()
+  const todayUtc = new Date(
+    Date.UTC(today.getFullYear(), today.getMonth(), today.getDate()),
+  )
+  const diffDays = Math.round(
+    (target.getTime() - todayUtc.getTime()) / (1000 * 60 * 60 * 24),
+  )
+  if (diffDays === 0) return "aujourd'hui"
+  if (diffDays === -1) return "hier"
+  if (diffDays === 1) return "demain"
+  if (diffDays < 0) return `il y a ${Math.abs(diffDays)} jours`
+  return `dans ${diffDays} jours`
+}
+
+/** Returns today as ISO YYYY-MM-DD (local time, used as default for date pickers). */
+export function todayIso(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}
+
+export function formatLateMinutes(minutes: number): string {
+  if (minutes <= 0) return ""
+  if (minutes < 60) return `${minutes} min`
+  const h = Math.floor(minutes / 60)
+  const m = minutes % 60
+  return m === 0 ? `${h}h` : `${h}h${String(m).padStart(2, "0")}`
+}

--- a/components/admin/teachers/tabs/TeacherAttendanceTab.tsx
+++ b/components/admin/teachers/tabs/TeacherAttendanceTab.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Plus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { useTeacherAttendanceStats } from "@/lib/hooks/useTeacherAttendance"
+import { AttendanceStatsHero } from "../attendance/AttendanceStatsHero"
+import { PendingValidationSection } from "../attendance/PendingValidationSection"
+import { AttendanceHistoryList } from "../attendance/AttendanceHistoryList"
+import { AttendanceRecordModal } from "../attendance/AttendanceRecordModal"
+
+interface TeacherAttendanceTabProps {
+  teacherId: number
+}
+
+export function TeacherAttendanceTab({ teacherId }: TeacherAttendanceTabProps) {
+  const { data: yearsData } = useAcademicYears({ page: 1, size: 50 })
+  const years = useMemo(() => {
+    const raw = yearsData
+    if (!raw) return []
+    if (Array.isArray(raw)) return raw
+    if (typeof raw === "object" && raw !== null && "data" in raw) {
+      const d = (raw as { data?: unknown }).data
+      if (Array.isArray(d)) return d
+    }
+    return []
+  }, [yearsData])
+
+  const currentYear = years.find(
+    (y) => (y as { is_current?: boolean }).is_current === true,
+  ) as { id: number; name: string } | undefined
+
+  const [selectedYearId, setSelectedYearId] = useState<number | undefined>(
+    undefined,
+  )
+  const activeYearId = selectedYearId ?? currentYear?.id
+
+  const { data: stats, isLoading: statsLoading } = useTeacherAttendanceStats(
+    teacherId,
+    activeYearId,
+  )
+
+  const [recordOpen, setRecordOpen] = useState(false)
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Select
+            value={activeYearId ? String(activeYearId) : ""}
+            onValueChange={(v) => setSelectedYearId(Number(v))}
+          >
+            <SelectTrigger className="h-9 w-[200px]">
+              <SelectValue placeholder="Année scolaire" />
+            </SelectTrigger>
+            <SelectContent>
+              {years.map((y) => {
+                const yy = y as {
+                  id: number
+                  name: string
+                  is_current?: boolean
+                }
+                return (
+                  <SelectItem key={yy.id} value={String(yy.id)}>
+                    {yy.name}
+                    {yy.is_current ? " · en cours" : ""}
+                  </SelectItem>
+                )
+              })}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button
+          onClick={() => setRecordOpen(true)}
+          className="h-11 font-semibold sm:h-9"
+        >
+          <Plus className="mr-1.5 h-4 w-4" />
+          Saisir une absence
+        </Button>
+      </div>
+
+      <AttendanceStatsHero stats={stats} isLoading={statsLoading} />
+
+      <PendingValidationSection
+        teacherId={teacherId}
+        academicYearId={activeYearId}
+      />
+
+      <AttendanceHistoryList
+        teacherId={teacherId}
+        academicYearId={activeYearId}
+      />
+
+      <AttendanceRecordModal
+        teacherId={teacherId}
+        open={recordOpen}
+        onClose={() => setRecordOpen(false)}
+      />
+    </div>
+  )
+}

--- a/components/admin/teachers/tabs/TeacherAttendanceTab.tsx
+++ b/components/admin/teachers/tabs/TeacherAttendanceTab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import { Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -23,20 +23,8 @@ interface TeacherAttendanceTabProps {
 
 export function TeacherAttendanceTab({ teacherId }: TeacherAttendanceTabProps) {
   const { data: yearsData } = useAcademicYears({ page: 1, size: 50 })
-  const years = useMemo(() => {
-    const raw = yearsData
-    if (!raw) return []
-    if (Array.isArray(raw)) return raw
-    if (typeof raw === "object" && raw !== null && "data" in raw) {
-      const d = (raw as { data?: unknown }).data
-      if (Array.isArray(d)) return d
-    }
-    return []
-  }, [yearsData])
-
-  const currentYear = years.find(
-    (y) => (y as { is_current?: boolean }).is_current === true,
-  ) as { id: number; name: string } | undefined
+  const years = yearsData?.items ?? []
+  const currentYear = years.find((y) => y.is_current)
 
   const [selectedYearId, setSelectedYearId] = useState<number | undefined>(
     undefined,
@@ -62,19 +50,12 @@ export function TeacherAttendanceTab({ teacherId }: TeacherAttendanceTabProps) {
               <SelectValue placeholder="Année scolaire" />
             </SelectTrigger>
             <SelectContent>
-              {years.map((y) => {
-                const yy = y as {
-                  id: number
-                  name: string
-                  is_current?: boolean
-                }
-                return (
-                  <SelectItem key={yy.id} value={String(yy.id)}>
-                    {yy.name}
-                    {yy.is_current ? " · en cours" : ""}
-                  </SelectItem>
-                )
-              })}
+              {years.map((y) => (
+                <SelectItem key={y.id} value={String(y.id)}>
+                  {y.name}
+                  {y.is_current ? " · en cours" : ""}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>

--- a/components/teacher/SelfDeclareAbsenceModal.tsx
+++ b/components/teacher/SelfDeclareAbsenceModal.tsx
@@ -6,24 +6,6 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Info } from "lucide-react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { useMyTimetable } from "@/lib/hooks/useTimetable"
 import { useSelfDeclareAttendance } from "@/lib/hooks/useTeacherAttendance"
 import {
@@ -31,7 +13,11 @@ import {
   type TeacherSelfDeclareCreate,
 } from "@/lib/contracts/teacher-attendance"
 import {
-  STATUS_LABEL,
+  AttendanceFormFields,
+  Form,
+} from "@/components/admin/teachers/attendance/AttendanceFormFields"
+import {
+  cleanNotes,
   todayIso,
 } from "@/components/admin/teachers/attendance/teacher-attendance-helpers"
 
@@ -40,20 +26,11 @@ interface SelfDeclareAbsenceModalProps {
   onClose: () => void
 }
 
-const FRENCH_DAY_LABEL: Record<string, string> = {
-  lundi: "Lundi",
-  mardi: "Mardi",
-  mercredi: "Mercredi",
-  jeudi: "Jeudi",
-  vendredi: "Vendredi",
-  samedi: "Samedi",
-  monday: "Lundi",
-  tuesday: "Mardi",
-  wednesday: "Mercredi",
-  thursday: "Jeudi",
-  friday: "Vendredi",
-  saturday: "Samedi",
-}
+const STATUS_OPTIONS: TeacherSelfDeclareCreate["status"][] = [
+  "absent_excused",
+  "absent_unexcused",
+  "late",
+]
 
 export function SelfDeclareAbsenceModal({
   open,
@@ -86,18 +63,19 @@ export function SelfDeclareAbsenceModal({
   }, [open, form])
 
   function onSubmit(data: TeacherSelfDeclareCreate) {
-    const cleaned: TeacherSelfDeclareCreate = {
-      ...data,
-      late_minutes: data.status === "late" ? data.late_minutes : 0,
-      notes: data.notes?.trim() ? data.notes.trim() : null,
-      slot_id: data.slot_id ?? null,
-    }
-    mutate(cleaned, {
-      onSuccess: () => {
-        form.reset()
-        onClose()
+    mutate(
+      {
+        ...data,
+        notes: cleanNotes(data.notes),
+        slot_id: data.slot_id ?? null,
       },
-    })
+      {
+        onSuccess: () => {
+          form.reset()
+          onClose()
+        },
+      },
+    )
   }
 
   return (
@@ -118,138 +96,16 @@ export function SelfDeclareAbsenceModal({
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
-            <div className="grid grid-cols-2 gap-4">
-              <FormField
-                control={form.control}
-                name="date"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Date</FormLabel>
-                    <FormControl>
-                      <Input type="date" className="h-11" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="status"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Motif</FormLabel>
-                    <Select
-                      value={field.value}
-                      onValueChange={(v) =>
-                        field.onChange(v as TeacherSelfDeclareCreate["status"])
-                      }
-                    >
-                      <FormControl>
-                        <SelectTrigger className="h-11">
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="absent_excused">
-                          {STATUS_LABEL.absent_excused}
-                        </SelectItem>
-                        <SelectItem value="absent_unexcused">
-                          {STATUS_LABEL.absent_unexcused}
-                        </SelectItem>
-                        <SelectItem value="late">
-                          {STATUS_LABEL.late}
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <FormField
-              control={form.control}
-              name="slot_id"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Cours concerné (optionnel)</FormLabel>
-                  <Select
-                    value={field.value ? String(field.value) : "none"}
-                    onValueChange={(v) =>
-                      field.onChange(v === "none" ? null : Number(v))
-                    }
-                    disabled={slotsLoading}
-                  >
-                    <FormControl>
-                      <SelectTrigger className="h-11">
-                        <SelectValue placeholder={slotsLoading ? "Chargement..." : "Aucun cours précis"} />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="none">
-                        Aucun cours précis (toute la journée)
-                      </SelectItem>
-                      {slots.map((slot) => {
-                        const dayLabel = FRENCH_DAY_LABEL[slot.day] ?? slot.day
-                        return (
-                          <SelectItem key={slot.id} value={String(slot.id)}>
-                            {dayLabel} {slot.start_time}–{slot.end_time} · {slot.subject_name} · {slot.class_name}
-                          </SelectItem>
-                        )
-                      })}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {status === "late" && (
-              <FormField
-                control={form.control}
-                name="late_minutes"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Minutes de retard</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        min={1}
-                        max={480}
-                        step={5}
-                        className="h-11"
-                        value={field.value}
-                        onChange={(e) =>
-                          field.onChange(Number(e.target.value) || 0)
-                        }
-                      />
-                    </FormControl>
-                    <FormDescription className="text-xs">
-                      Entre 1 et 480 (8h max).
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            )}
-
-            <FormField
-              control={form.control}
-              name="notes"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Précision (optionnel)</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      rows={3}
-                      placeholder="Ex : Rendez-vous médical, urgence familiale, retard transport..."
-                      value={field.value ?? ""}
-                      onChange={field.onChange}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+            <AttendanceFormFields
+              form={form}
+              statusOptions={STATUS_OPTIONS}
+              statusLabel="Motif"
+              slots={slots}
+              slotsLoading={slotsLoading}
+              slotLabel="Cours concerné (optionnel)"
+              noSlotLabel="Aucun cours précis (toute la journée)"
+              notesLabel="Précision (optionnel)"
+              notesPlaceholder="Ex : Rendez-vous médical, urgence familiale, retard transport..."
             />
 
             <div className="flex justify-end gap-2 pt-2">

--- a/components/teacher/SelfDeclareAbsenceModal.tsx
+++ b/components/teacher/SelfDeclareAbsenceModal.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import { useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Info } from "lucide-react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useMyTimetable } from "@/lib/hooks/useTimetable"
+import { useSelfDeclareAttendance } from "@/lib/hooks/useTeacherAttendance"
+import {
+  TeacherSelfDeclareCreateSchema,
+  type TeacherSelfDeclareCreate,
+} from "@/lib/contracts/teacher-attendance"
+import {
+  STATUS_LABEL,
+  todayIso,
+} from "@/components/admin/teachers/attendance/teacher-attendance-helpers"
+
+interface SelfDeclareAbsenceModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+const FRENCH_DAY_LABEL: Record<string, string> = {
+  lundi: "Lundi",
+  mardi: "Mardi",
+  mercredi: "Mercredi",
+  jeudi: "Jeudi",
+  vendredi: "Vendredi",
+  samedi: "Samedi",
+  monday: "Lundi",
+  tuesday: "Mardi",
+  wednesday: "Mercredi",
+  thursday: "Jeudi",
+  friday: "Vendredi",
+  saturday: "Samedi",
+}
+
+export function SelfDeclareAbsenceModal({
+  open,
+  onClose,
+}: SelfDeclareAbsenceModalProps) {
+  const { data: slots = [], isLoading: slotsLoading } = useMyTimetable()
+  const { mutate, isPending } = useSelfDeclareAttendance()
+
+  const form = useForm<TeacherSelfDeclareCreate>({
+    resolver: zodResolver(TeacherSelfDeclareCreateSchema),
+    defaultValues: {
+      slot_id: null,
+      date: todayIso(),
+      status: "absent_excused",
+      late_minutes: 0,
+      notes: null,
+    },
+  })
+
+  const status = form.watch("status")
+
+  useEffect(() => {
+    if (status !== "late" && form.getValues("late_minutes") !== 0) {
+      form.setValue("late_minutes", 0, { shouldValidate: true })
+    }
+  }, [status, form])
+
+  useEffect(() => {
+    if (!open) form.reset()
+  }, [open, form])
+
+  function onSubmit(data: TeacherSelfDeclareCreate) {
+    const cleaned: TeacherSelfDeclareCreate = {
+      ...data,
+      late_minutes: data.status === "late" ? data.late_minutes : 0,
+      notes: data.notes?.trim() ? data.notes.trim() : null,
+      slot_id: data.slot_id ?? null,
+    }
+    mutate(cleaned, {
+      onSuccess: () => {
+        form.reset()
+        onClose()
+      },
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (!v ? onClose() : undefined)}>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Me déclarer absent ou en retard</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+          <p>
+            Votre déclaration sera envoyée à l&apos;administration pour
+            validation avant d&apos;être comptabilisée. Pensez à informer aussi
+            le secrétariat par téléphone si urgent.
+          </p>
+        </div>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date</FormLabel>
+                    <FormControl>
+                      <Input type="date" className="h-11" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Motif</FormLabel>
+                    <Select
+                      value={field.value}
+                      onValueChange={(v) =>
+                        field.onChange(v as TeacherSelfDeclareCreate["status"])
+                      }
+                    >
+                      <FormControl>
+                        <SelectTrigger className="h-11">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="absent_excused">
+                          {STATUS_LABEL.absent_excused}
+                        </SelectItem>
+                        <SelectItem value="absent_unexcused">
+                          {STATUS_LABEL.absent_unexcused}
+                        </SelectItem>
+                        <SelectItem value="late">
+                          {STATUS_LABEL.late}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="slot_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Cours concerné (optionnel)</FormLabel>
+                  <Select
+                    value={field.value ? String(field.value) : "none"}
+                    onValueChange={(v) =>
+                      field.onChange(v === "none" ? null : Number(v))
+                    }
+                    disabled={slotsLoading}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="h-11">
+                        <SelectValue placeholder={slotsLoading ? "Chargement..." : "Aucun cours précis"} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="none">
+                        Aucun cours précis (toute la journée)
+                      </SelectItem>
+                      {slots.map((slot) => {
+                        const dayLabel = FRENCH_DAY_LABEL[slot.day] ?? slot.day
+                        return (
+                          <SelectItem key={slot.id} value={String(slot.id)}>
+                            {dayLabel} {slot.start_time}–{slot.end_time} · {slot.subject_name} · {slot.class_name}
+                          </SelectItem>
+                        )
+                      })}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {status === "late" && (
+              <FormField
+                control={form.control}
+                name="late_minutes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Minutes de retard</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={480}
+                        step={5}
+                        className="h-11"
+                        value={field.value}
+                        onChange={(e) =>
+                          field.onChange(Number(e.target.value) || 0)
+                        }
+                      />
+                    </FormControl>
+                    <FormDescription className="text-xs">
+                      Entre 1 et 480 (8h max).
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Précision (optionnel)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={3}
+                      placeholder="Ex : Rendez-vous médical, urgence familiale, retard transport..."
+                      value={field.value ?? ""}
+                      onChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" variant="outline" onClick={onClose} className="h-11">
+                Annuler
+              </Button>
+              <Button type="submit" disabled={isPending} className="h-11 font-semibold">
+                {isPending ? "Envoi..." : "Envoyer la déclaration"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
 import {
   CalendarDays,
@@ -8,17 +9,21 @@ import {
   ClipboardList,
   ChevronRight,
   AlertTriangle,
+  CalendarX,
 } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
 import { useTeacherDashboard } from "@/lib/hooks/useTeacherPortal"
 import type { TeacherUpcomingEval } from "@/lib/contracts/teacher-portal"
+import { SelfDeclareAbsenceModal } from "./SelfDeclareAbsenceModal"
 
 export function TeacherDashboardClient() {
   const { data, isLoading, isError, refetch } = useTeacherDashboard()
+  const [selfDeclareOpen, setSelfDeclareOpen] = useState(false)
 
   if (isLoading) return <DashboardSkeleton />
 
@@ -53,6 +58,19 @@ export function TeacherDashboardClient() {
         currentYear={data.current_academic_year}
         role="teacher"
       />
+
+      {/* Action rapide — déclaration d'absence */}
+      <div className="flex justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setSelfDeclareOpen(true)}
+          className="h-11 border-amber-200 bg-amber-50 font-medium text-amber-900 hover:bg-amber-100 sm:h-9"
+        >
+          <CalendarX className="mr-1.5 h-4 w-4" />
+          Me déclarer absent
+        </Button>
+      </div>
 
       {/* Prochain cours */}
       <Card className="border-primary/20 bg-primary/5">
@@ -133,6 +151,11 @@ export function TeacherDashboardClient() {
           </div>
         )}
       </div>
+
+      <SelfDeclareAbsenceModal
+        open={selfDeclareOpen}
+        onClose={() => setSelfDeclareOpen(false)}
+      />
     </div>
   )
 }

--- a/lib/api/teacher-attendance.ts
+++ b/lib/api/teacher-attendance.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import { apiFetch, safeValidate } from "./client"
 import {
   TeacherAttendanceListResponseSchema,
@@ -19,6 +20,16 @@ function unwrap(json: unknown): unknown {
   return json
 }
 
+async function fetchAndValidate<T>(
+  schema: z.ZodType<T>,
+  path: string,
+  context: string,
+  init?: { method?: string; body?: string },
+): Promise<T> {
+  const json = await apiFetch<unknown>(path, init)
+  return safeValidate(schema, unwrap(json), context)
+}
+
 export interface TeacherAttendanceListParams {
   academic_year_id?: number
   status?: string
@@ -38,64 +49,43 @@ function toQueryString(params: TeacherAttendanceListParams): string {
 }
 
 export const teacherAttendanceApi = {
-  list: async (
+  list: (
     teacherId: number,
     params: TeacherAttendanceListParams = {},
   ): Promise<TeacherAttendanceListResponse> => {
-    const json = await apiFetch<unknown>(
-      `/admin/teachers/${teacherId}/attendance${toQueryString(params)}`,
-    )
-    return safeValidate(
-      TeacherAttendanceListResponseSchema,
-      unwrap(json),
-      `GET /admin/teachers/${teacherId}/attendance`,
-    )
+    const path = `/admin/teachers/${teacherId}/attendance${toQueryString(params)}`
+    return fetchAndValidate(TeacherAttendanceListResponseSchema, path, `GET ${path}`)
   },
 
-  stats: async (
+  stats: (
     teacherId: number,
     academicYearId?: number,
   ): Promise<TeacherAttendanceStats> => {
-    const qs =
-      academicYearId !== undefined ? `?academic_year_id=${academicYearId}` : ""
-    const json = await apiFetch<unknown>(
-      `/admin/teachers/${teacherId}/attendance/stats${qs}`,
-    )
-    return safeValidate(
-      TeacherAttendanceStatsSchema,
-      unwrap(json),
-      `GET /admin/teachers/${teacherId}/attendance/stats`,
-    )
+    const qs = academicYearId !== undefined ? `?academic_year_id=${academicYearId}` : ""
+    const path = `/admin/teachers/${teacherId}/attendance/stats${qs}`
+    return fetchAndValidate(TeacherAttendanceStatsSchema, path, `GET ${path}`)
   },
 
-  recordAsAdmin: async (
+  recordAsAdmin: (
     teacherId: number,
     data: TeacherAttendanceCreate,
   ): Promise<TeacherAttendanceResponse> => {
-    const json = await apiFetch<unknown>(
-      `/admin/teachers/${teacherId}/attendance`,
-      { method: "POST", body: JSON.stringify(data) },
-    )
-    return safeValidate(
-      TeacherAttendanceResponseSchema,
-      unwrap(json),
-      `POST /admin/teachers/${teacherId}/attendance`,
-    )
+    const path = `/admin/teachers/${teacherId}/attendance`
+    return fetchAndValidate(TeacherAttendanceResponseSchema, path, `POST ${path}`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
   },
 
-  validate: async (
+  validate: (
     attendanceId: number,
     data: TeacherAttendanceValidateInput,
   ): Promise<TeacherAttendanceResponse> => {
-    const json = await apiFetch<unknown>(
-      `/admin/teacher-attendance/${attendanceId}/validate`,
-      { method: "PATCH", body: JSON.stringify(data) },
-    )
-    return safeValidate(
-      TeacherAttendanceResponseSchema,
-      unwrap(json),
-      `PATCH /admin/teacher-attendance/${attendanceId}/validate`,
-    )
+    const path = `/admin/teacher-attendance/${attendanceId}/validate`
+    return fetchAndValidate(TeacherAttendanceResponseSchema, path, `PATCH ${path}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    })
   },
 
   delete: async (attendanceId: number): Promise<void> => {
@@ -104,17 +94,13 @@ export const teacherAttendanceApi = {
     })
   },
 
-  selfDeclare: async (
+  selfDeclare: (
     data: TeacherSelfDeclareCreate,
   ): Promise<TeacherAttendanceResponse> => {
-    const json = await apiFetch<unknown>("/teacher/attendance/self-declare", {
+    const path = "/teacher/attendance/self-declare"
+    return fetchAndValidate(TeacherAttendanceResponseSchema, path, `POST ${path}`, {
       method: "POST",
       body: JSON.stringify(data),
     })
-    return safeValidate(
-      TeacherAttendanceResponseSchema,
-      unwrap(json),
-      "POST /teacher/attendance/self-declare",
-    )
   },
 }

--- a/lib/api/teacher-attendance.ts
+++ b/lib/api/teacher-attendance.ts
@@ -1,0 +1,120 @@
+import { apiFetch, safeValidate } from "./client"
+import {
+  TeacherAttendanceListResponseSchema,
+  TeacherAttendanceResponseSchema,
+  TeacherAttendanceStatsSchema,
+  type TeacherAttendanceCreate,
+  type TeacherAttendanceListResponse,
+  type TeacherAttendanceResponse,
+  type TeacherAttendanceStats,
+  type TeacherAttendanceValidateInput,
+  type TeacherSelfDeclareCreate,
+} from "@/lib/contracts/teacher-attendance"
+
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object") {
+    const obj = json as Record<string, unknown>
+    if (obj.data !== undefined) return obj.data
+  }
+  return json
+}
+
+export interface TeacherAttendanceListParams {
+  academic_year_id?: number
+  status?: string
+  date_from?: string
+  date_to?: string
+  page?: number
+  per_page?: number
+}
+
+function toQueryString(params: TeacherAttendanceListParams): string {
+  const query = new URLSearchParams()
+  for (const [key, val] of Object.entries(params)) {
+    if (val !== undefined && val !== null && val !== "") query.set(key, String(val))
+  }
+  const qs = query.toString()
+  return qs ? `?${qs}` : ""
+}
+
+export const teacherAttendanceApi = {
+  list: async (
+    teacherId: number,
+    params: TeacherAttendanceListParams = {},
+  ): Promise<TeacherAttendanceListResponse> => {
+    const json = await apiFetch<unknown>(
+      `/admin/teachers/${teacherId}/attendance${toQueryString(params)}`,
+    )
+    return safeValidate(
+      TeacherAttendanceListResponseSchema,
+      unwrap(json),
+      `GET /admin/teachers/${teacherId}/attendance`,
+    )
+  },
+
+  stats: async (
+    teacherId: number,
+    academicYearId?: number,
+  ): Promise<TeacherAttendanceStats> => {
+    const qs =
+      academicYearId !== undefined ? `?academic_year_id=${academicYearId}` : ""
+    const json = await apiFetch<unknown>(
+      `/admin/teachers/${teacherId}/attendance/stats${qs}`,
+    )
+    return safeValidate(
+      TeacherAttendanceStatsSchema,
+      unwrap(json),
+      `GET /admin/teachers/${teacherId}/attendance/stats`,
+    )
+  },
+
+  recordAsAdmin: async (
+    teacherId: number,
+    data: TeacherAttendanceCreate,
+  ): Promise<TeacherAttendanceResponse> => {
+    const json = await apiFetch<unknown>(
+      `/admin/teachers/${teacherId}/attendance`,
+      { method: "POST", body: JSON.stringify(data) },
+    )
+    return safeValidate(
+      TeacherAttendanceResponseSchema,
+      unwrap(json),
+      `POST /admin/teachers/${teacherId}/attendance`,
+    )
+  },
+
+  validate: async (
+    attendanceId: number,
+    data: TeacherAttendanceValidateInput,
+  ): Promise<TeacherAttendanceResponse> => {
+    const json = await apiFetch<unknown>(
+      `/admin/teacher-attendance/${attendanceId}/validate`,
+      { method: "PATCH", body: JSON.stringify(data) },
+    )
+    return safeValidate(
+      TeacherAttendanceResponseSchema,
+      unwrap(json),
+      `PATCH /admin/teacher-attendance/${attendanceId}/validate`,
+    )
+  },
+
+  delete: async (attendanceId: number): Promise<void> => {
+    await apiFetch<unknown>(`/admin/teacher-attendance/${attendanceId}`, {
+      method: "DELETE",
+    })
+  },
+
+  selfDeclare: async (
+    data: TeacherSelfDeclareCreate,
+  ): Promise<TeacherAttendanceResponse> => {
+    const json = await apiFetch<unknown>("/teacher/attendance/self-declare", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(
+      TeacherAttendanceResponseSchema,
+      unwrap(json),
+      "POST /teacher/attendance/self-declare",
+    )
+  },
+}

--- a/lib/contracts/teacher-attendance.ts
+++ b/lib/contracts/teacher-attendance.ts
@@ -1,0 +1,97 @@
+import { z } from "zod"
+
+export const TEACHER_ATTENDANCE_STATUSES = [
+  "present",
+  "absent_excused",
+  "absent_unexcused",
+  "late",
+] as const
+
+export const TeacherAttendanceStatusSchema = z.enum(TEACHER_ATTENDANCE_STATUSES)
+export type TeacherAttendanceStatus = z.infer<typeof TeacherAttendanceStatusSchema>
+
+export const TeacherAttendanceResponseSchema = z.object({
+  id: z.number(),
+  teacher_id: z.number(),
+  teacher_full_name: z.string(),
+  slot_id: z.number().nullable(),
+  slot_summary: z.string().nullable(),
+  date: z.string(),
+  academic_year_id: z.number(),
+  status: TeacherAttendanceStatusSchema,
+  late_minutes: z.number().int().min(0),
+  notes: z.string().nullable(),
+
+  declared_by_user_id: z.number(),
+  declared_by_email: z.string().nullable(),
+  declared_at: z.string(),
+  is_validated: z.boolean(),
+  validated_by_user_id: z.number().nullable(),
+  validated_by_email: z.string().nullable(),
+  validated_at: z.string().nullable(),
+
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const TeacherAttendanceListResponseSchema = z.object({
+  items: z.array(TeacherAttendanceResponseSchema),
+  total: z.number(),
+})
+
+export const TeacherAttendanceStatsSchema = z.object({
+  teacher_id: z.number(),
+  academic_year_id: z.number(),
+  academic_year_name: z.string(),
+
+  total_sessions: z.number(),
+  sessions_present: z.number(),
+  sessions_absent_excused: z.number(),
+  sessions_absent_unexcused: z.number(),
+  sessions_late: z.number(),
+
+  attendance_rate: z.number(),
+  total_late_minutes: z.number(),
+  avg_late_minutes_when_late: z.number(),
+
+  pending_validation_count: z.number(),
+})
+
+// ---------- Input schemas (forms) ----------
+
+export const TeacherAttendanceCreateSchema = z
+  .object({
+    slot_id: z.number().int().positive().nullable().optional(),
+    date: z.string().min(1, "La date est requise"),
+    status: TeacherAttendanceStatusSchema,
+    late_minutes: z
+      .number({ invalid_type_error: "Minutes en chiffres" })
+      .int()
+      .min(0, "Doit être >= 0")
+      .max(480, "Maximum 8h (480 minutes)")
+      .default(0),
+    notes: z.string().max(1000, "1000 caractères maximum").nullable().optional(),
+  })
+  .refine(
+    (data) => data.status === "late" || data.late_minutes === 0,
+    {
+      message: "Les minutes de retard ne s'appliquent qu'au statut 'En retard'",
+      path: ["late_minutes"],
+    },
+  )
+
+export const TeacherSelfDeclareCreateSchema = TeacherAttendanceCreateSchema
+
+export const TeacherAttendanceValidateSchema = z.object({
+  approved: z.boolean().default(true),
+  admin_notes: z.string().max(500).nullable().optional(),
+})
+
+// ---------- Exported types ----------
+
+export type TeacherAttendanceResponse = z.infer<typeof TeacherAttendanceResponseSchema>
+export type TeacherAttendanceListResponse = z.infer<typeof TeacherAttendanceListResponseSchema>
+export type TeacherAttendanceStats = z.infer<typeof TeacherAttendanceStatsSchema>
+export type TeacherAttendanceCreate = z.infer<typeof TeacherAttendanceCreateSchema>
+export type TeacherSelfDeclareCreate = z.infer<typeof TeacherSelfDeclareCreateSchema>
+export type TeacherAttendanceValidateInput = z.infer<typeof TeacherAttendanceValidateSchema>

--- a/lib/contracts/teacher-attendance.ts
+++ b/lib/contracts/teacher-attendance.ts
@@ -59,28 +59,59 @@ export const TeacherAttendanceStatsSchema = z.object({
 
 // ---------- Input schemas (forms) ----------
 
+const LATE_MINUTES_FIELD = z
+  .number({ invalid_type_error: "Minutes en chiffres" })
+  .int()
+  .min(0, "Doit être >= 0")
+  .max(480, "Maximum 8h (480 minutes)")
+  .default(0)
+
+const NOTES_FIELD = z
+  .string()
+  .max(1000, "1000 caractères maximum")
+  .nullable()
+  .optional()
+
+const LATE_MINUTES_RULE = {
+  message:
+    "Les minutes de retard ne s'appliquent qu'au statut 'En retard' et doivent être > 0",
+  path: ["late_minutes"],
+}
+
+function lateMinutesMatchStatus<T extends { status: string; late_minutes: number }>(
+  data: T,
+): boolean {
+  return data.status === "late" ? data.late_minutes > 0 : data.late_minutes === 0
+}
+
 export const TeacherAttendanceCreateSchema = z
   .object({
     slot_id: z.number().int().positive().nullable().optional(),
     date: z.string().min(1, "La date est requise"),
     status: TeacherAttendanceStatusSchema,
-    late_minutes: z
-      .number({ invalid_type_error: "Minutes en chiffres" })
-      .int()
-      .min(0, "Doit être >= 0")
-      .max(480, "Maximum 8h (480 minutes)")
-      .default(0),
-    notes: z.string().max(1000, "1000 caractères maximum").nullable().optional(),
+    late_minutes: LATE_MINUTES_FIELD,
+    notes: NOTES_FIELD,
   })
-  .refine(
-    (data) => data.status === "late" || data.late_minutes === 0,
-    {
-      message: "Les minutes de retard ne s'appliquent qu'au statut 'En retard'",
-      path: ["late_minutes"],
-    },
-  )
+  .refine(lateMinutesMatchStatus, LATE_MINUTES_RULE)
 
-export const TeacherSelfDeclareCreateSchema = TeacherAttendanceCreateSchema
+// Self-declare narrows the status enum: a teacher cannot declare themselves
+// "present" via this endpoint (use the regular attendance flow for that).
+// Mirrors the BE business rule even though the BE accepts the wider enum.
+export const TeacherSelfDeclareStatusSchema = z.enum([
+  "absent_excused",
+  "absent_unexcused",
+  "late",
+])
+
+export const TeacherSelfDeclareCreateSchema = z
+  .object({
+    slot_id: z.number().int().positive().nullable().optional(),
+    date: z.string().min(1, "La date est requise"),
+    status: TeacherSelfDeclareStatusSchema,
+    late_minutes: LATE_MINUTES_FIELD,
+    notes: NOTES_FIELD,
+  })
+  .refine(lateMinutesMatchStatus, LATE_MINUTES_RULE)
 
 export const TeacherAttendanceValidateSchema = z.object({
   approved: z.boolean().default(true),

--- a/lib/hooks/useTeacherAttendance.ts
+++ b/lib/hooks/useTeacherAttendance.ts
@@ -1,0 +1,114 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import {
+  teacherAttendanceApi,
+  type TeacherAttendanceListParams,
+} from "@/lib/api/teacher-attendance"
+import type {
+  TeacherAttendanceCreate,
+  TeacherAttendanceValidateInput,
+  TeacherSelfDeclareCreate,
+} from "@/lib/contracts/teacher-attendance"
+
+export const teacherAttendanceKeys = {
+  all: ["teacher-attendance"] as const,
+  list: (teacherId: number, params: TeacherAttendanceListParams) =>
+    ["teacher-attendance", "list", teacherId, params] as const,
+  stats: (teacherId: number, academicYearId?: number) =>
+    ["teacher-attendance", "stats", teacherId, academicYearId] as const,
+}
+
+export function useTeacherAttendanceList(
+  teacherId: number,
+  params: TeacherAttendanceListParams,
+  options: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    queryKey: teacherAttendanceKeys.list(teacherId, params),
+    queryFn: () => teacherAttendanceApi.list(teacherId, params),
+    enabled: options.enabled !== false && teacherId > 0,
+    staleTime: 1000 * 60, // 1 minute
+  })
+}
+
+export function useTeacherAttendanceStats(
+  teacherId: number,
+  academicYearId?: number,
+) {
+  return useQuery({
+    queryKey: teacherAttendanceKeys.stats(teacherId, academicYearId),
+    queryFn: () => teacherAttendanceApi.stats(teacherId, academicYearId),
+    enabled: teacherId > 0,
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useRecordTeacherAttendance(teacherId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: TeacherAttendanceCreate) =>
+      teacherAttendanceApi.recordAsAdmin(teacherId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: teacherAttendanceKeys.all })
+      toast.success("Pointage enregistré")
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Erreur lors de l'enregistrement")
+    },
+  })
+}
+
+export function useValidateTeacherAttendance() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: {
+      attendanceId: number
+      data: TeacherAttendanceValidateInput
+    }) => teacherAttendanceApi.validate(params.attendanceId, params.data),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: teacherAttendanceKeys.all })
+      toast.success(
+        vars.data.approved === false
+          ? "Déclaration rejetée"
+          : "Déclaration validée",
+      )
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Erreur lors de la validation")
+    },
+  })
+}
+
+export function useDeleteTeacherAttendance() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (attendanceId: number) =>
+      teacherAttendanceApi.delete(attendanceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: teacherAttendanceKeys.all })
+      toast.success("Pointage annulé")
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Erreur lors de l'annulation")
+    },
+  })
+}
+
+export function useSelfDeclareAttendance() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: TeacherSelfDeclareCreate) =>
+      teacherAttendanceApi.selfDeclare(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: teacherAttendanceKeys.all })
+      toast.success("Déclaration envoyée", {
+        description: "En attente de validation par l'administration.",
+      })
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Erreur lors de la déclaration")
+    },
+  })
+}

--- a/lib/hooks/useTeacherAttendance.ts
+++ b/lib/hooks/useTeacherAttendance.ts
@@ -20,6 +20,8 @@ export const teacherAttendanceKeys = {
     ["teacher-attendance", "stats", teacherId, academicYearId] as const,
 }
 
+const STALE_TIME = 1000 * 60 // 1 minute
+
 export function useTeacherAttendanceList(
   teacherId: number,
   params: TeacherAttendanceListParams,
@@ -29,7 +31,7 @@ export function useTeacherAttendanceList(
     queryKey: teacherAttendanceKeys.list(teacherId, params),
     queryFn: () => teacherAttendanceApi.list(teacherId, params),
     enabled: options.enabled !== false && teacherId > 0,
-    staleTime: 1000 * 60, // 1 minute
+    staleTime: STALE_TIME,
   })
 }
 
@@ -41,8 +43,13 @@ export function useTeacherAttendanceStats(
     queryKey: teacherAttendanceKeys.stats(teacherId, academicYearId),
     queryFn: () => teacherAttendanceApi.stats(teacherId, academicYearId),
     enabled: teacherId > 0,
-    staleTime: 1000 * 60,
+    staleTime: STALE_TIME,
   })
+}
+
+/** Shared error toast for mutations: BE message si présent, fallback générique. */
+function errorToast(fallback: string) {
+  return (err: Error) => toast.error(err.message || fallback)
 }
 
 export function useRecordTeacherAttendance(teacherId: number) {
@@ -54,9 +61,7 @@ export function useRecordTeacherAttendance(teacherId: number) {
       queryClient.invalidateQueries({ queryKey: teacherAttendanceKeys.all })
       toast.success("Pointage enregistré")
     },
-    onError: (err: Error) => {
-      toast.error(err.message || "Erreur lors de l'enregistrement")
-    },
+    onError: errorToast("Erreur lors de l'enregistrement"),
   })
 }
 
@@ -69,15 +74,10 @@ export function useValidateTeacherAttendance() {
     }) => teacherAttendanceApi.validate(params.attendanceId, params.data),
     onSuccess: (_data, vars) => {
       queryClient.invalidateQueries({ queryKey: teacherAttendanceKeys.all })
-      toast.success(
-        vars.data.approved === false
-          ? "Déclaration rejetée"
-          : "Déclaration validée",
-      )
+      const approved = vars.data.approved !== false
+      toast.success(approved ? "Déclaration validée" : "Déclaration rejetée")
     },
-    onError: (err: Error) => {
-      toast.error(err.message || "Erreur lors de la validation")
-    },
+    onError: errorToast("Erreur lors de la validation"),
   })
 }
 
@@ -90,9 +90,7 @@ export function useDeleteTeacherAttendance() {
       queryClient.invalidateQueries({ queryKey: teacherAttendanceKeys.all })
       toast.success("Pointage annulé")
     },
-    onError: (err: Error) => {
-      toast.error(err.message || "Erreur lors de l'annulation")
-    },
+    onError: errorToast("Erreur lors de l'annulation"),
   })
 }
 
@@ -107,8 +105,6 @@ export function useSelfDeclareAttendance() {
         description: "En attente de validation par l'administration.",
       })
     },
-    onError: (err: Error) => {
-      toast.error(err.message || "Erreur lors de la déclaration")
-    },
+    onError: errorToast("Erreur lors de la déclaration"),
   })
 }


### PR DESCRIPTION
## Pourquoi

Phase 7b BE foundation (klassci-college-backend #146) a livré les 6 endpoints `teacher_session_attendance`. Cette PR rend la feature **utilisable end-to-end** côté FE.

Dépend de [klassci-college-backend#148](https://github.com/African-DC/klassci-college-backend/pull/148) (seed permissions, sinon 403).

## Architecture (detail-tab-split-pattern)

### Couche données
- `lib/contracts/teacher-attendance.ts` — 6 schemas Zod miroir des Pydantic BE
- `lib/api/teacher-attendance.ts` — 6 méthodes (list / stats / record / validate / delete / selfDeclare) avec `safeValidate` partout
- `lib/hooks/useTeacherAttendance.ts` — 5 hooks TanStack Query (1 query + 4 mutations) avec invalidation ciblée et toast Sonner

### Couche UI admin (`/admin/teachers/[id]` tab Présences)
- `tabs/TeacherAttendanceTab.tsx` — orchestrateur 109 LOC (year selector + bouton saisir + 3 sous-composants)
- `attendance/AttendanceStatsHero.tsx` — 4 KPI cards (taux présence vert, absences rose, retards minutes bleu, en attente amber)
- `attendance/PendingValidationSection.tsx` — panel amber pour auto-déclarations prof : Valider (Dialog notes admin) / Rejeter (AlertDialog raison)
- `attendance/AttendanceHistoryList.tsx` — liste filtrable par statut, kebab supprimer avec confirmation
- `attendance/AttendanceRecordModal.tsx` — formulaire RHF + Zod : date + statut + créneau EDT (option) + retard minutes (conditionnel) + notes
- `attendance/teacher-attendance-helpers.ts` — labels FR, chip classes, date formatting

### Couche UI teacher (`/teacher/dashboard`)
- `teacher/SelfDeclareAbsenceModal.tsx` — bouton amber 'Me déclarer absent' avec encart Info rappelant le contact secrétariat si urgent

## Patterns respectés

- ✅ Zod safeValidate sur tous les fetches (api-client-zod-validation)
- ✅ `handleExpiredSession` via apiFetch (handle-401-globally)
- ✅ detail-tab-split-pattern : orchestrateur léger + composants cohérents <260 LOC chacun
- ✅ Touch targets `h-11` mobile + `sm:h-9` desktop (persona Mme Diallo)
- ✅ Contenu UI français, accents propres, no em dashes
- ✅ shadcn/ui primitives (Dialog, AlertDialog, Card, Select, Form RHF)
- ✅ Empty state contextualisé (no god empty)
- ✅ Toast Sonner sur chaque mutation, invalidation TanStack ciblée
- ✅ Production-grade dès v1 : loading skeletons, erreurs gérées, confirmations destructives, validation FR

## Test plan

- [ ] CI green (lint + tsc + tests)
- [ ] `pnpm tsc --noEmit` clean (verifié local)
- [ ] Login admin → /admin/teachers/1 → tab Présences charge
- [ ] Saisir une absence (date=lundi, status=absent_unexcused, slot=Maths 6e B) → toast OK
- [ ] KPI 'Absences' passe de 0 à 1, 'Taux présence' diminue
- [ ] Historique liste la nouvelle entrée avec chip rose
- [ ] Logout, login prof → dashboard → bouton 'Me déclarer absent' → submit retard 15min → toast OK
- [ ] Logout, login admin → panel amber 'En attente' montre la déclaration prof
- [ ] Valider → notes optionnelles → toast OK, KPI 'Retards' passe à 1, 'En attente' à 0

## CHANGELOG

Ajouté 3 entrées Added pour la feature complète persona admin + enseignant.

## Liens

- Task #79
- BE pré-requis : klassci-college-backend#148