### PR TITLE
feat(portals): polish sub-pages student + parent mobile + a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Portail élève — historique de présence sur mobile : la table 4 colonnes est remplacée par des cartes verticales avec jour en clair, heure d'arrivée, notes éventuelles et badge statut coloré. Les boutons de pagination passent à h-11 et reçoivent un aria-label *(élève)*.
+- Portail élève — bulletins : empty state plus rassurant qui explique « Vos bulletins apparaîtront ici après publication par l'administration » au lieu d'une phrase opaque. Bouton PDF passe à h-11 mobile + toast succès au téléchargement *(élève)*.
+- Portail parent — bulletins : flèche retour passe à h-11 mobile (touch target Itel S661), boutons PDF h-11 mobile avec aria-label explicite. Empty state explique quand les bulletins apparaîtront *(parent)*.
+- Portail parent — pages Notes et Frais : flèche retour passe à h-11 mobile pour une meilleure ergonomie sur petit écran *(parent)*.
+
 - Section Bulletins : navigation entre les trois types de rapports (Bulletins, Conseil de classe, Statistiques DREN) désormais visible en onglets cliquables au sommet de chaque page au lieu d'être cachée dans le menu latéral *(admin)*.
 - Section Rôles &amp; Permissions : la colonne Permissions du tableau affiche désormais les groupes de permissions accordées au rôle sous forme de pastilles colorées (« Élèves 3, Paiements 2, Notes 4… ») au lieu d'un simple compteur opaque *(admin)*.
 

--- a/components/parent/ParentChildBulletinsClient.tsx
+++ b/components/parent/ParentChildBulletinsClient.tsx
@@ -44,13 +44,14 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
       <div className="flex items-center gap-3">
         <Link
           href="/parent/children"
-          className="flex h-9 w-9 items-center justify-center rounded-lg border hover:bg-muted"
+          aria-label="Retour à la liste des enfants"
+          className="flex h-11 w-11 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
         >
-          <ArrowLeft className="h-4 w-4" />
+          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
         </Link>
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <FileText className="h-5 w-5 text-primary" />
+            <FileText aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Bulletins</h1>
@@ -97,7 +98,7 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
                 </div>
                 {bulletin.mention && (
                   <div className="flex items-center gap-2">
-                    <Award className="h-4 w-4 text-amber-500" />
+                    <Award aria-hidden="true" className="h-4 w-4 text-amber-500" />
                     <span className="text-sm font-medium">{bulletin.mention}</span>
                   </div>
                 )}
@@ -105,14 +106,15 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
                   <Button
                     size="sm"
                     variant="outline"
-                    className="w-full"
                     onClick={() => handleDownload(bulletin.id)}
                     disabled={downloadingId === bulletin.id}
+                    aria-label={`Télécharger le bulletin du trimestre ${bulletin.trimester} en PDF`}
+                    className="h-11 w-full sm:h-9"
                   >
                     {downloadingId === bulletin.id ? (
-                      <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                      <Loader2 aria-hidden="true" className="mr-1.5 h-4 w-4 animate-spin" />
                     ) : (
-                      <Download className="mr-1 h-3 w-3" />
+                      <Download aria-hidden="true" className="mr-1.5 h-4 w-4" />
                     )}
                     Télécharger PDF
                   </Button>
@@ -124,8 +126,12 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
       ) : (
         <Card className="border-0 shadow-sm ring-1 ring-border">
           <CardContent className="py-12 text-center">
-            <FileText className="mx-auto h-10 w-10 text-muted-foreground/50" />
+            <FileText aria-hidden="true" className="mx-auto h-10 w-10 text-muted-foreground/50" />
             <p className="mt-3 text-sm text-muted-foreground">Aucun bulletin disponible.</p>
+            <p className="mt-1 text-xs text-muted-foreground/80">
+              Les bulletins apparaîtront ici à la fin de chaque trimestre, une fois
+              publiés par l&apos;administration.
+            </p>
           </CardContent>
         </Card>
       )}

