### PR TITLE
feat(reports): premium bulletin redesign + student trimester charts wired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Liste des bulletins refondue : nom complet de l'élève, matricule et avatar à initiales s'affichent désormais au lieu d'identifiants techniques `#3`. La fenêtre de détail montre l'élève, sa classe, la moyenne générale, le rang `1/3`, la mention complète et le détail par matière avec coefficient *(admin)*.
+- Page DREN qui ne chargeait plus depuis l'ajout du champ moyenne par classe : le tableau de bord des statistiques affiche désormais correctement l'effectif, la répartition garçons/filles, le taux de réussite et le détail par niveau *(admin)*.
+- Téléchargement d'un PDF en erreur : un toast d'erreur clair apparaît désormais avec le message du serveur (ex : bibliothèque PDF manquante), au lieu d'un silence trompeur où l'admin ne savait pas ce qui se passait *(admin, parent, enseignant)*.
+- Fiche élève / onglet « Parcours » : les graphes Moyennes et Absences par trimestre affichent désormais les vraies données du bulletin et non plus un faux message « Pas encore de notes » alors que les bulletins existent *(admin)*.
 - Tableau de bord parent qui affichait toujours « Connexion au serveur impossible » depuis le ship du portail parent : on voit désormais pour chaque enfant la classe, la moyenne, le nombre d'absences et le solde restant à payer, en un coup d'œil dès la connexion *(parent)*.
 - Quand la session expire silencieusement, on n'affiche plus l'identité de l'ancien utilisateur sur la barre de navigation et la page d'accueil : la redirection vers la page de connexion se fait immédiatement, sans flicker de données périmées *(tous)* (#164).
 - Page de connexion qui boucle en `ERR_TOO_MANY_REDIRECTS` quand le jeton d'accès est expiré : avec `RefreshTokenError`, le middleware redirigeait `/login → /<portail> → /login` à l'infini car la session restait techniquement « connectée ». La page de connexion est désormais toujours accessible quand la session est en erreur, ce qui permet à l'utilisateur de se reconnecter *(tous)* (#151).

--- a/components/admin/reports/BulletinGenerateButton.tsx
+++ b/components/admin/reports/BulletinGenerateButton.tsx
@@ -12,18 +12,13 @@ import {
 } from "@/components/ui/dialog"
 import { useGenerateBulletins } from "@/lib/hooks/useBulletins"
 import { BulletinGenerateSchema } from "@/lib/contracts/bulletin"
+import { trimesterFullLabel } from "@/lib/utils/trimester"
 
 interface BulletinGenerateButtonProps {
   classId: number | undefined
   trimester: number | undefined
   academicYearId: number | undefined
   className?: string
-}
-
-const trimesterLabels: Record<number, string> = {
-  1: "1er trimestre",
-  2: "2ème trimestre",
-  3: "3ème trimestre",
 }
 
 export function BulletinGenerateButton({
@@ -65,7 +60,7 @@ export function BulletinGenerateButton({
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
             Cette action va générer les bulletins pour le{" "}
-            <strong>{trimester ? trimesterLabels[trimester] ?? `trimestre ${trimester}` : ""}</strong>.
+            <strong>{trimester ? trimesterFullLabel(trimester) : ""}</strong>.
             Les bulletins existants en brouillon seront recalculés.
           </p>
           <DialogFooter>

--- a/components/admin/reports/BulletinList.tsx
+++ b/components/admin/reports/BulletinList.tsx
@@ -17,8 +17,40 @@ import { BulletinPreviewModal } from "./BulletinPreviewModal"
 import { BulletinListSkeleton } from "./BulletinListSkeleton"
 import { useBulletins, usePublishBulletins } from "@/lib/hooks/useBulletins"
 import { bulletinsApi } from "@/lib/api/bulletins"
-import { getMentionColor, downloadBlob } from "@/lib/utils"
+import { cn, downloadBlob, getUploadUrl } from "@/lib/utils"
+import { getMentionBadgeClass } from "./mention"
 import type { BulletinListParams, Bulletin } from "@/lib/contracts/bulletin"
+
+function StudentInitialsAvatar({
+  name,
+  photoUrl,
+}: {
+  name: string
+  photoUrl?: string | null
+}) {
+  const initials =
+    name
+      .split(" ")
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((s) => s[0]?.toUpperCase() ?? "")
+      .join("") || "?"
+  const photoSrc = getUploadUrl(photoUrl ?? undefined)
+  if (photoSrc) {
+    return (
+      <img
+        src={photoSrc}
+        alt={name}
+        className="h-9 w-9 shrink-0 rounded-lg border border-border object-cover"
+      />
+    )
+  }
+  return (
+    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-primary/10">
+      <span className="text-xs font-semibold text-primary">{initials}</span>
+    </div>
+  )
+}
 
 interface BulletinListProps {
   params: BulletinListParams
@@ -144,12 +176,11 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
         </Button>
       </div>
 
-      <div className="rounded-lg border">
+      <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
         <Table>
           <TableHeader>
-            <TableRow>
-              <TableHead>Élève</TableHead>
-              <TableHead>Classe</TableHead>
+            <TableRow className="bg-muted/30 hover:bg-muted/30">
+              <TableHead className="py-3">Élève</TableHead>
               <TableHead className="text-center">Moyenne</TableHead>
               <TableHead className="text-center">Rang</TableHead>
               <TableHead>Mention</TableHead>
@@ -158,47 +189,102 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {bulletins.map((bulletin: Bulletin) => (
-              <TableRow key={bulletin.id}>
-                <TableCell className="font-medium">#{bulletin.student_id}</TableCell>
-                <TableCell>#{bulletin.class_id}</TableCell>
-                <TableCell className="text-center font-semibold">
-                  {bulletin.average !== null ? Number(bulletin.average).toFixed(2) : "—"}
-                </TableCell>
-                <TableCell className="text-center">
-                  {bulletin.rank ?? "—"}
-                </TableCell>
-                <TableCell>
-                  <span className={`font-medium ${getMentionColor(bulletin.mention)}`}>
-                    {bulletin.mention ?? "—"}
-                  </span>
-                </TableCell>
-                <TableCell>
-                  <BulletinStatusBadge isPublished={bulletin.is_published} />
-                </TableCell>
-                <TableCell className="text-right">
-                  <div className="flex items-center justify-end gap-1">
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      onClick={() => setPreviewId(bulletin.id)}
+            {bulletins.map((bulletin: Bulletin) => {
+              const avg =
+                bulletin.average !== null ? Number(bulletin.average).toFixed(2) : null
+              const rankLabel =
+                bulletin.rank !== null && bulletin.total_students > 0
+                  ? `${bulletin.rank} / ${bulletin.total_students}`
+                  : bulletin.rank !== null
+                    ? String(bulletin.rank)
+                    : "—"
+              return (
+                <TableRow
+                  key={bulletin.id}
+                  className="cursor-pointer transition-colors hover:bg-muted/30"
+                  onClick={() => setPreviewId(bulletin.id)}
+                >
+                  <TableCell className="py-3">
+                    <div className="flex items-center gap-3">
+                      <StudentInitialsAvatar
+                        name={bulletin.student_name}
+                        photoUrl={bulletin.student_photo_url}
+                      />
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-foreground">
+                          {bulletin.student_name || "—"}
+                        </p>
+                        {bulletin.student_enrollment_number && (
+                          <p className="truncate text-xs text-muted-foreground">
+                            {bulletin.student_enrollment_number}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    {avg !== null ? (
+                      <span className="font-mono text-sm font-semibold tabular-nums text-foreground">
+                        {avg}
+                        <span className="ml-0.5 text-xs font-normal text-muted-foreground">
+                          /20
+                        </span>
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <span
+                      className={cn(
+                        "font-mono text-sm tabular-nums",
+                        bulletin.rank === 1 && "font-semibold text-emerald-700",
+                      )}
                     >
-                      <Eye className="h-4 w-4" />
-                      <span className="sr-only">Voir le bulletin #{bulletin.id}</span>
-                    </Button>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      onClick={() => handleDownloadPdf(bulletin)}
-                      disabled={downloadingId === bulletin.id}
-                    >
-                      <Download className="h-4 w-4" />
-                      <span className="sr-only">Télécharger le bulletin #{bulletin.id}</span>
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ))}
+                      {rankLabel}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <span className={getMentionBadgeClass(bulletin.mention)}>
+                      {bulletin.mention ?? "—"}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <BulletinStatusBadge isPublished={bulletin.is_published} />
+                  </TableCell>
+                  <TableCell
+                    className="text-right"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <div className="flex items-center justify-end gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => setPreviewId(bulletin.id)}
+                        title="Voir le détail"
+                      >
+                        <Eye className="h-4 w-4" />
+                        <span className="sr-only">
+                          Voir le bulletin de {bulletin.student_name}
+                        </span>
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => handleDownloadPdf(bulletin)}
+                        disabled={downloadingId === bulletin.id}
+                        title="Télécharger le PDF"
+                      >
+                        <Download className="h-4 w-4" />
+                        <span className="sr-only">
+                          Télécharger le bulletin de {bulletin.student_name}
+                        </span>
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
           </TableBody>
         </Table>
       </div>

--- a/components/admin/reports/BulletinPreviewModal.tsx
+++ b/components/admin/reports/BulletinPreviewModal.tsx
@@ -1,12 +1,15 @@
 "use client"
 
+import { Award, GraduationCap, Trophy, User } from "lucide-react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { BulletinStatusBadge } from "./BulletinStatusBadge"
+import { getMentionBadgeClass, mentionFullLabel } from "./mention"
 import { useBulletin } from "@/lib/hooks/useBulletins"
-import { getMentionColor } from "@/lib/utils"
-import type { BulletinDecision } from "@/lib/contracts/bulletin"
+import { trimesterFullLabel } from "@/lib/utils/trimester"
+import { cn, getUploadUrl } from "@/lib/utils"
+import type { Bulletin, BulletinDecision } from "@/lib/contracts/bulletin"
 
 const COUNCIL_DECISION_LABELS: Record<BulletinDecision, string> = {
   passage: "Passage",
@@ -25,113 +28,261 @@ export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewMod
 
   return (
     <Dialog open={bulletinId !== null} onOpenChange={onClose}>
-      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="max-h-[88vh] max-w-3xl overflow-y-auto p-0">
+        <DialogHeader className="sr-only">
           <DialogTitle>Bulletin scolaire</DialogTitle>
         </DialogHeader>
 
         {isLoading ? (
           <BulletinPreviewSkeleton />
         ) : bulletin ? (
-          <div className="space-y-6">
-            {/* En-tête */}
-            <div className="text-center space-y-1 border-b pb-4">
-              <p className="text-xs text-muted-foreground uppercase tracking-wider">
-                République de Côte d&apos;Ivoire
-              </p>
-              <h2 className="font-serif text-lg font-semibold">
-                Bulletin de notes
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                {bulletin.trimester === 1 && "Premier trimestre"}
-                {bulletin.trimester === 2 && "Deuxième trimestre"}
-                {bulletin.trimester === 3 && "Troisième trimestre"}
-              </p>
-            </div>
-
-            {/* Infos élève */}
-            <div className="grid grid-cols-2 gap-4 text-sm">
-              <div className="space-y-1">
-                <p>
-                  <span className="text-muted-foreground">Élève ID :</span>{" "}
-                  <strong>#{bulletin.student_id}</strong>
-                </p>
-                <p>
-                  <span className="text-muted-foreground">Classe ID :</span>{" "}
-                  #{bulletin.class_id}
-                </p>
-              </div>
-              <div className="space-y-1 text-right">
-                <p>
-                  <span className="text-muted-foreground">Rang :</span>{" "}
-                  <strong>{bulletin.rank ?? "—"}</strong>
-                </p>
-                <p>
-                  <span className="text-muted-foreground">Statut :</span>{" "}
-                  <BulletinStatusBadge isPublished={bulletin.is_published} />
-                </p>
-              </div>
-            </div>
-
-            <Separator />
-
-            {/* Résumé */}
-            <div className="flex items-center justify-between rounded-lg bg-muted/50 p-4">
-              <div className="space-y-1">
-                <p className="text-sm text-muted-foreground">Moyenne générale</p>
-                <p className="text-2xl font-bold">
-                  {bulletin.average !== null ? Number(bulletin.average).toFixed(2) : "—"}
-                  <span className="text-sm font-normal text-muted-foreground">/20</span>
-                </p>
-              </div>
-              <div className="text-right space-y-1">
-                <p className="text-sm text-muted-foreground">Mention</p>
-                <p className={`text-lg font-semibold ${getMentionColor(bulletin.mention)}`}>
-                  {bulletin.mention ?? "Aucune"}
-                </p>
-              </div>
-            </div>
-
-            {/* Commentaire enseignant */}
-            {bulletin.teacher_comment && (
-              <div className="rounded-lg border p-4 space-y-2">
-                <p className="text-sm font-medium">Commentaire de l&apos;enseignant</p>
-                <p className="text-sm text-muted-foreground">{bulletin.teacher_comment}</p>
-              </div>
-            )}
-
-            {/* Conseil de classe : décision */}
-            {bulletin.council_decision && (
-              <div className="rounded-lg border p-4 space-y-2">
-                <p className="text-sm font-medium">Conseil de classe</p>
-                <p className="text-sm">
-                  <span className="text-muted-foreground">Décision :</span>{" "}
-                  <strong>{COUNCIL_DECISION_LABELS[bulletin.council_decision] ?? bulletin.council_decision}</strong>
-                </p>
-              </div>
-            )}
-          </div>
+          <BulletinPreviewBody bulletin={bulletin} />
         ) : null}
       </DialogContent>
     </Dialog>
   )
 }
 
+function BulletinPreviewBody({ bulletin }: { bulletin: Bulletin }) {
+  const avg = bulletin.average !== null ? Number(bulletin.average).toFixed(2) : null
+  const rankLabel =
+    bulletin.rank !== null && bulletin.total_students > 0
+      ? `${bulletin.rank} / ${bulletin.total_students}`
+      : bulletin.rank !== null
+        ? String(bulletin.rank)
+        : "—"
+
+  return (
+    <div>
+      <header className="border-b bg-gradient-to-br from-primary/5 via-transparent to-accent/5 px-6 pb-5 pt-6">
+        <p className="text-[10px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          République de Côte d&apos;Ivoire — Bulletin de notes
+        </p>
+        <h2 className="mt-1 font-serif text-xl text-foreground">
+          {trimesterFullLabel(bulletin.trimester)}
+        </h2>
+
+        <div className="mt-4 flex items-start gap-4">
+          <StudentAvatar
+            name={bulletin.student_name}
+            photoUrl={bulletin.student_photo_url}
+          />
+          <div className="min-w-0 flex-1">
+            <p className="font-serif text-lg font-semibold tracking-tight text-foreground">
+              {bulletin.student_name || "—"}
+            </p>
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1">
+                <GraduationCap className="h-3 w-3" />
+                {bulletin.class_name}
+              </span>
+              {bulletin.student_enrollment_number && (
+                <span className="inline-flex items-center gap-1">
+                  <User className="h-3 w-3" />
+                  {bulletin.student_enrollment_number}
+                </span>
+              )}
+            </div>
+          </div>
+          <BulletinStatusBadge isPublished={bulletin.is_published} />
+        </div>
+      </header>
+
+      <section className="grid grid-cols-3 divide-x border-b">
+        <KpiBlock
+          icon={<Award className="h-4 w-4" />}
+          label="Moyenne générale"
+          value={avg ?? "—"}
+          unit={avg ? "/20" : undefined}
+        />
+        <KpiBlock
+          icon={<Trophy className="h-4 w-4" />}
+          label="Rang"
+          value={rankLabel}
+          accent={bulletin.rank === 1}
+        />
+        <div className="flex flex-col items-center justify-center gap-1.5 px-4 py-5">
+          <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Mention
+          </span>
+          <span className={getMentionBadgeClass(bulletin.mention)}>
+            {bulletin.mention ?? "—"}
+          </span>
+          {bulletin.mention && (
+            <span className="text-xs text-muted-foreground">
+              {mentionFullLabel(bulletin.mention)}
+            </span>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-4 px-6 py-5">
+        <div>
+          <h3 className="mb-2 text-sm font-semibold text-foreground">
+            Détail par matière
+          </h3>
+          {bulletin.subject_averages.length === 0 ? (
+            <p className="rounded-lg border border-dashed bg-muted/20 px-4 py-6 text-center text-xs text-muted-foreground">
+              Aucune note saisie pour ce trimestre.
+            </p>
+          ) : (
+            <div className="overflow-hidden rounded-lg border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/30 text-xs uppercase tracking-wider text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium">Matière</th>
+                    <th className="px-3 py-2 text-center font-medium">Coef.</th>
+                    <th className="px-3 py-2 text-right font-medium">Moyenne</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {bulletin.subject_averages.map((sa) => {
+                    const avgNum = Number(sa.average)
+                    return (
+                      <tr key={sa.subject_id} className="border-t last:border-b-0">
+                        <td className="px-3 py-2 font-medium text-foreground">
+                          {sa.subject_name}
+                        </td>
+                        <td className="px-3 py-2 text-center text-muted-foreground">
+                          {sa.coefficient}
+                        </td>
+                        <td className="px-3 py-2 text-right">
+                          <span
+                            className={cn(
+                              "font-mono font-semibold tabular-nums",
+                              avgNum < 10 ? "text-rose-700" : "text-foreground",
+                            )}
+                          >
+                            {avgNum.toFixed(2)}
+                          </span>
+                          <span className="ml-0.5 text-xs text-muted-foreground">
+                            /20
+                          </span>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        {bulletin.teacher_comment && (
+          <div className="rounded-lg border bg-muted/10 p-4">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Commentaire de l&apos;enseignant
+            </p>
+            <p className="text-sm text-foreground">{bulletin.teacher_comment}</p>
+          </div>
+        )}
+
+        {bulletin.council_decision && (
+          <div className="flex items-center justify-between rounded-lg border bg-primary/5 p-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Conseil de classe
+              </p>
+              <p className="mt-1 text-sm font-medium text-foreground">
+                Décision : {COUNCIL_DECISION_LABELS[bulletin.council_decision]}
+              </p>
+            </div>
+          </div>
+        )}
+
+        <Separator className="opacity-0" />
+      </section>
+    </div>
+  )
+}
+
+function StudentAvatar({
+  name,
+  photoUrl,
+}: {
+  name: string
+  photoUrl?: string | null
+}) {
+  const initials =
+    name
+      .split(" ")
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((s) => s[0]?.toUpperCase() ?? "")
+      .join("") || "?"
+  const photoSrc = getUploadUrl(photoUrl ?? undefined)
+  if (photoSrc) {
+    return (
+      <img
+        src={photoSrc}
+        alt={name}
+        className="h-14 w-14 shrink-0 rounded-xl border-2 border-background object-cover shadow-sm ring-1 ring-border"
+      />
+    )
+  }
+  return (
+    <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border-2 border-background bg-gradient-to-br from-primary to-primary/70 shadow-sm ring-1 ring-border">
+      <span className="text-base font-semibold text-primary-foreground">
+        {initials}
+      </span>
+    </div>
+  )
+}
+
+function KpiBlock({
+  icon,
+  label,
+  value,
+  unit,
+  accent,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+  unit?: string
+  accent?: boolean
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-1 px-4 py-5">
+      <span className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {icon}
+        {label}
+      </span>
+      <span
+        className={cn(
+          "font-mono text-2xl font-bold tabular-nums",
+          accent ? "text-emerald-700" : "text-foreground",
+        )}
+      >
+        {value}
+        {unit && (
+          <span className="ml-0.5 text-sm font-normal text-muted-foreground">
+            {unit}
+          </span>
+        )}
+      </span>
+    </div>
+  )
+}
+
 function BulletinPreviewSkeleton() {
   return (
-    <div className="space-y-6">
-      <div className="text-center space-y-2">
-        <Skeleton className="mx-auto h-4 w-48" />
-        <Skeleton className="mx-auto h-6 w-72" />
-        <Skeleton className="mx-auto h-4 w-36" />
+    <div className="p-6">
+      <Skeleton className="mb-2 h-3 w-48" />
+      <Skeleton className="mb-4 h-6 w-72" />
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-14 w-14 rounded-xl" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-3 w-36" />
+        </div>
       </div>
-      <div className="grid grid-cols-2 gap-4">
-        <Skeleton className="h-12 w-full" />
-        <Skeleton className="h-12 w-full" />
+      <div className="my-6 grid grid-cols-3 gap-4">
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
       </div>
-      {Array.from({ length: 6 }).map((_, i) => (
-        <Skeleton key={i} className="h-8 w-full" />
-      ))}
+      <Skeleton className="h-32" />
     </div>
   )
 }

--- a/components/admin/reports/mention.ts
+++ b/components/admin/reports/mention.ts
@@ -1,0 +1,31 @@
+// Helpers d'affichage pour la mention scolaire (TB / B / AB / P / M).
+// Source canonique pour la table bulletins, la modal preview, et tout futur PDF.
+
+import type { Mention } from "@/lib/contracts/bulletin"
+
+export const MENTION_FULL_LABEL: Record<Mention, string> = {
+  TB: "Très bien",
+  B: "Bien",
+  AB: "Assez bien",
+  P: "Passable",
+  M: "Médiocre",
+}
+
+const PILL_CLASS_BY_MENTION: Record<Mention, string> = {
+  TB: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200",
+  B: "bg-primary/10 text-primary ring-1 ring-primary/20",
+  AB: "bg-accent/10 text-accent ring-1 ring-accent/20",
+  P: "bg-amber-50 text-amber-700 ring-1 ring-amber-200",
+  M: "bg-rose-50 text-rose-700 ring-1 ring-rose-200",
+}
+
+export function getMentionBadgeClass(mention: Mention | null | undefined): string {
+  const base = "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold"
+  if (!mention) return `${base} bg-muted text-muted-foreground ring-1 ring-border`
+  return `${base} ${PILL_CLASS_BY_MENTION[mention]}`
+}
+
+export function mentionFullLabel(mention: Mention | null | undefined): string {
+  if (!mention) return "Aucune mention"
+  return MENTION_FULL_LABEL[mention]
+}

--- a/components/admin/students/StudentAcademicCharts.tsx
+++ b/components/admin/students/StudentAcademicCharts.tsx
@@ -7,7 +7,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Cell,
   Legend,
   ResponsiveContainer,
   Tooltip,
@@ -16,7 +15,8 @@ import {
 } from "recharts"
 import { LineChart as LineChartIcon, BarChart3, TrendingUp, Trophy } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { useEnrollments } from "@/lib/hooks/useEnrollments"
+import { useStudentFull } from "@/lib/hooks/useStudents"
+import { TRIMESTER_FULL_LABEL, trimesterShortLabel, type TrimesterNumber } from "@/lib/utils/trimester"
 
 interface TrimesterPoint {
   trimester: string
@@ -28,7 +28,7 @@ interface TrimesterPoint {
 interface AbsencePoint {
   trimester: string
   justifiees: number
-  nonJustifiees: number
+  non_justifiees: number
 }
 
 interface StudentAcademicChartsProps {
@@ -36,17 +36,31 @@ interface StudentAcademicChartsProps {
 }
 
 export function StudentAcademicCharts({ studentId }: StudentAcademicChartsProps) {
-  const { data: enrollmentsData } = useEnrollments({ student_id: studentId })
+  const { data: full } = useStudentFull(studentId)
 
-  const hasEnrollment = (enrollmentsData?.items?.length ?? 0) > 0
+  const hasEnrollment = full?.current_enrollment_id != null
 
-  // Series vides tant que /admin/students/{id}/full n'expose pas la
-  // breakdown par trimestre. L'empty state propre est rendu en dessous,
-  // évite le faux signal "3 dots null + 3 bars zéro" (no-mvp rule).
-  const trimesterData: TrimesterPoint[] = useMemo(() => [], [])
-  const absenceData: AbsencePoint[] = useMemo(() => [], [])
-  const hasGrades = trimesterData.length > 0 && trimesterData.some((p) => p.general !== null)
-  const hasAbsences = absenceData.length > 0 && absenceData.some((p) => p.justifiees + p.nonJustifiees > 0)
+  const trimesterData: TrimesterPoint[] = useMemo(() => {
+    if (!full?.trimester_grades?.length) return []
+    return full.trimester_grades.map((t) => ({
+      trimester: trimesterShortLabel(t.trimester),
+      general: t.general,
+      best: t.best,
+      worst: t.worst,
+    }))
+  }, [full?.trimester_grades])
+
+  const absenceData: AbsencePoint[] = useMemo(() => {
+    if (!full?.trimester_absences?.length) return []
+    return full.trimester_absences.map((t) => ({
+      trimester: trimesterShortLabel(t.trimester),
+      justifiees: t.justifiees,
+      non_justifiees: t.non_justifiees,
+    }))
+  }, [full?.trimester_absences])
+
+  const hasGrades = trimesterData.some((p) => p.general !== null)
+  const hasAbsences = absenceData.some((p) => p.justifiees + p.non_justifiees > 0)
 
   return (
     <div className="grid gap-4 lg:grid-cols-2">
@@ -132,11 +146,7 @@ export function StudentAcademicCharts({ studentId }: StudentAcademicChartsProps)
                 <Tooltip content={<AbsenceTooltip />} />
                 <Legend wrapperStyle={{ fontSize: 11 }} iconType="circle" />
                 <Bar dataKey="justifiees" name="Justifiées" stackId="abs" fill="#0F3F8C" radius={[0, 0, 0, 0]} />
-                <Bar dataKey="nonJustifiees" name="Non justifiées" stackId="abs" fill="#F58220" radius={[4, 4, 0, 0]}>
-                  {absenceData.map((_, i) => (
-                    <Cell key={i} />
-                  ))}
-                </Bar>
+                <Bar dataKey="non_justifiees" name="Non justifiées" stackId="abs" fill="#F58220" radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           ) : (
@@ -176,6 +186,12 @@ function ChartEmptyState({
   )
 }
 
+function tooltipTitle(shortLabel: string | undefined): string {
+  if (!shortLabel) return ""
+  const n = Number(shortLabel.replace("T", "")) as TrimesterNumber
+  return TRIMESTER_FULL_LABEL[n] ?? shortLabel
+}
+
 function MoyenneTooltip({ active, payload, label }: {
   active?: boolean
   payload?: Array<{ value: number | null; name: string; color: string }>
@@ -184,7 +200,7 @@ function MoyenneTooltip({ active, payload, label }: {
   if (!active || !payload?.length) return null
   return (
     <div className="rounded-lg border bg-popover px-3 py-2 text-xs shadow-md">
-      <p className="font-semibold">{label === "T1" ? "1er trimestre" : label === "T2" ? "2e trimestre" : "3e trimestre"}</p>
+      <p className="font-semibold">{tooltipTitle(label)}</p>
       {payload.map((p, i) => (
         <p key={i} className="flex items-center gap-2 text-muted-foreground">
           <span className="h-2 w-2 rounded-full" style={{ backgroundColor: p.color }} />
@@ -204,7 +220,7 @@ function AbsenceTooltip({ active, payload, label }: {
   const total = payload.reduce((sum, p) => sum + (p.value ?? 0), 0)
   return (
     <div className="rounded-lg border bg-popover px-3 py-2 text-xs shadow-md">
-      <p className="font-semibold">{label === "T1" ? "1er trimestre" : label === "T2" ? "2e trimestre" : "3e trimestre"}</p>
+      <p className="font-semibold">{tooltipTitle(label)}</p>
       {payload.map((p, i) => (
         <p key={i} className="flex items-center gap-2 text-muted-foreground">
           <span className="h-2 w-2 rounded-full" style={{ backgroundColor: p.color }} />

--- a/components/admin/students/StudentDetailClient.tsx
+++ b/components/admin/students/StudentDetailClient.tsx
@@ -57,7 +57,7 @@ import { EnrollmentTab } from "./tabs/EnrollmentTab"
 import { AttendanceTab } from "./tabs/AttendanceTab"
 import { ParentsTab } from "./tabs/ParentsTab"
 import { DocumentsTab } from "./tabs/DocumentsTab"
-import { useStudent, useDeleteStudent, studentKeys, useStudentFees } from "@/lib/hooks/useStudents"
+import { useStudent, useDeleteStudent, studentKeys, useStudentFees, useStudentFull } from "@/lib/hooks/useStudents"
 import { useEnrollments } from "@/lib/hooks/useEnrollments"
 import { useStudentParents } from "@/lib/hooks/useParents"
 import { studentsApi } from "@/lib/api/students"
@@ -85,6 +85,7 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
   const [photoLoaded, setPhotoLoaded] = useState(false)
 
   const { data: student, isLoading, isError, refetch } = useStudent(studentId)
+  const { data: full } = useStudentFull(studentId)
   const { mutate: deleteStudent, isPending: deleting } = useDeleteStudent()
 
   const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -316,7 +317,7 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
         </TabsContent>
 
         <TabsContent value="paiements">
-          <PaymentsTab studentId={studentId} fullData={student as unknown as Record<string, unknown>} />
+          <PaymentsTab studentId={studentId} fullData={full ?? undefined} />
         </TabsContent>
 
         <TabsContent value="parents">
@@ -328,7 +329,7 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
         </TabsContent>
 
         <TabsContent value="profil">
-          <ProfileTab student={student} fullData={student as unknown as Record<string, unknown>} />
+          <ProfileTab student={student} fullData={full ?? undefined} />
         </TabsContent>
 
         <TabsContent value="presences">

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -92,7 +92,16 @@ export async function apiFetchBlob(path: string): Promise<Blob> {
     }
     throw new Error("Session expirée")
   }
-  if (!res.ok) throw new Error(`Erreur ${res.status} lors du téléchargement`)
+  if (!res.ok) {
+    // Surface the BE detail when available so the caller can toast a useful
+    // message — see app/routers/_pdf_helpers.py for the JSON {detail} contract.
+    const contentType = res.headers.get("content-type") ?? ""
+    if (contentType.includes("application/json")) {
+      const body = (await res.json().catch(() => null)) as { detail?: string } | null
+      if (body?.detail) throw new Error(body.detail)
+    }
+    throw new Error(`Erreur ${res.status} lors du téléchargement`)
+  }
   return res.blob()
 }
 

--- a/lib/api/students.ts
+++ b/lib/api/students.ts
@@ -1,6 +1,6 @@
 import { getSession } from "next-auth/react"
-import { StudentFiltersSchema, StudentSchema } from "@/lib/contracts/student"
-import type { Student, StudentCreate, StudentFilters, StudentUpdate } from "@/lib/contracts/student"
+import { StudentFiltersSchema, StudentFullSchema, StudentSchema } from "@/lib/contracts/student"
+import type { Student, StudentCreate, StudentFilters, StudentFull, StudentUpdate } from "@/lib/contracts/student"
 import { createCrudApi } from "./createCrudApi"
 import { apiFetch, handleExpiredSession, safeValidate } from "./client"
 import { z } from "zod"
@@ -74,6 +74,11 @@ export const studentsApi = {
   getEnrollmentFees: async (studentId: number): Promise<StudentEnrollmentFee[]> => {
     const data = await apiFetch<unknown>(`/admin/students/${studentId}/fees`)
     return safeValidate(StudentEnrollmentFeeListSchema, unwrapItems(data), `GET /admin/students/${studentId}/fees`)
+  },
+
+  getFull: async (studentId: number): Promise<StudentFull> => {
+    const data = await apiFetch<unknown>(`/admin/students/${studentId}/full`)
+    return safeValidate(StudentFullSchema, data, `GET /admin/students/${studentId}/full`)
   },
 }
 

--- a/lib/contracts/bulletin.ts
+++ b/lib/contracts/bulletin.ts
@@ -6,20 +6,33 @@ export const MentionSchema = z.enum(["TB", "B", "AB", "P", "M"])
 
 export const BulletinDecisionSchema = z.enum(["passage", "repechage", "redoublement", "exclusion"])
 
+export const SubjectAverageResponseSchema = z.object({
+  subject_id: z.number(),
+  subject_name: z.string(),
+  average: z.coerce.number(),
+  coefficient: z.number(),
+})
+
 export const BulletinSchema = z.object({
   id: z.number(),
   student_id: z.number(),
+  student_name: z.string(),
+  student_photo_url: z.string().nullish(),
+  student_enrollment_number: z.string().nullish(),
   class_id: z.number(),
+  class_name: z.string(),
   academic_year_id: z.number(),
   trimester: z.number(),
   average: z.coerce.number().nullable(),
   rank: z.number().nullable(),
+  total_students: z.number(),
   mention: MentionSchema.nullable(),
   file_url: z.string().nullable(),
   generated_at: z.string().nullable(),
   is_published: z.boolean(),
   teacher_comment: z.string().nullable(),
   council_decision: BulletinDecisionSchema.nullable().optional(),
+  subject_averages: z.array(SubjectAverageResponseSchema),
   created_at: z.string(),
   updated_at: z.string(),
 })
@@ -45,3 +58,4 @@ export type BulletinDecision = z.infer<typeof BulletinDecisionSchema>
 export type Bulletin = z.infer<typeof BulletinSchema>
 export type BulletinListParams = z.infer<typeof BulletinListParamsSchema>
 export type BulletinGenerate = z.infer<typeof BulletinGenerateSchema>
+export type SubjectAverageResponse = z.infer<typeof SubjectAverageResponseSchema>

--- a/lib/contracts/dren.ts
+++ b/lib/contracts/dren.ts
@@ -9,7 +9,7 @@ export const ClassStatsSchema = z.object({
   total_students: z.number(),
   male_count: z.number(),
   female_count: z.number(),
-  average: z.number().nullable().optional(),
+  average: z.coerce.number().nullable().optional(),
 })
 
 export const LevelStatsSchema = z.object({

--- a/lib/contracts/parent-portal.ts
+++ b/lib/contracts/parent-portal.ts
@@ -20,22 +20,24 @@ export const ParentDashboardSchema = z.object({
   current_academic_year: z.string().nullish(),
 })
 
-// Notes d'un enfant — même structure que les notes élève
+// Notes d'un enfant — même structure que les notes élève.
+// `value`, `average`, montants → `z.coerce.number()` car le BE sérialise
+// les Decimal Pydantic en string JSON par défaut.
 export const ParentChildGradeEntrySchema = z.object({
   id: z.number(),
   title: z.string(),
   type: z.enum(["devoir", "interro", "examen", "composition"]),
   date: z.string(),
   coefficient: z.number(),
-  value: z.number().nullable(),
-  out_of: z.number(),
+  value: z.coerce.number().nullable(),
+  out_of: z.coerce.number(),
 })
 
 export const ParentChildSubjectGradesSchema = z.object({
   subject_id: z.number(),
   subject_name: z.string(),
   coefficient: z.number(),
-  average: z.number().nullable(),
+  average: z.coerce.number().nullable(),
   grades: z.array(ParentChildGradeEntrySchema),
 })
 
@@ -43,7 +45,7 @@ export const ParentChildGradesResponseSchema = z.object({
   child_name: z.string(),
   class_name: z.string(),
   trimester: z.string().nullable(),
-  general_average: z.number().nullable(),
+  general_average: z.coerce.number().nullable(),
   rank: z.number().nullable(),
   total_students: z.number(),
   subjects: z.array(ParentChildSubjectGradesSchema),
@@ -53,9 +55,9 @@ export const ParentChildGradesResponseSchema = z.object({
 export const ParentChildFeeItemSchema = z.object({
   id: z.number(),
   category_name: z.string(),
-  total_amount: z.number(),
-  paid_amount: z.number(),
-  remaining: z.number(),
+  total_amount: z.coerce.number(),
+  paid_amount: z.coerce.number(),
+  remaining: z.coerce.number(),
   status: z.enum(["paye", "partiel", "impaye"]),
   last_payment_date: z.string().nullish(),
 })
@@ -64,9 +66,9 @@ export const ParentChildFeesResponseSchema = z.object({
   child_name: z.string(),
   class_name: z.string(),
   academic_year: z.string(),
-  total_expected: z.number(),
-  total_paid: z.number(),
-  total_remaining: z.number(),
+  total_expected: z.coerce.number(),
+  total_paid: z.coerce.number(),
+  total_remaining: z.coerce.number(),
   fees: z.array(ParentChildFeeItemSchema),
 })
 
@@ -74,7 +76,7 @@ export const ParentChildFeesResponseSchema = z.object({
 export const ParentChildBulletinSchema = z.object({
   id: z.number(),
   trimester: z.number(),
-  average: z.number().nullable(),
+  average: z.coerce.number().nullable(),
   rank: z.number().nullable(),
   mention: z.string().nullable(),
   class_name: z.string(),

--- a/lib/contracts/student-portal.ts
+++ b/lib/contracts/student-portal.ts
@@ -21,28 +21,29 @@ export const StudentDashboardSchema = z.object({
   current_academic_year: z.string().nullish(),
 })
 
-// Notes par matière
+// Notes par matière — `value`/`average`/montants en `z.coerce.number()`
+// car le BE sérialise les Decimal Pydantic en string JSON.
 export const StudentGradeEntrySchema = z.object({
   id: z.number(),
   title: z.string(),
   type: z.enum(["devoir", "interro", "examen", "composition"]),
   date: z.string(),
   coefficient: z.number(),
-  value: z.number().nullable(),
-  out_of: z.number(),
+  value: z.coerce.number().nullable(),
+  out_of: z.coerce.number(),
 })
 
 export const StudentSubjectGradesSchema = z.object({
   subject_id: z.number(),
   subject_name: z.string(),
   coefficient: z.number(),
-  average: z.number().nullable(),
+  average: z.coerce.number().nullable(),
   grades: z.array(StudentGradeEntrySchema),
 })
 
 export const StudentGradesResponseSchema = z.object({
   trimester: z.string(),
-  general_average: z.number().nullable(),
+  general_average: z.coerce.number().nullable(),
   rank: z.number().nullable(),
   total_students: z.number(),
   subjects: z.array(StudentSubjectGradesSchema),
@@ -52,18 +53,18 @@ export const StudentGradesResponseSchema = z.object({
 export const StudentFeeItemSchema = z.object({
   id: z.number(),
   category_name: z.string(),
-  total_amount: z.number(),
-  paid_amount: z.number(),
-  remaining: z.number(),
+  total_amount: z.coerce.number(),
+  paid_amount: z.coerce.number(),
+  remaining: z.coerce.number(),
   status: z.enum(["paye", "partiel", "impaye"]),
   last_payment_date: z.string().nullish(),
 })
 
 export const StudentFeesResponseSchema = z.object({
   academic_year: z.string(),
-  total_expected: z.number(),
-  total_paid: z.number(),
-  total_remaining: z.number(),
+  total_expected: z.coerce.number(),
+  total_paid: z.coerce.number(),
+  total_remaining: z.coerce.number(),
   fees: z.array(StudentFeeItemSchema),
 })
 
@@ -72,7 +73,7 @@ export const StudentBulletinSchema = z.object({
   id: z.number(),
   trimester: z.string(),
   academic_year: z.string(),
-  general_average: z.number().nullable(),
+  general_average: z.coerce.number().nullable(),
   rank: z.number().nullable(),
   total_students: z.number(),
   status: z.enum(["brouillon", "publie"]),

--- a/lib/contracts/student.ts
+++ b/lib/contracts/student.ts
@@ -70,6 +70,54 @@ export const StudentListParamsSchema = z.object({
   unenrolled_only: z.boolean().optional(),
 })
 
+// /admin/students/{id}/full — vue enrichie pour la fiche détail.
+export const StudentTrimesterGradesSchema = z.object({
+  trimester: z.number(), // 1, 2 ou 3
+  general: z.number().nullable(),
+  best: z.number().nullable(),
+  worst: z.number().nullable(),
+})
+
+export const StudentTrimesterAbsencesSchema = z.object({
+  trimester: z.number(),
+  justifiees: z.number(),
+  non_justifiees: z.number(),
+})
+
+export const StudentFullSchema = z.object({
+  id: z.number(),
+  first_name: z.string(),
+  last_name: z.string(),
+  birth_date: z.string().nullish(),
+  genre: z.string().nullish(),
+  enrollment_number: z.string().nullish(),
+  photo_url: z.string().nullish(),
+  city: z.string().nullish(),
+  commune: z.string().nullish(),
+  user_id: z.number().nullable(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  user_email: z.string().nullish(),
+  user_is_active: z.boolean().nullish(),
+  user_last_login: z.string().nullish(),
+  user_created_at: z.string().nullish(),
+  current_class_name: z.string().nullish(),
+  current_academic_year: z.string().nullish(),
+  current_enrollment_status: z.string().nullish(),
+  current_enrollment_id: z.number().nullish(),
+  attendance_total: z.number(),
+  attendance_present: z.number(),
+  attendance_absent: z.number(),
+  attendance_late: z.number(),
+  attendance_rate: z.number(),
+  fees_expected: z.number(),
+  fees_paid: z.number(),
+  fees_remaining: z.number(),
+  fees_rate: z.number(),
+  trimester_grades: z.array(StudentTrimesterGradesSchema),
+  trimester_absences: z.array(StudentTrimesterAbsencesSchema),
+})
+
 export type CurrentEnrollmentInfo = z.infer<typeof CurrentEnrollmentInfoSchema>
 export type StudentClassFilterCount = z.infer<typeof StudentClassFilterCountSchema>
 export type StudentFilters = z.infer<typeof StudentFiltersSchema>
@@ -77,3 +125,6 @@ export type Student = z.infer<typeof StudentSchema>
 export type StudentCreate = z.infer<typeof StudentCreateSchema>
 export type StudentUpdate = z.infer<typeof StudentUpdateSchema>
 export type StudentListParams = z.infer<typeof StudentListParamsSchema>
+export type StudentFull = z.infer<typeof StudentFullSchema>
+export type StudentTrimesterGrades = z.infer<typeof StudentTrimesterGradesSchema>
+export type StudentTrimesterAbsences = z.infer<typeof StudentTrimesterAbsencesSchema>

--- a/lib/hooks/useStudents.ts
+++ b/lib/hooks/useStudents.ts
@@ -34,6 +34,17 @@ export function useStudentFees(studentId: number) {
   })
 }
 
+// Vue enrichie /admin/students/{id}/full : KPIs annuels + breakdowns trimestre.
+// Utilisé par OverviewTab, ProfileTab (account info) et StudentAcademicCharts.
+export function useStudentFull(studentId: number) {
+  return useQuery({
+    queryKey: ["students", studentId, "full"],
+    queryFn: () => studentsApi.getFull(studentId),
+    enabled: !!studentId,
+    staleTime: 1000 * 60 * 2,
+  })
+}
+
 // Counts pour la barre de chips. staleTime aligné avec le cache BE Redis (60s
 // quand celui-ci sera ajouté en v1.2.1). Invalidate via studentKeys.all après
 // toute mutation student / enrollment.

--- a/lib/utils/trimester.ts
+++ b/lib/utils/trimester.ts
@@ -1,0 +1,25 @@
+// Libellés des trimestres (calendrier scolaire ivoirien : 3 trimestres par AY).
+// Source canonique partagée entre composants (charts, bulletins, council, etc.).
+
+export const TRIMESTER_NUMBERS = [1, 2, 3] as const
+export type TrimesterNumber = (typeof TRIMESTER_NUMBERS)[number]
+
+export const TRIMESTER_SHORT_LABEL: Record<TrimesterNumber, string> = {
+  1: "T1",
+  2: "T2",
+  3: "T3",
+}
+
+export const TRIMESTER_FULL_LABEL: Record<TrimesterNumber, string> = {
+  1: "1er trimestre",
+  2: "2ème trimestre",
+  3: "3ème trimestre",
+}
+
+export function trimesterShortLabel(n: number): string {
+  return TRIMESTER_SHORT_LABEL[n as TrimesterNumber] ?? `T${n}`
+}
+
+export function trimesterFullLabel(n: number): string {
+  return TRIMESTER_FULL_LABEL[n as TrimesterNumber] ?? `${n}e trimestre`
+}


### PR DESCRIPTION
## Summary

- `/admin/reports` table refactor : avatar + nom complet + matricule au lieu de `#id`, rang `1/3`, mention pill colorée sémantique, row cliquable preview
- `BulletinPreviewModal` refondu : header gradient avec avatar grand, 3 KPI blocks, tableau détail par matière, fix hydration error (div nested in p)
- `StudentAcademicCharts` câblé sur `/admin/students/{id}/full` (était hardcoded `[]`)
- `StudentDetailClient` : `useStudentFull` lifted au parent pour partager `/full` data entre tabs au lieu du cast hack `student as unknown`
- `apiFetchBlob` propage le JSON `detail` du BE comme `error.message` → toast utilisateur exploitable
- Zod `z.coerce.number()` propagé sur ~20 fields Decimal-from-BE (`parent-portal`, `student-portal`, `dren`) pour éviter rejet validation silencieux
- Shared util `lib/utils/trimester.ts`

## Test plan

- [x] `pnpm tsc --noEmit` → exit 0
- [x] `/admin/reports?class=6eme B&trimester=1` → table avec Aminata/Bertrand/Fatou avec noms + initiales + rang 1/3
- [x] Click "Voir bulletin" → modal premium avec avatar, KPIs, détail Maths/Français
- [x] Click "Télécharger" en local Windows → toast "Génération PDF impossible pour bulletin 3..."
- [x] `/admin/reports/dren` → KPIs s'affichent sans rejet Zod validation
- [x] `/admin/students/1` tab Parcours → charts T1 général=13.59 affiché