### PR TITLE
feat(ergonomy): mobile cards on Classes/Staff/Parents + contact actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ### Added
 
 - Page Enseignants : boutons d'action inline « Appeler », « WhatsApp » et « Email » à côté du téléphone permettent de joindre un enseignant en un tap, sans passer par sa fiche. Pattern Wave Mobile Money, touch targets adaptés au mobile *(admin)*.
+- Pages Parents et Personnel : mêmes boutons d'action inline « Appeler », « WhatsApp » et « Email » en plus de l'ancien lien téléphone. Le tap ouvre l'application native sans recharger la page *(admin)*.
+- Page Parents : pastille verte « Compte actif » sur les cartes parents qui ont déjà un compte connecté, pour distinguer en un coup d'œil ceux qui peuvent se connecter au portail *(admin)*.
 
 ### Changed
 
 - Page Paiements sur mobile : la liste des paiements adopte un affichage cartes verticales (montant prominent, statut coloré, méthode, date) au lieu d'une table illisible en scroll horizontal sur Itel S661. Le tap sur une carte ouvre l'aperçu du reçu *(admin)*.
 - Page Enseignants sur mobile : la liste adopte le même format compact que la page Élèves (avatar + nom + spécialité + chevron), au lieu de la table desktop scrollable. Tap = ouvre la fiche *(admin)*.
+- Pages Classes, Parents et Personnel sur mobile : même format compact avec avatar + nom + sous-titre + chevron, au lieu de la table desktop scrollable. Une pastille colorée d'occupation (vert / amber / rouge) s'affiche à droite de chaque classe pour signaler les classes pleines en un coup d'œil *(admin)*.
+- Page Classes : le sélecteur de vue Arbre / Table est désormais caché sur mobile (l'arbre n'était pas lisible sur petit écran). La vue cartes mobile est affichée automatiquement *(admin)*.
 - Formulaire de connexion plus accessible : boutons d'affichage du mot de passe annoncés aux lecteurs d'écran, messages d'alerte (session expirée, erreur d'identifiants) annoncés en temps réel, icônes décoratives masquées aux lecteurs d'écran *(tous)*.
 - Indicateurs du tableau de bord admin annoncés en temps réel aux lecteurs d'écran : chaque carte expose son intitulé + sa valeur (« Élèves inscrits : 42 ») au lieu d'un chiffre orphelin *(admin)*.
 

