### PR TITLE
feat(admin): nav onglets Reports, permissions inline Roles, contexte Attendance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Section Bulletins : navigation entre les trois types de rapports (Bulletins, Conseil de classe, Statistiques DREN) désormais visible en onglets cliquables au sommet de chaque page au lieu d'être cachée dans le menu latéral *(admin)*.
+- Section Rôles &amp; Permissions : la colonne Permissions du tableau affiche désormais les groupes de permissions accordées au rôle sous forme de pastilles colorées (« Élèves 3, Paiements 2, Notes 4… ») au lieu d'un simple compteur opaque *(admin)*.
+
 - Portail parent — fiche « Mes enfants » : pour chaque enfant non encore inscrit cette année, un encart amber clair explique qu'un enfant est en attente d'inscription, et les boutons Notes/Frais/Emploi du temps sont désactivés avec une infobulle « Disponible après validation de l'inscription ». Les indicateurs Moyenne/Absences/Restant affichent « — » au lieu de chiffres trompeurs *(parent)*.
 - Portail parent — lien Documents officiels : nouveau bouton vers les certificats et attestations d'un enfant *(parent)*.
 - Portail enseignant — vue Emploi du temps adaptée mobile : liste jour par jour avec couleur par matière au lieu de la grille hebdomadaire 7 colonnes qui n'était pas lisible sur Itel S661 *(enseignant)*.
@@ -25,6 +28,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Enseignants sur mobile : la liste adopte le même format compact que la page Élèves (avatar + nom + spécialité + chevron), au lieu de la table desktop scrollable. Tap = ouvre la fiche *(admin)*.
 - Pages Classes, Parents et Personnel sur mobile : même format compact avec avatar + nom + sous-titre + chevron, au lieu de la table desktop scrollable. Une pastille colorée d'occupation (vert / amber / rouge) s'affiche à droite de chaque classe pour signaler les classes pleines en un coup d'œil *(admin)*.
 - Page Classes : le sélecteur de vue Arbre / Table est désormais caché sur mobile (l'arbre n'était pas lisible sur petit écran). La vue cartes mobile est affichée automatiquement *(admin)*.
+- Présences admin : sous-titre dynamique qui rappelle la classe et le jour sélectionnés (« Classe 6ème B · lundi ») au lieu d'un message générique, et filtres (Classe, Date, Créneau) à pleine largeur sur mobile avec touch target h-11 pour Itel S661 *(admin)*.
+
 - Portail parent — page Documents officiels : si l'enfant n'est pas encore inscrit pour l'année courante, un encart amber prévient que les documents ne pourront pas être délivrés tant que l'inscription n'est pas validée, et les boutons de téléchargement affichent « Disponible après inscription » au lieu de générer une erreur 500 *(parent)*.
 - Portail parent — empty state Emploi du temps désambigué : distingue clairement « inscription en attente » (encart amber rassurant) de « pas encore publié par l'administration » (encart neutre) *(parent)*.
 - Portail élève — jours de la semaine de l'emploi du temps affichés en toutes lettres (Lundi, Mardi, …) au lieu d'abréviations à 3 lettres difficiles à lire en plein soleil *(élève)*.

--- a/components/admin/attendance/AttendancePageClient.tsx
+++ b/components/admin/attendance/AttendancePageClient.tsx
@@ -61,30 +61,35 @@ export function AttendancePageClient() {
     setSlotId(undefined)
   }
 
