### PR TITLE
feat(portals): ergonomy fixes parent/student/teacher persona-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Portail parent — fiche « Mes enfants » : pour chaque enfant non encore inscrit cette année, un encart amber clair explique qu'un enfant est en attente d'inscription, et les boutons Notes/Frais/Emploi du temps sont désactivés avec une infobulle « Disponible après validation de l'inscription ». Les indicateurs Moyenne/Absences/Restant affichent « — » au lieu de chiffres trompeurs *(parent)*.
+- Portail parent — lien Documents officiels : nouveau bouton vers les certificats et attestations d'un enfant *(parent)*.
+- Portail enseignant — vue Emploi du temps adaptée mobile : liste jour par jour avec couleur par matière au lieu de la grille hebdomadaire 7 colonnes qui n'était pas lisible sur Itel S661 *(enseignant)*.
+- Portail enseignant — vue Présences adaptée mobile : cartes par élève avec taux prominent et compteurs présent/absent/retard/excusé en ligne secondaire, au lieu de la table 6 colonnes illisible sous 320 px *(enseignant)*.
+
 - Page Enseignants : boutons d'action inline « Appeler », « WhatsApp » et « Email » à côté du téléphone permettent de joindre un enseignant en un tap, sans passer par sa fiche. Pattern Wave Mobile Money, touch targets adaptés au mobile *(admin)*.
 - Pages Parents et Personnel : mêmes boutons d'action inline « Appeler », « WhatsApp » et « Email » en plus de l'ancien lien téléphone. Le tap ouvre l'application native sans recharger la page *(admin)*.
 - Page Parents : pastille verte « Compte actif » sur les cartes parents qui ont déjà un compte connecté, pour distinguer en un coup d'œil ceux qui peuvent se connecter au portail *(admin)*.
@@ -20,6 +25,11 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Enseignants sur mobile : la liste adopte le même format compact que la page Élèves (avatar + nom + spécialité + chevron), au lieu de la table desktop scrollable. Tap = ouvre la fiche *(admin)*.
 - Pages Classes, Parents et Personnel sur mobile : même format compact avec avatar + nom + sous-titre + chevron, au lieu de la table desktop scrollable. Une pastille colorée d'occupation (vert / amber / rouge) s'affiche à droite de chaque classe pour signaler les classes pleines en un coup d'œil *(admin)*.
 - Page Classes : le sélecteur de vue Arbre / Table est désormais caché sur mobile (l'arbre n'était pas lisible sur petit écran). La vue cartes mobile est affichée automatiquement *(admin)*.
+- Portail parent — page Documents officiels : si l'enfant n'est pas encore inscrit pour l'année courante, un encart amber prévient que les documents ne pourront pas être délivrés tant que l'inscription n'est pas validée, et les boutons de téléchargement affichent « Disponible après inscription » au lieu de générer une erreur 500 *(parent)*.
+- Portail parent — empty state Emploi du temps désambigué : distingue clairement « inscription en attente » (encart amber rassurant) de « pas encore publié par l'administration » (encart neutre) *(parent)*.
+- Portail élève — jours de la semaine de l'emploi du temps affichés en toutes lettres (Lundi, Mardi, …) au lieu d'abréviations à 3 lettres difficiles à lire en plein soleil *(élève)*.
+- Sélecteur de classe sur l'écran Présences enseignant : pleine largeur sur mobile et touch target h-11 (au lieu de h-10 largeur fixe 256 px) *(enseignant)*.
+
 - Formulaire de connexion plus accessible : boutons d'affichage du mot de passe annoncés aux lecteurs d'écran, messages d'alerte (session expirée, erreur d'identifiants) annoncés en temps réel, icônes décoratives masquées aux lecteurs d'écran *(tous)*.
 - Indicateurs du tableau de bord admin annoncés en temps réel aux lecteurs d'écran : chaque carte expose son intitulé + sa valeur (« Élèves inscrits : 42 ») au lieu d'un chiffre orphelin *(admin)*.
 

--- a/components/parent/ChildTimetableClient.tsx
+++ b/components/parent/ChildTimetableClient.tsx
@@ -1,10 +1,12 @@
 "use client"
 
+import { Clock, Calendar } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { useParentChildTimetable } from "@/lib/hooks/useParentPortal"
 import type { ChildTimetableSlot } from "@/lib/api/parent-portal"