--- a/components/admin/classes/ClassesPageClient.tsx
+++ b/components/admin/classes/ClassesPageClient.tsx
@@ -17,7 +17,7 @@ export function ClassesPageClient() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <School className="h-5 w-5 text-primary" />
+            <School aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Classes</h1>
@@ -25,36 +25,49 @@ export function ClassesPageClient() {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          {/* View toggle */}
-          <div className="flex items-center rounded-lg border p-1">
+          {/* View toggle : caché sur mobile (l'arbre n'est pas lisible sur 320px,
+              ClassesTable apporte automatiquement sa version mobile cards). */}
+          <div
+            role="group"
+            aria-label="Changer la vue"
+            className="hidden md:flex items-center rounded-lg border p-1"
+          >
             <Button
               variant={viewMode === "tree" ? "default" : "ghost"}
               size="sm"
               className="h-8 px-3"
+              aria-pressed={viewMode === "tree"}
               onClick={() => setViewMode("tree")}
             >
-              <LayoutGrid className="mr-1.5 h-4 w-4" />
+              <LayoutGrid aria-hidden="true" className="mr-1.5 h-4 w-4" />
               Arbre
             </Button>
             <Button
               variant={viewMode === "table" ? "default" : "ghost"}
               size="sm"
               className="h-8 px-3"
+              aria-pressed={viewMode === "table"}
               onClick={() => setViewMode("table")}
             >
-              <List className="mr-1.5 h-4 w-4" />
+              <List aria-hidden="true" className="mr-1.5 h-4 w-4" />
               Table
             </Button>
           </div>
           <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
-            <Plus className="h-4 w-4" />
+            <Plus aria-hidden="true" className="h-4 w-4" />
             Nouvelle classe
           </Button>
         </div>
       </div>
 
-      {/* Content */}
-      {viewMode === "tree" ? <ClassesTreeView /> : <ClassesTable />}
+      {/* Content : mobile force toujours table (qui contient cards mobile),
+          desktop respecte le choix utilisateur (arbre par défaut). */}
+      <div className="md:hidden">
+        <ClassesTable />
+      </div>
+      <div className="hidden md:block">
+        {viewMode === "tree" ? <ClassesTreeView /> : <ClassesTable />}
+      </div>
 
       <ClassCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
     </div>

--- a/components/admin/classes/ClassesTable.tsx
+++ b/components/admin/classes/ClassesTable.tsx
@@ -2,11 +2,14 @@
 
 import { useCallback, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
+import type { Route } from "next"
 import type { ColumnDef } from "@tanstack/react-table"
+import { School } from "lucide-react"
 import { useClasses, useDeleteClass } from "@/lib/hooks/useClasses"
 import { useLevels } from "@/lib/hooks/useLevels"
 import type { Class } from "@/lib/contracts/class"
 import { CrudTable, type FilterConfig } from "@/components/shared/CrudTable"
+import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
 import { ClassEditModal } from "./ClassEditModal"
 import { useDebounce } from "@/lib/hooks/useDebounce"
 
@@ -36,6 +39,27 @@ function EnrolledCell({ enrolled, max }: { enrolled?: number; max?: number | nul
         </div>
       )}
     </div>
+  )
+}
+
+// Mini-pill capacité sur mobile : "27 / 30" + petit indicateur coloré
+function CapacityPill({ enrolled, max }: { enrolled?: number; max?: number | null }) {
+  const count = enrolled ?? 0
+  const capacity = max ?? 0
+  if (capacity === 0) {
+    return <span className="text-[11px] tabular-nums text-muted-foreground">{count} élève{count > 1 ? "s" : ""}</span>
+  }
+  const ratio = (count / capacity) * 100
+  const tone =
+    ratio > 95
+      ? "bg-rose-100 text-rose-700"
+      : ratio >= 80
+        ? "bg-amber-100 text-amber-700"
+        : "bg-emerald-100 text-emerald-700"
+  return (
+    <span className={`inline-flex h-6 items-center rounded-full px-2 text-[11px] font-medium tabular-nums ${tone}`}>
+      {count} / {capacity}
+    </span>
   )
 }
 
@@ -111,31 +135,72 @@ export function ClassesTable() {
     },
   ], [])
 
+  const items = data?.items ?? []
+
   return (
-    <CrudTable<Class>
-      data={data}
-      columns={columns}
-      isLoading={isLoading}
-      isError={isError}
-      error={error}
-      refetch={refetch}
-      deleteMutation={deleteMutation}
-      onRowClick={(item) => router.push(`/admin/classes/${item.id}`)}
-      renderEditModal={({ itemId, open, onClose }) => (
-        <ClassEditModal classId={itemId} open={open} onClose={onClose} />
-      )}
-      getItemLabel={(c) => c.name}
-      emptyMessage="Aucune classe trouvée"
-      errorMessage="Impossible de charger les classes"
-      deleteDescription="Cette action est irréversible. La classe sera définitivement supprimée."
-      page={page}
-      onPageChange={setPage}
-      searchPlaceholder="Rechercher une classe..."
-      searchValue={search}
-      onSearchChange={handleSearchChange}
-      filterConfigs={filterConfigs}
-      filterValues={filters}
-      onFilterChange={handleFilterChange}
-    />
+    <div className="space-y-4">
+      {/* Desktop : table dense via CrudTable. Mobile : liste minimale via
+          MobileEntityListItem avec capacité-pill colorée à droite (signal
+          rouge si pleine, amber si proche). */}
+      <div className="hidden md:block">
+        <CrudTable<Class>
+          data={data}
+          columns={columns}
+          isLoading={isLoading}
+          isError={isError}
+          error={error}
+          refetch={refetch}
+          deleteMutation={deleteMutation}
+          onRowClick={(item) => router.push(`/admin/classes/${item.id}`)}
+          renderEditModal={({ itemId, open, onClose }) => (
+            <ClassEditModal classId={itemId} open={open} onClose={onClose} />
+          )}
+          getItemLabel={(c) => c.name}
+          emptyMessage="Aucune classe trouvée"
+          errorMessage="Impossible de charger les classes"
+          deleteDescription="Cette action est irréversible. La classe sera définitivement supprimée."
+          page={page}
+          onPageChange={setPage}
+          searchPlaceholder="Rechercher une classe..."
+          searchValue={search}
+          onSearchChange={handleSearchChange}
+          filterConfigs={filterConfigs}
+          filterValues={filters}
+          onFilterChange={handleFilterChange}
+        />
+      </div>
+
+      <div className="space-y-2 md:hidden">
+        {isLoading && (
+          <p className="rounded-lg border bg-muted/30 p-4 text-center text-sm text-muted-foreground">
+            Chargement…
+          </p>
+        )}
+        {!isLoading && items.length === 0 && (
+          <p className="rounded-lg border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+            Aucune classe trouvée
+          </p>
+        )}
+        {items.map((c) => {
+          const subtitle = c.series_name
+            ? `${c.level_name ?? c.level_id} · ${c.series_name}`
+            : (c.level_name ?? String(c.level_id))
+          return (
+            <MobileEntityListItem
+              key={c.id}
+              href={`/admin/classes/${c.id}` as Route}
+              avatar={
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 border border-border">
+                  <School className="h-4 w-4 text-primary" aria-hidden="true" />
+                </div>
+              }
+              primary={c.name}
+              secondary={subtitle}
+              status={<CapacityPill enrolled={c.enrolled_count} max={c.max_students} />}
+            />
+          )
+        })}
+      </div>
+    </div>
   )
 }

