### PR TITLE
feat(detail-pages): a11y polish back-buttons + teacher classes empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Fiches détail Élève, Enseignant, Personnel, Parent, Classe, Inscription : la flèche de retour passe à h-11 sur mobile (touch target Itel S661) au lieu de h-8/h-9 trop petit. Aria-label rendu explicite « Retour à la liste des inscriptions » au lieu de « Retour » seul *(admin)*.
+- Page Promotions admin : icône d'en-tête masquée aux lecteurs d'écran, bouton « Recommencer » passe à h-11 sur mobile *(admin)*.
+- Portail enseignant — fiche « Mes classes » : empty state plus chaleureux « Aucune classe assignée pour le moment » + invite à contacter l'administration. Bouton « Gérer les notes » passe à h-11 sur mobile avec aria-label explicite incluant la classe et la matière, pour mieux distinguer plusieurs cartes côte à côte *(enseignant)*.
+
 - Page Matières admin : la vue Kanban est désormais réservée au mode bureau (drag-drop impossible sous 320 px), la vue mobile bascule automatiquement en table. Le sélecteur Kanban/Table est masqué sur mobile pour éviter la confusion *(admin)*.
 - Page Emploi du temps admin : boutons navigation semaine et sélecteur de classe avec aria-label, touch targets h-11 mobile sur Itel S661, boutons d'export PDF et de génération en flex-wrap mobile *(admin)*.
 - Portail élève — empty state Notes plus rassurant qui explique « Vos résultats apparaîtront ici dès que vos enseignants saisiront les notes » au lieu d'une phrase opaque *(élève)*.

--- a/components/admin/classes/ClassDetailClient.tsx
+++ b/components/admin/classes/ClassDetailClient.tsx
@@ -56,8 +56,14 @@ export function ClassDetailClient({ classId }: ClassDetailClientProps) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="icon" onClick={() => router.push("/admin/classes")}>
-            <ArrowLeft className="h-5 w-5" />
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Retour à la liste des classes"
+            className="h-11 w-11 sm:h-10 sm:w-10"
+            onClick={() => router.push("/admin/classes")}
+          >
+            <ArrowLeft aria-hidden="true" className="h-5 w-5" />
           </Button>
           <div>
             <h1 className="text-2xl font-bold">{classData.name}</h1>

