### PR TITLE
feat(ui): KPIs, recherche intelligente et filtres sur les pages de gestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Indicateurs clés (KPI), recherche instantanée et filtres ajoutés sur les pages de gestion qui en manquaient : Classes, Matières, Niveaux, Années scolaires, Inscriptions, Salles, Notifications, Frais, ainsi que les listes Élèves, Enseignants, Personnel et Parents. La recherche ignore les accents et la casse (taper « traore » trouve « Traoré ») *(admin)*.
+- Portails Enseignant et Parent : bandeau d'indicateurs en tête des listes « Mes classes », « Mes évaluations » et « Mes enfants », plus une recherche rapide pour retrouver une classe ou une évaluation *(enseignant, parent)*.
 - Fiches détail Élève, Enseignant, Personnel, Parent, Classe, Inscription : la flèche de retour passe à h-11 sur mobile (touch target Itel S661) au lieu de h-8/h-9 trop petit. Aria-label rendu explicite « Retour à la liste des inscriptions » au lieu de « Retour » seul *(admin)*.
 - Page Promotions admin : icône d'en-tête masquée aux lecteurs d'écran, bouton « Recommencer » passe à h-11 sur mobile *(admin)*.
 - Portail enseignant — fiche « Mes classes » : empty state plus chaleureux « Aucune classe assignée pour le moment » + invite à contacter l'administration. Bouton « Gérer les notes » passe à h-11 sur mobile avec aria-label explicite incluant la classe et la matière, pour mieux distinguer plusieurs cartes côte à côte *(enseignant)*.

--- a/components/admin/academic-years/AcademicYearsTable.tsx
+++ b/components/admin/academic-years/AcademicYearsTable.tsx
@@ -2,19 +2,74 @@
 
 import { useMemo, useState } from "react"
 import type { ColumnDef } from "@tanstack/react-table"
-import { CheckCircle2, Circle } from "lucide-react"
+import { CheckCircle2, Circle, CalendarRange, CalendarCheck, History, CalendarClock } from "lucide-react"
 import { useAcademicYears, useDeleteAcademicYear, useSetCurrentYear } from "@/lib/hooks/useAcademicYears"
 import type { AcademicYear } from "@/lib/contracts/academic-year"
