### PR TITLE
feat(admin+student): a11y polish remaining + Subjects/Timetable mobile + empty states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Page Matières admin : la vue Kanban est désormais réservée au mode bureau (drag-drop impossible sous 320 px), la vue mobile bascule automatiquement en table. Le sélecteur Kanban/Table est masqué sur mobile pour éviter la confusion *(admin)*.
+- Page Emploi du temps admin : boutons navigation semaine et sélecteur de classe avec aria-label, touch targets h-11 mobile sur Itel S661, boutons d'export PDF et de génération en flex-wrap mobile *(admin)*.
+- Portail élève — empty state Notes plus rassurant qui explique « Vos résultats apparaîtront ici dès que vos enseignants saisiront les notes » au lieu d'une phrase opaque *(élève)*.
+- Portail élève — empty state Frais désambigué : message guide à contacter le secrétariat si aucun frais n'apparaît malgré inscription validée. Indicateurs « Payé » et « Restant » désormais neutralisés en gris quand aucun frais (au lieu de signal vert trompeur) *(élève)*.
+- Icônes décoratives des en-têtes admin enfin masquées aux lecteurs d'écran (aria-hidden) sur les pages Académique, Salles, Notifications, Élèves, Parents, Personnel, Niveaux, Frais, Inscriptions, Matières, Paramètres, Emploi du temps *(tous)*.
+
 - Portail élève — historique de présence sur mobile : la table 4 colonnes est remplacée par des cartes verticales avec jour en clair, heure d'arrivée, notes éventuelles et badge statut coloré. Les boutons de pagination passent à h-11 et reçoivent un aria-label *(élève)*.
 - Portail élève — bulletins : empty state plus rassurant qui explique « Vos bulletins apparaîtront ici après publication par l'administration » au lieu d'une phrase opaque. Bouton PDF passe à h-11 mobile + toast succès au téléchargement *(élève)*.
 - Portail parent — bulletins : flèche retour passe à h-11 mobile (touch target Itel S661), boutons PDF h-11 mobile avec aria-label explicite. Empty state explique quand les bulletins apparaîtront *(parent)*.

--- a/app/(admin)/admin/timetable/page.tsx
+++ b/app/(admin)/admin/timetable/page.tsx
@@ -144,26 +144,27 @@ export default function TimetablePage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Calendar className="h-5 w-5 text-primary" />
+            <Calendar aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Emploi du temps</h1>
             <p className="text-sm text-muted-foreground">Gérez les créneaux horaires par classe</p>
           </div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Button
             variant="outline"
             onClick={handleExportPdf}
             disabled={!selectedClassId || exportingPdf}
+            className="h-11 sm:h-10"
           >
             {exportingPdf ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
             ) : (
-              <FileDown className="mr-2 h-4 w-4" />
+              <FileDown aria-hidden="true" className="mr-2 h-4 w-4" />
             )}
             Exporter PDF
           </Button>
@@ -171,11 +172,12 @@ export default function TimetablePage() {
             variant="outline"
             onClick={handleGenerateClick}
             disabled={!selectedClassId || isGenerating}
+            className="h-11 sm:h-10"
           >
             {isGenerating ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
             ) : (
-              <Wand2 className="mr-2 h-4 w-4" />
+              <Wand2 aria-hidden="true" className="mr-2 h-4 w-4" />
             )}
             Générer automatiquement
           </Button>
