### PR TITLE
fix(deploy): make ssh-keyscan defensive when EC2 host unreachable

### DIFF
--- a/.github/workflows/deploy-fe.yml
+++ b/.github/workflows/deploy-fe.yml
@@ -85,15 +85,21 @@ jobs:
           mkdir -p ~/.ssh
           echo "$EC2_SSH_KEY" > ~/.ssh/id_deploy
           chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          # ssh-keyscan en best-effort : si l'host est down (instance stoppée, IP
+          # changée, network down), le workflow continue. Le scp/ssh suivants
+          # utilisent StrictHostKeyChecking=accept-new pour TOFU et lèveront
+          # l'erreur réelle (connection refused, timeout) si le host est down.
+          ssh-keyscan -H -T 10 ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || \
+            echo "ssh-keyscan failed (host unreachable?), falling back to accept-new"
 
       - name: Ship + atomic swap + health check + rollback
         env:
           HOST: ${{ secrets.EC2_HOST }}
         run: |
           set -e
-          scp -i ~/.ssh/id_deploy standalone.tgz ubuntu@$HOST:/tmp/
-          ssh -i ~/.ssh/id_deploy ubuntu@$HOST 'bash -se' <<'REMOTE'
+          SSH_OPTS="-i ~/.ssh/id_deploy -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15"
+          scp $SSH_OPTS standalone.tgz ubuntu@$HOST:/tmp/
+          ssh $SSH_OPTS ubuntu@$HOST 'bash -se' <<'REMOTE'
           set -euo pipefail
           APP=/home/ubuntu/klassci/klassci-frontend
           STAGE=/tmp/standalone-new-$(date +%s)


### PR DESCRIPTION
Closes #196

## Summary
Symmetric to klassci-college-backend#158. `ssh-keyscan` exit code 1 when host is unreachable was killing every deploy workflow under `set -e`. Add `-T 10` timeout + defensive fallback + `StrictHostKeyChecking=accept-new` on the actual scp/ssh.

## Test plan
- [x] Local YAML lint passes
- [ ] Auto-deploy fires on merge → workflow reaches the `Ship` step instead of failing in `Setup SSH key`
- [ ] If EC2 is up, ship succeeds and health check passes
- [ ] If EC2 is down, scp fails with explicit connection refused/timeout

## skip-changelog rationale
Pure CI/devops fix, no user-facing impact. Applied `skip-changelog` label.