### PR TITLE
fix(reports): add DialogDescription to bulletin preview and generate modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Aperçu et confirmation des bulletins compatibles lecteur d'écran : les boîtes de dialogue décrivent désormais leur contenu aux lecteurs d'écran (« Aperçu détaillé du bulletin de notes avec moyenne, rang, mention et détail par matière », résumé de la génération de bulletins) *(tous)*.
 - Mode « Réviser » d'une évaluation : les notes déjà saisies sont désormais pré-remplies dans les champs au lieu de s'afficher vides. L'enseignant ou l'admin peut donc relire et modifier en place les notes existantes au lieu de tout ressaisir *(enseignant, admin)*.
 
 ### Changed

--- a/components/admin/reports/BulletinGenerateButton.tsx
+++ b/components/admin/reports/BulletinGenerateButton.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -57,12 +58,12 @@ export function BulletinGenerateButton({
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>Générer les bulletins</DialogTitle>
+            <DialogDescription>
+              Cette action va générer les bulletins pour le{" "}
+              <strong>{trimester ? trimesterFullLabel(trimester) : ""}</strong>.
+              Les bulletins existants en brouillon seront recalculés.
+            </DialogDescription>
           </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            Cette action va générer les bulletins pour le{" "}
-            <strong>{trimester ? trimesterFullLabel(trimester) : ""}</strong>.
-            Les bulletins existants en brouillon seront recalculés.
-          </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setConfirmOpen(false)}>
               Annuler

--- a/components/admin/reports/BulletinPreviewModal.tsx
+++ b/components/admin/reports/BulletinPreviewModal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Award, GraduationCap, Trophy, User } from "lucide-react"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { BulletinStatusBadge } from "./BulletinStatusBadge"
@@ -31,6 +31,9 @@ export function BulletinPreviewModal({ bulletinId, onClose }: BulletinPreviewMod
       <DialogContent className="max-h-[88vh] max-w-3xl overflow-y-auto p-0">
         <DialogHeader className="sr-only">
           <DialogTitle>Bulletin scolaire</DialogTitle>
+          <DialogDescription>
+            Aperçu détaillé du bulletin de notes avec moyenne, rang, mention et détail par matière.
+          </DialogDescription>
         </DialogHeader>
 
         {isLoading ? (


### PR DESCRIPTION
## Summary

- **Bug** : Radix UI émettait un warning `Missing 'Description' or 'aria-describedby={undefined}' for {DialogContent}` (×2) à chaque ouverture du modal preview bulletin sur `/admin/reports`. Conséquence : lecteurs d'écran ne disposaient pas d'une description claire du contenu.
- **Fix** : Ajout d'un `<DialogDescription>` explicite dans les 2 dialogs concernés :
  - `BulletinPreviewModal` — description `sr-only` résumant l'aperçu (« Aperçu détaillé du bulletin de notes avec moyenne, rang, mention et détail par matière. »)
  - `BulletinGenerateButton` — migration du `<p>` introductif en `<DialogDescription>` correctement imbriqué dans `DialogHeader`

## Découvert pendant

Régression visual-check post-merge de [#188 / #189](https://github.com/African-DC/klassci-college-frontend/pull/188) — l'audit console du flow Aminata → bulletin a relevé ces 2 warnings. Tous les autres modals (CouncilPageClient, CouncilValidateButton) avaient déjà la bonne structure.

## Test plan

- [x] Console clean après hot-reload : 0 warning `DialogContent missing aria-describedby` au lieu de 2
- [x] Snapshot a11y du dialog : `dialog "Bulletin scolaire" description="Aperçu détaillé..."` (Radix wire correctement `aria-describedby`)
- [x] Modal preview Aminata s'ouvre toujours correctement avec header, KPIs, table détail
- [x] Build prod local valide (after env path-casing fix; CI Ubuntu non concerné)