-import { CrudTable } from "@/components/shared/CrudTable"
+import type { PaginatedResponse } from "@/lib/contracts"
+import { CrudTable, type FilterConfig } from "@/components/shared/CrudTable"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { AcademicYearEditModal } from "./AcademicYearEditModal"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { matchesSearch } from "@/lib/utils/list-search"
+
+type StatusFilter = "" | "current" | "past" | "upcoming"
+
+function yearStatus(y: AcademicYear, now: number): Exclude<StatusFilter, ""> | "current" {
+  if (y.is_current) return "current"
+  if (new Date(y.end_date).getTime() < now) return "past"
+  if (new Date(y.start_date).getTime() > now) return "upcoming"
+  return "current"
+}
 
 export function AcademicYearsTable() {
-  const [page, setPage] = useState(1)
-  const { data, isLoading, isError, error, refetch } = useAcademicYears({ page })
+  // Les années scolaires sont peu nombreuses : on charge tout et on filtre côté
+  // client (recherche multi-champs + statut), pas de pagination serveur.
+  const { data, isLoading, isError, error, refetch } = useAcademicYears({ size: 100 })
   const deleteMutation = useDeleteAcademicYear()
   const setCurrentMutation = useSetCurrentYear()
+
+  const [search, setSearch] = useState("")
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("")
+
+  const allItems = useMemo(() => data?.items ?? [], [data])
+  const now = Date.now()
+
+  const kpis: KpiItem[] = useMemo(() => {
+    const current = allItems.find((y) => y.is_current)
+    const past = allItems.filter((y) => !y.is_current && new Date(y.end_date).getTime() < now).length
+    const upcoming = allItems.filter((y) => !y.is_current && new Date(y.start_date).getTime() > now).length
+    return [
+      { label: "Années", value: allItems.length, icon: CalendarRange, tone: "primary" },
+      { label: "Année courante", value: current?.name ?? "—", icon: CalendarCheck, tone: current ? "emerald" : "default" },
+      { label: "Passées", value: past, icon: History, tone: "default" },
+      { label: "À venir", value: upcoming, icon: CalendarClock, tone: "default" },
+    ]
+  }, [allItems, now])
+
+  const filtered = useMemo(() => {
+    return allItems.filter((y) => {
+      if (statusFilter && yearStatus(y, now) !== statusFilter) return false
+      return matchesSearch([y.name, y.label], search)
+    })
+  }, [allItems, search, statusFilter, now])
+
+  const tableData: PaginatedResponse<AcademicYear> | undefined = data
+    ? { items: filtered, total: filtered.length, page: 1, size: filtered.length || 1, total_pages: 1 }
+    : undefined
+
+  const filterConfigs: FilterConfig[] = [
+    {
+      key: "status",
+      label: "Statut",
+      type: "select",
+      options: [
+        { value: "current", label: "Année courante" },
+        { value: "past", label: "Passées" },
+        { value: "upcoming", label: "À venir" },
+      ],
+    },
+  ]
 
   const columns: ColumnDef<AcademicYear>[] = useMemo(() => [
     {
@@ -24,7 +79,7 @@ export function AcademicYearsTable() {
     },
     {
       accessorKey: "start_date",
-      header: "Debut",
+      header: "Début",
       cell: ({ row }) => (
         <span className="text-sm text-muted-foreground">
           {new Date(row.original.start_date).toLocaleDateString("fr-FR")}
@@ -62,7 +117,7 @@ export function AcademicYearsTable() {
             onClick={() => setCurrentMutation.mutate(row.original.id)}
           >
             <Circle className="h-3 w-3" />
-            Definir comme courante
+            Définir comme courante
           </Button>
         )
       },
@@ -70,23 +125,30 @@ export function AcademicYearsTable() {
   ], [setCurrentMutation])
 
   return (
-    <CrudTable<AcademicYear>
-      data={data}
-      columns={columns}
-      isLoading={isLoading}
-      isError={isError}
-      error={error}
-      refetch={refetch}
-      deleteMutation={deleteMutation}
-      renderEditModal={({ itemId, open, onClose }) => (
-        <AcademicYearEditModal yearId={itemId} open={open} onClose={onClose} />
-      )}
-      getItemLabel={(y) => y.name}
-      emptyMessage="Aucune annee academique trouvee"
-      errorMessage="Impossible de charger les annees academiques"
-      deleteDescription="Cette action est irreversible. L'annee academique sera definitivement supprimee."
-      page={page}
-      onPageChange={setPage}
-    />
+    <div className="space-y-4">
+      <KpiStrip items={kpis} />
+      <CrudTable<AcademicYear>
+        data={tableData}
+        columns={columns}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        refetch={refetch}
+        deleteMutation={deleteMutation}
+        renderEditModal={({ itemId, open, onClose }) => (
+          <AcademicYearEditModal yearId={itemId} open={open} onClose={onClose} />
+        )}
+        getItemLabel={(y) => y.name}
+        emptyMessage="Aucune année académique trouvée"
+        errorMessage="Impossible de charger les années académiques"
+        deleteDescription="Cette action est irréversible. L'année académique sera définitivement supprimée."
+        searchPlaceholder="Rechercher une année…"
+        searchValue={search}
+        onSearchChange={setSearch}
+        filterConfigs={filterConfigs}
+        filterValues={{ status: statusFilter }}
+        onFilterChange={(_key, value) => setStatusFilter(value as StatusFilter)}
+      />
+    </div>
   )
 }

--- a/components/admin/attendance/AttendancePageClient.tsx
+++ b/components/admin/attendance/AttendancePageClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { ClipboardList, ClipboardCheck, History, BarChart3, UserCheck } from "lucide-react"
+import { ClipboardList, ClipboardCheck, History, BarChart3, UserCheck, School, BookOpen, CalendarDays } from "lucide-react"
 import {
   Select,
   SelectContent,
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/select"
 import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { AttendanceGrid } from "./AttendanceGrid"
 import { AttendanceHistory } from "./AttendanceHistory"
 import { AttendanceStats } from "./AttendanceStats"
@@ -68,6 +69,22 @@ export function AttendancePageClient() {
     ? `Classe ${selectedClass.name}${dayOfWeek ? ` · ${dayOfWeek}` : ""}`
     : "Pointage des présences par session de cours, historique et statistiques"
 
+  const kpis: KpiItem[] = [
+    { label: "Classes", value: classes.length, icon: School, tone: "primary" },
+    {
+      label: selectedClass ? "Créneaux de la classe" : "Créneaux",
+      value: selectedClass ? (slots?.length ?? 0) : "—",
+      icon: BookOpen,
+      tone: "default",
+    },
+    {
+      label: "Créneaux ce jour",
+      value: selectedClass ? availableSlots.length : "—",
+      icon: CalendarDays,
+      tone: selectedClass && availableSlots.length === 0 ? "accent" : "default",
+    },
+  ]
+
   return (
     <div className="space-y-6">
       {/* En-tête */}
@@ -80,6 +97,8 @@ export function AttendancePageClient() {
           <p className="text-sm text-muted-foreground capitalize">{subtitle}</p>
         </div>
       </div>
+
+      <KpiStrip items={kpis} columns={3} />
 
       {/* Filtres principaux */}
       <div className="flex flex-wrap items-end gap-3">

--- a/components/admin/classes/ClassesPageClient.tsx
+++ b/components/admin/classes/ClassesPageClient.tsx
@@ -1,11 +1,33 @@
 "use client"
 
-import { useState } from "react"
-import { School, Plus, LayoutGrid, List } from "lucide-react"
+import { useMemo, useState } from "react"
+import { School, Plus, LayoutGrid, List, Users, Gauge, AlertTriangle } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { useClasses } from "@/lib/hooks/useClasses"
 import { ClassesTable } from "./ClassesTable"
 import { ClassesTreeView } from "./ClassesTreeView"
 import { ClassCreateModal } from "./ClassCreateModal"
+
+function ClassesKpis() {
+  const { data } = useClasses({ size: 200 })
+  const kpis: KpiItem[] = useMemo(() => {
+    const items = data?.items ?? []
+    const enrolled = items.reduce((s, c) => s + (c.enrolled_count ?? 0), 0)
+    const capacity = items.reduce((s, c) => s + (c.max_students ?? 0), 0)
+    const rate = capacity > 0 ? Math.round((enrolled / capacity) * 100) : 0
+    const full = items.filter(
+      (c) => (c.max_students ?? 0) > 0 && (c.enrolled_count ?? 0) / (c.max_students ?? 1) > 0.95,
+    ).length
+    return [
+      { label: "Classes", value: items.length, icon: School, tone: "primary" },
+      { label: "Élèves inscrits", value: enrolled, icon: Users, tone: "default" },
+      { label: "Taux d'occupation", value: `${rate}%`, icon: Gauge, tone: rate >= 80 ? "accent" : "emerald" },
+      { label: "Classes pleines", value: full, icon: AlertTriangle, tone: full > 0 ? "destructive" : "default" },
+    ]
+  }, [data])
+  return <KpiStrip items={kpis} />
+}
 
 export function ClassesPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
@@ -59,6 +81,8 @@ export function ClassesPageClient() {
           </Button>
         </div>
       </div>
+
+      <ClassesKpis />
 
       {/* Content : mobile force toujours table (qui contient cards mobile),
           desktop respecte le choix utilisateur (arbre par défaut). */}

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -1,12 +1,31 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useSearchParams } from "next/navigation"
-import { GraduationCap, Plus } from "lucide-react"
+import { GraduationCap, Plus, ListChecks, CheckCircle2, Clock, XCircle } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { EnrollmentsTable } from "./EnrollmentsTable"
 import { EnrollmentCreateModal } from "./EnrollmentCreateModal"
 import { useEnrollments } from "@/lib/hooks/useEnrollments"
+
+function EnrollmentsKpis() {
+  const { data } = useEnrollments({ size: 300 })
+  const kpis: KpiItem[] = useMemo(() => {
+    const items = data?.items ?? []
+    const total = data?.total ?? items.length
+    const valid = items.filter((e) => e.status === "valide").length
+    const pending = items.filter((e) => e.status === "prospect" || e.status === "en_validation").length
+    const closed = items.filter((e) => e.status === "rejete" || e.status === "annule").length
+    return [
+      { label: "Inscriptions", value: total, icon: ListChecks, tone: "primary" },
+      { label: "Validées", value: valid, icon: CheckCircle2, tone: "emerald" },
+      { label: "À valider", value: pending, icon: Clock, tone: pending > 0 ? "accent" : "default" },
+      { label: "Rejetées / annulées", value: closed, icon: XCircle, tone: "default" },
+    ]
+  }, [data])
+  return <KpiStrip items={kpis} />
+}
 
 // Subtitle informatif sans redondance avec les chips. Le total renseigne
 // l'admin sur la volumétrie de la queue ; les counts par statut sont sur
@@ -60,6 +79,8 @@ export function EnrollmentsPageClient() {
           Nouvelle inscription
         </Button>
       </div>
+
+      <EnrollmentsKpis />
 
       <EnrollmentsTable />
 

--- a/components/admin/fees/FeesPageClient.tsx
+++ b/components/admin/fees/FeesPageClient.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { Plus, Pencil, Trash2, Wallet, Search, X, Shield, CircleDot, Layers } from "lucide-react"
+import { Plus, Pencil, Trash2, Wallet, Search, X, Shield, CircleDot, Layers, Coins } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { FilterChips } from "@/components/shared/list/FilterChips"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   AlertDialog,
@@ -39,6 +41,7 @@ export function FeesPageClient() {
   const [deleteTarget, setDeleteTarget] = useState<{ type: "category" | "variant"; id: number; name: string } | null>(null)
   const [optionsCategory, setOptionsCategory] = useState<FeeCategory | null>(null)
   const [searchVariant, setSearchVariant] = useState("")
+  const [categoryFilter, setCategoryFilter] = useState<"all" | "mandatory" | "optional">("all")
 
   const { data: academicYearsData } = useAcademicYears()
   const currentYearId = academicYearsData?.items?.[0]?.id
@@ -87,6 +90,21 @@ export function FeesPageClient() {
   const totalMandatory = categories?.filter((c) => c.is_mandatory).length ?? 0
   const totalOptional = categories?.filter((c) => !c.is_mandatory).length ?? 0
   const totalVariants = variants?.length ?? 0
+  const totalConfigured = variants?.reduce((sum, v) => sum + v.amount, 0) ?? 0
+
+  const kpis: KpiItem[] = [
+    { label: "Obligatoires", value: totalMandatory, icon: Shield, tone: "primary" },
+    { label: "Optionnels", value: totalOptional, icon: CircleDot, tone: "default" },
+    { label: "Variantes", value: totalVariants, icon: Layers, tone: "default" },
+    { label: "Montant configuré", value: `${totalConfigured.toLocaleString("fr-FR")} F`, icon: Coins, tone: "accent" },
+  ]
+
+  // Filtre obligatoire/optionnel sur les catégories affichées.
+  const displayedCategories = (categories ?? []).filter((c) => {
+    if (categoryFilter === "mandatory") return c.is_mandatory
+    if (categoryFilter === "optional") return !c.is_mandatory
+    return true
+  })
 
   function handleConfirmDelete() {
     if (!deleteTarget) return
@@ -126,54 +144,32 @@ export function FeesPageClient() {
       </div>
 
       {/* KPI summary */}
-      <div className="grid grid-cols-3 gap-4">
-        <Card className="border-0 shadow-sm ring-1 ring-border">
-          <CardContent className="p-4 flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-red-100">
-              <Shield className="h-4 w-4 text-red-600" />
-            </div>
-            <div>
-              <p className="text-xs text-muted-foreground">Obligatoires</p>
-              <p className="text-xl font-bold">{totalMandatory}</p>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-0 shadow-sm ring-1 ring-border">
-          <CardContent className="p-4 flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-100">
-              <CircleDot className="h-4 w-4 text-blue-600" />
-            </div>
-            <div>
-              <p className="text-xs text-muted-foreground">Optionnels</p>
-              <p className="text-xl font-bold">{totalOptional}</p>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-0 shadow-sm ring-1 ring-border">
-          <CardContent className="p-4 flex items-center gap-3">
-            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-100">
-              <Layers className="h-4 w-4 text-emerald-600" />
-            </div>
-            <div>
-              <p className="text-xs text-muted-foreground">Variantes</p>
-              <p className="text-xl font-bold">{totalVariants}</p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <KpiStrip items={kpis} />
 
       {/* Categories as premium cards */}
       <div>
-        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">Catégories de frais</h2>
+        <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">Catégories de frais</h2>
+          <FilterChips
+            aria-label="Filtrer les catégories"
+            value={categoryFilter}
+            onChange={(v) => setCategoryFilter(v as "all" | "mandatory" | "optional")}
+            options={[
+              { value: "all", label: "Toutes", count: (categories ?? []).length },
+              { value: "mandatory", label: "Obligatoires", count: totalMandatory },
+              { value: "optional", label: "Optionnels", count: totalOptional },
+            ]}
+          />
+        </div>
         {loadingCategories ? (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 3 }).map((_, i) => (
               <Skeleton key={i} className="h-32 rounded-xl" />
             ))}
           </div>
-        ) : categories && categories.length > 0 ? (
+        ) : displayedCategories.length > 0 ? (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {categories.map((cat) => {
+            {displayedCategories.map((cat) => {
               const color = cat.is_mandatory ? MANDATORY_COLOR : OPTIONAL_COLOR
               const catVariants = variantsByCategory.get(cat.id) ?? []
               const totalAmount = catVariants.reduce((sum, v) => sum + v.amount, 0)

--- a/components/admin/levels/LevelsAndSeriesPageClient.tsx
+++ b/components/admin/levels/LevelsAndSeriesPageClient.tsx
@@ -11,6 +11,7 @@ import {
   GraduationCap,
   BookOpen,
   GripVertical,
+  AlertTriangle,
 } from "lucide-react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
@@ -27,6 +28,9 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { ListSearchBar } from "@/components/shared/list/ListSearchBar"
+import { matchesSearch } from "@/lib/utils/list-search"
 import { useLevels, useDeleteLevel } from "@/lib/hooks/useLevels"
 import { useSeriesList, useDeleteSeries, seriesKeys } from "@/lib/hooks/useSeries"
 import { seriesApi } from "@/lib/api/series"
@@ -51,6 +55,7 @@ export function LevelsAndSeriesPageClient() {
   const [editSeriesId, setEditSeriesId] = useState<number | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<{ type: "level" | "series"; id: number; name: string } | null>(null)
   const [dragOverLevelId, setDragOverLevelId] = useState<number | null>(null)
+  const [search, setSearch] = useState("")
 
   const queryClient = useQueryClient()
 
@@ -89,6 +94,33 @@ export function LevelsAndSeriesPageClient() {
   }
 
   const sortedLevels = [...levels].sort((a, b) => a.order - b.order)
+
+  // KPIs (données peu nombreuses : calcul direct à chaque render).
+  const noSeriesCount = levels.filter((l) => (seriesByLevel.get(l.id)?.length ?? 0) === 0).length
+  const avgSeries = levels.length > 0 ? (allSeries.length / levels.length).toFixed(1) : "0"
+  const kpis: KpiItem[] = [
+    { label: "Niveaux", value: levels.length, icon: GraduationCap, tone: "primary" },
+    { label: "Séries", value: allSeries.length, icon: BookOpen, tone: "default" },
+    { label: "Séries / niveau", value: avgSeries, icon: Layers, tone: "default" },
+    { label: "Niveaux sans série", value: noSeriesCount, icon: AlertTriangle, tone: noSeriesCount > 0 ? "accent" : "default" },
+  ]
+
+  // Recherche : filtre les niveaux par nom OU par nom de série. Quand un niveau
+  // matche par son nom, on garde toutes ses séries ; sinon on ne montre que les
+  // séries qui matchent.
+  const q = search.trim()
+  const seriesToShow = (levelId: number, levelName: string): Series[] => {
+    const list = seriesByLevel.get(levelId) ?? []
+    if (!q || matchesSearch([levelName], q)) return list
+    return list.filter((s) => matchesSearch([s.name, `série ${s.name}`], q))
+  }
+  const displayLevels = !q
+    ? sortedLevels
+    : sortedLevels.filter(
+        (l) =>
+          matchesSearch([l.name], q) ||
+          (seriesByLevel.get(l.id) ?? []).some((s) => matchesSearch([s.name], q)),
+      )
 
   const toggleExpand = (levelId: number) => {
     setExpanded((prev) => {
@@ -163,6 +195,15 @@ export function LevelsAndSeriesPageClient() {
         </div>
       </div>
 
+      <KpiStrip items={kpis} />
+
+      <ListSearchBar
+        value={search}
+        onChange={setSearch}
+        placeholder="Rechercher un niveau ou une série…"
+        aria-label="Rechercher un niveau ou une série"
+      />
+
       {/* Tree */}
       {sortedLevels.length === 0 ? (
         <div className="rounded-lg border bg-card flex flex-col items-center justify-center py-16 text-center">
@@ -175,9 +216,15 @@ export function LevelsAndSeriesPageClient() {
         </div>
       ) : (
         <div className="rounded-lg border bg-card overflow-hidden select-none p-3 space-y-1">
-          {sortedLevels.map((level) => {
-            const isOpen = expanded.has(level.id)
-            const levelSeries = seriesByLevel.get(level.id) ?? []
+          {displayLevels.length === 0 && (
+            <p className="px-2 py-10 text-center text-sm text-muted-foreground">
+              Aucun niveau ou série ne correspond à « {search} ».
+            </p>
+          )}
+          {displayLevels.map((level) => {
+            // En recherche, on force l'ouverture pour révéler les séries matchées.
+            const isOpen = q ? true : expanded.has(level.id)
+            const levelSeries = seriesToShow(level.id, level.name)
 
             return (
               <div

--- a/components/admin/notifications/NotificationsPageClient.tsx
+++ b/components/admin/notifications/NotificationsPageClient.tsx
@@ -12,11 +12,18 @@ import {
   Check,
   CheckCheck,
   Filter,
+  MailOpen,
+  Mail,
+  Inbox,
+  Layers,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { ListSearchBar } from "@/components/shared/list/ListSearchBar"
+import { matchesSearch } from "@/lib/utils/list-search"
 import {
   Select,
   SelectContent,
@@ -97,6 +104,7 @@ const NOTIFICATION_TYPES: NotificationType[] = [
 export function NotificationsPageClient() {
   const [typeFilter, setTypeFilter] = useState<NotificationType | "all">("all")
   const [readFilter, setReadFilter] = useState<"all" | "unread" | "read">("all")
+  const [search, setSearch] = useState("")
 
   const params = {
     ...(typeFilter !== "all" && { type: typeFilter }),
@@ -105,11 +113,28 @@ export function NotificationsPageClient() {
   }
 
   const { data: notifications, isLoading, isError, refetch } = useNotifications(params)
+  // Liste non filtrée pour les KPIs (totaux indépendants des filtres actifs).
+  const { data: allNotifications } = useNotifications({})
   const { data: countData } = useNotificationCount()
   const markAsRead = useMarkAsRead()
   const markAllAsRead = useMarkAllAsRead()
 
   const unreadCount = countData?.count ?? 0
+
+  const all = allNotifications ?? []
+  const total = all.length
+  const distinctTypes = new Set(all.map((n) => n.type)).size
+  const kpis: KpiItem[] = [
+    { label: "Total", value: total, icon: Inbox, tone: "primary" },
+    { label: "Non lues", value: unreadCount, icon: Mail, tone: unreadCount > 0 ? "accent" : "default" },
+    { label: "Lues", value: Math.max(total - unreadCount, 0), icon: MailOpen, tone: "default" },
+    { label: "Types actifs", value: distinctTypes, icon: Layers, tone: "default" },
+  ]
+
+  // Recherche client sur titre + corps (par-dessus les filtres serveur type/lu).
+  const visibleNotifications = (notifications ?? []).filter((n) =>
+    matchesSearch([n.title, n.body], search),
+  )
 
   return (
     <div className="space-y-6">
@@ -141,8 +166,16 @@ export function NotificationsPageClient() {
         )}
       </div>
 
-      {/* Filtres */}
-      <div className="flex gap-3">
+      <KpiStrip items={kpis} />
+
+      {/* Recherche + Filtres */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <ListSearchBar
+          value={search}
+          onChange={setSearch}
+          placeholder="Rechercher dans les notifications…"
+          aria-label="Rechercher une notification"
+        />
         <Select
           value={typeFilter}
           onValueChange={(v) => setTypeFilter(v as NotificationType | "all")}
@@ -184,14 +217,16 @@ export function NotificationsPageClient() {
           message="Impossible de charger les notifications."
           onRetry={() => refetch()}
         />
-      ) : !notifications || notifications.length === 0 ? (
+      ) : visibleNotifications.length === 0 ? (
         <div className="py-16 text-center">
           <Bell className="mx-auto mb-3 h-10 w-10 text-muted-foreground/40" />
-          <p className="text-sm text-muted-foreground">Aucune notification.</p>
+          <p className="text-sm text-muted-foreground">
+            {search ? `Aucune notification ne correspond à « ${search} ».` : "Aucune notification."}
+          </p>
         </div>
       ) : (
         <div className="space-y-2">
-          {notifications.map((notification) => (
+          {visibleNotifications.map((notification) => (
             <NotificationRow
               key={notification.id}
               notification={notification}

--- a/components/admin/parents/ParentsPageClient.tsx
+++ b/components/admin/parents/ParentsPageClient.tsx
@@ -1,16 +1,29 @@
 "use client"
 
-import { useState } from "react"
-import { HeartHandshake, Plus } from "lucide-react"
+import { useMemo, useState } from "react"
+import { HeartHandshake, Plus, Users, UserCheck, UserX, Mail } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { useParents } from "@/lib/hooks/useParents"
 import { ParentsTable } from "./ParentsTable"
 import { ParentCreateModal } from "./ParentCreateModal"
 
 export function ParentsPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
-  const { data } = useParents({ size: 1 })
+  const { data } = useParents({ size: 200 })
   const total = data?.total ?? 0
+
+  const kpis: KpiItem[] = useMemo(() => {
+    const items = data?.items ?? []
+    const withAccount = items.filter((p) => !!p.user_id).length
+    const withEmail = items.filter((p) => p.email?.trim()).length
+    return [
+      { label: "Parents au total", value: total, icon: Users, tone: "primary" },
+      { label: "Avec compte", value: withAccount, icon: UserCheck, tone: "emerald" },
+      { label: "Sans compte", value: items.length - withAccount, icon: UserX, tone: items.length - withAccount > 0 ? "accent" : "default" },
+      { label: "Avec email", value: withEmail, icon: Mail, tone: "default" },
+    ]
+  }, [data, total])
 
   return (
     <div className="space-y-6">
@@ -31,6 +44,7 @@ export function ParentsPageClient() {
           Nouveau parent
         </Button>
       </div>
+      <KpiStrip items={kpis} />
       <ParentsTable />
       <ParentCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
     </div>

--- a/components/admin/parents/ParentsTable.tsx
+++ b/components/admin/parents/ParentsTable.tsx
@@ -7,10 +7,14 @@ import type { Route } from "next"
 import { Phone, Mail, MessageCircle, UserCircle2 } from "lucide-react"
 import { useParents, useDeleteParent } from "@/lib/hooks/useParents"
 import type { Parent } from "@/lib/contracts/parent"
+import type { PaginatedResponse } from "@/lib/contracts"
 import { CrudTable } from "@/components/shared/CrudTable"
+import { FilterChips } from "@/components/shared/list/FilterChips"
 import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
 import { useDebounce } from "@/lib/hooks/useDebounce"
 import { ParentEditModal } from "./ParentEditModal"
+
+type AccountFilter = "all" | "with" | "without"
 
 // Actions inline Wave-style : Appeler / WhatsApp / Email
 function ContactActions({ parent }: { parent: Parent }) {
@@ -83,6 +87,19 @@ export function ParentsTable() {
   const { data, isLoading, isError, error, refetch } = useParents(params)
   const deleteMutation = useDeleteParent()
 
+  // Filtre compte (avec/sans) appliqué côté client sur la page chargée.
+  const [accountFilter, setAccountFilter] = useState<AccountFilter>("all")
+  const rawItems = useMemo(() => data?.items ?? [], [data])
+  const withAccountCount = useMemo(() => rawItems.filter((p) => !!p.user_id).length, [rawItems])
+  const filteredItems = useMemo(() => {
+    if (accountFilter === "with") return rawItems.filter((p) => !!p.user_id)
+    if (accountFilter === "without") return rawItems.filter((p) => !p.user_id)
+    return rawItems
+  }, [rawItems, accountFilter])
+  const tableData: PaginatedResponse<Parent> | undefined = data
+    ? { ...data, items: filteredItems }
+    : undefined
+
   const columns: ColumnDef<Parent>[] = useMemo(() => [
     {
       accessorKey: "last_name",
@@ -141,13 +158,21 @@ export function ParentsTable() {
     },
   ], [])
 
-  const items = data?.items ?? []
-
   return (
     <div className="space-y-4">
+      <FilterChips
+        aria-label="Filtrer par compte"
+        value={accountFilter}
+        onChange={(v) => setAccountFilter(v as AccountFilter)}
+        options={[
+          { value: "all", label: "Tous", count: rawItems.length },
+          { value: "with", label: "Avec compte", count: withAccountCount, tone: "default" },
+          { value: "without", label: "Sans compte", count: rawItems.length - withAccountCount, tone: "warning" },
+        ]}
+      />
       <div className="hidden md:block">
         <CrudTable<Parent>
-          data={data}
+          data={tableData}
           columns={columns}
           isLoading={isLoading}
           isError={isError}
@@ -176,12 +201,12 @@ export function ParentsTable() {
             Chargement…
           </p>
         )}
-        {!isLoading && items.length === 0 && (
+        {!isLoading && filteredItems.length === 0 && (
           <p className="rounded-lg border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
             Aucun parent trouvé
           </p>
         )}
-        {items.map((p) => {
+        {filteredItems.map((p) => {
           const loc = [p.city, p.commune].filter(Boolean).join(" / ")
           return (
             <MobileEntityListItem

--- a/components/admin/rooms/RoomsPageClient.tsx
+++ b/components/admin/rooms/RoomsPageClient.tsx
@@ -26,6 +26,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import {
   Dialog,
   DialogContent,
@@ -76,9 +77,12 @@ export function RoomsPageClient() {
   }), [debouncedSearch, typeFilter])
 
   const { data, isLoading, isError, error, refetch } = useRooms(params)
+  // Requête non filtrée pour les KPIs (le `data` ci-dessus est filtré par type/recherche).
+  const { data: allRoomsData } = useRooms({ size: 200 })
   const { data: classesData } = useClasses({ size: 100 })
   const deleteMutation = useDeleteRoom()
   const rooms = data?.items ?? []
+  const allRooms = useMemo(() => allRoomsData?.items ?? [], [allRoomsData])
   const allClasses = classesData?.items ?? []
 
   // Classes without a room
@@ -86,6 +90,19 @@ export function RoomsPageClient() {
     const roomClassIds = new Set(rooms.filter((r) => r.class_id).map((r) => r.class_id))
     return allClasses.filter((c) => !c.room_id && !roomClassIds.has(c.id))
   }, [allClasses, rooms])
+
+  const roomsKpis: KpiItem[] = useMemo(() => {
+    const totalCapacity = allRooms.reduce((s, r) => s + (r.capacity ?? 0), 0)
+    const classrooms = allRooms.filter((r) => r.room_type === "classroom").length
+    const noRoomClassIds = new Set(allRooms.filter((r) => r.class_id).map((r) => r.class_id))
+    const noRoom = allClasses.filter((c) => !c.room_id && !noRoomClassIds.has(c.id)).length
+    return [
+      { label: "Salles", value: allRooms.length, icon: DoorOpen, tone: "primary" },
+      { label: "Capacité totale", value: totalCapacity, icon: Users, tone: "default" },
+      { label: "Salles de classe", value: classrooms, icon: School, tone: "default" },
+      { label: "Classes sans salle", value: noRoom, icon: AlertTriangle, tone: noRoom > 0 ? "accent" : "default" },
+    ]
+  }, [allRooms, allClasses])
 
   // Batch create mutation
   const batchMutation = useMutation({
@@ -133,6 +150,8 @@ export function RoomsPageClient() {
           Nouvelle salle
         </Button>
       </div>
+
+      <KpiStrip items={roomsKpis} />
 
       {/* Classes without room — banner */}
       {classesWithoutRoom.length > 0 && (

--- a/components/admin/staff/StaffPageClient.tsx
+++ b/components/admin/staff/StaffPageClient.tsx
@@ -1,31 +1,29 @@
 "use client"
 
-import { Briefcase, Users } from "lucide-react"
-import { Card, CardContent } from "@/components/ui/card"
+import { useMemo } from "react"
+import { Briefcase, Users, BadgeCheck, Phone, UserX } from "lucide-react"
 import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { StaffTable } from "./StaffTable"
 import { StaffCreateModal } from "./StaffCreateModal"
 import { useStaffList } from "@/lib/hooks/useStaff"
 
 function StaffKpis() {
-  const { data } = useStaffList({ size: 1 })
-  const total = data?.total ?? 0
-
-  return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-4 flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
-            <Users aria-hidden="true" className="h-4 w-4 text-primary" />
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">Personnel</p>
-            <p className="text-xl font-bold">{total}</p>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  )
+  const { data } = useStaffList({ size: 200 })
+  const kpis: KpiItem[] = useMemo(() => {
+    const items = data?.items ?? []
+    const total = data?.total ?? items.length
+    const distinctPositions = new Set(items.map((s) => s.position?.trim()).filter(Boolean)).size
+    const withPhone = items.filter((s) => s.phone?.trim()).length
+    const withoutPosition = items.filter((s) => !s.position?.trim()).length
+    return [
+      { label: "Personnel", value: total, icon: Users, tone: "primary" },
+      { label: "Postes distincts", value: distinctPositions, icon: BadgeCheck, tone: "default" },
+      { label: "Avec téléphone", value: withPhone, icon: Phone, tone: "default" },
+      { label: "Sans poste", value: withoutPosition, icon: UserX, tone: withoutPosition > 0 ? "accent" : "default" },
+    ]
+  }, [data])
+  return <KpiStrip items={kpis} />
 }
 
 export function StaffPageClient() {

--- a/components/admin/students/StudentsPageClient.tsx
+++ b/components/admin/students/StudentsPageClient.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { Plus, Users } from "lucide-react"
+import { Plus, Users, UserCheck, UserPlus, School } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { StudentsTable } from "./StudentsTable"
 import { useStudentFilters } from "@/lib/hooks/useStudents"
 import { useState } from "react"
@@ -26,6 +27,14 @@ export function StudentsPageClient() {
 
   const total = filters?.total ?? 0
   const noCurrent = filters?.no_current_enrollment_count ?? 0
+  const classesCount = filters?.by_class?.length ?? 0
+
+  const kpis: KpiItem[] = [
+    { label: "Élèves au total", value: total, icon: Users, tone: "primary" },
+    { label: "Inscrits", value: Math.max(total - noCurrent, 0), icon: UserCheck, tone: "emerald" },
+    { label: "À inscrire", value: noCurrent, icon: UserPlus, tone: noCurrent > 0 ? "accent" : "default" },
+    { label: "Classes", value: classesCount, icon: School, tone: "default" },
+  ]
 
   return (
     <div className="space-y-6">
@@ -61,6 +70,7 @@ export function StudentsPageClient() {
           Nouvelle inscription
         </Button>
       </div>
+      <KpiStrip items={kpis} />
       <StudentsTable initialUnenrolledOnly={unenrolledChip} onChipsConsumed={() => setUnenrolledChip(false)} />
     </div>
   )

--- a/components/admin/subjects/SubjectsPageClient.tsx
+++ b/components/admin/subjects/SubjectsPageClient.tsx
@@ -1,11 +1,31 @@
 "use client"
 
-import { useState } from "react"
-import { BookMarked, Plus, LayoutGrid, List } from "lucide-react"
+import { useMemo, useState } from "react"
+import { BookMarked, Plus, LayoutGrid, List, Layers, UserX, Clock } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { useSubjects } from "@/lib/hooks/useSubjects"
 import { SubjectsTable } from "./SubjectsTable"
 import { SubjectsKanbanView } from "./SubjectsKanbanView"
 import { SubjectCreateModal } from "./SubjectCreateModal"
+
+function SubjectsKpis() {
+  const { data } = useSubjects({ size: 200 })
+  const kpis: KpiItem[] = useMemo(() => {
+    const items = data?.items ?? []
+    const uniqueNames = new Set(items.map((s) => s.name)).size
+    const instances = items.filter((s) => s.level_id !== null)
+    const withoutTeacher = instances.filter((s) => !s.teacher_id).length
+    const hours = instances.reduce((sum, s) => sum + (s.hours_per_week ?? 0), 0)
+    return [
+      { label: "Matières uniques", value: uniqueNames, icon: BookMarked, tone: "primary" },
+      { label: "Instances par niveau", value: instances.length, icon: Layers, tone: "default" },
+      { label: "Sans enseignant", value: withoutTeacher, icon: UserX, tone: withoutTeacher > 0 ? "accent" : "default" },
+      { label: "Heures / semaine", value: `${hours}h`, icon: Clock, tone: "default" },
+    ]
+  }, [data])
+  return <KpiStrip items={kpis} />
+}
 
 export function SubjectsPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
@@ -59,6 +79,8 @@ export function SubjectsPageClient() {
           </Button>
         </div>
       </div>
+
+      <SubjectsKpis />
 
       {/* Mobile : toujours table. Desktop : respecte le choix utilisateur. */}
       <div className="md:hidden">

--- a/components/admin/subjects/SubjectsTable.tsx
+++ b/components/admin/subjects/SubjectsTable.tsx
@@ -117,18 +117,6 @@ export function SubjectsTable() {
     })
   }, [groups, debouncedSearch, levelFilter, teacherFilter])
 
-  const totalInstances = useMemo(
-    () => subjects.filter((s) => s.level_id !== null).length,
-    [subjects],
-  )
-  const totalHours = useMemo(
-    () =>
-      subjects
-        .filter((s) => s.level_id !== null)
-        .reduce((sum, s) => sum + s.hours_per_week, 0),
-    [subjects],
-  )
-
   function toggleExpanded(name: string) {
     setExpanded((prev) => {
       const next = new Set(prev)
@@ -160,26 +148,6 @@ export function SubjectsTable() {
 
   return (
     <div className="space-y-4">
-      {/* KPI hero strip */}
-      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
-        <div className="flex items-baseline gap-1.5">
-          <span className="text-3xl font-bold text-primary tabular-nums">
-            {groups.length}
-          </span>
-          <span className="text-sm text-muted-foreground">matières uniques</span>
-        </div>
-        <span className="text-border" aria-hidden>·</span>
-        <div className="flex items-baseline gap-1.5">
-          <span className="text-3xl font-bold tabular-nums">{totalInstances}</span>
-          <span className="text-sm text-muted-foreground">instances par niveau</span>
-        </div>
-        <span className="text-border" aria-hidden>·</span>
-        <div className="flex items-baseline gap-1.5">
-          <span className="text-3xl font-bold tabular-nums">{totalHours}h</span>
-          <span className="text-sm text-muted-foreground">/ semaine au total</span>
-        </div>
-      </div>
-
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-2">
         <div className="relative min-w-[240px] flex-1">

--- a/components/admin/teachers/TeachersPageClient.tsx
+++ b/components/admin/teachers/TeachersPageClient.tsx
@@ -1,31 +1,29 @@
 "use client"
 
-import { BookOpen, Users } from "lucide-react"
-import { Card, CardContent } from "@/components/ui/card"
+import { useMemo } from "react"
+import { BookOpen, Users, Award, Phone, UserX } from "lucide-react"
 import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { TeachersTable } from "./TeachersTable"
 import { TeacherCreateModal } from "./TeacherCreateModal"
 import { useTeachers } from "@/lib/hooks/useTeachers"
 
 function TeacherKpis() {
-  const { data } = useTeachers({ size: 1 })
-  const total = data?.total ?? 0
-
-  return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-4 flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10">
-            <Users className="h-4 w-4 text-primary" />
-          </div>
-          <div>
-            <p className="text-xs text-muted-foreground">Enseignants</p>
-            <p className="text-xl font-bold">{total}</p>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  )
+  const { data } = useTeachers({ size: 200 })
+  const kpis: KpiItem[] = useMemo(() => {
+    const items = data?.items ?? []
+    const total = data?.total ?? items.length
+    const withSpeciality = items.filter((t) => t.speciality?.trim()).length
+    const withPhone = items.filter((t) => t.phone?.trim()).length
+    const withoutSpeciality = items.length - withSpeciality
+    return [
+      { label: "Enseignants", value: total, icon: Users, tone: "primary" },
+      { label: "Avec spécialité", value: withSpeciality, icon: Award, tone: "default" },
+      { label: "Avec téléphone", value: withPhone, icon: Phone, tone: "default" },
+      { label: "Sans spécialité", value: withoutSpeciality, icon: UserX, tone: withoutSpeciality > 0 ? "accent" : "default" },
+    ]
+  }, [data])
+  return <KpiStrip items={kpis} />
 }
 
 export function TeachersPageClient() {

--- a/components/parent/ParentChildrenClient.tsx
+++ b/components/parent/ParentChildrenClient.tsx
@@ -37,7 +37,7 @@ export function ParentChildrenClient() {
         {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
       </div>
 
-      {children && children.length > 0 && <ChildrenKpis children={children} />}
+      {children && children.length > 0 && <ChildrenKpis childList={children} />}
 
       {isLoading ? (
         <ChildrenSkeleton />
@@ -64,9 +64,9 @@ export function ParentChildrenClient() {
   )
 }
 
-function ChildrenKpis({ children }: { children: ParentChild[] }) {
-  const summary = summarizeEnrollment(children)
-  const remaining = children
+function ChildrenKpis({ childList }: { childList: ParentChild[] }) {
+  const summary = summarizeEnrollment(childList)
+  const remaining = childList
     .filter((c) => isEnrolledFromClassName(c.class_name))
     .reduce((s, c) => s + (c.fees_remaining ?? 0), 0)
   const kpis: KpiItem[] = [

--- a/components/parent/ParentChildrenClient.tsx
+++ b/components/parent/ParentChildrenClient.tsx
@@ -2,11 +2,12 @@
 
 import Link from "next/link"
 import type { Route } from "next"
-import { Users, GraduationCap, Wallet, AlertCircle, FileText, Calendar, Clock } from "lucide-react"
+import { Users, GraduationCap, Wallet, AlertCircle, FileText, Calendar, Clock, UserCheck } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { useParentChildren } from "@/lib/hooks/useParentPortal"
 import type { ParentChild } from "@/lib/contracts/parent-portal"
 import { isEnrolledFromClassName, summarizeEnrollment } from "@/lib/utils/enrollment-status"
@@ -36,6 +37,8 @@ export function ParentChildrenClient() {
         {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
       </div>
 
+      {children && children.length > 0 && <ChildrenKpis children={children} />}
+
       {isLoading ? (
         <ChildrenSkeleton />
       ) : isError ? (
@@ -59,6 +62,25 @@ export function ParentChildrenClient() {
       )}
     </div>
   )
+}
+
+function ChildrenKpis({ children }: { children: ParentChild[] }) {
+  const summary = summarizeEnrollment(children)
+  const remaining = children
+    .filter((c) => isEnrolledFromClassName(c.class_name))
+    .reduce((s, c) => s + (c.fees_remaining ?? 0), 0)
+  const kpis: KpiItem[] = [
+    { label: "Enfants", value: summary.total, icon: Users, tone: "primary" },
+    { label: "Inscrits", value: summary.enrolled, icon: UserCheck, tone: "emerald" },
+    { label: "En attente", value: summary.pending, icon: Clock, tone: summary.pending > 0 ? "accent" : "default" },
+    {
+      label: "Restant total",
+      value: `${remaining.toLocaleString("fr-FR")} F`,
+      icon: Wallet,
+      tone: remaining > 0 ? "accent" : "default",
+    },
+  ]
+  return <KpiStrip items={kpis} />
 }
 
 function ChildDetailCard({ child }: { child: ParentChild }) {

--- a/components/shared/list/FilterChips.tsx
+++ b/components/shared/list/FilterChips.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Chips de filtre horizontaux (1 tap = 1 filtre), pattern persona-first repris
+ * de la page Élèves. Mono-sélection : une valeur active, `value` contrôlée par
+ * le parent. Scroll horizontal sur mobile, touch target h-9/h-11.
+ *
+ * Le `count` est optionnel (certaines dimensions n'ont pas de compteur).
+ */
+export type ChipTone = "default" | "warning" | "destructive"
+
+export interface FilterChipOption {
+  value: string
+  label: string
+  count?: number
+  tone?: ChipTone
+}
+
+interface FilterChipsProps {
+  options: FilterChipOption[]
+  value: string
+  onChange: (value: string) => void
+  className?: string
+  "aria-label"?: string
+}
+
+const activeToneClass: Record<ChipTone, string> = {
+  default: "border-primary bg-primary text-primary-foreground",
+  warning: "border-amber-500 bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100",
+  destructive: "border-destructive bg-destructive text-destructive-foreground",
+}
+
+const activeBadgeClass: Record<ChipTone, string> = {
+  default: "bg-primary-foreground/20 text-primary-foreground",
+  warning: "bg-amber-200 text-amber-900",
+  destructive: "bg-destructive-foreground/20 text-destructive-foreground",
+}
+
+export function FilterChip({
+  label,
+  count,
+  isActive,
+  onClick,
+  tone = "default",
+}: {
+  label: string
+  count?: number
+  isActive: boolean
+  onClick: () => void
+  tone?: ChipTone
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isActive}
+      className={cn(
+        "inline-flex h-11 shrink-0 items-center gap-1.5 rounded-full border px-3.5 text-sm font-medium transition-colors sm:h-9",
+        isActive
+          ? activeToneClass[tone]
+          : "border-border bg-muted/40 text-foreground hover:bg-muted",
+      )}
+    >
+      <span>{label}</span>
+      {count !== undefined && (
+        <span
+          className={cn(
+            "rounded-full px-1.5 text-[11px] font-semibold tabular-nums",
+            isActive ? activeBadgeClass[tone] : "bg-background text-muted-foreground",
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  )
+}
+
+export function FilterChips({
+  options,
+  value,
+  onChange,
+  className,
+  "aria-label": ariaLabel,
+}: FilterChipsProps) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel ?? "Filtres"}
+      className={cn("flex gap-2 overflow-x-auto pb-1", className)}
+    >
+      {options.map((opt) => (
+        <FilterChip
+          key={opt.value}
+          label={opt.label}
+          count={opt.count}
+          tone={opt.tone}
+          isActive={value === opt.value}
+          onClick={() => onChange(opt.value)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/components/shared/list/KpiStrip.tsx
+++ b/components/shared/list/KpiStrip.tsx
@@ -1,0 +1,89 @@
+import type { LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Card, CardContent } from "@/components/ui/card"
+
+/**
+ * Bande de KPI compacte pour les listes admin/portails. Réutilise le langage
+ * visuel des dashboards (Card shadcn neutre + système de tons restreint).
+ *
+ * Tons : default (muted) · primary (bleu KLASSCI) · accent (orange) ·
+ * destructive (alerte) · emerald (positif). Garder 1 ton structurant max par
+ * strip pour rester monochrome (règle « 1 accent + monochrome »).
+ */
+export type KpiTone = "default" | "primary" | "accent" | "destructive" | "emerald"
+
+const toneStyles: Record<KpiTone, string> = {
+  default: "bg-muted text-muted-foreground",
+  primary: "bg-primary/10 text-primary",
+  accent: "bg-accent/10 text-accent",
+  destructive: "bg-destructive/10 text-destructive",
+  emerald: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+}
+
+export interface KpiItem {
+  label: string
+  value: React.ReactNode
+  hint?: React.ReactNode
+  icon?: LucideIcon
+  tone?: KpiTone
+}
+
+interface KpiStripProps {
+  items: KpiItem[]
+  /** Nombre de colonnes au plus large breakpoint (par défaut 4). */
+  columns?: 2 | 3 | 4
+  className?: string
+}
+
+const colClass: Record<2 | 3 | 4, string> = {
+  2: "grid-cols-2",
+  3: "grid-cols-2 lg:grid-cols-3",
+  4: "grid-cols-2 lg:grid-cols-4",
+}
+
+export function KpiStrip({ items, columns = 4, className }: KpiStripProps) {
+  if (items.length === 0) return null
+  return (
+    <div className={cn("grid gap-3", colClass[columns], className)}>
+      {items.map((item, i) => {
+        const Icon = item.icon
+        const valueText =
+          typeof item.value === "string" || typeof item.value === "number"
+            ? String(item.value)
+            : ""
+        return (
+          <Card
+            key={i}
+            role="group"
+            aria-label={valueText ? `${item.label} : ${valueText}` : item.label}
+            className="shadow-sm"
+          >
+            <CardContent className="flex items-start justify-between gap-3 p-4">
+              <div className="min-w-0 space-y-0.5">
+                <p className="truncate text-xs font-medium text-muted-foreground">
+                  {item.label}
+                </p>
+                <div className="text-2xl font-bold tracking-tight tabular-nums">
+                  {item.value}
+                </div>
+                {item.hint && (
+                  <div className="text-[11px] text-muted-foreground">{item.hint}</div>
+                )}
+              </div>
+              {Icon && (
+                <span
+                  className={cn(
+                    "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+                    toneStyles[item.tone ?? "default"],
+                  )}
+                >
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                </span>
+              )}
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/shared/list/ListSearchBar.tsx
+++ b/components/shared/list/ListSearchBar.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { Search, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Input } from "@/components/ui/input"
+
+/**
+ * Barre de recherche standard des listes (Input shadcn + icône loupe + bouton
+ * effacer). Présentationnelle et contrôlée : le parent gère la valeur et le
+ * filtrage (multi-champs via `matchesSearch`, ou param serveur). Touch target
+ * h-11 sur mobile (persona Mme Diallo, Itel S661).
+ */
+interface ListSearchBarProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  className?: string
+  "aria-label"?: string
+}
+
+export function ListSearchBar({
+  value,
+  onChange,
+  placeholder = "Rechercher…",
+  className,
+  "aria-label": ariaLabel,
+}: ListSearchBarProps) {
+  return (
+    <div className={cn("relative w-full sm:max-w-xs", className)}>
+      <Search
+        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <Input
+        type="search"
+        inputMode="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label={ariaLabel ?? placeholder}
+        className="h-11 pl-9 pr-9 sm:h-10"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          aria-label="Effacer la recherche"
+          className="absolute right-2.5 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/components/teacher/TeacherClassesClient.tsx
+++ b/components/teacher/TeacherClassesClient.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useMemo, useState } from "react"
 import Link from "next/link"
 import type { Route } from "next"
 import {
@@ -7,16 +8,47 @@ import {
   GraduationCap,
   ClipboardList,
   ChevronRight,
+  School,
 } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
+import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { ListSearchBar } from "@/components/shared/list/ListSearchBar"
+import { matchesSearch } from "@/lib/utils/list-search"
 import { useTeacherClasses } from "@/lib/hooks/useTeacherPortal"
 import type { TeacherClass } from "@/lib/contracts/teacher-portal"
 
 export function TeacherClassesClient() {
   const { data: classes, isLoading, isError, refetch } = useTeacherClasses()
+  const [search, setSearch] = useState("")
+
+  const list = useMemo(() => classes ?? [], [classes])
+  const kpis: KpiItem[] = useMemo(() => {
+    const students = list.reduce((s, c) => s + (c.student_count ?? 0), 0)
+    const evals = list.reduce((s, c) => s + (c.total_evaluations ?? 0), 0)
+    const graded = list.filter((c) => c.general_average !== null && c.general_average !== undefined)
+    const avg = graded.length
+      ? graded.reduce((s, c) => s + (c.general_average ?? 0), 0) / graded.length
+      : null
+    return [
+      { label: "Classes", value: list.length, icon: School, tone: "primary" },
+      { label: "Élèves", value: students, icon: Users, tone: "default" },
+      { label: "Évaluations", value: evals, icon: ClipboardList, tone: "default" },
+      {
+        label: "Moyenne globale",
+        value: avg !== null ? avg.toFixed(2) : "—",
+        icon: GraduationCap,
+        tone: avg === null ? "default" : avg >= 10 ? "emerald" : "destructive",
+      },
+    ]
+  }, [list])
+
+  const filtered = useMemo(
+    () => list.filter((c) => matchesSearch([c.class_name, c.subject_name, c.level_name], search)),
+    [list, search],
+  )
 
   return (
     <div className="space-y-6">
@@ -45,11 +77,28 @@ export function TeacherClassesClient() {
           </p>
         </div>
       ) : (
-        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {classes.map((cls) => (
-            <ClassCard key={cls.class_id} cls={cls} />
-          ))}
-        </div>
+        <>
+          <KpiStrip items={kpis} />
+          {list.length > 3 && (
+            <ListSearchBar
+              value={search}
+              onChange={setSearch}
+              placeholder="Rechercher une classe ou une matière…"
+              aria-label="Rechercher une classe"
+            />
+          )}
+          {filtered.length === 0 ? (
+            <p className="rounded-lg border bg-muted/30 py-10 text-center text-sm text-muted-foreground">
+              Aucune classe ne correspond à « {search} ».
+            </p>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+              {filtered.map((cls) => (
+                <ClassCard key={cls.class_id} cls={cls} />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/components/teacher/grades/TeacherEvaluationsList.tsx
+++ b/components/teacher/grades/TeacherEvaluationsList.tsx
@@ -33,6 +33,8 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { DataError } from "@/components/shared/DataError"
+import { ListSearchBar } from "@/components/shared/list/ListSearchBar"
+import { matchesSearch } from "@/lib/utils/list-search"
 
 const TYPE_LABELS: Record<string, string> = {
   controle: "Contrôle",
@@ -56,6 +58,7 @@ export function TeacherEvaluationsList() {
   const { data, isLoading, isError, refetch } = useTeacherEvaluations()
   const [classFilter, setClassFilter] = useState<string>("all")
   const [tab, setTab] = useState<FilterTab>("all")
+  const [search, setSearch] = useState("")
 
   const evaluations = data ?? []
 
@@ -72,9 +75,10 @@ export function TeacherEvaluationsList() {
       if (tab === "overdue" && !isOverdue(e.date, e.graded_students, e.total_students))
         return false
       if (tab === "done" && !isDone(e.graded_students, e.total_students)) return false
+      if (!matchesSearch([e.title, e.subject_name, e.class_name], search)) return false
       return true
     })
-  }, [evaluations, classFilter, tab])
+  }, [evaluations, classFilter, tab, search])
 
   const stats = useMemo(() => {
     const total = evaluations.length
@@ -134,6 +138,15 @@ export function TeacherEvaluationsList() {
       {/* ─── Filtres ──────────────────────────────────────────────── */}
       {!isLoading && evaluations.length > 0 && (
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="flex-1 min-w-[200px] max-w-xs">
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">Recherche</label>
+            <ListSearchBar
+              value={search}
+              onChange={setSearch}
+              placeholder="Titre, matière, classe…"
+              aria-label="Rechercher une évaluation"
+            />
+          </div>
           <div className="flex-1 min-w-[160px] max-w-xs">
             <label className="mb-1 block text-xs font-medium text-muted-foreground">Classe</label>
             <Select value={classFilter} onValueChange={setClassFilter}>

--- a/lib/utils/list-search.ts
+++ b/lib/utils/list-search.ts
@@ -1,0 +1,38 @@
+/**
+ * Recherche « intelligente » côté client : insensible à la casse ET aux
+ * accents (Mme Diallo tape "traore" et trouve "Traoré"), tokenisée en ET
+ * (chaque mot de la requête doit matcher au moins un champ).
+ *
+ * Utilisé par les listes admin/portails pour un filtre multi-champs instantané.
+ */
+
+// Marques diacritiques combinantes (U+0300 à U+036F) supprimées après NFD.
+const DIACRITICS = /[̀-ͯ]/g
+
+/** Minuscule + suppression des diacritiques (é → e, ï → i, ç → c…). */
+export function normalizeText(value: string): string {
+  return value.normalize("NFD").replace(DIACRITICS, "").toLowerCase().trim()
+}
+
+/**
+ * Vrai si la requête matche les champs fournis. Chaque token (mot) de la
+ * requête doit apparaître dans au moins un des champs (logique ET entre tokens,
+ * OU entre champs). Une requête vide matche toujours.
+ *
+ * @param fields  Les valeurs textuelles de l'entité (nom, matricule, email…).
+ * @param query   La saisie utilisateur.
+ */
+export function matchesSearch(
+  fields: Array<string | null | undefined | number>,
+  query: string,
+): boolean {
+  const q = normalizeText(query)
+  if (!q) return true
+  const haystack = normalizeText(
+    fields
+      .filter((f) => f !== null && f !== undefined && f !== "")
+      .map(String)
+      .join(" "),
+  )
+  return q.split(/\s+/).every((token) => haystack.includes(token))
+}


### PR DESCRIPTION
## Objectif

Ajouter, en composants **shadcn/ui uniquement**, des **KPI**, une **barre de recherche intelligente** (insensible aux accents/casse, multi-champs) et des **filtres** sur toutes les pages de gestion qui en manquaient (admin + portails conso).

## Primitives partagées (réutilisables)
- `components/shared/list/KpiStrip.tsx` : bande de KPI compacte (Card shadcn, tons restreints primary/accent/destructive/emerald/muted).
- `components/shared/list/ListSearchBar.tsx` : Input + loupe + effacer, touch target h-11.
- `components/shared/list/FilterChips.tsx` : chips de filtre mono-sélection.
- `lib/utils/list-search.ts` : `matchesSearch` (NFD + suppression diacritiques + tokens ET).

## Admin
- **Académique** : Années scolaires (KPI + recherche + filtre statut), Classes (KPI occupation), Matières (KPI niveau kanban+table), Niveaux & séries (KPI + recherche arbre).
- **People** : Élèves (KPI), Enseignants & Personnel (KPI strip enrichi), Parents (KPI + filtre compte). Recherche + filtres spécialité/poste déjà présents.
- **Finance / Vie scolaire** : Inscriptions (KPI statuts), Salles (KPI occupation), Notifications (KPI + recherche), Frais (KPI strip + filtre obligatoire/optionnel), Présences (KPI contextuel).

## Portails conso
- Enseignant : « Mes classes » (KPI + recherche), « Mes évaluations » (recherche en plus des filtres/onglets).
- Parent : « Mes enfants » (KPI).

## Notes
- Aucune logique métier touchée ; toutes les protections existantes (non-inscrit, anti faux-signal) conservées.
- `tsc --noEmit` : OK (clean) sur chaque batch.
- Les pages déjà complètes (Paiements) ne sont pas modifiées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)