@@ -192,7 +194,10 @@ export default function TimetablePage() {
             value={selectedClassId?.toString() ?? ""}
             onValueChange={(v) => setSelectedClassId(v ? Number(v) : null)}
           >
-            <SelectTrigger className="h-10 w-56">
+            <SelectTrigger
+              aria-label="Sélectionner une classe"
+              className="h-11 w-full sm:h-10 sm:w-56"
+            >
               <SelectValue placeholder="Sélectionner une classe" />
             </SelectTrigger>
             <SelectContent>
@@ -206,14 +211,32 @@ export default function TimetablePage() {
         </div>
 
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="icon" className="h-9 w-9" onClick={prevWeek}>
-            <ChevronLeft className="h-4 w-4" />
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Semaine précédente"
+            className="h-11 w-11 sm:h-9 sm:w-9"
+            onClick={prevWeek}
+          >
+            <ChevronLeft aria-hidden="true" className="h-4 w-4" />
           </Button>
-          <Button variant="ghost" size="sm" onClick={resetWeek} className="text-sm min-w-[120px]">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={resetWeek}
+            aria-label="Revenir à cette semaine"
+            className="h-11 text-sm min-w-[120px] sm:h-9"
+          >
             {weekOffset === 0 ? "Cette semaine" : `Semaine ${weekOffset > 0 ? "+" : ""}${weekOffset}`}
           </Button>
-          <Button variant="outline" size="icon" className="h-9 w-9" onClick={nextWeek}>
-            <ChevronRight className="h-4 w-4" />
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Semaine suivante"
+            className="h-11 w-11 sm:h-9 sm:w-9"
+            onClick={nextWeek}
+          >
+            <ChevronRight aria-hidden="true" className="h-4 w-4" />
           </Button>
         </div>
       </div>

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -48,7 +48,7 @@ export function EnrollmentsPageClient() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <GraduationCap className="h-5 w-5 text-primary" />
+            <GraduationCap aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Inscriptions</h1>
@@ -56,7 +56,7 @@ export function EnrollmentsPageClient() {
           </div>
         </div>
         <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
-          <Plus className="h-4 w-4" />
+          <Plus aria-hidden="true" className="h-4 w-4" />
           Nouvelle inscription
         </Button>
       </div>

--- a/components/admin/fees/FeesPageClient.tsx
+++ b/components/admin/fees/FeesPageClient.tsx
@@ -104,7 +104,7 @@ export function FeesPageClient() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Wallet className="h-5 w-5 text-primary" />
+            <Wallet aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Frais scolaires</h1>

--- a/components/admin/levels/LevelsAndSeriesPageClient.tsx
+++ b/components/admin/levels/LevelsAndSeriesPageClient.tsx
@@ -132,7 +132,7 @@ export function LevelsAndSeriesPageClient() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Layers className="h-5 w-5 text-primary" />
+            <Layers aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-xl tracking-tight">Niveaux & Séries</h1>

--- a/components/admin/notifications/NotificationsPageClient.tsx
+++ b/components/admin/notifications/NotificationsPageClient.tsx
@@ -117,7 +117,7 @@ export function NotificationsPageClient() {
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Bell className="h-5 w-5 text-primary" />
+            <Bell aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Notifications</h1>

--- a/components/admin/parents/ParentsPageClient.tsx
+++ b/components/admin/parents/ParentsPageClient.tsx
@@ -17,7 +17,7 @@ export function ParentsPageClient() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <HeartHandshake className="h-5 w-5 text-primary" />
+            <HeartHandshake aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Parents</h1>

--- a/components/admin/rooms/RoomsPageClient.tsx
+++ b/components/admin/rooms/RoomsPageClient.tsx
@@ -119,7 +119,7 @@ export function RoomsPageClient() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <DoorOpen className="h-5 w-5 text-primary" />
+            <DoorOpen aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Salles</h1>

--- a/components/admin/settings/SettingsPageClient.tsx
+++ b/components/admin/settings/SettingsPageClient.tsx
@@ -19,7 +19,7 @@ export function SettingsPageClient() {
       {/* En-tête */}
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-          <Settings className="h-5 w-5 text-primary" />
+          <Settings aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
         <div>
           <h1 className="font-serif text-2xl tracking-tight">Paramètres</h1>
@@ -64,10 +64,11 @@ export function SettingsPageClient() {
       {/* Discoverability link to roles & permissions */}
       <Link
         href="/admin/roles"
+        aria-label="Accéder à la gestion des rôles et permissions"
         className="group flex items-center gap-4 rounded-xl border bg-card p-5 transition-colors hover:border-primary/30 hover:bg-primary/[0.02]"
       >
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-          <Shield className="h-5 w-5 text-primary" />
+          <Shield aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
         <div className="min-w-0 flex-1">
           <p className="font-medium">Rôles &amp; permissions</p>
@@ -76,7 +77,7 @@ export function SettingsPageClient() {
             évaluations, valider les paiements, gérer les inscriptions…).
           </p>
         </div>
-        <ArrowRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+        <ArrowRight aria-hidden="true" className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
       </Link>
     </div>
   )

--- a/components/admin/staff/StaffPageClient.tsx
+++ b/components/admin/staff/StaffPageClient.tsx
@@ -16,7 +16,7 @@ function StaffKpis() {
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardContent className="p-4 flex items-center gap-3">
           <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
-            <Users className="h-4 w-4 text-primary" />
+            <Users aria-hidden="true" className="h-4 w-4 text-primary" />
           </div>
           <div>
             <p className="text-xs text-muted-foreground">Personnel</p>

--- a/components/admin/students/StudentsPageClient.tsx
+++ b/components/admin/students/StudentsPageClient.tsx
@@ -32,7 +32,7 @@ export function StudentsPageClient() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <Users className="h-5 w-5 text-primary" />
+            <Users aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Élèves</h1>

--- a/components/admin/subjects/SubjectsPageClient.tsx
+++ b/components/admin/subjects/SubjectsPageClient.tsx
@@ -14,45 +14,59 @@ export function SubjectsPageClient() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <BookMarked className="h-5 w-5 text-primary" />
+            <BookMarked aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Matières</h1>
             <p className="text-sm text-muted-foreground">Gestion des matières par niveau</p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <div className="flex items-center rounded-lg border p-1">
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Kanban inadapté sous 320px (drag-drop entre colonnes impossible) :
+              toggle visible uniquement desktop, mobile force la vue table. */}
+          <div
+            role="group"
+            aria-label="Changer la vue"
+            className="hidden md:flex items-center rounded-lg border p-1"
+          >
             <Button
               variant={viewMode === "kanban" ? "default" : "ghost"}
               size="sm"
               className="h-8 px-3"
+              aria-pressed={viewMode === "kanban"}
               onClick={() => setViewMode("kanban")}
             >
-              <LayoutGrid className="mr-1.5 h-4 w-4" />
+              <LayoutGrid aria-hidden="true" className="mr-1.5 h-4 w-4" />
               Kanban
             </Button>
             <Button
               variant={viewMode === "table" ? "default" : "ghost"}
               size="sm"
               className="h-8 px-3"
+              aria-pressed={viewMode === "table"}
               onClick={() => setViewMode("table")}
             >
-              <List className="mr-1.5 h-4 w-4" />
+              <List aria-hidden="true" className="mr-1.5 h-4 w-4" />
               Table
             </Button>
           </div>
-          <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
+          <Button onClick={() => setCreateOpen(true)} className="h-11 sm:h-10">
+            <Plus aria-hidden="true" className="mr-2 h-4 w-4" />
             Nouvelle matière
           </Button>
         </div>
       </div>
 
-      {viewMode === "kanban" ? <SubjectsKanbanView /> : <SubjectsTable />}
+      {/* Mobile : toujours table. Desktop : respecte le choix utilisateur. */}
+      <div className="md:hidden">
+        <SubjectsTable />
+      </div>
+      <div className="hidden md:block">
+        {viewMode === "kanban" ? <SubjectsKanbanView /> : <SubjectsTable />}
+      </div>
 
       <SubjectCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
     </div>

--- a/components/shared/CrudPageLayout.tsx
+++ b/components/shared/CrudPageLayout.tsx
@@ -23,7 +23,7 @@ export function CrudPageLayout({ title, subtitle, createLabel, icon: Icon, table
         <div className="flex items-center gap-3">
           {Icon && (
             <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-              <Icon className="h-5 w-5 text-primary" />
+              <Icon aria-hidden="true" className="h-5 w-5 text-primary" />
             </div>
           )}
           <div>

--- a/components/student/StudentFeesClient.tsx
+++ b/components/student/StudentFeesClient.tsx
@@ -37,12 +37,17 @@ export function StudentFeesClient() {
       ) : isError ? (
         <DataError message="Impossible de charger les frais scolaires." onRetry={() => refetch()} />
       ) : !data ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          Aucune information de frais disponible.
+        <div className="rounded-lg border bg-muted/30 py-12 text-center">
+          <p className="text-sm text-muted-foreground">Aucune information de frais disponible.</p>
+          <p className="mt-1 text-xs text-muted-foreground/80">
+            Si votre inscription est validée et qu&apos;aucun frais n&apos;apparaît, contactez le secrétariat.
+          </p>
         </div>
       ) : (
         <>
-          {/* Résumé financier */}
+          {/* Résumé financier — Wave-style 3 KPIs amount-first.
+              Neutralisé en gris si total_expected=0 (signal vert "—FCFA payé"
+              quand rien à payer = faux signal — cf. rule not-enrolled-empty-state). */}
           <div className="grid grid-cols-3 gap-3">
             <SummaryCard
               label="Total"
@@ -51,12 +56,18 @@ export function StudentFeesClient() {
             <SummaryCard
               label="Payé"
               value={`${data.total_paid.toLocaleString("fr-FR")} FCFA`}
-              className="text-emerald-600 dark:text-emerald-400"
+              className={data.total_expected > 0 ? "text-emerald-600 dark:text-emerald-400" : "text-muted-foreground"}
             />
             <SummaryCard
               label="Restant"
               value={`${data.total_remaining.toLocaleString("fr-FR")} FCFA`}
-              className={data.total_remaining === 0 ? "text-emerald-600 dark:text-emerald-400" : "text-accent"}
+              className={
+                data.total_expected === 0
+                  ? "text-muted-foreground"
+                  : data.total_remaining === 0
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-accent"
+              }
             />
           </div>
 

--- a/components/student/StudentGradesClient.tsx
+++ b/components/student/StudentGradesClient.tsx
@@ -54,7 +54,10 @@ export function StudentGradesClient() {
           value={trimester ?? "all"}
           onValueChange={(v) => setTrimester(v === "all" ? undefined : v)}
         >
-          <SelectTrigger className="w-44">
+          <SelectTrigger
+            aria-label="Filtrer par trimestre"
+            className="h-11 w-full sm:h-10 sm:w-44"
+          >
             <SelectValue placeholder="Trimestre" />
           </SelectTrigger>
           <SelectContent>
@@ -71,8 +74,11 @@ export function StudentGradesClient() {
       ) : isError ? (
         <DataError message="Impossible de charger les notes." onRetry={() => refetch()} />
       ) : !data ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          Aucune note disponible.
+        <div className="rounded-lg border bg-muted/30 py-12 text-center">
+          <p className="text-sm text-muted-foreground">Aucune note disponible.</p>
+          <p className="mt-1 text-xs text-muted-foreground/80">
+            Vos résultats apparaîtront ici dès que vos enseignants saisiront les notes.
+          </p>
         </div>
       ) : (
         <>


### PR DESCRIPTION
## Summary

Polish final couvrant les pages restantes au-delà des 27 déjà auditées dans la journée. Couverture exhaustive des 60 pages atteinte.

### A11y systématique (13 pages admin)
aria-hidden sur les icônes décoratives des en-têtes admin + fix dans shared/CrudPageLayout (propage à toutes les pages qui l'utilisent).

### Admin Subjects
- Kanban inadapté mobile → cache toggle + force table mobile
- Header flex-col + aria-pressed + h-11

### Admin Timetable
- Header flex-col mobile + boutons en flex-wrap
- Navigation semaine h-11 + aria-label
- Sélecteur classe full-width mobile + aria-label

### Student Grades + Fees
- Empty states explicites et désambigués
- KPIs Fees neutralisés gris si rien à payer (anti-faux-signal vert)

Closes #211