### PR TITLE
style(dashboard): refonte des dashboards en shadcn monochrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Tableaux de bord redessinés sur les portails Administration, Enseignant, Élève et Parent : présentation plus claire et épurée, en-tête sobre sans dégradé, indicateurs lisibles d'un coup d'œil et une seule couleur d'accent. Plus lisible en plein soleil sur petit écran *(tous)*.
 - Page Paiements sur mobile : la liste des paiements adopte un affichage cartes verticales (montant prominent, statut coloré, méthode, date) au lieu d'une table illisible en scroll horizontal sur Itel S661. Le tap sur une carte ouvre l'aperçu du reçu *(admin)*.
 - Page Enseignants sur mobile : la liste adopte le même format compact que la page Élèves (avatar + nom + spécialité + chevron), au lieu de la table desktop scrollable. Tap = ouvre la fiche *(admin)*.
 - Pages Classes, Parents et Personnel sur mobile : même format compact avec avatar + nom + sous-titre + chevron, au lieu de la table desktop scrollable. Une pastille colorée d'occupation (vert / amber / rouge) s'affiche à droite de chaque classe pour signaler les classes pleines en un coup d'œil *(admin)*.

--- a/components/admin/dashboard/DashboardCharts.tsx
+++ b/components/admin/dashboard/DashboardCharts.tsx
@@ -18,15 +18,14 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { useDrenStats } from "@/lib/hooks/useDrenStats"
 
+// Palette dérivée des tokens shadcn `--chart-1..5` (définis dans globals.css).
+// Reste cohérente avec le thème (clair/sombre) et la règle monochrome + accent.
 const COLORS = [
-  "hsl(var(--primary))",
-  "hsl(var(--accent))",
-  "hsl(215, 70%, 50%)",
-  "hsl(150, 60%, 45%)",
-  "hsl(280, 60%, 55%)",
-  "hsl(340, 65%, 50%)",
-  "hsl(45, 80%, 50%)",
-  "hsl(180, 50%, 45%)",
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
 ]
 
 // Custom premium tooltip
