### PR TITLE
fix(auth): redirect to /login?expired=1 when BE rejects a JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Session zombie après expiration du jeton : la barre de navigation et les listes affichaient parfois 28 erreurs 401 en silence sans rediriger vers la page de connexion. Le redirect vers `/login?expired=1` se déclenche désormais dès qu'une requête authentifiée échoue, avec un secours qui force la redirection même si la déconnexion bloque *(tous)*.
 - Liste des bulletins refondue : nom complet de l'élève, matricule et avatar à initiales s'affichent désormais au lieu d'identifiants techniques `#3`. La fenêtre de détail montre l'élève, sa classe, la moyenne générale, le rang `1/3`, la mention complète et le détail par matière avec coefficient *(admin)*.
 - Page DREN qui ne chargeait plus depuis l'ajout du champ moyenne par classe : le tableau de bord des statistiques affiche désormais correctement l'effectif, la répartition garçons/filles, le taux de réussite et le détail par niveau *(admin)*.
 - Téléchargement d'un PDF en erreur : un toast d'erreur clair apparaît désormais avec le message du serveur (ex : bibliothèque PDF manquante), au lieu d'un silence trompeur où l'admin ne savait pas ce qui se passait *(admin, parent, enseignant)*.

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -30,10 +30,22 @@ export async function handleExpiredSession(): Promise<void> {
   } catch {
     // ignore
   }