+import { isEnrolledFromClassName } from "@/lib/utils/enrollment-status"
 
 const DAYS = ["lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"] as const
 const DAY_LABELS: Record<string, string> = {
@@ -67,9 +69,35 @@ export function ChildTimetableClient({ childId }: ChildTimetableClientProps) {
       ) : isLoading ? (
         <TimetableSkeleton />
       ) : slots.length === 0 ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          Aucun emploi du temps disponible.
-        </div>
+        // Empty state désambigué : distinguer "enfant pas inscrit" vs
+        // "inscrit mais aucun cours cette semaine" pour rassurer le parent.
+        !isEnrolledFromClassName(className) ? (
+          <Card className="border-amber-200 bg-amber-50">
+            <CardContent className="flex flex-col items-center py-10 text-center">
+              <Clock aria-hidden="true" className="mb-3 h-10 w-10 text-amber-500" />
+              <p className="text-sm font-medium text-amber-900">
+                Inscription en attente
+              </p>
+              <p className="mt-1 text-xs text-amber-800">
+                L&apos;emploi du temps apparaîtra ici une fois l&apos;inscription validée
+                par l&apos;administration.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <Card className="bg-muted/30">
+            <CardContent className="flex flex-col items-center py-10 text-center">
+              <Calendar aria-hidden="true" className="mb-3 h-10 w-10 text-muted-foreground/50" />
+              <p className="text-sm text-muted-foreground">
+                Aucun cours programmé cette semaine.
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground/80">
+                L&apos;administration n&apos;a pas encore publié l&apos;emploi du temps. Contactez
+                le secrétariat si la situation persiste.
+              </p>
+            </CardContent>
+          </Card>
+        )
       ) : (
         <div className="space-y-4">
           {DAYS.map((day) => {

--- a/components/parent/ParentChildDocumentsClient.tsx
+++ b/components/parent/ParentChildDocumentsClient.tsx
@@ -1,12 +1,15 @@
 "use client"
 
 import { useState } from "react"
-import { ArrowLeft, Award, FileCheck2, Loader2 } from "lucide-react"
+import { ArrowLeft, Award, FileCheck2, Loader2, Clock } from "lucide-react"
 import Link from "next/link"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
 import { studentDocumentsApi } from "@/lib/api/student-documents"
 import { downloadBlob } from "@/lib/utils"
+import { useParentChildren } from "@/lib/hooks/useParentPortal"
+import { isEnrolledFromClassName } from "@/lib/utils/enrollment-status"
 
 interface ParentChildDocumentsClientProps {
   childId: number
@@ -46,6 +49,16 @@ export function ParentChildDocumentsClient({
   childId,
 }: ParentChildDocumentsClientProps) {
   const [downloading, setDownloading] = useState<DocKind | null>(null)
+  const { data: children } = useParentChildren()
+  const child = children?.find((c) => c.id === childId)
+  // Documents officiels (certificat/attestation) ne sont émis que pour les
+  // élèves dont l'inscription est validée pour l'année courante. Si on tente
+  // de télécharger sur un enfant pas inscrit, le BE répond une erreur peu
+  // exploitable. On affiche un guard explicite pour Mme Aïcha avant le clic.
+  const isEnrolled = child ? isEnrolledFromClassName(child.class_name) : true
+  // isEnrolled est initialisé à `true` tant que children n'est pas chargé
+  // pour ne pas masquer l'UI pendant le fetch initial — le guard apparaît
+  // une fois la donnée arrivée si pertinent.
 
   async function handleDownload(doc: (typeof DOCS)[number]) {
     setDownloading(doc.kind)
@@ -81,10 +94,30 @@ export function ParentChildDocumentsClient({
         </div>
       </div>
 
+      {!isEnrolled && (
+        <Card className="border-amber-200 bg-amber-50">
+          <CardContent className="flex items-start gap-3 py-4">
+            <Clock aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-amber-900">
+                Documents indisponibles pour le moment
+              </p>
+              <p className="text-xs text-amber-800">
+                Les documents officiels (certificat de scolarité, attestation de
+                fréquentation) sont délivrés uniquement pour les élèves dont
+                l&apos;inscription est validée pour l&apos;année courante. Contactez le
+                secrétariat pour finaliser le dossier.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="space-y-3">
         {DOCS.map((doc) => {
           const Icon = doc.icon
           const isDownloading = downloading === doc.kind
+          const disabled = isDownloading || !isEnrolled
           return (
             <div
               key={doc.kind}
@@ -92,7 +125,7 @@ export function ParentChildDocumentsClient({
             >
               <div className="flex items-start gap-3">
                 <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                  <Icon className="h-6 w-6" />
+                  <Icon aria-hidden="true" className="h-6 w-6" />
                 </div>
                 <div className="flex-1 min-w-0">
                   <p className="text-base font-medium">{doc.title}</p>
@@ -104,14 +137,17 @@ export function ParentChildDocumentsClient({
               <Button
                 size="lg"
                 onClick={() => handleDownload(doc)}
-                disabled={isDownloading}
+                disabled={disabled}
+                aria-disabled={disabled}
                 className="h-11 w-full"
               >
                 {isDownloading ? (
                   <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
                     Génération...
                   </>
+                ) : !isEnrolled ? (
+                  "Disponible après inscription"
                 ) : (
                   "Télécharger PDF"
                 )}

--- a/components/parent/ParentChildrenClient.tsx
+++ b/components/parent/ParentChildrenClient.tsx
@@ -1,13 +1,16 @@
 "use client"
 
 import Link from "next/link"
-import { Users, GraduationCap, Wallet, AlertCircle, ChevronRight, FileText } from "lucide-react"
+import type { Route } from "next"
+import { Users, GraduationCap, Wallet, AlertCircle, FileText, Calendar, Clock } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { useParentChildren } from "@/lib/hooks/useParentPortal"
 import type { ParentChild } from "@/lib/contracts/parent-portal"
+import { isEnrolledFromClassName, summarizeEnrollment } from "@/lib/utils/enrollment-status"
+import { cn } from "@/lib/utils"
 
 /** Seuil d'absences au-delà duquel on affiche un avertissement */
 const ABSENCES_WARNING_THRESHOLD = 5
@@ -15,11 +18,22 @@ const ABSENCES_WARNING_THRESHOLD = 5
 export function ParentChildrenClient() {
   const { data: children, isLoading, isError, refetch } = useParentChildren()
 
+  // Subtitle adapté : si tous enfants inscrits → "X enfants", sinon breakdown
+  // "X inscrits · Y en attente" pour clarifier le statut tri-état.
+  const subtitle = (() => {
+    if (!children || children.length === 0) return null
+    const summary = summarizeEnrollment(children)
+    if (summary.pending === 0) {
+      return `${summary.total} enfant${summary.total > 1 ? "s" : ""}`
+    }
+    return `${summary.enrolled} inscrit${summary.enrolled > 1 ? "s" : ""} · ${summary.pending} en attente d'inscription`
+  })()
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="font-serif text-xl tracking-tight">Mes enfants</h1>
-        <p className="text-sm text-muted-foreground">Liste des enfants inscrits</p>
+        {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
       </div>
 
       {isLoading ? (
@@ -27,10 +41,15 @@ export function ParentChildrenClient() {
       ) : isError ? (
         <DataError message="Impossible de charger la liste des enfants." onRetry={() => refetch()} />
       ) : !children || children.length === 0 ? (
-        <div className="py-12 text-center">
-          <Users className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
-          <p className="text-sm text-muted-foreground">Aucun enfant inscrit.</p>
-        </div>
+        <Card className="border-amber-200 bg-amber-50">
+          <CardContent className="flex flex-col items-center py-10 text-center">
+            <Users aria-hidden="true" className="mb-3 h-10 w-10 text-amber-500" />
+            <p className="text-sm font-medium text-amber-900">Aucun enfant rattaché à votre compte.</p>
+            <p className="mt-1 text-xs text-amber-800">
+              Rendez-vous au secrétariat de l&apos;école pour faire le rattachement.
+            </p>
+          </CardContent>
+        </Card>
       ) : (
         <div className="space-y-3">
           {children.map((child) => (
@@ -43,10 +62,12 @@ export function ParentChildrenClient() {
 }
 
 function ChildDetailCard({ child }: { child: ParentChild }) {
+  const isEnrolled = isEnrolledFromClassName(child.class_name)
+
   return (
     <Card className="border-0 shadow-sm ring-1 ring-border">
       <CardContent className="p-4">
-        <div className="flex items-start justify-between mb-3">
+        <div className="mb-3 flex items-start justify-between">
           <div className="flex items-center gap-3">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
               <span className="text-sm font-bold text-primary">
@@ -54,69 +75,150 @@ function ChildDetailCard({ child }: { child: ParentChild }) {
               </span>
             </div>
             <div>
-              <p className="font-semibold text-sm">{child.full_name}</p>
-              <Badge variant="secondary" className="text-[10px]">{child.class_name}</Badge>
+              <p className="text-sm font-semibold">{child.full_name}</p>
+              {isEnrolled ? (
+                <Badge variant="secondary" className="text-[10px]">{child.class_name}</Badge>
+              ) : (
+                <span className="inline-flex h-5 items-center rounded-full bg-amber-100 px-2 text-[10px] font-medium text-amber-800">
+                  En attente d&apos;inscription
+                </span>
+              )}
             </div>
           </div>
         </div>
 
-        {/* Indicateurs */}
-        <div className="grid grid-cols-3 gap-3 mb-3">
+        {/* Banner explicite quand pas inscrit : signal clair à Mme Aïcha,
+            pas de KPIs trompeurs (0 FCFA vert quand rien à payer parce que
+            pas inscrit). Cf. rule `not-enrolled-empty-state.md`. */}
+        {!isEnrolled && (
+          <div role="status" className="mb-3 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+            <Clock aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <p className="text-xs text-amber-900">
+              L&apos;inscription n&apos;est pas encore validée par l&apos;administration. Notes, frais
+              et emploi du temps apparaîtront ici une fois l&apos;inscription confirmée.
+            </p>
+          </div>
+        )}
+
+        {/* Indicateurs : neutralisés à "—" muted gris quand pas inscrit
+            (au lieu de "0 FCFA" vert success qui suggérait à tort
+            "tout est payé !"). */}
+        <div className="mb-3 grid grid-cols-3 gap-3">
           <div className="flex items-center gap-2">
-            <GraduationCap className="h-4 w-4 text-muted-foreground" />
+            <GraduationCap aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
             <div>
-              <p className={`text-sm font-bold ${child.general_average === null ? "text-muted-foreground" : child.general_average >= 10 ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}`}>
-                {child.general_average !== null ? `${child.general_average.toFixed(2)}/20` : "—"}
+              <p className={cn(
+                "text-sm font-bold",
+                !isEnrolled || child.general_average === null
+                  ? "text-muted-foreground"
+                  : child.general_average >= 10
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-destructive",
+              )}>
+                {isEnrolled && child.general_average !== null
+                  ? `${child.general_average.toFixed(2)}/20`
+                  : "—"}
               </p>
               <p className="text-[10px] text-muted-foreground">Moyenne</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <AlertCircle className="h-4 w-4 text-muted-foreground" />
+            <AlertCircle aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
             <div>
-              <p className={`text-sm font-bold ${child.total_absences > ABSENCES_WARNING_THRESHOLD ? "text-accent" : ""}`}>
-                {child.total_absences}
+              <p className={cn(
+                "text-sm font-bold",
+                !isEnrolled
+                  ? "text-muted-foreground"
+                  : child.total_absences > ABSENCES_WARNING_THRESHOLD
+                    ? "text-accent"
+                    : "",
+              )}>
+                {isEnrolled ? child.total_absences : "—"}
               </p>
               <p className="text-[10px] text-muted-foreground">Absences</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <Wallet className="h-4 w-4 text-muted-foreground" />
+            <Wallet aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
             <div>
-              <p className={`text-sm font-bold ${child.fees_remaining > 0 ? "text-accent" : "text-emerald-600 dark:text-emerald-400"}`}>
-                {child.fees_remaining.toLocaleString("fr-FR")} FCFA
+              <p className={cn(
+                "text-sm font-bold",
+                !isEnrolled
+                  ? "text-muted-foreground"
+                  : child.fees_remaining > 0
+                    ? "text-accent"
+                    : "text-emerald-600 dark:text-emerald-400",
+              )}>
+                {isEnrolled ? `${child.fees_remaining.toLocaleString("fr-FR")} FCFA` : "—"}
               </p>
               <p className="text-[10px] text-muted-foreground">Restant</p>
             </div>
           </div>
         </div>
 
-        {/* Actions */}
-        <div className="grid grid-cols-3 gap-2">
-          <Link
-            href={`/parent/children/${child.id}/grades`}
-            className="flex items-center justify-center gap-1 rounded-md bg-primary/5 px-2 py-2.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
-          >
-            <GraduationCap className="h-3.5 w-3.5" />
-            Notes
-          </Link>
-          <Link
-            href={`/parent/children/${child.id}/fees`}
-            className="flex items-center justify-center gap-1 rounded-md bg-primary/5 px-2 py-2.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
-          >
-            <Wallet className="h-3.5 w-3.5" />
-            Frais
-          </Link>
-          <Link
-            href={`/parent/children/${child.id}/documents` as never}
-            className="flex items-center justify-center gap-1 rounded-md bg-primary/5 px-2 py-2.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
-          >
-            <FileText className="h-3.5 w-3.5" />
-            Documents
-          </Link>
+        {/* Actions : 4 liens — Notes / Frais / EDT / Documents. Disabled si
+            pas inscrit (sauf Documents qui ont leur propre fallback côté
+            ParentChildDocumentsClient). */}
+        <div className="grid grid-cols-4 gap-2">
+          <ChildActionLink
+            href={`/parent/children/${child.id}/grades` as Route}
+            icon={GraduationCap}
+            label="Notes"
+            disabled={!isEnrolled}
+          />
+          <ChildActionLink
+            href={`/parent/children/${child.id}/fees` as Route}
+            icon={Wallet}
+            label="Frais"
+            disabled={!isEnrolled}
+          />
+          <ChildActionLink
+            href={`/parent/children/${child.id}/timetable` as Route}
+            icon={Calendar}
+            label="EDT"
+            disabled={!isEnrolled}
+          />
+          <ChildActionLink
+            href={`/parent/children/${child.id}/documents` as Route}
+            icon={FileText}
+            label="Docs"
+            disabled={false}
+          />
         </div>
       </CardContent>
     </Card>
+  )
+}
+
+function ChildActionLink({
+  href,
+  icon: Icon,
+  label,
+  disabled,
+}: {
+  href: Route
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" | "false" }>
+  label: string
+  disabled: boolean
+}) {
+  const baseClasses = "flex items-center justify-center gap-1 rounded-md px-2 py-2.5 text-xs font-medium transition-colors"
+  if (disabled) {
+    return (
+      <span
+        aria-disabled="true"
+        title="Disponible après validation de l'inscription"
+        className={cn(baseClasses, "cursor-not-allowed bg-muted/40 text-muted-foreground")}
+      >
+        <Icon aria-hidden="true" className="h-3.5 w-3.5" />
+        {label}
+      </span>
+    )
+  }
+  return (
+    <Link href={href} className={cn(baseClasses, "bg-primary/5 text-primary hover:bg-primary/10")}>
+      <Icon aria-hidden="true" className="h-3.5 w-3.5" />
+      {label}
+    </Link>
   )
 }
 

--- a/components/student/StudentTimetableClient.tsx
+++ b/components/student/StudentTimetableClient.tsx
@@ -7,13 +7,13 @@ import { useStudentTimetable } from "@/lib/hooks/useStudentPortal"
 import type { TimetableSlot } from "@/lib/contracts/timetable"
 
 const DAYS = ["lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"] as const
-const DAY_LABELS: Record<string, string> = {
-  lundi: "Lun",
-  mardi: "Mar",
-  mercredi: "Mer",
-  jeudi: "Jeu",
-  vendredi: "Ven",
-  samedi: "Sam",
+const DAY_FULL: Record<string, string> = {
+  lundi: "Lundi",
+  mardi: "Mardi",
+  mercredi: "Mercredi",
+  jeudi: "Jeudi",
+  vendredi: "Vendredi",
+  samedi: "Samedi",
 }
 
 // Couleurs par matière pour différencier visuellement
@@ -65,8 +65,8 @@ export function StudentTimetableClient() {
             if (daySlots.length === 0) return null
             return (
               <div key={day}>
-                <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-                  {DAY_LABELS[day]}
+                <h2 className="mb-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+                  {DAY_FULL[day]}
                 </h2>
                 <div className="space-y-2">
                   {daySlots.map((slot) => (

--- a/components/teacher/TeacherAttendanceClient.tsx
+++ b/components/teacher/TeacherAttendanceClient.tsx
@@ -32,7 +32,7 @@ export function TeacherAttendanceClient() {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-          <ClipboardCheck className="h-5 w-5 text-primary" />
+          <ClipboardCheck aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
         <div>
           <h1 className="font-serif text-2xl tracking-tight">Présences</h1>
@@ -47,13 +47,13 @@ export function TeacherAttendanceClient() {
         </CardHeader>
         <CardContent>
           {loadingClasses ? (
-            <Skeleton className="h-10 w-64" />
+            <Skeleton className="h-11 w-full sm:w-64" />
           ) : (
             <Select
               value={selectedClassId?.toString() ?? ""}
               onValueChange={(v) => setSelectedClassId(Number(v))}
             >
-              <SelectTrigger className="w-64">
+              <SelectTrigger className="h-11 w-full sm:h-10 sm:w-64" aria-label="Choisir une classe">
                 <SelectValue placeholder="Choisir une classe" />
               </SelectTrigger>
               <SelectContent>
@@ -92,34 +92,64 @@ export function TeacherAttendanceClient() {
                 ))}
               </div>
             ) : stats && stats.students.length > 0 ? (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Élève</TableHead>
-                    <TableHead className="text-center">Présent</TableHead>
-                    <TableHead className="text-center">Absent</TableHead>
-                    <TableHead className="text-center">Retard</TableHead>
-                    <TableHead className="text-center">Excusé</TableHead>
-                    <TableHead className="text-right">Taux</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {stats.students.map((s) => (
-                    <TableRow key={s.student_id}>
-                      <TableCell className="font-medium">{s.last_name} {s.first_name}</TableCell>
-                      <TableCell className="text-center">{s.present_count}</TableCell>
-                      <TableCell className="text-center">{s.absent_count}</TableCell>
-                      <TableCell className="text-center">{s.late_count}</TableCell>
-                      <TableCell className="text-center">{s.excused_count}</TableCell>
-                      <TableCell className="text-right">
-                        <Badge variant={s.attendance_rate >= 90 ? "default" : s.attendance_rate >= 75 ? "secondary" : "destructive"}>
-                          {s.attendance_rate.toFixed(1)}%
-                        </Badge>
-                      </TableCell>
+              <>
+              {/* Desktop : table dense 6 colonnes (Élève / 4 compteurs / Taux). */}
+              <div className="hidden md:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Élève</TableHead>
+                      <TableHead className="text-center">Présent</TableHead>
+                      <TableHead className="text-center">Absent</TableHead>
+                      <TableHead className="text-center">Retard</TableHead>
+                      <TableHead className="text-center">Excusé</TableHead>
+                      <TableHead className="text-right">Taux</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {stats.students.map((s) => (
+                      <TableRow key={s.student_id}>
+                        <TableCell className="font-medium">{s.last_name} {s.first_name}</TableCell>
+                        <TableCell className="text-center">{s.present_count}</TableCell>
+                        <TableCell className="text-center">{s.absent_count}</TableCell>
+                        <TableCell className="text-center">{s.late_count}</TableCell>
+                        <TableCell className="text-center">{s.excused_count}</TableCell>
+                        <TableCell className="text-right">
+                          <Badge variant={s.attendance_rate >= 90 ? "default" : s.attendance_rate >= 75 ? "secondary" : "destructive"}>
+                            {s.attendance_rate.toFixed(1)}%
+                          </Badge>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              {/* Mobile : cards par élève avec taux prominent, compteurs en
+                  ligne secondaire. Plus lisible que la table 6 colonnes
+                  qui se compresse sous 320px (rule UX target user Itel S661). */}
+              <div className="space-y-2 md:hidden">
+                {stats.students.map((s) => (
+                  <div key={s.student_id} className="flex items-start justify-between gap-3 rounded-lg border bg-card p-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium">{s.last_name} {s.first_name}</p>
+                      <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground tabular-nums">
+                        <span>✓ {s.present_count}</span>
+                        <span className="text-rose-600">✗ {s.absent_count}</span>
+                        <span className="text-amber-600">↻ {s.late_count}</span>
+                        <span>– {s.excused_count}</span>
+                      </div>
+                    </div>
+                    <Badge
+                      variant={s.attendance_rate >= 90 ? "default" : s.attendance_rate >= 75 ? "secondary" : "destructive"}
+                      className="shrink-0 tabular-nums"
+                    >
+                      {s.attendance_rate.toFixed(1)}%
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+              </>
             ) : (
               <p className="py-6 text-center text-sm text-muted-foreground">
                 Aucune session de présence enregistrée pour cette classe.

--- a/components/teacher/timetable/TeacherScheduleView.tsx
+++ b/components/teacher/timetable/TeacherScheduleView.tsx
@@ -126,7 +126,48 @@ export function TeacherScheduleView({ teacherId }: TeacherScheduleViewProps) {
   const hours = Array.from({ length: END_HOUR - START_HOUR }, (_, i) => START_HOUR + i)
 
   return (
-    <div className="rounded-lg border bg-card overflow-x-auto">
+    <>
+    {/* Mobile : liste jour-par-jour, plus lisible sur Itel S661 que la grille
+        7 colonnes 900px qui necessite un scroll horizontal invisible. */}
+    <div className="space-y-4 md:hidden">
+      {DAYS.map((day) => {
+        const daySlots = slotsByDay[day]
+        if (!daySlots || daySlots.length === 0) return null
+        return (
+          <div key={day}>
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+              {DAY_LABELS[day]}
+            </h2>
+            <div className="space-y-2">
+              {daySlots.map((slot) => (
+                <div
+                  key={slot.id}
+                  className={cn(
+                    "flex items-center gap-3 rounded-lg border p-3",
+                    SLOT_COLORS[slot.subject_id % SLOT_COLORS.length],
+                  )}
+                >
+                  <div className="min-w-[58px] text-center">
+                    <p className="text-xs font-bold tabular-nums">{slot.start_time}</p>
+                    <p className="text-[10px] opacity-70 tabular-nums">{slot.end_time}</p>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-semibold">{slot.subject_name}</p>
+                    <p className="truncate text-[11px] opacity-75">
+                      {slot.class_name}
+                      {slot.room && ` • ${slot.room}`}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+
+    {/* Desktop : grille hebdo absolue 7 colonnes (900px). */}
+    <div className="hidden rounded-lg border bg-card overflow-x-auto md:block">
       <div className="min-w-[900px]">
         {/* Header */}
         <div className="grid grid-cols-7 border-b bg-muted/30">
@@ -208,5 +249,6 @@ export function TeacherScheduleView({ teacherId }: TeacherScheduleViewProps) {
         </div>
       </div>
     </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

Audit ergonomique de la session `/klassci-e2e-test` 2026-05-21 a identifié 6 bugs persona-first dans les 3 portails consommateurs. Ce PR les fixe tous.

### Parent (Mme Aïcha)
1. **ParentChildrenClient** : Label trompeur, KPIs vert sur enfant pas inscrit → banner amber + KPIs '—' neutres + actions disabled
2. **ParentChildDocumentsClient** : Aucun guard non-inscrit → banner + boutons disabled 'Disponible après inscription'
3. **ChildTimetableClient** : Empty state ambigu (3 causes même message) → désambigué 'Inscription en attente' (amber) vs 'Pas encore publié' (neutre)

### Teacher (Mme Diallo)
4. **TeacherScheduleView** : Grid 900px invisible sur Itel S661 → vue mobile day-stacked + desktop grille préservée
5. **TeacherAttendanceClient** : Table 6 colonnes illisible mobile → cards avec taux prominent + compteurs ligne 2 + SelectTrigger plein-width h-11

### Student
6. **StudentTimetableClient** : DAY_LABELS 3-char abbrev → labels complets 'Lundi/Mardi/...'

## Test plan

- [x] pnpm tsc --noEmit zéro erreur
- [x] Persona parent (Mariam) : Aminata inscrite → KPIs colorés, actions actives. Si on simule `class_name="—"` : banner + KPIs gris + actions disabled
- [x] Persona teacher (Aïssatou) : sur mobile (devtools 412px), liste day-stacked au lieu de scroll horizontal invisible
- [x] Persona student (Aminata) : 'Lundi' lisible au lieu de 'Lun'

Closes #204