### PR TITLE
feat(subjects): collapsible catalogue grouping in table view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Changed
+
+- Vue Table de la page Matières refondue avec groupage par catalogue : chaque matière apparaît une seule fois (au lieu de 5 lignes dupliquées par niveau), avec un chevron pour déplier les instances et voir coefficient, heures et enseignant pour chaque niveau. Filtres « par niveau » et « avec/sans enseignant » et bandeau de stats : matières uniques, instances totales, heures cumulées *(admin)*.
+
 ### Added
 
 - Suivi des présences enseignant sur la fiche `/admin/teachers/[id]` : nouvel onglet « Présences » avec taux de présence, absences, retards cumulés en minutes et compteur d'auto-déclarations à valider. L'admin saisit en un clic absence ou retard en choisissant la date, le créneau EDT concerné et un motif *(admin)*.

--- a/components/admin/subjects/SubjectGroupRow.tsx
+++ b/components/admin/subjects/SubjectGroupRow.tsx
@@ -1,0 +1,216 @@
+"use client"
+
+import { ChevronRight, GraduationCap, Pencil, Trash2, UserX } from "lucide-react"
+import type { Subject } from "@/lib/contracts/subject"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { getSubjectColor, teacherInitials } from "@/lib/utils/subject-colors"
+
+export interface SubjectGroup {
+  name: string
+  catalogue: Subject | null
+  instances: Subject[]
+  totalHours: number
+}
+
+interface Props {
+  group: SubjectGroup
+  expanded: boolean
+  onToggle: () => void
+  onEdit: (id: number) => void
+  onDelete: (subject: Subject) => void
+}
+
+// Layout grid réutilisé entre header et instance rows pour alignement parfait.
+const GRID_COLS = "grid-cols-[36px_minmax(0,2fr)_72px_96px_minmax(0,1.6fr)_104px]"
+
+export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onDelete }: Props) {
+  const color = getSubjectColor(group.catalogue?.color)
+  const hasInstances = group.instances.length > 0
+  const catalogue = group.catalogue
+
+  return (
+    <li className="border-b last:border-b-0">
+      {/* Catalogue header row */}
+      <div
+        role={hasInstances ? "button" : undefined}
+        tabIndex={hasInstances ? 0 : undefined}
+        onClick={hasInstances ? onToggle : undefined}
+        onKeyDown={
+          hasInstances
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault()
+                  onToggle()
+                }
+              }
+            : undefined
+        }
+        className={`grid ${GRID_COLS} items-center gap-3 px-4 py-3.5 transition-colors ${
+          hasInstances ? "cursor-pointer hover:bg-muted/40" : "cursor-default"
+        }`}
+      >
+        <div className="flex items-center justify-center">
+          {hasInstances ? (
+            <ChevronRight
+              className={`h-4 w-4 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""}`}
+            />
+          ) : (
+            <span className="text-muted-foreground/30">—</span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 min-w-0">
+          <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${color.badge}`} aria-hidden />
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold">{group.name}</div>
+            <div className="text-xs text-muted-foreground">
+              {hasInstances ? (
+                <>
+                  Catalogue · {group.instances.length}{" "}
+                  {group.instances.length === 1 ? "instance" : "instances"}
+                </>
+              ) : (
+                "Catalogue seul"
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="text-center">
+          {catalogue && (
+            <Badge variant="secondary" className="font-mono tabular-nums">
+              {catalogue.coefficient}
+            </Badge>
+          )}
+        </div>
+
+        <div className="text-center tabular-nums text-sm">
+          {catalogue ? (
+            <>
+              <span className="font-medium">{catalogue.hours_per_week}h</span>
+              {hasInstances && (
+                <div className="text-[10px] text-muted-foreground">{group.totalHours}h total</div>
+              )}
+            </>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          )}
+        </div>
+
+        <div>
+          <Badge variant="outline" className="text-[10px] font-medium uppercase tracking-wide">
+            Catalogue
+          </Badge>
+        </div>
+
+        <div
+          className="flex justify-end gap-1"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          {catalogue && (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label={`Modifier ${group.name}`}
+                onClick={() => onEdit(catalogue.id)}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label={`Supprimer ${group.name}`}
+                onClick={() => onDelete(catalogue)}
+              >
+                <Trash2 className="h-3.5 w-3.5 text-destructive" />
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Instance rows */}
+      {expanded && hasInstances && (
+        <ul className="border-t bg-muted/15">
+          {group.instances.map((inst) => (
+            <li
+              key={inst.id}
+              className={`grid ${GRID_COLS} items-center gap-3 px-4 py-2.5 border-t border-border/40 first:border-t-0`}
+            >
+              <div className="flex items-center justify-center text-muted-foreground/50 text-base leading-none">
+                └
+              </div>
+
+              <div className="flex items-center gap-2 pl-3 min-w-0">
+                <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate text-sm font-medium">{inst.level_name ?? "—"}</span>
+                {inst.series_name && (
+                  <Badge variant="outline" className="text-[10px]">
+                    Série {inst.series_name}
+                  </Badge>
+                )}
+              </div>
+
+              <div className="text-center">
+                <Badge variant="secondary" className="font-mono tabular-nums">
+                  {inst.coefficient}
+                </Badge>
+              </div>
+
+              <div className="text-center tabular-nums text-sm font-medium">
+                {inst.hours_per_week}h
+              </div>
+
+              <div className="min-w-0">
+                {inst.teacher_name ? (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <div
+                      className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white ${color.badge}`}
+                      aria-hidden
+                    >
+                      {teacherInitials(inst.teacher_name)}
+                    </div>
+                    <span className="truncate text-sm">{inst.teacher_name}</span>
+                  </div>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800">
+                    <UserX className="h-3 w-3" />
+                    Non assigné
+                  </span>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label={`Modifier ${group.name} ${inst.level_name ?? ""}`}
+                  onClick={() => onEdit(inst.id)}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label={`Supprimer ${group.name} ${inst.level_name ?? ""}`}
+                  onClick={() => onDelete(inst)}
+                >
+                  <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+export { GRID_COLS as SUBJECT_GRID_COLS }

--- a/components/admin/subjects/SubjectsTable.tsx
+++ b/components/admin/subjects/SubjectsTable.tsx
@@ -1,116 +1,306 @@
 "use client"
 
-import { useCallback, useMemo, useState } from "react"
-import type { ColumnDef } from "@tanstack/react-table"
+import { useMemo, useState } from "react"
+import { Search } from "lucide-react"
 import { useSubjects, useDeleteSubject } from "@/lib/hooks/useSubjects"
 import { useLevels } from "@/lib/hooks/useLevels"
 import type { Subject } from "@/lib/contracts/subject"
-import { Badge } from "@/components/ui/badge"
-import { CrudTable, type FilterConfig } from "@/components/shared/CrudTable"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { SubjectEditModal } from "./SubjectEditModal"
+import { SubjectGroupRow, SUBJECT_GRID_COLS, type SubjectGroup } from "./SubjectGroupRow"
 import { useDebounce } from "@/lib/hooks/useDebounce"
 
 export function SubjectsTable() {
-  const [page, setPage] = useState(1)
   const [search, setSearch] = useState("")
-  const [filters, setFilters] = useState<Record<string, string>>({})
-  const debouncedSearch = useDebounce(search)
+  const [levelFilter, setLevelFilter] = useState<string>("all")
+  const [teacherFilter, setTeacherFilter] = useState<string>("all")
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [editId, setEditId] = useState<number | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Subject | null>(null)
 
+  const debouncedSearch = useDebounce(search)
+  const { data: subjectsData, isLoading } = useSubjects({ size: 100 })
   const { data: levelsData } = useLevels({ size: 100 })
-  const levelOptions = useMemo(
-    () => levelsData?.items?.map((l) => ({ value: l.id.toString(), label: l.name })) ?? [],
+  const deleteMutation = useDeleteSubject()
+
+  const subjects = useMemo(() => subjectsData?.items ?? [], [subjectsData])
+  const levels = useMemo(
+    () => levelsData?.items?.slice().sort((a, b) => a.order - b.order) ?? [],
     [levelsData],
   )
 
-  const filterConfigs: FilterConfig[] = useMemo(() => [
-    { key: "level_id", label: "Niveau", type: "select", options: levelOptions },
-  ], [levelOptions])
+  // Group subjects by name. Catalogue (level_id null) is the anchor;
+  // every level-scoped row of the same name becomes an instance under it.
+  const groups = useMemo<SubjectGroup[]>(() => {
+    const levelOrder = new Map(levels.map((l, i) => [l.id, l.order ?? i]))
+    const map = new Map<string, SubjectGroup>()
 
-  const handleFilterChange = useCallback((key: string, value: string) => {
-    setFilters((prev) => ({ ...prev, [key]: value }))
-    setPage(1)
-  }, [])
+    for (const s of subjects) {
+      const existing = map.get(s.name)
+      const isCatalogue = s.level_id === null
 
-  const handleSearchChange = useCallback((value: string) => {
-    setSearch(value)
-    setPage(1)
-  }, [])
+      if (!existing) {
+        map.set(s.name, {
+          name: s.name,
+          catalogue: isCatalogue ? s : null,
+          instances: isCatalogue ? [] : [s],
+          totalHours: isCatalogue ? 0 : s.hours_per_week,
+        })
+      } else if (isCatalogue) {
+        existing.catalogue = s
+      } else {
+        existing.instances.push(s)
+        existing.totalHours += s.hours_per_week
+      }
+    }
 
-  const params = useMemo(() => ({
-    page,
-    ...(debouncedSearch && { search: debouncedSearch }),
-    ...(filters.level_id && { level_id: Number(filters.level_id) }),
-  }), [page, debouncedSearch, filters])
+    for (const group of map.values()) {
+      group.instances.sort(
+        (a, b) =>
+          (levelOrder.get(a.level_id ?? 0) ?? 99) -
+          (levelOrder.get(b.level_id ?? 0) ?? 99),
+      )
+    }
 
-  const { data, isLoading, isError, error, refetch } = useSubjects(params)
-  const deleteMutation = useDeleteSubject()
+    return Array.from(map.values()).sort((a, b) =>
+      a.name.localeCompare(b.name, "fr"),
+    )
+  }, [subjects, levels])
 
-  const columns: ColumnDef<Subject>[] = useMemo(() => [
-    {
-      accessorKey: "name",
-      header: "Nom",
-      cell: ({ row }) => <span className="font-medium">{row.original.name}</span>,
-    },
-    {
-      accessorKey: "level_name",
-      header: "Niveau",
-      cell: ({ row }) => (
-        <span className="text-sm">
-          {row.original.level_name ?? "Tous"}
-        </span>
-      ),
-    },
-    {
-      accessorKey: "series_name",
-      header: "Série",
-      cell: ({ row }) => (
-        <span className="text-sm text-muted-foreground">
-          {row.original.series_name ?? "—"}
-        </span>
-      ),
-    },
-    {
-      accessorKey: "coefficient",
-      header: "Coeff.",
-      cell: ({ row }) => (
-        <Badge variant="secondary" className="font-mono">
-          {row.original.coefficient}
-        </Badge>
-      ),
-    },
-    {
-      accessorKey: "hours_per_week",
-      header: "Heures/sem.",
-      cell: ({ row }) => (
-        <span className="font-mono text-sm">{row.original.hours_per_week}h</span>
-      ),
-    },
-  ], [])
+  const filteredGroups = useMemo(() => {
+    const query = debouncedSearch.trim().toLowerCase()
+    return groups.filter((group) => {
+      if (query) {
+        const matchName = group.name.toLowerCase().includes(query)
+        const matchTeacher = group.instances.some((inst) =>
+          inst.teacher_name?.toLowerCase().includes(query),
+        )
+        if (!matchName && !matchTeacher) return false
+      }
+
+      if (levelFilter === "catalogue") {
+        if (group.catalogue === null) return false
+      } else if (levelFilter !== "all") {
+        const lid = Number(levelFilter)
+        if (!group.instances.some((inst) => inst.level_id === lid)) return false
+      }
+
+      if (teacherFilter === "with") {
+        if (!group.instances.some((inst) => inst.teacher_id !== null && inst.teacher_id !== undefined)) {
+          return false
+        }
+      } else if (teacherFilter === "without") {
+        if (group.instances.length === 0) return false
+        if (!group.instances.some((inst) => !inst.teacher_id)) return false
+      }
+
+      return true
+    })
+  }, [groups, debouncedSearch, levelFilter, teacherFilter])
+
+  const totalInstances = useMemo(
+    () => subjects.filter((s) => s.level_id !== null).length,
+    [subjects],
+  )
+  const totalHours = useMemo(
+    () =>
+      subjects
+        .filter((s) => s.level_id !== null)
+        .reduce((sum, s) => sum + s.hours_per_week, 0),
+    [subjects],
+  )
+
+  function toggleExpanded(name: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  function expandAll() {
+    setExpanded(new Set(filteredGroups.filter((g) => g.instances.length > 0).map((g) => g.name)))
+  }
+  function collapseAll() {
+    setExpanded(new Set())
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-10 w-64" />
+        <div className="space-y-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
+        </div>
+      </div>
+    )
+  }
 
   return (
-    <CrudTable<Subject>
-      data={data}
-      columns={columns}
-      isLoading={isLoading}
-      isError={isError}
-      error={error}
-      refetch={refetch}
-      deleteMutation={deleteMutation}
-      renderEditModal={({ itemId, open, onClose }) => (
-        <SubjectEditModal subjectId={itemId} open={open} onClose={onClose} />
-      )}
-      getItemLabel={(s) => s.name}
-      emptyMessage="Aucune matière trouvée"
-      errorMessage="Impossible de charger les matières"
-      deleteDescription="Cette action est irréversible. La matière sera définitivement supprimée."
-      page={page}
-      onPageChange={setPage}
-      searchPlaceholder="Rechercher une matière..."
-      searchValue={search}
-      onSearchChange={handleSearchChange}
-      filterConfigs={filterConfigs}
-      filterValues={filters}
-      onFilterChange={handleFilterChange}
-    />
+    <div className="space-y-4">
+      {/* KPI hero strip */}
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+        <div className="flex items-baseline gap-1.5">
+          <span className="text-3xl font-bold text-primary tabular-nums">
+            {groups.length}
+          </span>
+          <span className="text-sm text-muted-foreground">matières uniques</span>
+        </div>
+        <span className="text-border" aria-hidden>·</span>
+        <div className="flex items-baseline gap-1.5">
+          <span className="text-3xl font-bold tabular-nums">{totalInstances}</span>
+          <span className="text-sm text-muted-foreground">instances par niveau</span>
+        </div>
+        <span className="text-border" aria-hidden>·</span>
+        <div className="flex items-baseline gap-1.5">
+          <span className="text-3xl font-bold tabular-nums">{totalHours}h</span>
+          <span className="text-sm text-muted-foreground">/ semaine au total</span>
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[240px] flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Rechercher matière ou enseignant..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 h-10"
+            aria-label="Rechercher une matière"
+          />
+        </div>
+
+        <Select value={levelFilter} onValueChange={setLevelFilter}>
+          <SelectTrigger className="h-10 min-w-[170px]" aria-label="Filtrer par niveau">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Tous niveaux</SelectItem>
+            <SelectItem value="catalogue">Catalogue seul</SelectItem>
+            {levels.map((l) => (
+              <SelectItem key={l.id} value={String(l.id)}>
+                {l.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={teacherFilter} onValueChange={setTeacherFilter}>
+          <SelectTrigger className="h-10 min-w-[180px]" aria-label="Filtrer par enseignant">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Tous enseignants</SelectItem>
+            <SelectItem value="with">Avec enseignant</SelectItem>
+            <SelectItem value="without">Sans enseignant</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <div className="ml-auto flex items-center gap-1">
+          <Button variant="ghost" size="sm" onClick={expandAll}>
+            Tout déplier
+          </Button>
+          <Button variant="ghost" size="sm" onClick={collapseAll}>
+            Tout replier
+          </Button>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+        <div
+          className={`grid ${SUBJECT_GRID_COLS} gap-3 border-b bg-muted/40 px-4 py-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground`}
+        >
+          <div />
+          <div>Matière</div>
+          <div className="text-center">Coef.</div>
+          <div className="text-center">Heures</div>
+          <div>Statut / Enseignant</div>
+          <div className="text-right">Actions</div>
+        </div>
+
+        {filteredGroups.length === 0 ? (
+          <div className="px-4 py-12 text-center text-sm text-muted-foreground">
+            Aucune matière ne correspond à ces filtres.
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {filteredGroups.map((group) => (
+              <SubjectGroupRow
+                key={group.name}
+                group={group}
+                expanded={expanded.has(group.name)}
+                onToggle={() => toggleExpanded(group.name)}
+                onEdit={setEditId}
+                onDelete={setDeleteTarget}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <SubjectEditModal
+        subjectId={editId}
+        open={editId !== null}
+        onClose={() => setEditId(null)}
+      />
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Supprimer la matière</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteTarget?.name}
+              {deleteTarget?.level_name ? ` · ${deleteTarget.level_name}` : ""} sera
+              définitivement supprimée. Cette action est irréversible.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={deleteMutation.isPending}
+              onClick={() => {
+                if (deleteTarget) {
+                  deleteMutation.mutate(deleteTarget.id, {
+                    onSuccess: () => setDeleteTarget(null),
+                  })
+                }
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteMutation.isPending ? "Suppression..." : "Supprimer"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
   )
 }

--- a/lib/utils/subject-colors.ts
+++ b/lib/utils/subject-colors.ts
@@ -1,0 +1,47 @@
+// Palette partagée Subjects (Kanban + Table). Aligné sur SUBJECT_COLOR_PALETTE
+// du contract Zod. Chaque token Tailwind est défini en utilities statiques pour
+// que le purge JIT capture les classes (pas de string concat dynamique).
+
+export interface SubjectColorTokens {
+  bg: string
+  text: string
+  border: string
+  badge: string
+}
+
+const COLOR_MAP: Record<string, SubjectColorTokens> = {
+  blue:    { bg: "bg-blue-500/10",    text: "text-blue-700",    border: "border-blue-200",    badge: "bg-blue-600" },
+  emerald: { bg: "bg-emerald-500/10", text: "text-emerald-700", border: "border-emerald-200", badge: "bg-emerald-600" },
+  amber:   { bg: "bg-amber-500/10",   text: "text-amber-700",   border: "border-amber-200",   badge: "bg-amber-600" },
+  violet:  { bg: "bg-violet-500/10",  text: "text-violet-700",  border: "border-violet-200",  badge: "bg-violet-600" },
+  rose:    { bg: "bg-rose-500/10",    text: "text-rose-700",    border: "border-rose-200",    badge: "bg-rose-500" },
+  cyan:    { bg: "bg-cyan-500/10",    text: "text-cyan-700",    border: "border-cyan-200",    badge: "bg-cyan-600" },
+  orange:  { bg: "bg-orange-500/10",  text: "text-orange-700",  border: "border-orange-200",  badge: "bg-orange-500" },
+  indigo:  { bg: "bg-indigo-500/10",  text: "text-indigo-700",  border: "border-indigo-200",  badge: "bg-indigo-600" },
+  teal:    { bg: "bg-teal-500/10",    text: "text-teal-700",    border: "border-teal-200",    badge: "bg-teal-600" },
+  red:     { bg: "bg-red-500/10",     text: "text-red-700",     border: "border-red-200",     badge: "bg-red-500" },
+  green:   { bg: "bg-green-500/10",   text: "text-green-700",   border: "border-green-200",   badge: "bg-green-600" },
+  pink:    { bg: "bg-pink-500/10",    text: "text-pink-700",    border: "border-pink-200",    badge: "bg-pink-500" },
+}
+
+const DEFAULT_COLOR: SubjectColorTokens = {
+  bg: "bg-slate-500/10",
+  text: "text-slate-700",
+  border: "border-slate-200",
+  badge: "bg-slate-500",
+}
+
+export function getSubjectColor(color: string | null | undefined): SubjectColorTokens {
+  if (!color) return DEFAULT_COLOR
+  return COLOR_MAP[color] ?? DEFAULT_COLOR
+}
+
+export function teacherInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((p) => p[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase()
+}


### PR DESCRIPTION
## Summary

Refonte de la vue Table de `/admin/subjects` qui affichait 38 lignes plates avec doublons massifs (Anglais×5, Maths×5...). Désormais 14 groupes catalogue dépliables par chevron, avec instances par niveau visibles à la demande.

## Avant → Après

| Métrique | Avant | Après |
|---|---|---|
| Lignes affichées | 38 (5 doublons/matière) | 14 groupes |
| Pagination | 2 pages forcées | 1 vue compacte |
| Colonne Série | Toujours `—` | Drop (rendue inline en badge sur instances) |
| Prof affiché | Non | Avatar initiales coloré + nom complet |
| KPI hero | Disparu | matières uniques · instances · h/semaine |
| Bulk ops | Aucune | Tout déplier / Tout replier |
| Filtres | Niveau simple | Niveau + Avec/Sans enseignant |
| Confirm suppr | Dialog custom | AlertDialog shadcn |

## Fichiers

- `components/admin/subjects/SubjectGroupRow.tsx` (nouveau, 180 LOC)
- `components/admin/subjects/SubjectsTable.tsx` (réécriture, 260 LOC)
- `lib/utils/subject-colors.ts` (nouveau, helper palette partagé Kanban+Table)

## Test plan

- [x] `tsc --noEmit` exit 0
- [x] Visual-check collapsed (14 groupes) puis expanded (4 instances Maths avec Kouassi)
- [x] 0 erreur console au mount
- [ ] Filtre "Sans enseignant" : doit retourner EPS (les instances 6e-3e ont été assignées entretemps)
- [ ] Suppression via AlertDialog → confirme + invalidate