### PR TITLE
fix(payments): KPI neutral gray when value=0 (no false-positive green)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Page Paiements : indicateurs "Collecté", "Attendu" et "Taux de recouvrement" affichent désormais une couleur neutre (gris) quand la valeur vaut zéro, au lieu d'un vert success trompeur qui suggérait à tort « tout est payé » alors qu'il n'y a juste aucun paiement enregistré *(admin)*.
 - Aperçu et confirmation des bulletins compatibles lecteur d'écran : les boîtes de dialogue décrivent désormais leur contenu aux lecteurs d'écran (« Aperçu détaillé du bulletin de notes avec moyenne, rang, mention et détail par matière », résumé de la génération de bulletins) *(tous)*.
 - Mode « Réviser » d'une évaluation : les notes déjà saisies sont désormais pré-remplies dans les champs au lieu de s'afficher vides. L'enseignant ou l'admin peut donc relire et modifier en place les notes existantes au lieu de tout ressaisir *(enseignant, admin)*.
 

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -580,6 +580,7 @@ const KPI_COLORS = {
   emerald: { bg: "bg-emerald-50", icon: "text-emerald-600 bg-emerald-100", ring: "ring-emerald-200/60" },
   amber: { bg: "bg-amber-50", icon: "text-amber-600 bg-amber-100", ring: "ring-amber-200/60" },
   rose: { bg: "bg-rose-50", icon: "text-rose-600 bg-rose-100", ring: "ring-rose-200/60" },
+  neutral: { bg: "bg-slate-50", icon: "text-slate-500 bg-slate-100", ring: "ring-slate-200/60" },
 }
 
 function KpiCard({
@@ -597,7 +598,11 @@ function KpiCard({
   isPercent?: boolean
   subtext?: string
 }) {
-  const c = KPI_COLORS[color]
+  // Empty-state guard : value=0 doit etre neutre, pas un faux signal vert/amber.
+  // Cf. rule `not-enrolled-empty-state.md` : "0 FCFA Collecté" en vert suggère
+  // a tort "tout paye !" alors qu'il n'y a juste aucun paiement enregistre.
+  const effectiveColor: keyof typeof KPI_COLORS = value === 0 ? "neutral" : color
+  const c = KPI_COLORS[effectiveColor]
   return (
     <Card className={`border-0 shadow-sm ring-1 ${c.ring} overflow-hidden`}>
       <CardContent className="p-4">


### PR DESCRIPTION
## Summary

Bug ergonomique détecté via /klassci-e2e-test 2026-05-21.

La KpiCard de /admin/payments affiche `Collecté 0 FCFA` en couleur **vert success** lorsqu'il n'y a aucun paiement enregistré. Cela suggère à tort « tout est payé » alors qu'il y a juste 0 paiement.

## Fix

KpiCard force la couleur `neutral` (slate gris) quand `value === 0`, peu importe la couleur prop. Ajout du token `neutral` à `KPI_COLORS`.

## Anti-pattern documenté

Rule `not-enrolled-empty-state.md` : ne JAMAIS afficher du vert success sur une valeur 0 (faux signal positif). Même classe que le bug parent dashboard `fees_remaining: 0 FCFA` en vert sur enfant pas inscrit, fixé en mai 2026.

## Test plan

- [x] Render local : 4 KPIs grises quand DB vide
- [x] Render local : KPIs colorés (blue/emerald/amber) quand summary contient des values >0
- [x] Aucune régression : la KpiCard accepte toujours toutes les couleurs originales

Closes #198