### PR TITLE
chore(super-admin): a11y polish Diagnose/Logs/Pats

### DIFF
--- a/components/super-admin/diagnose/DiagnoseDashboard.tsx
+++ b/components/super-admin/diagnose/DiagnoseDashboard.tsx
@@ -29,7 +29,7 @@ export function DiagnoseDashboard() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-start justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Diagnose</h1>
           <p className="text-sm text-muted-foreground">
@@ -39,14 +39,23 @@ export function DiagnoseDashboard() {
             )}
           </p>
         </div>
-        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
-          <RefreshCw className={`mr-1.5 h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          aria-label="Rafraîchir l'état de la plateforme"
+          className="h-11 sm:h-9"
+        >
+          <RefreshCw aria-hidden="true" className={`mr-1.5 h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
           Rafraîchir
         </Button>
       </div>
 
       {data && (
         <div
+          role="status"
+          aria-live="polite"
           className={`rounded-md border p-4 ${
             data.overall === "ok"
               ? "border-emerald-300 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950"

--- a/components/super-admin/logs/LogsViewer.tsx
+++ b/components/super-admin/logs/LogsViewer.tsx
@@ -63,12 +63,26 @@ export function LogsViewer() {
           />
         </div>
         <div className="ml-auto flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => setPaused((p) => !p)}>
-            {paused ? <Play className="mr-1.5 h-3.5 w-3.5" /> : <Pause className="mr-1.5 h-3.5 w-3.5" />}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPaused((p) => !p)}
+            aria-pressed={paused}
+            aria-label={paused ? "Reprendre l'auto-rafraîchissement" : "Mettre en pause l'auto-rafraîchissement"}
+          >
+            {paused
+              ? <Play aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />
+              : <Pause aria-hidden="true" className="mr-1.5 h-3.5 w-3.5" />}
             {paused ? "Reprendre" : "Pause"}
           </Button>
-          <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
-            <RefreshCw className={`h-3.5 w-3.5 ${isFetching ? "animate-spin" : ""}`} />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isFetching}
+            aria-label="Rafraîchir les logs manuellement"
+          >
+            <RefreshCw aria-hidden="true" className={`h-3.5 w-3.5 ${isFetching ? "animate-spin" : ""}`} />
           </Button>
         </div>
       </div>

--- a/components/super-admin/pats/PatsPanel.tsx
+++ b/components/super-admin/pats/PatsPanel.tsx
@@ -121,7 +121,9 @@ export function PatsPanel() {
                     setTimeout(() => setCopied(false), 2000)
                   }}
                 >
-                  {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                  {copied
+                    ? <Check aria-hidden="true" className="h-3 w-3" />
+                    : <Copy aria-hidden="true" className="h-3 w-3" />}
                 </Button>
               </div>
               <Button
@@ -174,9 +176,10 @@ export function PatsPanel() {
                       variant="ghost"
                       size="icon"
                       onClick={() => setRevokeId(pat.id)}
-                      aria-label="Révoquer"
+                      aria-label={`Révoquer le token ${pat.name}`}
+                      className="h-11 w-11 sm:h-10 sm:w-10"
                     >
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 aria-hidden="true" className="h-4 w-4" />
                     </Button>
                   )}
                 </div>


### PR DESCRIPTION
Polish a11y des 3 dernières pages super-admin (Diagnose / Logs / Pats) pour clore la couverture exhaustive : aria-hidden sur icônes décoratives, aria-label explicite sur boutons icon-only, h-11 mobile sur boutons d'action, role=status+aria-live sur banner état Diagnose, aria-pressed sur toggle Pause/Reprendre Logs.