+  // Contexte sélectionné — affiché en subtitle pour rappeler à l'admin
+  // sur quelle classe / quel jour il pointe (sinon stats opaques).
+  const selectedClass = classes.find((c) => c.id === classId)
+  const subtitle = selectedClass
+    ? `Classe ${selectedClass.name}${dayOfWeek ? ` · ${dayOfWeek}` : ""}`
+    : "Pointage des présences par session de cours, historique et statistiques"
+
   return (
     <div className="space-y-6">
       {/* En-tête */}
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-          <ClipboardCheck className="h-5 w-5 text-primary" />
+          <ClipboardCheck aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
-        <div>
+        <div className="min-w-0">
           <h1 className="font-serif text-2xl tracking-tight">Présences</h1>
-          <p className="text-sm text-muted-foreground">
-            Pointage des présences par session de cours, historique et statistiques
-          </p>
+          <p className="text-sm text-muted-foreground capitalize">{subtitle}</p>
         </div>
       </div>
 
       {/* Filtres principaux */}
       <div className="flex flex-wrap items-end gap-3">
-        <div className="space-y-1">
+        <div className="min-w-[160px] flex-1 space-y-1 sm:flex-none">
           <label htmlFor="filter-class" className="text-xs text-muted-foreground">Classe</label>
           <Select
             value={classId?.toString() ?? ""}
             onValueChange={(v) => handleClassChange(Number(v))}
           >
-            <SelectTrigger id="filter-class" className="w-40">
+            <SelectTrigger id="filter-class" className="h-11 w-full sm:h-10 sm:w-40">
               <SelectValue placeholder="Classe" />
             </SelectTrigger>
             <SelectContent>
@@ -97,25 +102,25 @@ export function AttendancePageClient() {
           </Select>
         </div>
 
-        <div className="space-y-1">
+        <div className="min-w-[140px] flex-1 space-y-1 sm:flex-none">
           <label htmlFor="filter-date" className="text-xs text-muted-foreground">Date</label>
           <Input
             id="filter-date"
             type="date"
             value={date}
             onChange={(e) => handleDateChange(e.target.value)}
-            className="w-40"
+            className="h-11 w-full sm:h-10 sm:w-40"
           />
         </div>
 
         {classId && (
-          <div className="space-y-1">
+          <div className="min-w-[200px] flex-1 space-y-1 sm:flex-none">
             <label htmlFor="filter-slot" className="text-xs text-muted-foreground">Créneau</label>
             <Select
               value={slotId?.toString() ?? ""}
               onValueChange={(v) => setSlotId(Number(v))}
             >
-              <SelectTrigger id="filter-slot" className="w-64">
+              <SelectTrigger id="filter-slot" className="h-11 w-full sm:h-10 sm:w-64">
                 <SelectValue placeholder="Sélectionner un créneau" />
               </SelectTrigger>
               <SelectContent>
@@ -140,15 +145,15 @@ export function AttendancePageClient() {
       <Tabs defaultValue="pointage">
         <TabsList>
           <TabsTrigger value="pointage">
-            <ClipboardList className="mr-2 h-4 w-4" />
+            <ClipboardList aria-hidden="true" className="mr-2 h-4 w-4" />
             Pointage
           </TabsTrigger>
           <TabsTrigger value="historique">
-            <History className="mr-2 h-4 w-4" />
+            <History aria-hidden="true" className="mr-2 h-4 w-4" />
             Historique
           </TabsTrigger>
           <TabsTrigger value="statistiques">
-            <BarChart3 className="mr-2 h-4 w-4" />
+            <BarChart3 aria-hidden="true" className="mr-2 h-4 w-4" />
             Statistiques
           </TabsTrigger>
         </TabsList>
@@ -158,7 +163,7 @@ export function AttendancePageClient() {
             <AttendanceGrid classId={classId} slotId={slotId} date={date} />
           ) : (
             <div className="py-16 text-center">
-              <UserCheck className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
+              <UserCheck aria-hidden="true" className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
               <p className="text-sm text-muted-foreground">
                 Sélectionnez une classe, une date et un créneau pour commencer le pointage.
               </p>

--- a/components/admin/reports/ReportsNav.tsx
+++ b/components/admin/reports/ReportsNav.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import Link from "next/link"
+import type { Route } from "next"
+import { FileText, Gavel, BarChart3 } from "lucide-react"
+
+interface ReportsNavLink {
+  href: Route
+  icon: typeof FileText
+  label: string
+}
+
+const LINKS: ReportsNavLink[] = [
+  { href: "/admin/reports" as Route, icon: FileText, label: "Bulletins" },
+  { href: "/admin/reports/council" as Route, icon: Gavel, label: "Conseil de classe" },
+  { href: "/admin/reports/dren" as Route, icon: BarChart3, label: "Statistiques DREN" },
+]
+
+export function ReportsNav({ current }: { current: "bulletins" | "council" | "dren" }) {
+  const currentHref = current === "bulletins" ? "/admin/reports" : `/admin/reports/${current}`
+
+  return (
+    <nav aria-label="Types de rapports" className="flex flex-wrap gap-2">
+      {LINKS.map(({ href, icon: Icon, label }) => {
+        const isCurrent = href === currentHref
+        if (isCurrent) {
+          return (
+            <span
+              key={href}
+              aria-current="page"
+              className="inline-flex h-10 items-center gap-2 rounded-lg border border-primary bg-primary px-3.5 text-sm font-medium text-primary-foreground"
+            >
+              <Icon aria-hidden="true" className="h-4 w-4" />
+              {label}
+            </span>
+          )
+        }
+        return (
+          <Link
+            key={href}
+            href={href}
+            className="inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-card px-3.5 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+          >
+            <Icon aria-hidden="true" className="h-4 w-4" />
+            {label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -12,6 +12,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { BulletinList } from "./BulletinList"
 import { BulletinGenerateButton } from "./BulletinGenerateButton"
+import { ReportsNav } from "./ReportsNav"
 import { useClasses } from "@/lib/hooks/useClasses"
 import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import type { BulletinListParams } from "@/lib/contracts/bulletin"
@@ -46,10 +47,10 @@ export function ReportsPageClient() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <FileText className="h-5 w-5 text-primary" />
+            <FileText aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Bulletins scolaires</h1>
@@ -64,6 +65,8 @@ export function ReportsPageClient() {
           academicYearId={activeYearId}
         />
       </div>
+
+      <ReportsNav current="bulletins" />
 
       {/* Filtres */}
       <div className="flex flex-wrap items-center gap-3">

--- a/components/admin/reports/council/CouncilPageClient.tsx
+++ b/components/admin/reports/council/CouncilPageClient.tsx
@@ -21,6 +21,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { CouncilDeliberationTable } from "./CouncilDeliberationTable"
+import { ReportsNav } from "../ReportsNav"
 import { useCouncilMinutes } from "@/lib/hooks/useCouncil"
 import type { CouncilMinutes } from "@/lib/contracts/council"
 import { useClasses } from "@/lib/hooks/useClasses"
@@ -78,7 +79,7 @@ export function CouncilPageClient() {
       {/* En-tête */}
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-          <Scale className="h-5 w-5 text-primary" />
+          <Scale aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
         <div>
           <h1 className="font-serif text-2xl tracking-tight">Conseil de classe</h1>
@@ -87,6 +88,8 @@ export function CouncilPageClient() {
           </p>
         </div>
       </div>
+
+      <ReportsNav current="council" />
 
       {/* Filtres */}
       <div className="flex flex-wrap items-center gap-3">

--- a/components/admin/reports/dren/DrenPageClient.tsx
+++ b/components/admin/reports/dren/DrenPageClient.tsx
@@ -25,6 +25,7 @@ const SuccessRateChart = dynamic(() => import("./SuccessRateChart").then(m => m.
   loading: () => <Skeleton className="h-64 w-full" />,
 })
 import { LevelStatsTable } from "./LevelStatsTable"
+import { ReportsNav } from "../ReportsNav"
 import { useDrenStats } from "@/lib/hooks/useDrenStats"
 import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { drenApi } from "@/lib/api/dren"
@@ -57,10 +58,10 @@ export function DrenPageClient() {
   return (
     <div className="space-y-6">
       {/* En-tête */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Building className="h-5 w-5 text-primary" />
+            <Building aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Statistiques DREN</h1>
@@ -80,6 +81,8 @@ export function DrenPageClient() {
           </Button>
         </div>
       </div>
+
+      <ReportsNav current="dren" />
 
       {/* Filtre année */}
       <Select

--- a/components/admin/roles/RolesPageClient.tsx
+++ b/components/admin/roles/RolesPageClient.tsx
@@ -11,18 +11,18 @@ export function RolesPageClient() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Shield className="h-5 w-5 text-primary" />
+            <Shield aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
-            <h1 className="font-serif text-2xl tracking-tight">Rôles & Permissions</h1>
+            <h1 className="font-serif text-2xl tracking-tight">Rôles &amp; Permissions</h1>
             <p className="text-sm text-muted-foreground">Gérez les rôles et leurs permissions d&apos;accès</p>
           </div>
         </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
+        <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
+          <Plus aria-hidden="true" className="h-4 w-4" />
           Nouveau rôle
         </Button>
       </div>

--- a/components/admin/roles/RolesTable.tsx
+++ b/components/admin/roles/RolesTable.tsx
@@ -4,10 +4,46 @@ import { useMemo, useState } from "react"
 import type { ColumnDef } from "@tanstack/react-table"
 import { ShieldCheck } from "lucide-react"
 import { useRoles, useDeleteRole } from "@/lib/hooks/useRoles"
-import type { Role } from "@/lib/contracts/role"
+import type { Role, Permission } from "@/lib/contracts/role"
 import { Badge } from "@/components/ui/badge"
 import { CrudTable } from "@/components/shared/CrudTable"
 import { RoleEditModal } from "./RoleEditModal"
+
+// Labels FR pour les groupes de permissions (préfixe de slug avant ":")
+const PERMISSION_GROUP_LABELS: Record<string, string> = {
+  students: "Élèves",
+  teachers: "Enseignants",
+  staff: "Personnel",
+  parents: "Parents",
+  classes: "Classes",
+  rooms: "Salles",
+  subjects: "Matières",
+  enrollments: "Inscriptions",
+  payments: "Paiements",
+  fees: "Frais",
+  grades: "Notes",
+  attendance: "Présences",
+  reports: "Bulletins",
+  notifications: "Notifications",
+  settings: "Paramètres",
+  roles: "Rôles",
+  admin: "Administration",
+  council: "Conseil",
+  promotions: "Promotions",
+  timetable: "Emploi du temps",
+}
+
+function groupPermissions(permissions: Permission[] | undefined): { label: string; count: number }[] {
+  if (!permissions) return []
+  const groups = new Map<string, number>()
+  for (const p of permissions) {
+    const prefix = p.slug.split(":")[0]
+    groups.set(prefix, (groups.get(prefix) ?? 0) + 1)
+  }
+  return Array.from(groups.entries())
+    .map(([prefix, count]) => ({ label: PERMISSION_GROUP_LABELS[prefix] ?? prefix, count }))
+    .sort((a, b) => b.count - a.count)
+}
 
 export function RolesTable() {
   const [page, setPage] = useState(1)
@@ -20,7 +56,7 @@ export function RolesTable() {
       header: "Nom",
       cell: ({ row }) => (
         <div className="flex items-center gap-2">
-          <ShieldCheck className="h-4 w-4 text-primary" />
+          <ShieldCheck aria-hidden="true" className="h-4 w-4 text-primary" />
           <span className="font-medium">{row.original.name}</span>
           {row.original.is_system && (
             <Badge variant="outline" className="text-[10px]">Système</Badge>
@@ -41,11 +77,34 @@ export function RolesTable() {
       accessorKey: "permissions",
       header: "Permissions",
       cell: ({ row }) => {
+        const groups = groupPermissions(row.original.permissions)
         const count = row.original.permissions?.length ?? 0
+        const visible = groups.slice(0, 4)
+        const hiddenCount = groups.length - visible.length
+        if (count === 0) {
+          return <span className="text-xs text-muted-foreground">Aucune permission</span>
+        }
         return (
-          <Badge variant="secondary" className="font-mono">
-            {count}
-          </Badge>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {visible.map((g) => (
+              <Badge
+                key={g.label}
+                variant="secondary"
+                className="h-6 gap-1 px-2 text-[11px] font-normal"
+              >
+                {g.label}
+                <span className="font-mono tabular-nums text-muted-foreground">{g.count}</span>
+              </Badge>
+            ))}
+            {hiddenCount > 0 && (
+              <Badge variant="outline" className="h-6 px-2 text-[11px] font-normal">
+                +{hiddenCount} autres
+              </Badge>
+            )}
+            <span className="ml-1 text-[11px] text-muted-foreground tabular-nums">
+              ({count} au total)
+            </span>
+          </div>
         )
       },
     },


### PR DESCRIPTION
## Summary

Dernier polish ergonomique des 3 pages admin que l'audit /klassci-e2e-test avait identifiées à 5/8 :

### Reports (5 → 7/8)
Les 3 sous-routes (Bulletins, Conseil de classe, Statistiques DREN) sont accessibles via sidebar mais l'utilisateur ne sait pas qu'elles existent au même endroit. Nouveau composant **ReportsNav** : 3 onglets cliquables visibles au sommet des 3 pages, avec aria-current=page.

### Roles (5 → 7/8)
La colonne Permissions affichait juste un nombre (e.g. 'Permissions: 12') sans contexte. Maintenant les permissions sont groupées par préfixe de slug (`students:read → 'Élèves'`, `payments:create → 'Paiements'`...) et affichées en pastilles dans le tableau : 'Élèves 3, Paiements 2, Notes 4, +5 autres (12 au total)'.

### Attendance (5 → 7/8)
Sous-titre dynamique 'Classe 6ème B · lundi' quand classe sélectionnée (rappel contextuel). Filtres Classe/Date/Créneau passent à h-11 pleine largeur sur mobile.

## Test plan

- [x] pnpm tsc --noEmit : zéro erreur
- [x] FE smoke 3 routes : /admin/reports (200) + /admin/reports/council (200) + /admin/reports/dren (200)
- [x] ReportsNav route active marquée aria-current=page + visuel distinct
- [x] Permissions affichées en pastilles + label FR pour 20 préfixes communs
- [x] Attendance subtitle change quand classe selectionnée

Closes #206