--- a/components/parent/ParentChildFeesClient.tsx
+++ b/components/parent/ParentChildFeesClient.tsx
@@ -37,9 +37,9 @@ export function ParentChildFeesClient({ childId }: ParentChildFeesClientProps) {
         <Link
           href="/parent/children"
           aria-label="Retour à la liste des enfants"
-          className="flex h-8 w-8 items-center justify-center rounded-md border hover:bg-muted transition-colors"
+          className="flex h-11 w-11 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
         >
-          <ArrowLeft className="h-4 w-4" />
+          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
         </Link>
         <div>
           <h1 className="font-serif text-xl tracking-tight">

--- a/components/parent/ParentChildGradesClient.tsx
+++ b/components/parent/ParentChildGradesClient.tsx
@@ -54,9 +54,9 @@ export function ParentChildGradesClient({ childId }: ParentChildGradesClientProp
         <Link
           href="/parent/children"
           aria-label="Retour à la liste des enfants"
-          className="flex h-8 w-8 items-center justify-center rounded-md border hover:bg-muted transition-colors"
+          className="flex h-11 w-11 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
         >
-          <ArrowLeft className="h-4 w-4" />
+          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
         </Link>
         <div>
           <h1 className="font-serif text-xl tracking-tight">

--- a/components/student/StudentAttendanceClient.tsx
+++ b/components/student/StudentAttendanceClient.tsx
@@ -46,7 +46,7 @@ export function StudentAttendanceClient() {
       {/* Header */}
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-          <ClipboardCheck className="h-5 w-5 text-primary" />
+          <ClipboardCheck aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
         <div>
           <h1 className="font-serif text-xl tracking-tight">Présences</h1>
@@ -63,7 +63,10 @@ export function StudentAttendanceClient() {
             setPage(1)
           }}
         >
-          <SelectTrigger className="w-44">
+          <SelectTrigger
+            aria-label="Filtrer par statut"
+            className="h-11 w-full sm:h-10 sm:w-44"
+          >
             <SelectValue placeholder="Statut" />
           </SelectTrigger>
           <SelectContent>
@@ -81,12 +84,13 @@ export function StudentAttendanceClient() {
       ) : isError ? (
         <DataError message="Impossible de charger les présences." onRetry={() => refetch()} />
       ) : !data || data.items.length === 0 ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          Aucun enregistrement de présence.
+        <div className="rounded-lg border bg-muted/30 py-12 text-center text-sm text-muted-foreground">
+          Aucun enregistrement de présence pour le moment.
         </div>
       ) : (
         <>
-          <div className="rounded-lg border">
+          {/* Desktop : table dense */}
+          <div className="hidden rounded-lg border md:block">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -127,22 +131,64 @@ export function StudentAttendanceClient() {
             </Table>
           </div>
 
-          {/* Pagination */}
+          {/* Mobile : cards date-prominent avec badge statut */}
+          <div className="space-y-2 md:hidden">
+            {data.items.map((record) => {
+              const config = getStatusConfig(record.status)
+              return (
+                <div key={record.id} className="rounded-lg border bg-card p-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium capitalize">
+                        {new Date(record.created_at).toLocaleDateString("fr-FR", {
+                          weekday: "long",
+                          day: "numeric",
+                          month: "long",
+                        })}
+                      </p>
+                      {record.time_in && (
+                        <p className="text-[11px] text-muted-foreground tabular-nums">
+                          Arrivée à {record.time_in}
+                        </p>
+                      )}
+                      {record.notes && (
+                        <p className="mt-1 truncate text-[11px] text-muted-foreground">
+                          {record.notes}
+                        </p>
+                      )}
+                    </div>
+                    <Badge
+                      variant={config.variant}
+                      className={`shrink-0 text-[10px] ${config.className ?? ""}`}
+                    >
+                      {config.label}
+                    </Badge>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Pagination — touch targets h-11 sur mobile */}
           {data.total > data.size && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-muted-foreground">
+              <span className="text-muted-foreground tabular-nums">
                 Page {data.page} sur {Math.ceil(data.total / data.size)}
               </span>
               <div className="flex gap-2">
                 <button
-                  className="px-3 py-1.5 rounded-md border text-sm disabled:opacity-50"
+                  type="button"
+                  aria-label="Page précédente"
+                  className="inline-flex h-11 items-center rounded-md border bg-card px-4 text-sm font-medium transition-colors hover:bg-muted disabled:opacity-50 sm:h-9 sm:px-3"
                   disabled={data.page <= 1}
                   onClick={() => setPage((p) => Math.max(1, p - 1))}
                 >
                   Précédent
                 </button>
                 <button
-                  className="px-3 py-1.5 rounded-md border text-sm disabled:opacity-50"
+                  type="button"
+                  aria-label="Page suivante"
+                  className="inline-flex h-11 items-center rounded-md border bg-card px-4 text-sm font-medium transition-colors hover:bg-muted disabled:opacity-50 sm:h-9 sm:px-3"
                   disabled={data.page >= Math.ceil(data.total / data.size)}
                   onClick={() => setPage((p) => p + 1)}
                 >

--- a/components/student/StudentBulletinsClient.tsx
+++ b/components/student/StudentBulletinsClient.tsx
@@ -28,10 +28,13 @@ export function StudentBulletinsClient() {
       ) : isError ? (
         <DataError message="Impossible de charger les bulletins." onRetry={() => refetch()} />
       ) : !bulletins || bulletins.length === 0 ? (
-        <div className="py-12 text-center">
-          <FileText className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
+        <div className="rounded-lg border bg-muted/30 py-12 text-center">
+          <FileText aria-hidden="true" className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
           <p className="text-sm text-muted-foreground">
             Aucun bulletin publié pour le moment.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground/80">
+            Vos bulletins apparaîtront ici après publication par l&apos;administration.
           </p>
         </div>
       ) : (
@@ -53,6 +56,7 @@ function BulletinCard({ bulletin }: { bulletin: StudentBulletin }) {
     try {
       const blob = await studentPortalApi.downloadBulletin(bulletin.id)
       downloadBlob(blob, `bulletin-${bulletin.trimester}-${bulletin.academic_year}.pdf`)
+      toast.success("Bulletin téléchargé")
     } catch (err) {
       console.error("[StudentBulletins] Download failed:", err)
       toast.error(err instanceof Error ? err.message : "Impossible de télécharger le bulletin")
@@ -65,30 +69,30 @@ function BulletinCard({ bulletin }: { bulletin: StudentBulletin }) {
 
   return (
     <Card className="border-0 shadow-sm ring-1 ring-border">
-      <CardContent className="flex items-center justify-between p-4">
-        <div className="flex items-center gap-3">
+      <CardContent className="flex items-center justify-between gap-3 p-4">
+        <div className="flex min-w-0 items-center gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <FileText className="h-5 w-5 text-primary" />
+            <FileText aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
-          <div>
-            <p className="text-sm font-semibold">{bulletin.trimester}</p>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold">{bulletin.trimester}</p>
             <p className="text-xs text-muted-foreground">{bulletin.academic_year}</p>
-            <div className="flex items-center gap-2 mt-1">
+            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5">
               {bulletin.general_average !== null && (
-                <span className={`text-xs font-medium ${bulletin.general_average >= 10 ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}`}>
+                <span className={`text-xs font-medium tabular-nums ${bulletin.general_average >= 10 ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}`}>
                   Moy. {bulletin.general_average.toFixed(2)}/20
                 </span>
               )}
               {bulletin.rank !== null && (
-                <span className="text-xs text-muted-foreground">
-                  Rang : {bulletin.rank}/{bulletin.total_students}
+                <span className="text-xs text-muted-foreground tabular-nums">
+                  Rang {bulletin.rank}/{bulletin.total_students}
                 </span>
               )}
             </div>
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           {!isPublished && (
             <Badge variant="secondary" className="text-[10px]">Brouillon</Badge>
           )}
@@ -98,11 +102,13 @@ function BulletinCard({ bulletin }: { bulletin: StudentBulletin }) {
               variant="outline"
               onClick={handleDownload}
               disabled={isDownloading}
+              aria-label={`Télécharger le bulletin ${bulletin.trimester} en PDF`}
+              className="h-11 sm:h-9"
             >
               {isDownloading ? (
-                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                <Loader2 aria-hidden="true" className="mr-1 h-4 w-4 animate-spin sm:h-3 sm:w-3" />
               ) : (
-                <Download className="mr-1 h-3 w-3" />
+                <Download aria-hidden="true" className="mr-1 h-4 w-4 sm:h-3 sm:w-3" />
               )}
               PDF
             </Button>


### PR DESCRIPTION
## Summary

Dernier polish ergonomique des sous-pages quotidiennes utilisées par Mme Aïcha (parent) et l'élève (Aminata) :

**StudentAttendanceClient** : table illisible mobile → cards verticales. Pagination h-11 + aria-label.

**StudentBulletinsClient** : empty state plus rassurant. PDF button h-11 + aria-label + toast success.

**ParentChildBulletinsClient + Fees + Grades** : back-button h-8/h-9 trop petit → h-11 mobile pour Itel S661. PDF button h-11 + aria-label complet. Empty states améliorés.

## Test plan
- [x] pnpm tsc zéro erreur
- [x] Mobile width 320-412px : cards verticales lisibles
- [x] Touch targets h-11 sur back-buttons + PDF buttons
- [x] aria-label sur boutons icon-only + aria-hidden sur icônes décoratives

Closes #208