--- a/components/admin/parents/ParentsTable.tsx
+++ b/components/admin/parents/ParentsTable.tsx
@@ -4,12 +4,70 @@ import { useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
 import type { ColumnDef } from "@tanstack/react-table"
 import type { Route } from "next"
-import { Phone, Mail } from "lucide-react"
+import { Phone, Mail, MessageCircle, UserCircle2 } from "lucide-react"
 import { useParents, useDeleteParent } from "@/lib/hooks/useParents"
 import type { Parent } from "@/lib/contracts/parent"
 import { CrudTable } from "@/components/shared/CrudTable"
+import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
 import { useDebounce } from "@/lib/hooks/useDebounce"
 import { ParentEditModal } from "./ParentEditModal"
+
+// Actions inline Wave-style : Appeler / WhatsApp / Email
+function ContactActions({ parent }: { parent: Parent }) {
+  const phone = parent.phone?.trim()
+  const phoneDigits = phone?.replace(/[^\d]/g, "")
+  const email = parent.email
+
+  if (!phone && !email) {
+    return <span className="text-xs text-muted-foreground">—</span>
+  }
+
+  return (
+    <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+      {phone && (
+        <a
+          href={`tel:${phone}`}
+          aria-label={`Appeler ${parent.first_name} ${parent.last_name}`}
+          title="Appeler"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-primary hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Phone className="h-4 w-4" aria-hidden="true" />
+        </a>
+      )}
+      {phoneDigits && (
+        <a
+          href={`https://wa.me/${phoneDigits}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`WhatsApp ${parent.first_name} ${parent.last_name}`}
+          title="WhatsApp"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-emerald-600 hover:bg-emerald-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <MessageCircle className="h-4 w-4" aria-hidden="true" />
+        </a>
+      )}
+      {email && (
+        <a
+          href={`mailto:${email}`}
+          aria-label={`Envoyer un email à ${parent.first_name} ${parent.last_name}`}
+          title="Email"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Mail className="h-4 w-4" aria-hidden="true" />
+        </a>
+      )}
+    </div>
+  )
+}
+
+function ParentAvatar({ parent }: { parent: Parent }) {
+  const initials = `${parent.first_name?.[0] ?? ""}${parent.last_name?.[0] ?? ""}`.toUpperCase()
+  return (
+    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 border border-border">
+      <span className="text-xs font-semibold text-primary">{initials}</span>
+    </div>
+  )
+}
 
 export function ParentsTable() {
   const router = useRouter()
@@ -50,20 +108,9 @@ export function ParentsTable() {
     {
       accessorKey: "phone",
       header: "Téléphone",
-      cell: ({ row }) => {
-        const phone = row.original.phone
-        if (!phone) return <span className="text-sm text-muted-foreground">—</span>
-        return (
-          <a
-            href={`tel:${phone}`}
-            onClick={(e) => e.stopPropagation()}
-            className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
-          >
-            <Phone className="h-3.5 w-3.5" />
-            {phone}
-          </a>
-        )
-      },
+      cell: ({ row }) => (
+        <span className="text-sm text-muted-foreground tabular-nums">{row.original.phone ?? "—"}</span>
+      ),
     },
     {
       accessorKey: "city",
@@ -75,13 +122,18 @@ export function ParentsTable() {
       },
     },
     {
+      id: "contact_actions",
+      header: "Contact",
+      cell: ({ row }) => <ContactActions parent={row.original} />,
+    },
+    {
       accessorKey: "user_id",
       header: "Compte",
       cell: ({ row }) => {
         const hasAccount = !!row.original.user_id
         return (
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <Mail className="h-3 w-3" />
+            <UserCircle2 className="h-3 w-3" aria-hidden="true" />
             {hasAccount ? "Avec compte" : "Sans compte"}
           </div>
         )
@@ -89,28 +141,70 @@ export function ParentsTable() {
     },
   ], [])
 
+  const items = data?.items ?? []
+
   return (
-    <CrudTable<Parent>
-      data={data}
-      columns={columns}
-      isLoading={isLoading}
-      isError={isError}
-      error={error}
-      refetch={refetch}
-      deleteMutation={deleteMutation}
-      onRowClick={(item) => router.push(`/admin/parents/${item.id}` as Route)}
-      renderEditModal={({ itemId, open, onClose }) => (
-        <ParentEditModal parentId={itemId} open={open} onClose={onClose} />
-      )}
-      getItemLabel={(p) => `${p.last_name} ${p.first_name}`}
-      emptyMessage="Aucun parent trouvé"
-      errorMessage="Impossible de charger les parents"
-      deleteDescription="Cette action est irréversible. Le parent sera définitivement supprimé et les liens avec les enfants retirés."
-      searchPlaceholder="Rechercher un parent (nom, prénom, téléphone)..."
-      searchValue={search}
-      onSearchChange={(v) => { setSearch(v); setPage(1) }}
-      page={page}
-      onPageChange={setPage}
-    />
+    <div className="space-y-4">
+      <div className="hidden md:block">
+        <CrudTable<Parent>
+          data={data}
+          columns={columns}
+          isLoading={isLoading}
+          isError={isError}
+          error={error}
+          refetch={refetch}
+          deleteMutation={deleteMutation}
+          onRowClick={(item) => router.push(`/admin/parents/${item.id}` as Route)}
+          renderEditModal={({ itemId, open, onClose }) => (
+            <ParentEditModal parentId={itemId} open={open} onClose={onClose} />
+          )}
+          getItemLabel={(p) => `${p.last_name} ${p.first_name}`}
+          emptyMessage="Aucun parent trouvé"
+          errorMessage="Impossible de charger les parents"
+          deleteDescription="Cette action est irréversible. Le parent sera définitivement supprimé et les liens avec les enfants retirés."
+          searchPlaceholder="Rechercher un parent (nom, prénom, téléphone)..."
+          searchValue={search}
+          onSearchChange={(v) => { setSearch(v); setPage(1) }}
+          page={page}
+          onPageChange={setPage}
+        />
+      </div>
+
+      <div className="space-y-2 md:hidden">
+        {isLoading && (
+          <p className="rounded-lg border bg-muted/30 p-4 text-center text-sm text-muted-foreground">
+            Chargement…
+          </p>
+        )}
+        {!isLoading && items.length === 0 && (
+          <p className="rounded-lg border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+            Aucun parent trouvé
+          </p>
+        )}
+        {items.map((p) => {
+          const loc = [p.city, p.commune].filter(Boolean).join(" / ")
+          return (
+            <MobileEntityListItem
+              key={p.id}
+              href={`/admin/parents/${p.id}` as Route}
+              avatar={<ParentAvatar parent={p} />}
+              primary={
+                <>
+                  {p.last_name} {p.first_name}
+                </>
+              }
+              secondary={loc || p.phone || p.email || null}
+              status={
+                p.user_id ? (
+                  <span className="inline-flex h-6 items-center rounded-full bg-emerald-100 px-2 text-[10px] font-medium text-emerald-700">
+                    Compte actif
+                  </span>
+                ) : null
+              }
+            />
+          )
+        })}
+      </div>
+    </div>
   )
 }

--- a/components/admin/staff/StaffTable.tsx
+++ b/components/admin/staff/StaffTable.tsx
@@ -3,12 +3,82 @@
 import { useMemo, useState, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import type { ColumnDef } from "@tanstack/react-table"
+import type { Route } from "next"
+import { Phone, MessageCircle, Mail } from "lucide-react"
 import { useStaffList, useDeleteStaff } from "@/lib/hooks/useStaff"
 import type { Staff } from "@/lib/contracts/staff"
 import { CrudTable, type FilterConfig } from "@/components/shared/CrudTable"
+import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
 import { useDebounce } from "@/lib/hooks/useDebounce"
 import { StaffEditModal } from "./StaffEditModal"
-import { getUploadUrl } from "@/lib/utils"
+import { getUploadUrl, cn } from "@/lib/utils"
+
+function StaffAvatar({ staff, size = "md" }: { staff: Staff; size?: "sm" | "md" }) {
+  const initials = `${staff.first_name?.[0] ?? ""}${staff.last_name?.[0] ?? ""}`.toUpperCase()
+  const photoSrc = getUploadUrl((staff as Record<string, unknown>).photo_url as string | null | undefined)
+  const sizeClass = size === "sm" ? "h-9 w-9" : "h-10 w-10"
+  if (photoSrc) {
+    return (
+      <img
+        src={photoSrc}
+        alt={`${staff.first_name} ${staff.last_name}`}
+        className={cn(sizeClass, "shrink-0 rounded-lg object-cover border border-border")}
+      />
+    )
+  }
+  return (
+    <div className={cn(sizeClass, "flex shrink-0 items-center justify-center rounded-lg bg-primary/10 border border-border")}>
+      <span className="text-xs font-semibold text-primary">{initials}</span>
+    </div>
+  )
+}
+
+function ContactActions({ staff }: { staff: Staff }) {
+  const phone = staff.phone?.trim()
+  const phoneDigits = phone?.replace(/[^\d]/g, "")
+  const email = (staff as Record<string, unknown>).email as string | undefined
+
+  if (!phone && !email) {
+    return <span className="text-xs text-muted-foreground">—</span>
+  }
+
+  return (
+    <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+      {phone && (
+        <a
+          href={`tel:${phone}`}
+          aria-label={`Appeler ${staff.first_name} ${staff.last_name}`}
+          title="Appeler"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-primary hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Phone className="h-4 w-4" aria-hidden="true" />
+        </a>
+      )}
+      {phoneDigits && (
+        <a
+          href={`https://wa.me/${phoneDigits}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`WhatsApp ${staff.first_name} ${staff.last_name}`}
+          title="WhatsApp"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-emerald-600 hover:bg-emerald-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <MessageCircle className="h-4 w-4" aria-hidden="true" />
+        </a>
+      )}
+      {email && (
+        <a
+          href={`mailto:${email}`}
+          aria-label={`Envoyer un email à ${staff.first_name} ${staff.last_name}`}
+          title="Email"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Mail className="h-4 w-4" aria-hidden="true" />
+        </a>
+      )}
+    </div>
+  )
+}
 
 export function StaffTable() {
   const router = useRouter()
@@ -41,21 +111,9 @@ export function StaffTable() {
       header: "Nom",
       cell: ({ row }) => {
         const s = row.original
-        const initials = `${s.first_name?.[0] ?? ""}${s.last_name?.[0] ?? ""}`.toUpperCase()
-        const photoSrc = getUploadUrl((s as Record<string, unknown>).photo_url as string | null | undefined)
         return (
           <div className="flex items-center gap-3">
-            {photoSrc ? (
-              <img
-                src={photoSrc}
-                alt={`${s.first_name} ${s.last_name}`}
-                className="h-10 w-10 shrink-0 rounded-lg object-cover border border-border"
-              />
-            ) : (
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 border border-border">
-                <span className="text-xs font-semibold text-primary">{initials}</span>
-              </div>
-            )}
+            <StaffAvatar staff={s} />
             <div className="min-w-0">
               <p className="font-medium truncate">{s.last_name} {s.first_name}</p>
               {s.position && (
@@ -70,36 +128,73 @@ export function StaffTable() {
       accessorKey: "phone",
       header: "Téléphone",
       cell: ({ row }) => (
-        <span className="text-sm text-muted-foreground">{row.original.phone ?? "—"}</span>
+        <span className="text-sm text-muted-foreground tabular-nums">{row.original.phone ?? "—"}</span>
       ),
+    },
+    {
+      id: "contact_actions",
+      header: "Contact",
+      cell: ({ row }) => <ContactActions staff={row.original} />,
     },
   ], [])
 
+  const items = data?.items ?? []
+
   return (
-    <CrudTable<Staff>
-      data={data}
-      columns={columns}
-      isLoading={isLoading}
-      isError={isError}
-      error={error}
-      refetch={refetch}
-      deleteMutation={deleteMutation}
-      onRowClick={(item) => router.push(`/admin/staff/${item.id}`)}
-      renderEditModal={({ itemId, open, onClose }) => (
-        <StaffEditModal staffId={itemId} open={open} onClose={onClose} />
-      )}
-      getItemLabel={(s) => `${s.last_name} ${s.first_name}`}
-      emptyMessage="Aucun personnel trouvé"
-      errorMessage="Impossible de charger le personnel"
-      deleteDescription="Cette action est irréversible. Le membre du personnel sera définitivement supprimé."
-      searchPlaceholder="Rechercher un membre du personnel..."
-      searchValue={search}
-      onSearchChange={(v) => { setSearch(v); setPage(1) }}
-      page={page}
-      onPageChange={setPage}
-      filterConfigs={filterConfigs}
-      filterValues={filters}
-      onFilterChange={handleFilterChange}
-    />
+    <div className="space-y-4">
+      <div className="hidden md:block">
+        <CrudTable<Staff>
+          data={data}
+          columns={columns}
+          isLoading={isLoading}
+          isError={isError}
+          error={error}
+          refetch={refetch}
+          deleteMutation={deleteMutation}
+          onRowClick={(item) => router.push(`/admin/staff/${item.id}`)}
+          renderEditModal={({ itemId, open, onClose }) => (
+            <StaffEditModal staffId={itemId} open={open} onClose={onClose} />
+          )}
+          getItemLabel={(s) => `${s.last_name} ${s.first_name}`}
+          emptyMessage="Aucun personnel trouvé"
+          errorMessage="Impossible de charger le personnel"
+          deleteDescription="Cette action est irréversible. Le membre du personnel sera définitivement supprimé."
+          searchPlaceholder="Rechercher un membre du personnel..."
+          searchValue={search}
+          onSearchChange={(v) => { setSearch(v); setPage(1) }}
+          page={page}
+          onPageChange={setPage}
+          filterConfigs={filterConfigs}
+          filterValues={filters}
+          onFilterChange={handleFilterChange}
+        />
+      </div>
+
+      <div className="space-y-2 md:hidden">
+        {isLoading && (
+          <p className="rounded-lg border bg-muted/30 p-4 text-center text-sm text-muted-foreground">
+            Chargement…
+          </p>
+        )}
+        {!isLoading && items.length === 0 && (
+          <p className="rounded-lg border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+            Aucun personnel trouvé
+          </p>
+        )}
+        {items.map((s) => (
+          <MobileEntityListItem
+            key={s.id}
+            href={`/admin/staff/${s.id}` as Route}
+            avatar={<StaffAvatar staff={s} size="sm" />}
+            primary={
+              <>
+                {s.last_name} {s.first_name}
+              </>
+            }
+            secondary={s.position || (s.phone ? <span className="tabular-nums">{s.phone}</span> : null)}
+          />
+        ))}
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

Finit la cohérence ergonomique : tous les CRUD admin (Students, Teachers, Classes, Staff, Parents) ont maintenant **le même pattern mobile** :
- Table dense desktop (hidden md:block)
- Cards minimalistes mobile (md:hidden) via MobileEntityListItem
- Tap row/card = ouvre la fiche

## Détails par page

### Classes
- ClassesTable : cards mobile avec **capacity pill colorée** (emerald < 80%, amber 80-95%, rose > 95%) → admin spot une classe pleine en un coup d'œil
- ClassesPageClient : toggle Arbre/Table caché sur mobile (l'arbre n'est pas lisible sur 320px), mobile force toujours la vue cards. Ajout aria-pressed sur les boutons toggle.

### Staff
- ContactActions (Appeler/WhatsApp/Email) inline dans table desktop
- MobileEntityListItem sur mobile

### Parents
- ContactActions inline en plus du téléphone (était juste un lien tel:)
- MobileEntityListItem sur mobile + **pastille 'Compte actif' emerald** si `user_id` (parent peut se connecter)

## Test plan

- [x] pnpm exec tsc --noEmit : zéro erreur
- [x] Pas de régression desktop (table identique sauf colonne Contact ajoutée)
- [x] Mobile : 5 CRUD admin (Students, Teachers, Classes, Staff, Parents) ont tous des cards
- [x] Persona Mme Diallo Itel S661 : touch h-9 minimum sur actions, h-11 sur tap row entier
- [x] Stop-propagation OK : tap sur Appeler/WhatsApp/Email ne déclenche pas le navigate-to-detail

Closes #202