### PR TITLE
fix(grades): pre-fill existing grades in revise mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Mode « Réviser » d'une évaluation : les notes déjà saisies sont désormais pré-remplies dans les champs au lieu de s'afficher vides. L'enseignant ou l'admin peut donc relire et modifier en place les notes existantes au lieu de tout ressaisir *(enseignant, admin)*.
+
 ### Changed
 
 - Vue Table de la page Matières refondue avec groupage par catalogue : chaque matière apparaît une seule fois (au lieu de 5 lignes dupliquées par niveau), avec un chevron pour déplier les instances et voir coefficient, heures et enseignant pour chaque niveau. Filtres « par niveau » et « avec/sans enseignant » et bandeau de stats : matières uniques, instances totales, heures cumulées *(admin)*.

--- a/components/teacher/grades/GradeEntryGrid.tsx
+++ b/components/teacher/grades/GradeEntryGrid.tsx
@@ -302,17 +302,32 @@ export function GradeEntryGrid({ evaluationId, classId }: GradeEntryGridProps) {
       {/* ─── Grade entries ──────────────────────────────────────────── */}
       <div className="overflow-hidden rounded-xl border bg-card">
         <div className="divide-y">
-          {grades.map((grade, index) => (
-            <GradeRow
-              key={grade.student_id}
-              index={index}
-              studentName={grade.student_name ?? `Élève #${grade.student_id}`}
-              value={localGrades.get(grade.student_id) ?? null}
-              status={cellStatus.get(grade.student_id) ?? "idle"}
-              originalStatus={grade.status}
-              onChange={(rawValue) => handleGradeChange(grade.student_id, rawValue)}
-            />
-          ))}
+          {grades.map((grade, index) => {
+            // `initialValue` est la valeur côté serveur — connue dès le mount
+            // de GradeRow (qui ne se monte qu'après que `grades` ait été
+            // récupéré). C'est elle qui pré-remplit l'input en mode "Réviser".
+            // `localGrades.get(...)` reste la source de vérité pour la
+            // catégorisation (couleur de cellule) qui suit les frappes en cours.
+            const serverValue =
+              grade.value !== null && grade.value !== undefined
+                ? Number(grade.value)
+                : null
+            const liveValue = localGrades.has(grade.student_id)
+              ? localGrades.get(grade.student_id) ?? null
+              : serverValue
+            return (
+              <GradeRow
+                key={grade.student_id}
+                index={index}
+                studentName={grade.student_name ?? `Élève #${grade.student_id}`}
+                initialValue={serverValue}
+                value={liveValue}
+                status={cellStatus.get(grade.student_id) ?? "idle"}
+                originalStatus={grade.status}
+                onChange={(rawValue) => handleGradeChange(grade.student_id, rawValue)}
+              />
+            )
+          })}
         </div>
       </div>
     </div>
@@ -354,21 +369,33 @@ function KpiTile({ label, value, tone, icon: Icon }: KpiTileProps) {
 interface GradeRowProps {
   index: number
   studentName: string
+  /** Valeur côté serveur — sert UNIQUEMENT à l'init de l'input (mode "Réviser"). */
+  initialValue: number | null
+  /** Valeur courante (serveur OU frappe locale en cours) — pour la catégorisation. */
   value: number | null
   status: CellStatus
   originalStatus: string
   onChange: (rawValue: string) => void
 }
 
-function GradeRow({ index, studentName, value, status, originalStatus, onChange }: GradeRowProps) {
+function GradeRow({
+  index,
+  studentName,
+  initialValue,
+  value,
+  status,
+  originalStatus,
+  onChange,
+}: GradeRowProps) {
   // rawInput est la source de vérité pour ce que l'utilisateur tape (incluant
   // les états transitoires comme "12," avant complétion). On l'initialise UNE
-  // SEULE FOIS depuis la prop, puis le user contrôle. Pas de useEffect [value]
-  // qui écraserait sa frappe (ex: "12," → parser → 12 → reset à "12" sans virgule).
-  // Trade-off : si le serveur refetch avec une valeur différente, le row reste
-  // sur la valeur tapée. Acceptable — single editor at a time.
+  // SEULE FOIS depuis `initialValue` (côté serveur), puis le user contrôle.
+  // Pas de useEffect [value] qui écraserait sa frappe (ex: "12," → parser → 12
+  // → reset à "12" sans virgule). Trade-off : si le serveur refetch avec une
+  // valeur différente, le row reste sur la valeur tapée. Acceptable — single
+  // editor at a time.
   const [rawInput, setRawInput] = useState<string>(
-    value !== null ? String(value).replace(".", ",") : "",
+    initialValue !== null ? String(initialValue).replace(".", ",") : "",
   )
 
   const category = categorizeGrade(value, originalStatus)


### PR DESCRIPTION
## Summary

Click « Réviser » sur `/admin/grades/[id]` affichait des champs **vides** alors que les notes étaient bel et bien saisies (KPI header confirme « 3/3 · Moyenne classe 14.50 »). L'enseignant ne pouvait donc pas corriger une faute de frappe sans tout retaper.

## Root cause

`GradeRow` initialisait `rawInput` via `useState(value)` au mount. Mais `value` venait de `localGrades` qui était hydratée via `useEffect` APRÈS le mount. Initial value capturée = `null` → `rawInput = ""`.

```tsx
// AVANT
function GradeRow({ value, ... }) {
  const [rawInput, setRawInput] = useState(
    value !== null ? String(value).replace(".", ",") : ""
  )
  // value est null au mount → rawInput="" capturé pour toujours
}
```

## Fix

Passer `initialValue={serverValue}` séparément de `value` (live). `serverValue` vient directement de `grade.value` (dispo dès que `useGrades` resolve), donc connu au mount. `value` reste live pour la catégorisation des couleurs en cours de frappe.

```tsx
// APRÈS
const serverValue = grade.value !== null ? Number(grade.value) : null
const liveValue = localGrades.has(grade.student_id)
  ? localGrades.get(grade.student_id) ?? null
  : serverValue
<GradeRow initialValue={serverValue} value={liveValue} ... />
```

Pas de `useEffect [value]` ajouté — la logique anti-écrasement de la frappe utilisateur est préservée (commentaire explicite ligne 369).

## Test plan

- [x] TypeCheck exit 0
- [x] Visual-check live `/admin/grades/1?classId=2` → Aminata 12,5 · Bertrand 14 · Fatou 17 désormais pré-remplis
- [ ] Saisir un nouveau caractère ne reset pas la valeur (single editor)
- [ ] Mode dictée affiche aussi les notes pré-remplies si applicable