### PR TITLE
fix(ui): KPI aggregates use size=100 (BE max)

### DIFF
--- a/components/admin/classes/ClassesPageClient.tsx
+++ b/components/admin/classes/ClassesPageClient.tsx
@@ -10,7 +10,7 @@ import { ClassesTreeView } from "./ClassesTreeView"
 import { ClassCreateModal } from "./ClassCreateModal"
 
 function ClassesKpis() {
-  const { data } = useClasses({ size: 200 })
+  const { data } = useClasses({ size: 100 })
   const kpis: KpiItem[] = useMemo(() => {
     const items = data?.items ?? []
     const enrolled = items.reduce((s, c) => s + (c.enrolled_count ?? 0), 0)

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -10,7 +10,7 @@ import { EnrollmentCreateModal } from "./EnrollmentCreateModal"
 import { useEnrollments } from "@/lib/hooks/useEnrollments"
 
 function EnrollmentsKpis() {
-  const { data } = useEnrollments({ size: 300 })
+  const { data } = useEnrollments({ size: 100 })
   const kpis: KpiItem[] = useMemo(() => {
     const items = data?.items ?? []
     const total = data?.total ?? items.length

--- a/components/admin/parents/ParentsPageClient.tsx
+++ b/components/admin/parents/ParentsPageClient.tsx
@@ -10,7 +10,7 @@ import { ParentCreateModal } from "./ParentCreateModal"
 
 export function ParentsPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
-  const { data } = useParents({ size: 200 })
+  const { data } = useParents({ size: 100 })
   const total = data?.total ?? 0
 
   const kpis: KpiItem[] = useMemo(() => {

--- a/components/admin/rooms/RoomsPageClient.tsx
+++ b/components/admin/rooms/RoomsPageClient.tsx
@@ -78,7 +78,7 @@ export function RoomsPageClient() {
 
   const { data, isLoading, isError, error, refetch } = useRooms(params)
   // Requête non filtrée pour les KPIs (le `data` ci-dessus est filtré par type/recherche).
-  const { data: allRoomsData } = useRooms({ size: 200 })
+  const { data: allRoomsData } = useRooms({ size: 100 })
   const { data: classesData } = useClasses({ size: 100 })
   const deleteMutation = useDeleteRoom()
   const rooms = data?.items ?? []

--- a/components/admin/staff/StaffPageClient.tsx
+++ b/components/admin/staff/StaffPageClient.tsx
@@ -9,7 +9,7 @@ import { StaffCreateModal } from "./StaffCreateModal"
 import { useStaffList } from "@/lib/hooks/useStaff"
 
 function StaffKpis() {
-  const { data } = useStaffList({ size: 200 })
+  const { data } = useStaffList({ size: 100 })
   const kpis: KpiItem[] = useMemo(() => {
     const items = data?.items ?? []
     const total = data?.total ?? items.length

--- a/components/admin/subjects/SubjectsPageClient.tsx
+++ b/components/admin/subjects/SubjectsPageClient.tsx
@@ -10,7 +10,7 @@ import { SubjectsKanbanView } from "./SubjectsKanbanView"
 import { SubjectCreateModal } from "./SubjectCreateModal"
 
 function SubjectsKpis() {
-  const { data } = useSubjects({ size: 200 })
+  const { data } = useSubjects({ size: 100 })
   const kpis: KpiItem[] = useMemo(() => {
     const items = data?.items ?? []
     const uniqueNames = new Set(items.map((s) => s.name)).size

--- a/components/admin/teachers/TeachersPageClient.tsx
+++ b/components/admin/teachers/TeachersPageClient.tsx
@@ -9,7 +9,7 @@ import { TeacherCreateModal } from "./TeacherCreateModal"
 import { useTeachers } from "@/lib/hooks/useTeachers"
 
 function TeacherKpis() {
-  const { data } = useTeachers({ size: 200 })
+  const { data } = useTeachers({ size: 100 })
   const kpis: KpiItem[] = useMemo(() => {
     const items = data?.items ?? []
     const total = data?.total ?? items.length


### PR DESCRIPTION
Les nouveaux KPI strips chargeaient size=200/300 pour agréger, mais les endpoints de liste rejettent size>100 et renvoient une page vide → les cartes affichaient 0. Aligné sur size=100 comme les tables/arbre existants. Fix d'une feature non publiée (#221), donc skip-changelog.