@@ -103,7 +102,7 @@ export function DashboardCharts() {
     return (
       <div className="grid gap-4 lg:grid-cols-2">
         {Array.from({ length: 4 }).map((_, i) => (
-          <Card key={i} className="border-0 shadow-sm ring-1 ring-border">
+          <Card key={i} className="shadow-sm">
             <CardHeader><Skeleton className="h-5 w-48" /></CardHeader>
             <CardContent><Skeleton className="h-[280px] w-full" /></CardContent>
           </Card>
@@ -115,9 +114,9 @@ export function DashboardCharts() {
   return (
     <div className="grid gap-4 lg:grid-cols-2">
       {/* Bar chart */}
-      <Card className="border-0 shadow-sm ring-1 ring-border">
+      <Card className="shadow-sm">
         <CardHeader className="pb-2">
-          <CardTitle className="text-base font-medium">
+          <CardTitle className="text-base font-semibold">
             Inscriptions validées par niveau
           </CardTitle>
           <CardDescription className="text-xs">
@@ -142,9 +141,9 @@ export function DashboardCharts() {
       </Card>
 
       {/* Donut — Répartition par niveau */}
-      <Card className="border-0 shadow-sm ring-1 ring-border">
+      <Card className="shadow-sm">
         <CardHeader className="pb-2">
-          <CardTitle className="text-base font-medium">
+          <CardTitle className="text-base font-semibold">
             Répartition par niveau
           </CardTitle>
           <CardDescription className="text-xs">
@@ -184,9 +183,9 @@ export function DashboardCharts() {
       </Card>
 
       {/* Donut — Garçons / Filles */}
-      <Card className="border-0 shadow-sm ring-1 ring-border">
+      <Card className="shadow-sm">
         <CardHeader className="pb-2">
-          <CardTitle className="text-base font-medium">
+          <CardTitle className="text-base font-semibold">
             Répartition garçons / filles
           </CardTitle>
           <CardDescription className="text-xs">
@@ -225,9 +224,9 @@ export function DashboardCharts() {
       </Card>
 
       {/* Donut — Répartition par classe */}
-      <Card className="border-0 shadow-sm ring-1 ring-border">
+      <Card className="shadow-sm">
         <CardHeader className="pb-2">
-          <CardTitle className="text-base font-medium">
+          <CardTitle className="text-base font-semibold">
             Répartition par classe
           </CardTitle>
           <CardDescription className="text-xs">

--- a/components/admin/dashboard/DashboardKpis.tsx
+++ b/components/admin/dashboard/DashboardKpis.tsx
@@ -33,6 +33,9 @@ export function DashboardKpis() {
     )
   }
 
+  const pendingPayments = data?.pending_payments ?? 0
+  const alerts = data?.alerts ?? 0
+
   return (
     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <KpiCard
@@ -41,42 +44,42 @@ export function DashboardKpis() {
         description={
           <span className="inline-flex flex-wrap items-center gap-x-2 gap-y-0.5">
             <span className="inline-flex items-center gap-1">
-              <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
               {data?.enrollment_validated ?? 0} validées
             </span>
             <span className="inline-flex items-center gap-1">
-              <span className="inline-block h-1.5 w-1.5 rounded-full bg-blue-500" />
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
               {data?.enrollment_prospect ?? 0} prospects
             </span>
             <span className="inline-flex items-center gap-1">
-              <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500" />
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-accent" />
               {data?.enrollment_pending ?? 0} en attente
             </span>
           </span>
         }
         icon={GraduationCap}
-        variant="blue"
+        tone="primary"
       />
       <KpiCard
         title="Paiements en attente"
-        value={data?.pending_payments ?? 0}
+        value={pendingPayments}
         description="À traiter"
         icon={Wallet}
-        variant="orange"
+        tone={pendingPayments > 0 ? "accent" : "default"}
       />
       <KpiCard
         title="Cours du jour"
         value={data?.courses_today ?? 0}
         description="Programmés aujourd'hui"
         icon={CalendarDays}
-        variant="emerald"
+        tone="default"
       />
       <KpiCard
         title="Alertes"
-        value={data?.alerts ?? 0}
+        value={alerts}
         description="Évaluations sans notes"
         icon={AlertTriangle}
-        variant="rose"
+        tone={alerts > 0 ? "destructive" : "default"}
       />
     </div>
   )

--- a/components/admin/dashboard/KpiCard.tsx
+++ b/components/admin/dashboard/KpiCard.tsx
@@ -1,29 +1,20 @@
 import { cn } from "@/lib/utils"
 import { Card, CardContent } from "@/components/ui/card"
 
-type KpiVariant = "blue" | "orange" | "emerald" | "rose"
+/**
+ * Tons sémantiques restreints (règle "1 accent + monochrome") :
+ * - default : icône muted, base monochrome
+ * - primary : bleu KLASSCI, métrique structurante (élèves)
+ * - accent  : orange KLASSCI, action/argent (paiements)
+ * - destructive : alerte active (> 0)
+ */
+type KpiTone = "default" | "primary" | "accent" | "destructive"
 
-const variantStyles: Record<KpiVariant, { bg: string; icon: string; ring: string }> = {
-  blue: {
-    bg: "bg-primary/8 dark:bg-primary/15",
-    icon: "text-primary",
-    ring: "ring-primary/20",
-  },
-  orange: {
-    bg: "bg-accent/10 dark:bg-accent/15",
-    icon: "text-accent",
-    ring: "ring-accent/20",
-  },
-  emerald: {
-    bg: "bg-emerald-500/10 dark:bg-emerald-500/15",
-    icon: "text-emerald-600 dark:text-emerald-400",
-    ring: "ring-emerald-500/20",
-  },
-  rose: {
-    bg: "bg-rose-500/10 dark:bg-rose-500/15",
-    icon: "text-rose-600 dark:text-rose-400",
-    ring: "ring-rose-500/20",
-  },
+const toneStyles: Record<KpiTone, string> = {
+  default: "bg-muted text-muted-foreground",
+  primary: "bg-primary/10 text-primary",
+  accent: "bg-accent/10 text-accent",
+  destructive: "bg-destructive/10 text-destructive",
 }
 
 interface KpiCardProps {
@@ -31,11 +22,7 @@ interface KpiCardProps {
   value: React.ReactNode
   description?: React.ReactNode
   icon: React.ComponentType<{ className?: string }>
-  variant?: KpiVariant
-  trend?: {
-    value: number
-    positive: boolean
-  }
+  tone?: KpiTone
   className?: string
 }
 
@@ -44,48 +31,37 @@ export function KpiCard({
   value,
   description,
   icon: Icon,
-  variant = "blue",
-  trend,
+  tone = "default",
   className,
 }: KpiCardProps) {
-  const styles = variantStyles[variant]
-
-  // aria-label fournit un nom accessible complet à la card (titre + valeur)
-  // pour les lecteurs d'écran, car la valeur seule (ex: "42") sans contexte
-  // n'a pas de sens. role=group + aria-live=polite permet d'annoncer les
-  // mises a jour TanStack Query auto-revalidate sans interrompre l'utilisateur.
+  // aria-label : nom accessible complet (titre + valeur) pour lecteurs d'écran.
+  // role=group + aria-live=polite annonce les revalidations TanStack Query.
   const valueText = typeof value === "string" || typeof value === "number" ? String(value) : ""
   const accessibleLabel = valueText ? `${title} : ${valueText}` : title
+
   return (
     <Card
       role="group"
       aria-label={accessibleLabel}
       aria-live="polite"
       aria-atomic="true"
-      className={cn("relative overflow-hidden border-0 shadow-sm ring-1", styles.ring, className)}
+      className={cn("shadow-sm", className)}
     >
-      <CardContent className="p-6">
-        <div className="flex items-start justify-between">
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-muted-foreground">{title}</p>
-            <div className="text-3xl font-bold tracking-tight">{value}</div>
-            {description && (
-              <p className="text-xs text-muted-foreground">{description}</p>
-            )}
-            {trend && (
-              <p
-                className={cn(
-                  "text-xs font-medium",
-                  trend.positive ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"
-                )}
-              >
-                {trend.positive ? "+" : ""}{trend.value}% vs mois dernier
-              </p>
-            )}
-          </div>
-          <div className={cn("flex h-12 w-12 shrink-0 items-center justify-center rounded-xl", styles.bg)}>
-            <Icon aria-hidden="true" className={cn("h-6 w-6", styles.icon)} />
-          </div>
+      <CardContent className="flex items-start justify-between gap-4 p-6">
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-muted-foreground">{title}</p>
+          <div className="text-3xl font-bold tracking-tight tabular-nums">{value}</div>
+          {description && (
+            <div className="pt-1 text-xs text-muted-foreground">{description}</div>
+          )}
+        </div>
+        <div
+          className={cn(
+            "flex h-11 w-11 shrink-0 items-center justify-center rounded-lg",
+            toneStyles[tone],
+          )}
+        >
+          <Icon aria-hidden="true" className="h-5 w-5" />
         </div>
       </CardContent>
     </Card>

--- a/components/admin/dashboard/KpiCardSkeleton.tsx
+++ b/components/admin/dashboard/KpiCardSkeleton.tsx
@@ -3,16 +3,14 @@ import { Skeleton } from "@/components/ui/skeleton"
 
 export function KpiCardSkeleton() {
   return (
-    <Card>
-      <CardContent className="p-6">
-        <div className="flex items-start justify-between">
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-8 w-16" />
-            <Skeleton className="h-3 w-32" />
-          </div>
-          <Skeleton className="h-12 w-12 rounded-xl" />
+    <Card className="shadow-sm">
+      <CardContent className="flex items-start justify-between gap-4 p-6">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-8 w-16" />
+          <Skeleton className="h-3 w-32" />
         </div>
+        <Skeleton className="h-11 w-11 rounded-lg" />
       </CardContent>
     </Card>
   )

--- a/components/admin/dashboard/QuickActions.tsx
+++ b/components/admin/dashboard/QuickActions.tsx
@@ -13,50 +13,20 @@ import {
 } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
-const actions: { label: string; href: Route; icon: LucideIcon; color: string }[] = [
-  {
-    label: "Nouvelle inscription",
-    href: "/admin/enrollments?action=create" as Route,
-    icon: UserPlus,
-    color: "text-primary bg-primary/10",
-  },
-  {
-    label: "Saisir des notes",
-    href: "/admin/grades",
-    icon: ClipboardList,
-    color: "text-emerald-600 bg-emerald-500/10 dark:text-emerald-400",
-  },
-  {
-    label: "Emploi du temps",
-    href: "/admin/timetable",
-    icon: CalendarDays,
-    color: "text-violet-600 bg-violet-500/10 dark:text-violet-400",
-  },
-  {
-    label: "Bulletins",
-    href: "/admin/reports",
-    icon: FileText,
-    color: "text-amber-600 bg-amber-500/10 dark:text-amber-400",
-  },
-  {
-    label: "Paiements",
-    href: "/admin/payments",
-    icon: CreditCard,
-    color: "text-accent bg-accent/10",
-  },
-  {
-    label: "Presences",
-    href: "/admin/attendance",
-    icon: UserCheck,
-    color: "text-sky-600 bg-sky-500/10 dark:text-sky-400",
-  },
+const actions: { label: string; href: Route; icon: LucideIcon }[] = [
+  { label: "Nouvelle inscription", href: "/admin/enrollments?action=create" as Route, icon: UserPlus },
+  { label: "Saisir des notes", href: "/admin/grades", icon: ClipboardList },
+  { label: "Emploi du temps", href: "/admin/timetable", icon: CalendarDays },
+  { label: "Bulletins", href: "/admin/reports", icon: FileText },
+  { label: "Paiements", href: "/admin/payments", icon: CreditCard },
+  { label: "Présences", href: "/admin/attendance", icon: UserCheck },
 ]
 
 export function QuickActions() {
   return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
+    <Card className="shadow-sm">
       <CardHeader>
-        <CardTitle className="text-base font-medium">Actions rapides</CardTitle>
+        <CardTitle className="text-base font-semibold">Actions rapides</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
@@ -64,12 +34,12 @@ export function QuickActions() {
             <Link
               key={action.href}
               href={action.href}
-              className="flex flex-col items-center gap-2 rounded-xl p-4 text-center transition-colors hover:bg-muted"
+              className="group flex flex-col items-center gap-2 rounded-lg border border-transparent p-4 text-center transition-colors hover:border-border hover:bg-muted"
             >
-              <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${action.color}`}>
-                <action.icon className="h-5 w-5" />
-              </div>
-              <span className="text-xs font-medium text-muted-foreground">
+              <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
+                <action.icon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <span className="text-xs font-medium text-muted-foreground group-hover:text-foreground">
                 {action.label}
               </span>
             </Link>

--- a/components/admin/dashboard/RecentActivity.tsx
+++ b/components/admin/dashboard/RecentActivity.tsx
@@ -16,41 +16,20 @@ import { cn } from "@/lib/utils"
 import { useDashboardActivity } from "@/lib/hooks/useDashboard"
 import type { ActivityItem } from "@/lib/contracts/dashboard"
 
-const entityConfig: Record<string, { icon: LucideIcon; variant: string }> = {
-  payment: {
-    icon: CreditCard,
-    variant: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
-  },
-  enrollment: {
-    icon: GraduationCap,
-    variant: "bg-primary/10 text-primary",
-  },
-  student: {
-    icon: User,
-    variant: "bg-primary/10 text-primary",
-  },
-  evaluation: {
-    icon: BookOpen,
-    variant: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
-  },
-  grade: {
-    icon: BookOpen,
-    variant: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
-  },
-  attendance: {
-    icon: ClipboardCheck,
-    variant: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
-  },
-  user: {
-    icon: Shield,
-    variant: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
-  },
+// Icône par type d'entité, mais chip monochrome uniforme (règle "1 accent
+// + monochrome") : la lisibilité vient de l'icône et du texte, pas de 6
+// teintes différentes. Le libellé porte le sens.
+const entityIcons: Record<string, LucideIcon> = {
+  payment: CreditCard,
+  enrollment: GraduationCap,
+  student: User,
+  evaluation: BookOpen,
+  grade: BookOpen,
+  attendance: ClipboardCheck,
+  user: Shield,
 }
 
-const defaultConfig = {
-  icon: Activity,
-  variant: "bg-muted text-muted-foreground",
-}
+const CHIP_CLASS = "bg-muted text-muted-foreground"
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime()
@@ -65,15 +44,14 @@ function timeAgo(dateStr: string): string {
 }
 
 function ActivityRow({ item }: { item: ActivityItem }) {
-  const config = entityConfig[item.entity_type] ?? defaultConfig
-  const Icon = config.icon
+  const Icon = entityIcons[item.entity_type] ?? Activity
 
   return (
     <div className="flex items-start gap-3">
       <div
         className={cn(
           "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-          config.variant
+          CHIP_CLASS
         )}
       >
         <Icon className="h-4 w-4" />
@@ -99,9 +77,9 @@ export function RecentActivity() {
   const items = data?.items ?? []
 
   return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
+    <Card className="shadow-sm">
       <CardHeader>
-        <CardTitle className="text-base font-medium">Activité récente</CardTitle>
+        <CardTitle className="text-base font-semibold">Activité récente</CardTitle>
       </CardHeader>
       <CardContent>
         {isLoading ? (

--- a/components/admin/dashboard/WelcomeHeader.tsx
+++ b/components/admin/dashboard/WelcomeHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useSession } from "next-auth/react"
 import { CalendarDays } from "lucide-react"
+import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 
 export function WelcomeHeader() {
@@ -22,37 +23,39 @@ export function WelcomeHeader() {
   const firstName = rawName.split(/[._]/)[0].replace(/^\w/, (c) => c.toUpperCase())
 
   return (
-    <div className="relative overflow-hidden rounded-xl bg-gradient-to-br from-primary to-primary/80 p-6 text-primary-foreground shadow-sm sm:p-8">
-      <div className="absolute -right-12 -top-12 h-40 w-40 rounded-full bg-white/5" />
-      <div className="absolute -bottom-8 -left-8 h-32 w-32 rounded-full bg-white/5" />
-      <div className="absolute right-1/4 top-1/2 h-20 w-20 rounded-full bg-white/[0.03]" />
-
-      <div className="relative z-10 space-y-2">
-        <h1 className="font-serif text-2xl tracking-tight sm:text-3xl">
-          Bonjour, {firstName}
-        </h1>
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-primary-foreground/70">
-          <span className="flex items-center gap-2">
-            <CalendarDays className="h-4 w-4" />
-            <span className="capitalize" suppressHydrationWarning>{today}</span>
-          </span>
+    <div className="space-y-4">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="font-serif text-2xl tracking-tight text-foreground sm:text-3xl">
+            Bonjour, {firstName}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Aperçu de votre établissement et des activités récentes.
+          </p>
         </div>
-        <p className="text-sm text-primary-foreground/60 max-w-lg">
-          Voici un aperçu de votre établissement. Consultez les indicateurs clés et les activités récentes.
-        </p>
+        <span className="flex items-center gap-2 text-sm text-muted-foreground">
+          <CalendarDays className="h-4 w-4" aria-hidden="true" />
+          <span className="capitalize" suppressHydrationWarning>
+            {today}
+          </span>
+        </span>
       </div>
+      <Separator />
     </div>
   )
 }
 
 export function WelcomeHeaderSkeleton() {
   return (
-    <div className="rounded-xl bg-gradient-to-br from-primary to-primary/80 p-6 sm:p-8">
-      <div className="space-y-3">
-        <Skeleton className="h-8 w-64 bg-white/20" />
-        <Skeleton className="h-4 w-48 bg-white/15" />
-        <Skeleton className="h-4 w-80 bg-white/10" />
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+        <Skeleton className="h-4 w-40" />
       </div>
+      <Separator />
     </div>
   )
 }

--- a/components/parent/ParentDashboardClient.tsx
+++ b/components/parent/ParentDashboardClient.tsx
@@ -3,6 +3,10 @@
 import Link from "next/link"
 import { Users, GraduationCap, Wallet, AlertCircle, ChevronRight } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
@@ -13,6 +17,15 @@ import { isEnrolledFromClassName, summarizeEnrollment } from "@/lib/utils/enroll
 
 /** Seuil d'absences au-delà duquel on affiche un avertissement */
 const ABSENCES_WARNING_THRESHOLD = 5
+
+function initials(name: string): string {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("")
+}
 
 export function ParentDashboardClient() {
   const { data, isLoading, isError, refetch } = useParentDashboard()
@@ -45,23 +58,18 @@ export function ParentDashboardClient() {
     <div className="space-y-6">
       <DashboardHeader name={data.parent_name} />
 
-      <AcademicYearBanner
-        currentYear={data.current_academic_year}
-        role="parent"
-      />
+      <AcademicYearBanner currentYear={data.current_academic_year} role="parent" />
 
-      {/* Résumé — "Mes enfants" (relation parent-enfant) avec breakdown
-          inscrit / en attente quand il y a un mix. Le label "Enfants inscrits"
-          précédent était trompeur : il comptait les enfants suivis, pas ceux
-          réellement inscrits à l'année courante. */}
-      <Card className="border-primary/20 bg-primary/5">
+      {/* Résumé "Mes enfants" — seul accent primary. Le label compte les
+          enfants suivis, avec un breakdown inscrits / en attente. */}
+      <Card className="border-primary/30 bg-primary/5 shadow-sm">
         <CardContent className="flex items-center gap-3 p-4">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <Users className="h-5 w-5 text-primary" />
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+            <Users className="h-5 w-5" aria-hidden="true" />
           </div>
           <div className="min-w-0 flex-1">
-            <p className="text-xs text-primary uppercase tracking-wider font-medium">Mes enfants</p>
-            <p className="text-2xl font-bold leading-tight">{enrollment.total}</p>
+            <p className="text-xs font-medium uppercase tracking-wider text-primary">Mes enfants</p>
+            <p className="text-2xl font-bold leading-tight tabular-nums">{enrollment.total}</p>
             {enrollment.total > 0 && (
               <p className="mt-0.5 text-xs text-muted-foreground">
                 {enrollment.enrolled} inscrit{enrollment.enrolled > 1 ? "s" : ""}
@@ -82,7 +90,7 @@ export function ParentDashboardClient() {
       {/* Cartes enfants */}
       {data.children.length === 0 ? (
         <div className="py-12 text-center">
-          <Users className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
+          <Users className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" aria-hidden="true" />
           <p className="text-sm text-muted-foreground">Aucun enfant lié à votre compte.</p>
         </div>
       ) : (
@@ -102,11 +110,14 @@ export function ParentDashboardClient() {
 
 function DashboardHeader({ name }: { name: string | null }) {
   return (
-    <div>
-      <h1 className="font-serif text-xl tracking-tight">
-        {name ? `Bonjour, ${name.split(" ")[0]}` : "Espace Parent"}
-      </h1>
-      <p className="text-sm text-muted-foreground">Résumé de vos enfants</p>
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h1 className="font-serif text-2xl tracking-tight">
+          {name ? `Bonjour, ${name.split(" ")[0]}` : "Espace Parent"}
+        </h1>
+        <p className="text-sm text-muted-foreground">Résumé de vos enfants</p>
+      </div>
+      <Separator />
     </div>
   )
 }
@@ -121,26 +132,31 @@ function ChildCard({
   const isEnrolled = isEnrolledFromClassName(child.class_name)
 
   return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
-      <CardContent className="p-4 space-y-3">
+    <Card className="shadow-sm">
+      <CardContent className="space-y-3 p-4">
         {/* En-tête enfant */}
-        <div className="flex items-center justify-between gap-3">
-          <div className="min-w-0">
-            <p className="font-semibold text-sm truncate">{child.full_name}</p>
-            <p className="text-xs text-muted-foreground">
-              {isEnrolled ? (
-                child.class_name
-              ) : (
-                <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
-                  En attente d&apos;inscription
-                </span>
-              )}
-            </p>
+        <div className="flex items-center gap-3">
+          <Avatar className="h-10 w-10">
+            <AvatarFallback className="bg-muted text-xs font-semibold text-muted-foreground">
+              {initials(child.full_name)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold">{child.full_name}</p>
+            {isEnrolled ? (
+              <p className="text-xs text-muted-foreground">{child.class_name}</p>
+            ) : (
+              <Badge
+                variant="secondary"
+                className="mt-0.5 bg-amber-100 text-[10px] font-medium uppercase tracking-wide text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+              >
+                En attente d&apos;inscription
+              </Badge>
+            )}
           </div>
         </div>
 
-        {/* Banner inline si pas inscrit — explique POURQUOI les KPIs sont
-            vides, et donne l'action à prendre (passage au secrétariat). */}
+        {/* Banner inline si pas inscrit */}
         {!isEnrolled && (
           <NotEnrolledBanner
             audience="parent"
@@ -150,75 +166,65 @@ function ChildCard({
           />
         )}
 
-        {/* KPIs — neutralisés (—) tant que l'enfant n'est pas inscrit.
-            Sinon faux signal vert "0 FCFA = tout payé" alors qu'aucun frais
-            n'a encore été affecté. */}
+        {/* KPIs — neutralisés (—) tant que l'enfant n'est pas inscrit. */}
         <div className="grid grid-cols-3 gap-2">
-          <div className="rounded-lg bg-muted/50 p-2 text-center">
-            <GraduationCap className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p
-              className={`text-sm font-bold ${
-                !isEnrolled || child.general_average === null
-                  ? "text-muted-foreground"
-                  : child.general_average >= 10
-                    ? "text-emerald-600 dark:text-emerald-400"
-                    : "text-destructive"
-              }`}
-            >
-              {isEnrolled && child.general_average !== null
+          <ChildKpi
+            icon={GraduationCap}
+            label="Moyenne"
+            value={
+              isEnrolled && child.general_average !== null
                 ? child.general_average.toFixed(2)
-                : "—"}
-            </p>
-            <p className="text-[10px] text-muted-foreground">Moyenne</p>
-          </div>
-          <div className="rounded-lg bg-muted/50 p-2 text-center">
-            <AlertCircle className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p
-              className={`text-sm font-bold ${
-                !isEnrolled
-                  ? "text-muted-foreground"
-                  : child.total_absences > ABSENCES_WARNING_THRESHOLD
-                    ? "text-accent"
-                    : ""
-              }`}
-            >
-              {isEnrolled ? child.total_absences : "—"}
-            </p>
-            <p className="text-[10px] text-muted-foreground">Absences</p>
-          </div>
-          <div className="rounded-lg bg-muted/50 p-2 text-center">
-            <Wallet className="mx-auto mb-1 h-4 w-4 text-muted-foreground" />
-            <p
-              className={`text-sm font-bold ${
-                !isEnrolled
-                  ? "text-muted-foreground"
-                  : child.fees_remaining > 0
-                    ? "text-accent"
-                    : "text-emerald-600 dark:text-emerald-400"
-              }`}
-            >
-              {isEnrolled ? child.fees_remaining.toLocaleString("fr-FR") : "—"}
-            </p>
-            <p className="text-[10px] text-muted-foreground">Reste (FCFA)</p>
-          </div>
+                : "—"
+            }
+            valueClassName={
+              !isEnrolled || child.general_average === null
+                ? "text-muted-foreground"
+                : child.general_average >= 10
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-destructive"
+            }
+          />
+          <ChildKpi
+            icon={AlertCircle}
+            label="Absences"
+            value={isEnrolled ? String(child.total_absences) : "—"}
+            valueClassName={
+              !isEnrolled
+                ? "text-muted-foreground"
+                : child.total_absences > ABSENCES_WARNING_THRESHOLD
+                  ? "text-accent"
+                  : "text-foreground"
+            }
+          />
+          <ChildKpi
+            icon={Wallet}
+            label="Reste (FCFA)"
+            value={isEnrolled ? child.fees_remaining.toLocaleString("fr-FR") : "—"}
+            valueClassName={
+              !isEnrolled
+                ? "text-muted-foreground"
+                : child.fees_remaining > 0
+                  ? "text-accent"
+                  : "text-emerald-600 dark:text-emerald-400"
+            }
+          />
         </div>
 
-        {/* Liens rapides — désactivés quand pas inscrit (pas de contenu utile
-            à voir, et éviter de générer des fetches 404/500 inutiles). */}
+        {/* Liens rapides — actifs seulement si inscrit */}
         {isEnrolled ? (
           <div className="flex gap-2">
-            <Link
-              href={`/parent/children/${child.id}/grades`}
-              className="flex flex-1 items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
-            >
-              Notes <ChevronRight className="h-3 w-3" />
-            </Link>
-            <Link
-              href={`/parent/children/${child.id}/fees`}
-              className="flex flex-1 items-center justify-center gap-1 rounded-md border px-3 py-2 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
-            >
-              Frais <ChevronRight className="h-3 w-3" />
-            </Link>
+            <Button asChild variant="outline" size="sm" className="h-11 flex-1 sm:h-9">
+              <Link href={`/parent/children/${child.id}/grades`}>
+                Notes
+                <ChevronRight className="ml-1 h-3.5 w-3.5" aria-hidden="true" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="sm" className="h-11 flex-1 sm:h-9">
+              <Link href={`/parent/children/${child.id}/fees`}>
+                Frais
+                <ChevronRight className="ml-1 h-3.5 w-3.5" aria-hidden="true" />
+              </Link>
+            </Button>
           </div>
         ) : (
           <p className="text-center text-[11px] text-muted-foreground">
@@ -230,11 +236,31 @@ function ChildCard({
   )
 }
 
+function ChildKpi({
+  icon: Icon,
+  label,
+  value,
+  valueClassName,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: string
+  valueClassName?: string
+}) {
+  return (
+    <div className="rounded-lg border bg-muted/30 p-2 text-center">
+      <Icon className="mx-auto mb-1 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+      <p className={`text-sm font-bold tabular-nums ${valueClassName ?? ""}`}>{value}</p>
+      <p className="text-[10px] text-muted-foreground">{label}</p>
+    </div>
+  )
+}
+
 function DashboardSkeleton() {
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-7 w-48" />
         <Skeleton className="h-4 w-32" />
       </div>
       <Skeleton className="h-20 rounded-lg" />

--- a/components/student/StudentDashboardClient.tsx
+++ b/components/student/StudentDashboardClient.tsx
@@ -2,6 +2,7 @@
 
 import { CalendarDays, ClipboardList, Wallet, AlertCircle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
 import { NotEnrolledBanner } from "@/components/shared/NotEnrolledBanner"
@@ -16,10 +17,7 @@ export function StudentDashboardClient() {
   if (isError || !data) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="font-serif text-xl tracking-tight">Espace Élève</h1>
-          <p className="text-sm text-muted-foreground">Votre résumé du jour</p>
-        </div>
+        <DashboardHeader title="Espace Élève" subtitle="Votre résumé du jour" />
         <div className="py-12 text-center text-sm text-muted-foreground">
           Impossible de charger le tableau de bord. Veuillez réessayer.
         </div>
@@ -30,61 +28,59 @@ export function StudentDashboardClient() {
   const isEnrolled = isEnrolledFromClassName(data.class_name)
   // Quand l'élève n'est pas (encore) inscrit, le BE renvoie `class_name: "—"`.
   // On ne montre PAS ce placeholder dans le sous-titre : il dégrade en
-  // mention temporelle simple, et le banner explique la situation en clair.
-  const subtitle = isEnrolled ? `${data.class_name} — Votre résumé du jour` : "Votre espace personnel"
+  // mention simple, et le banner explique la situation en clair.
+  const subtitle = isEnrolled
+    ? `${data.class_name} · Votre résumé du jour`
+    : "Votre espace personnel"
 
   return (
     <div className="space-y-6">
-      {/* En-tête */}
-      <div>
-        <h1 className="font-serif text-xl tracking-tight">
-          Bonjour, {data.student_name.split(" ")[0]}
-        </h1>
-        <p className="text-sm text-muted-foreground">{subtitle}</p>
-      </div>
-
-      <AcademicYearBanner
-        currentYear={data.current_academic_year}
-        role="student"
+      <DashboardHeader
+        title={`Bonjour, ${data.student_name.split(" ")[0]}`}
+        subtitle={subtitle}
       />
+
+      <AcademicYearBanner currentYear={data.current_academic_year} role="student" />
 
       {!isEnrolled && (
         <NotEnrolledBanner audience="student" academicYear={data.current_academic_year} />
       )}
 
-      {/* Prochain cours */}
-      <Card className="border-primary/20 bg-primary/5">
+      {/* Prochain cours — seul accent primary */}
+      <Card className="border-primary/30 bg-primary/5 shadow-sm">
         <CardContent className="flex items-center gap-4 p-4">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
-            <CalendarDays className="h-6 w-6" />
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+            <CalendarDays className="h-6 w-6" aria-hidden="true" />
           </div>
           <div className="min-w-0">
-            <p className="text-xs font-medium text-primary uppercase tracking-wider">Prochain cours</p>
+            <p className="text-xs font-medium uppercase tracking-wider text-primary">
+              Prochain cours
+            </p>
             {data.next_course ? (
               <div className="mt-1">
                 <p className="text-sm font-semibold">{data.next_course.subject_name}</p>
                 <p className="text-xs text-muted-foreground">
                   {data.next_course.start_time} - {data.next_course.end_time}
-                  {data.next_course.room && ` • Salle ${data.next_course.room}`}
-                  {" • "}{data.next_course.teacher_name}
+                  {data.next_course.room && ` · Salle ${data.next_course.room}`}
+                  {" · "}
+                  {data.next_course.teacher_name}
                 </p>
               </div>
             ) : (
-              <p className="text-sm text-muted-foreground mt-1">Aucun cours programmé</p>
+              <p className="mt-1 text-sm text-muted-foreground">Aucun cours programmé</p>
             )}
           </div>
         </CardContent>
       </Card>
 
-      {/* KPIs — colorés seulement si vraiment applicables. Sinon `—` muted
-          pour éviter le faux signal "0 FCFA vert = tout payé" quand en fait
-          l'élève n'a juste pas encore de frais affectés. */}
+      {/* KPIs — `—` muted quand non applicable pour éviter le faux signal
+          "0 FCFA vert = tout payé" alors qu'aucun frais n'est encore affecté. */}
       <div className="grid grid-cols-3 gap-3">
-        <KpiCard
+        <KpiTile
           icon={ClipboardList}
           label="Moyenne"
           value={data.general_average !== null ? `${data.general_average.toFixed(2)}/20` : "—"}
-          className={
+          valueClassName={
             data.general_average === null
               ? "text-muted-foreground"
               : data.general_average >= 10
@@ -92,11 +88,11 @@ export function StudentDashboardClient() {
                 : "text-amber-600"
           }
         />
-        <KpiCard
+        <KpiTile
           icon={Wallet}
           label="Frais restants"
           value={isEnrolled ? `${data.fees_remaining.toLocaleString("fr-FR")} FCFA` : "—"}
-          className={
+          valueClassName={
             !isEnrolled
               ? "text-muted-foreground"
               : data.fees_remaining === 0
@@ -104,16 +100,16 @@ export function StudentDashboardClient() {
                 : "text-accent"
           }
         />
-        <KpiCard
+        <KpiTile
           icon={AlertCircle}
           label="Absences"
           value={isEnrolled ? String(data.total_absences) : "—"}
-          className={
+          valueClassName={
             !isEnrolled
               ? "text-muted-foreground"
               : data.total_absences > 5
                 ? "text-destructive"
-                : "text-muted-foreground"
+                : "text-foreground"
           }
         />
       </div>
@@ -121,22 +117,34 @@ export function StudentDashboardClient() {
   )
 }
 
-function KpiCard({
+function DashboardHeader({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h1 className="font-serif text-2xl tracking-tight">{title}</h1>
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
+      </div>
+      <Separator />
+    </div>
+  )
+}
+
+function KpiTile({
   icon: Icon,
   label,
   value,
-  className,
+  valueClassName,
 }: {
   icon: React.ComponentType<{ className?: string }>
   label: string
   value: string
-  className?: string
+  valueClassName?: string
 }) {
   return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
+    <Card className="shadow-sm">
       <CardContent className="p-3 text-center">
-        <Icon className="mx-auto mb-1 h-5 w-5 text-muted-foreground" />
-        <p className={`text-lg font-bold ${className ?? ""}`}>{value}</p>
+        <Icon className="mx-auto mb-1 h-5 w-5 text-muted-foreground" aria-hidden="true" />
+        <p className={`text-lg font-bold tabular-nums ${valueClassName ?? ""}`}>{value}</p>
         <p className="text-[10px] text-muted-foreground">{label}</p>
       </CardContent>
     </Card>

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -8,12 +8,13 @@ import {
   BookOpen,
   ClipboardList,
   ChevronRight,
-  AlertTriangle,
   CalendarX,
 } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
@@ -52,95 +53,72 @@ export function TeacherDashboardClient() {
 
   return (
     <div className="space-y-6">
-      <DashboardHeader name={data.teacher_name} />
-
-      <AcademicYearBanner
-        currentYear={data.current_academic_year}
-        role="teacher"
-      />
-
-      {/* Action rapide — déclaration d'absence */}
-      <div className="flex justify-end">
+      <DashboardHeader name={data.teacher_name}>
         <Button
           variant="outline"
           size="sm"
           onClick={() => setSelfDeclareOpen(true)}
-          className="h-11 border-amber-200 bg-amber-50 font-medium text-amber-900 hover:bg-amber-100 sm:h-9"
+          className="h-11 sm:h-9"
         >
-          <CalendarX className="mr-1.5 h-4 w-4" />
+          <CalendarX className="mr-1.5 h-4 w-4" aria-hidden="true" />
           Me déclarer absent
         </Button>
-      </div>
+      </DashboardHeader>
 
-      {/* Prochain cours */}
-      <Card className="border-primary/20 bg-primary/5">
+      <AcademicYearBanner currentYear={data.current_academic_year} role="teacher" />
+
+      {/* Prochain cours — seul accent primary (mise en valeur) */}
+      <Card className="border-primary/30 bg-primary/5 shadow-sm">
         <CardContent className="flex items-center gap-4 p-4">
-          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
-            <CalendarDays className="h-6 w-6" />
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+            <CalendarDays className="h-6 w-6" aria-hidden="true" />
           </div>
           <div className="min-w-0">
-            <p className="text-xs font-medium text-primary uppercase tracking-wider">
+            <p className="text-xs font-medium uppercase tracking-wider text-primary">
               Prochain cours
             </p>
             {data.next_course ? (
               <div className="mt-1">
-                <p className="text-sm font-semibold">
-                  {data.next_course.subject_name}
-                </p>
+                <p className="text-sm font-semibold">{data.next_course.subject_name}</p>
                 <p className="text-xs text-muted-foreground">
                   {data.next_course.start_time} - {data.next_course.end_time}
-                  {" • "}{data.next_course.class_name}
-                  {data.next_course.room && ` • Salle ${data.next_course.room}`}
+                  {" · "}
+                  {data.next_course.class_name}
+                  {data.next_course.room && ` · Salle ${data.next_course.room}`}
                 </p>
               </div>
             ) : (
-              <p className="text-sm text-muted-foreground mt-1">
-                Aucun cours programmé
-              </p>
+              <p className="mt-1 text-sm text-muted-foreground">Aucun cours programmé</p>
             )}
           </div>
         </CardContent>
       </Card>
 
-      {/* KPIs */}
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-        <Card className="border-0 shadow-sm ring-1 ring-border">
-          <CardContent className="flex items-center gap-3 p-4">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-              <Users className="h-5 w-5 text-primary" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold">{data.total_students}</p>
-              <p className="text-[10px] text-muted-foreground">Élèves</p>
-            </div>
-          </CardContent>
-        </Card>
-        <Link href="/teacher/classes">
-          <Card className="border-0 shadow-sm ring-1 ring-border hover:ring-primary/50 transition-colors">
-            <CardContent className="flex items-center gap-3 p-4">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-                <BookOpen className="h-5 w-5 text-primary" />
-              </div>
-              <div className="flex-1">
-                <p className="text-2xl font-bold">{data.total_classes}</p>
-                <p className="text-[10px] text-muted-foreground">Classes</p>
-              </div>
-              <ChevronRight className="h-4 w-4 text-muted-foreground" />
-            </CardContent>
-          </Card>
+      {/* KPIs — Card neutres shadcn */}
+      <div className="grid grid-cols-2 gap-3">
+        <StatCard icon={Users} value={data.total_students} label="Élèves" />
+        <Link href="/teacher/classes" className="group">
+          <StatCard
+            icon={BookOpen}
+            value={data.total_classes}
+            label="Classes"
+            className="transition-colors group-hover:border-primary/40"
+            trailing={<ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
+          />
         </Link>
       </div>
 
       {/* Évaluations à venir */}
-      <div>
-        <h2 className="text-sm font-semibold mb-3">Évaluations à venir</h2>
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold">Évaluations à venir</h2>
         {data.upcoming_evaluations.length === 0 ? (
-          <Card className="border-0 shadow-sm ring-1 ring-border">
+          <Card className="shadow-sm">
             <CardContent className="py-8 text-center">
-              <ClipboardList className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" />
-              <p className="text-sm text-muted-foreground">
-                Aucune évaluation programmée.
-              </p>
+              <ClipboardList
+                className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50"
+                aria-hidden="true"
+              />
+              <p className="text-sm text-muted-foreground">Aucune évaluation programmée.</p>
             </CardContent>
           </Card>
         ) : (
@@ -150,7 +128,7 @@ export function TeacherDashboardClient() {
             ))}
           </div>
         )}
-      </div>
+      </section>
 
       <SelfDeclareAbsenceModal
         open={selfDeclareOpen}
@@ -160,16 +138,55 @@ export function TeacherDashboardClient() {
   )
 }
 
-function DashboardHeader({ name }: { name: string | null }) {
+function DashboardHeader({
+  name,
+  children,
+}: {
+  name: string | null
+  children?: React.ReactNode
+}) {
   return (
-    <div>
-      <h1 className="font-serif text-xl tracking-tight">
-        {name ? `Bonjour, ${name.split(" ")[0]}` : "Espace Enseignant"}
-      </h1>
-      <p className="text-sm text-muted-foreground">
-        Votre journée en un coup d&apos;œil
-      </p>
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h1 className="font-serif text-2xl tracking-tight">
+            {name ? `Bonjour, ${name.split(" ")[0]}` : "Espace Enseignant"}
+          </h1>
+          <p className="text-sm text-muted-foreground">Votre journée en un coup d&apos;œil</p>
+        </div>
+        {children}
+      </div>
+      <Separator />
     </div>
+  )
+}
+
+function StatCard({
+  icon: Icon,
+  value,
+  label,
+  className,
+  trailing,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  value: React.ReactNode
+  label: string
+  className?: string
+  trailing?: React.ReactNode
+}) {
+  return (
+    <Card className={`shadow-sm ${className ?? ""}`}>
+      <CardContent className="flex items-center gap-3 p-4">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+          <Icon className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div className="flex-1">
+          <p className="text-2xl font-bold tabular-nums">{value}</p>
+          <p className="text-xs text-muted-foreground">{label}</p>
+        </div>
+        {trailing}
+      </CardContent>
+    </Card>
   )
 }
 
@@ -181,27 +198,33 @@ function EvaluationCard({ evaluation }: { evaluation: TeacherUpcomingEval }) {
   const needsGrading = evaluation.graded_students < evaluation.total_students
 
   return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
-      <CardContent className="p-3">
+    <Card className="shadow-sm">
+      <CardContent className="space-y-2 p-3">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
-            <p className="text-sm font-semibold truncate">{evaluation.title}</p>
+            <p className="truncate text-sm font-semibold">{evaluation.title}</p>
             <p className="text-xs text-muted-foreground">
-              {evaluation.class_name} • {evaluation.subject_name}
+              {evaluation.class_name} · {evaluation.subject_name}
             </p>
             <p className="text-xs text-muted-foreground">{evaluation.date}</p>
           </div>
-          <div className="flex flex-col items-end gap-1 shrink-0">
-            <Badge variant="secondary" className="text-[10px]">
-              {evaluation.type}
-            </Badge>
-            {needsGrading && (
-              <span className="flex items-center gap-1 text-[10px] text-accent">
-                <AlertTriangle className="h-3 w-3" />
-                {gradedPercent}% noté
-              </span>
-            )}
-          </div>
+          <Badge variant="secondary" className="shrink-0 text-[10px] capitalize">
+            {evaluation.type}
+          </Badge>
+        </div>
+        <div className="flex items-center gap-2">
+          <Progress
+            value={gradedPercent}
+            className="h-1.5"
+            aria-label={`${gradedPercent}% des copies notées`}
+          />
+          <span
+            className={`shrink-0 text-[10px] font-medium tabular-nums ${
+              needsGrading ? "text-accent" : "text-muted-foreground"
+            }`}
+          >
+            {gradedPercent}% noté
+          </span>
         </div>
       </CardContent>
     </Card>
@@ -216,7 +239,7 @@ function DashboardSkeleton() {
         <Skeleton className="h-4 w-64" />
       </div>
       <Skeleton className="h-20 rounded-xl" />
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3">
         <Skeleton className="h-20 rounded-lg" />
         <Skeleton className="h-20 rounded-lg" />
       </div>


### PR DESCRIPTION
## Objectif

Refonte du design des 4 tableaux de bord des portails (Administration, Enseignant, Élève, Parent) en utilisant uniquement des composants shadcn/ui, direction **clean monochrome** (1 seul accent + neutres), conformément aux préférences design (no AI slop).

## Changements

**Admin**
- `WelcomeHeader` : suppression du hero en dégradé + orbes décoratifs (AI slop banni) → en-tête sobre titre + date + `Separator`.
- `KpiCard` : système de `variant` arc-en-ciel (blue/orange/emerald/rose) remplacé par un système de `tone` restreint (primary / accent / destructive / muted). Cartes shadcn neutres.
- `DashboardKpis` : tons sémantiques (paiements en accent si > 0, alertes en destructive si > 0, sinon muted).
- `QuickActions` : icônes monochromes (muted) avec survol primary, au lieu de 6 couleurs par action.
- `RecentActivity` : pastilles d'activité monochromes uniformes (l'icône + le libellé portent le sens).
- `DashboardCharts` : palette pilotée par les tokens `--chart-1..5` du thème (shadcn-native) au lieu d'un tableau de 8 couleurs codées en dur.

**Enseignant / Élève / Parent**
- En-tête sobre uniforme + `Separator`.
- Carte « Prochain cours » / « Mes enfants » = unique accent primary.
- KPIs en `Card` shadcn neutres, sémantique conservée (vert/orange/rouge seulement quand ça a du sens).
- Enseignant : barre `Progress` shadcn pour l'avancement des notes.
- Parent : `Avatar` shadcn par enfant, boutons Notes/Frais en `Button` outline (h-11 mobile).
- Logique « non inscrit » / faux signal « 0 FCFA vert » **conservée intacte**.

## Notes

- Aucune modification de logique métier ni de data fetching : refonte purement présentationnelle.
- `tsc --noEmit` : OK (clean).
- Le super-admin `/dashboard` est un simple `redirect()` vers la liste des tenants : pas d'UI de dashboard à refondre.
- Visual-check à effectuer après déploiement (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)