--- a/components/admin/enrollments/EnrollmentDetailClient.tsx
+++ b/components/admin/enrollments/EnrollmentDetailClient.tsx
@@ -83,9 +83,9 @@ export function EnrollmentDetailClient({ enrollmentId }: EnrollmentDetailClientP
           <Link
             href="/admin/enrollments"
             aria-label="Retour à la liste des inscriptions"
-            className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border hover:bg-muted transition-colors"
+            className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
           >
-            <ArrowLeft className="h-4 w-4" />
+            <ArrowLeft aria-hidden="true" className="h-4 w-4" />
           </Link>
 
           <Avatar className="h-20 w-20 text-2xl shrink-0">

--- a/components/admin/parents/ParentDetailClient.tsx
+++ b/components/admin/parents/ParentDetailClient.tsx
@@ -92,10 +92,10 @@ export function ParentDetailClient({ parentId }: ParentDetailClientProps) {
         <button
           type="button"
           onClick={() => router.back()}
-          aria-label="Retour"
-          className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-md border hover:bg-muted transition-colors"
+          aria-label="Retour à la liste des parents"
+          className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
         >
-          <ArrowLeft className="h-4 w-4" />
+          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
         </button>
 
         <Avatar className="h-16 w-16 shrink-0 rounded-2xl border-2 border-border sm:h-24 sm:w-24">

--- a/components/admin/promotions/PromotionsClient.tsx
+++ b/components/admin/promotions/PromotionsClient.tsx
@@ -120,7 +120,7 @@ export function PromotionsClient() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <ArrowUpFromLine className="h-5 w-5 text-primary" />
+            <ArrowUpFromLine aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Promotions</h1>
@@ -130,8 +130,8 @@ export function PromotionsClient() {
           </div>
         </div>
         {step === "preview" && (
-          <Button variant="outline" onClick={reset} className="h-10 gap-2">
-            <RotateCcw className="h-4 w-4" />
+          <Button variant="outline" onClick={reset} className="h-11 gap-2 sm:h-10">
+            <RotateCcw aria-hidden="true" className="h-4 w-4" />
             Recommencer
           </Button>
         )}

--- a/components/admin/staff/StaffDetailClient.tsx
+++ b/components/admin/staff/StaffDetailClient.tsx
@@ -113,9 +113,9 @@ export function StaffDetailClient({ staffId }: StaffDetailClientProps) {
         <Link
           href="/admin/staff"
           aria-label="Retour à la liste du personnel"
-          className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-md border hover:bg-muted transition-colors"
+          className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
         >
-          <ArrowLeft className="h-4 w-4" />
+          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
         </Link>
 
         <button

--- a/components/admin/students/tabs/StudentDetailHeader.tsx
+++ b/components/admin/students/tabs/StudentDetailHeader.tsx
@@ -91,9 +91,9 @@ export function StudentDetailHeader({
           <Link
             href="/admin/students"
             aria-label="Retour \u00e0 la liste des \u00e9l\u00e8ves"
-            className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border hover:bg-muted transition-colors"
+            className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
           >
-            <ArrowLeft className="h-4 w-4" />
+            <ArrowLeft aria-hidden="true" className="h-4 w-4" />
           </Link>
 
           {/* Avatar with photo upload */}
@@ -109,11 +109,11 @@ export function StudentDetailHeader({
                 {initials}
               </AvatarFallback>
             </Avatar>
-            <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity">
+            <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
               {uploading ? (
-                <Clock className="h-5 w-5 text-white animate-spin" />
+                <Clock aria-hidden="true" className="h-5 w-5 animate-spin text-white" />
               ) : (
-                <Camera className="h-5 w-5 text-white" />
+                <Camera aria-hidden="true" className="h-5 w-5 text-white" />
               )}
             </div>
             <input

--- a/components/admin/teachers/TeacherDetailClient.tsx
+++ b/components/admin/teachers/TeacherDetailClient.tsx
@@ -128,9 +128,9 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
         <Link
           href="/admin/teachers"
           aria-label="Retour à la liste des enseignants"
-          className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-md border hover:bg-muted transition-colors"
+          className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
         >
-          <ArrowLeft className="h-4 w-4" />
+          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
         </Link>
 
         <button

--- a/components/teacher/TeacherClassesClient.tsx
+++ b/components/teacher/TeacherClassesClient.tsx
@@ -35,10 +35,13 @@ export function TeacherClassesClient() {
           onRetry={() => refetch()}
         />
       ) : !classes || classes.length === 0 ? (
-        <div className="py-12 text-center">
-          <Users className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
+        <div className="rounded-lg border bg-muted/30 py-12 text-center">
+          <Users aria-hidden="true" className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
           <p className="text-sm text-muted-foreground">
-            Aucune classe assignée.
+            Aucune classe assignée pour le moment.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground/80">
+            Contactez l&apos;administration pour vérifier votre planning.
           </p>
         </div>
       ) : (
@@ -72,14 +75,14 @@ function ClassCard({ cls }: { cls: TeacherClass }) {
         {/* Indicateurs */}
         <div className="grid grid-cols-3 gap-2">
           <div className="rounded-lg bg-muted/50 p-2 text-center">
-            <Users className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p className="text-sm font-bold">{cls.student_count}</p>
+            <Users aria-hidden="true" className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
+            <p className="text-sm font-bold tabular-nums">{cls.student_count}</p>
             <p className="text-[10px] text-muted-foreground">Élèves</p>
           </div>
           <div className="rounded-lg bg-muted/50 p-2 text-center">
-            <GraduationCap className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
+            <GraduationCap aria-hidden="true" className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
             <p
-              className={`text-sm font-bold ${
+              className={`text-sm font-bold tabular-nums ${
                 average === null
                   ? "text-muted-foreground"
                   : average >= 10
@@ -92,18 +95,20 @@ function ClassCard({ cls }: { cls: TeacherClass }) {
             <p className="text-[10px] text-muted-foreground">Moyenne</p>
           </div>
           <div className="rounded-lg bg-muted/50 p-2 text-center">
-            <ClipboardList className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p className="text-sm font-bold">{totalEvals}</p>
+            <ClipboardList aria-hidden="true" className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
+            <p className="text-sm font-bold tabular-nums">{totalEvals}</p>
             <p className="text-[10px] text-muted-foreground">Évals</p>
           </div>
         </div>
 
-        {/* Action */}
+        {/* Action — touch target h-11 mobile pour la fonction la plus utilisée
+            (la prof gère les notes en plein soleil sur Itel S661). */}
         <Link
           href={`/teacher/grades/${cls.class_id}` as Route}
-          className="flex items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
+          aria-label={`Gérer les notes de ${cls.class_name} en ${cls.subject_name}`}
+          className="flex h-11 items-center justify-center gap-1 rounded-md border px-3 text-sm font-medium text-primary transition-colors hover:bg-primary/5 sm:h-10 sm:text-xs"
         >
-          Gérer les notes <ChevronRight className="h-3 w-3" />
+          Gérer les notes <ChevronRight aria-hidden="true" className="h-3 w-3" />
         </Link>
       </CardContent>
     </Card>

--- a/components/teacher/grades/TeacherEvaluationsList.tsx
+++ b/components/teacher/grades/TeacherEvaluationsList.tsx
@@ -102,7 +102,7 @@ export function TeacherEvaluationsList() {
       <div className="rounded-2xl border bg-gradient-to-br from-primary/5 via-card to-card p-5">
         <div className="flex items-start gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <ClipboardList className="h-5 w-5 text-primary" />
+            <ClipboardList aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0 flex-1">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-primary">
@@ -219,7 +219,7 @@ export function TeacherEvaluationsList() {
               <TableRow>
                 <TableCell colSpan={8} className="h-32 text-center">
                   <div className="flex flex-col items-center gap-2 text-muted-foreground">
-                    <BookOpen className="h-8 w-8 opacity-40" />
+                    <BookOpen aria-hidden="true" className="h-8 w-8 opacity-40" />
                     <p className="text-sm">
                       {evaluations.length === 0
                         ? "Aucune évaluation pour le moment. Demandez à un admin d'en créer une au besoin."


### PR DESCRIPTION
## Summary

Dernier polish couvrant les fiches détail admin (6 fiches : élève, enseignant, personnel, parent, classe, inscription) + 2 pages teacher restantes + admin promotions.

### Détail admin (back-buttons)
Tous les back-buttons (flèche retour) passent de h-8/h-9 fixe → **h-11 mobile** (touch target Itel S661 44dp) + aria-label explicite avec contexte.

### Teacher Classes
Empty state plus chaleureux + bouton 'Gérer les notes' h-11 mobile + aria-label explicite.

### Promotions / Evaluations
Icônes aria-hidden + bouton Recommencer h-11.

Closes #213