-  // Clear the NextAuth cookie. redirect:false because we trigger a full
-  // navigation ourselves to also reset TanStack Query / Zustand state.
-  await signOut({ redirect: false }).catch(() => {})
-  window.location.href = "/login?expired=1"
+  // Belt-and-suspenders: even if signOut hangs or rejects, the redirect
+  // must fire — otherwise we get the zombie state observed 2026-05-20
+  // (28×401 with the session-token cookie still set, no redirect, UI
+  // stays mounted on /admin/*).
+  const redirect = () => {
+    window.location.href = "/login?expired=1"
+  }
+  const fallback = window.setTimeout(redirect, 1500)
+  try {
+    await signOut({ redirect: false })
+  } catch {
+    // ignore — we redirect regardless
+  } finally {
+    window.clearTimeout(fallback)
+    redirect()
+  }
 }
 
 interface RequestOptions extends Omit<RequestInit, "headers"> {
@@ -74,6 +86,15 @@ async function getCachedSession(): Promise<Session | null> {
 async function authHeaders(): Promise<Record<string, string>> {
   const session = await getCachedSession()
   const headers: Record<string, string> = { "Content-Type": "application/json" }
+  // auth.ts sets session.error = "RefreshTokenError" when isTokenExpired() is
+  // truthy on the next jwt() pass, but it still exposes session.accessToken
+  // (the stale JWT). Don't send that to the BE: bail out and trigger the
+  // signOut/redirect flow immediately. Middleware would catch it on the next
+  // server navigation, but client-side fetches need their own handler.
+  if (session?.error === "RefreshTokenError") {
+    void handleExpiredSession()
+    throw new Error("Session expirée")
+  }
   if (session?.accessToken) {
     headers["Authorization"] = `Bearer ${session.accessToken}`
   }
@@ -84,11 +105,16 @@ async function authHeaders(): Promise<Record<string, string>> {
 export async function apiFetchBlob(path: string): Promise<Blob> {
   const headers = await authHeaders()
   delete headers["Content-Type"]
+  const hadToken = "Authorization" in headers
   const res = await fetch(`${getBaseUrl()}${path}`, { headers })
   if (res.status === 401) {
-    const session = await getCachedSession()
-    if (session?.accessToken) {
-      await handleExpiredSession()
+    // We sent a Bearer that the BE rejected → JWT expired or revoked.
+    // Gate on the header we actually sent (not a re-read of the session)
+    // so the post-login race — cookie set but getSession() not yet primed,
+    // so no Authorization header in the first fetch — doesn't trigger an
+    // immediate signOut right after login.
+    if (hadToken) {
+      void handleExpiredSession()
     }
     throw new Error("Session expirée")
   }
@@ -108,18 +134,20 @@ export async function apiFetchBlob(path: string): Promise<Blob> {
 export async function apiFetch<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { schema, ...fetchOptions } = options
   const headers = { ...(await authHeaders()), ...fetchOptions.headers }
+  const hadToken = "Authorization" in headers
   const res = await fetch(`${getBaseUrl()}${path}`, { ...fetchOptions, headers })
 
   // 401: the JWT carried in the Authorization header is missing or expired.
-  // We only trigger signOut+redirect if we actually had a session — otherwise
-  // we'd race with the login flow (cookies set but not yet readable by
-  // getSession() on the first post-login fetch). When there's no session,
-  // throwing a plain error is enough: the middleware will redirect on the
+  // Gate on the header we actually sent (not a re-read of the session)
+  // — the session cache may report `accessToken` truthy even when the BE
+  // is rejecting that very token, and re-reading it before deciding can
+  // race with handleExpiredSession() clearing the cache. The post-login
+  // race (cookie set but no Authorization header yet) is handled by
+  // hadToken=false: throwing is enough, the middleware redirects on the
   // next navigation.
   if (res.status === 401) {
-    const session = await getCachedSession()
-    if (session?.accessToken) {
-      await handleExpiredSession()
+    if (hadToken) {
+      void handleExpiredSession()
     }
     throw new Error("Session expirée")
   }

--- a/lib/api/staff.ts
+++ b/lib/api/staff.ts
@@ -25,17 +25,23 @@ export const staffApi = {
 
   uploadPhoto: async (staffId: number, file: File): Promise<{ photo_url: string }> => {
     const session = await getSession()
+    if (session?.error === "RefreshTokenError") {
+      void handleExpiredSession()
+      throw new Error("Session expirée")
+    }
     const formData = new FormData()
     formData.append("file", file)
+    const headers: Record<string, string> = session?.accessToken
+      ? { Authorization: `Bearer ${session.accessToken}` }
+      : {}
+    const hadToken = "Authorization" in headers
     const res = await fetch(`${getBaseUrl()}/admin/staff/${staffId}/photo`, {
       method: "POST",
-      headers: {
-        ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-      },
+      headers,
       body: formData,
     })
     if (res.status === 401) {
-      if (session?.accessToken) await handleExpiredSession()
+      if (hadToken) void handleExpiredSession()
       throw new Error("Session expirée")
     }
     if (!res.ok) throw new Error("Upload failed")

--- a/lib/api/students.ts
+++ b/lib/api/students.ts
@@ -44,17 +44,23 @@ export const studentsApi = {
     // FormData multipart upload — can't go through apiFetch (which JSON-encodes).
     // We replicate the 401 → handleExpiredSession contract manually.
     const session = await getSession()
+    if (session?.error === "RefreshTokenError") {
+      void handleExpiredSession()
+      throw new Error("Session expirée")
+    }
     const formData = new FormData()
     formData.append("file", file)
+    const headers: Record<string, string> = session?.accessToken
+      ? { Authorization: `Bearer ${session.accessToken}` }
+      : {}
+    const hadToken = "Authorization" in headers
     const res = await fetch(`${getBaseUrl()}/admin/students/${studentId}/photo`, {
       method: "POST",
-      headers: {
-        ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-      },
+      headers,
       body: formData,
     })
     if (res.status === 401) {
-      if (session?.accessToken) await handleExpiredSession()
+      if (hadToken) void handleExpiredSession()
       throw new Error("Session expirée")
     }
     if (!res.ok) throw new Error("Upload failed")

--- a/lib/api/teachers.ts
+++ b/lib/api/teachers.ts
@@ -27,17 +27,23 @@ export const teachersApi = {
     // FormData multipart upload — can't go through apiFetch (JSON-encoded).
     // 401 → handleExpiredSession contract replicated manually.
     const session = await getSession()
+    if (session?.error === "RefreshTokenError") {
+      void handleExpiredSession()
+      throw new Error("Session expirée")
+    }
     const formData = new FormData()
     formData.append("file", file)
+    const headers: Record<string, string> = session?.accessToken
+      ? { Authorization: `Bearer ${session.accessToken}` }
+      : {}
+    const hadToken = "Authorization" in headers
     const res = await fetch(`${getBaseUrl()}/admin/teachers/${teacherId}/photo`, {
       method: "POST",
-      headers: {
-        ...(session?.accessToken ? { Authorization: `Bearer ${session.accessToken}` } : {}),
-      },
+      headers,
       body: formData,
     })
     if (res.status === 401) {
-      if (session?.accessToken) await handleExpiredSession()
+      if (hadToken) void handleExpiredSession()
       throw new Error("Session expirée")
     }
     if (!res.ok) throw new Error("Upload failed")


### PR DESCRIPTION
## Summary

Le redirect `/login?expired=1` ne firait pas après expiration du JWT BE. La SPA restait montée avec 28 erreurs 401 silencieuses (observé 2026-05-20 visual-check `/admin/subjects`).

## Root cause

`auth.ts` set `session.error = "RefreshTokenError"` quand `isTokenExpired(token.accessToken)` retourne vrai, mais expose toujours `session.accessToken` (stale). Le client envoyait ce token mort au BE → 401. Le handler `apiFetch` gateait sur `session?.accessToken` (truthy) ET sur `getCachedSession()` re-lu après coup, ce qui ouvrait une race avec `handleExpiredSession()` qui vide ce cache.

## Fix

| Fichier | Changement |
|---|---|
| `lib/api/client.ts` | `authHeaders()` détecte `session.error` → fire + throw. 401 branch gate sur `hadToken` local (header Authorization envoyé). `handleExpiredSession()` a un `setTimeout` fallback qui force le redirect même si `signOut()` hang |
| `lib/api/students.ts` / `staff.ts` / `teachers.ts` | Même contrat propagé aux 3 uploadPhoto (FormData paths qui contournent `apiFetch`) |

## Verified live

Reload `/admin/subjects` après stale session → toast amber « Session expirée », redirect vers `/login?expired=1` avec banner ad hoc.

## Test plan

- [x] TypeCheck exit 0
- [x] Visual-check live : redirect + banner ad hoc affichés
- [ ] Login normal toujours OK (pas de boucle post-login)
- [ ] Login après expiration → banner s'efface dès qu'on tape un caractère