### PR TITLE
feat(dashboard): KPI strips consomment l'agrégat serveur /dashboard/summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Changed
+
+- Indicateurs clés des pages de gestion désormais alimentés par un calcul serveur : les chiffres restent exacts même au-delà de 100 lignes (grands établissements), là où ils étaient auparavant tronqués *(admin)*.
+
 ### Added
 
 - Indicateurs clés (KPI), recherche instantanée et filtres ajoutés sur les pages de gestion qui en manquaient : Classes, Matières, Niveaux, Années scolaires, Inscriptions, Salles, Notifications, Frais, ainsi que les listes Élèves, Enseignants, Personnel et Parents. La recherche ignore les accents et la casse (taper « traore » trouve « Traoré ») *(admin)*.

--- a/components/admin/classes/ClassesPageClient.tsx
+++ b/components/admin/classes/ClassesPageClient.tsx
@@ -4,26 +4,21 @@ import { useMemo, useState } from "react"
 import { School, Plus, LayoutGrid, List, Users, Gauge, AlertTriangle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
-import { useClasses } from "@/lib/hooks/useClasses"
+import { useAdminSummary } from "@/lib/hooks/useDashboard"
 import { ClassesTable } from "./ClassesTable"
 import { ClassesTreeView } from "./ClassesTreeView"
 import { ClassCreateModal } from "./ClassCreateModal"
 
 function ClassesKpis() {
-  const { data } = useClasses({ size: 100 })
+  const { data } = useAdminSummary()
   const kpis: KpiItem[] = useMemo(() => {
-    const items = data?.items ?? []
-    const enrolled = items.reduce((s, c) => s + (c.enrolled_count ?? 0), 0)
-    const capacity = items.reduce((s, c) => s + (c.max_students ?? 0), 0)
-    const rate = capacity > 0 ? Math.round((enrolled / capacity) * 100) : 0
-    const full = items.filter(
-      (c) => (c.max_students ?? 0) > 0 && (c.enrolled_count ?? 0) / (c.max_students ?? 1) > 0.95,
-    ).length
+    const c = data?.classes
+    const rate = c && c.capacity > 0 ? Math.round((c.enrolled / c.capacity) * 100) : 0
     return [
-      { label: "Classes", value: items.length, icon: School, tone: "primary" },
-      { label: "Élèves inscrits", value: enrolled, icon: Users, tone: "default" },
+      { label: "Classes", value: c?.total ?? 0, icon: School, tone: "primary" },
+      { label: "Élèves inscrits", value: c?.enrolled ?? 0, icon: Users, tone: "default" },
       { label: "Taux d'occupation", value: `${rate}%`, icon: Gauge, tone: rate >= 80 ? "accent" : "emerald" },
-      { label: "Classes pleines", value: full, icon: AlertTriangle, tone: full > 0 ? "destructive" : "default" },
+      { label: "Classes pleines", value: c?.full ?? 0, icon: AlertTriangle, tone: (c?.full ?? 0) > 0 ? "destructive" : "default" },
     ]
   }, [data])
   return <KpiStrip items={kpis} />

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -8,20 +8,18 @@ import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { EnrollmentsTable } from "./EnrollmentsTable"
 import { EnrollmentCreateModal } from "./EnrollmentCreateModal"
 import { useEnrollments } from "@/lib/hooks/useEnrollments"
+import { useAdminSummary } from "@/lib/hooks/useDashboard"
 
 function EnrollmentsKpis() {
-  const { data } = useEnrollments({ size: 100 })
+  const { data } = useAdminSummary()
   const kpis: KpiItem[] = useMemo(() => {
-    const items = data?.items ?? []
-    const total = data?.total ?? items.length
-    const valid = items.filter((e) => e.status === "valide").length
-    const pending = items.filter((e) => e.status === "prospect" || e.status === "en_validation").length
-    const closed = items.filter((e) => e.status === "rejete" || e.status === "annule").length
+    const e = data?.enrollments
+    const pending = e?.pending ?? 0
     return [
-      { label: "Inscriptions", value: total, icon: ListChecks, tone: "primary" },
-      { label: "Validées", value: valid, icon: CheckCircle2, tone: "emerald" },
+      { label: "Inscriptions", value: e?.total ?? 0, icon: ListChecks, tone: "primary" },
+      { label: "Validées", value: e?.valid ?? 0, icon: CheckCircle2, tone: "emerald" },
       { label: "À valider", value: pending, icon: Clock, tone: pending > 0 ? "accent" : "default" },
-      { label: "Rejetées / annulées", value: closed, icon: XCircle, tone: "default" },
+      { label: "Rejetées / annulées", value: e?.closed ?? 0, icon: XCircle, tone: "default" },
     ]
   }, [data])
   return <KpiStrip items={kpis} />

--- a/components/admin/parents/ParentsPageClient.tsx
+++ b/components/admin/parents/ParentsPageClient.tsx
@@ -4,24 +4,23 @@ import { useMemo, useState } from "react"
 import { HeartHandshake, Plus, Users, UserCheck, UserX, Mail } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
-import { useParents } from "@/lib/hooks/useParents"
+import { useAdminSummary } from "@/lib/hooks/useDashboard"
 import { ParentsTable } from "./ParentsTable"
 import { ParentCreateModal } from "./ParentCreateModal"
 
 export function ParentsPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
-  const { data } = useParents({ size: 100 })
-  const total = data?.total ?? 0
+  const { data } = useAdminSummary()
+  const total = data?.parents.total ?? 0
 
   const kpis: KpiItem[] = useMemo(() => {
-    const items = data?.items ?? []
-    const withAccount = items.filter((p) => !!p.user_id).length
-    const withEmail = items.filter((p) => p.email?.trim()).length
+    const p = data?.parents
+    const withoutAccount = p?.without_account ?? 0
     return [
       { label: "Parents au total", value: total, icon: Users, tone: "primary" },
-      { label: "Avec compte", value: withAccount, icon: UserCheck, tone: "emerald" },
-      { label: "Sans compte", value: items.length - withAccount, icon: UserX, tone: items.length - withAccount > 0 ? "accent" : "default" },
-      { label: "Avec email", value: withEmail, icon: Mail, tone: "default" },
+      { label: "Avec compte", value: p?.with_account ?? 0, icon: UserCheck, tone: "emerald" },
+      { label: "Sans compte", value: withoutAccount, icon: UserX, tone: withoutAccount > 0 ? "accent" : "default" },
+      { label: "Avec email", value: p?.with_email ?? 0, icon: Mail, tone: "default" },
     ]
   }, [data, total])
 

--- a/components/admin/rooms/RoomsPageClient.tsx
+++ b/components/admin/rooms/RoomsPageClient.tsx
@@ -27,6 +27,7 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { useAdminSummary } from "@/lib/hooks/useDashboard"
 import {
   Dialog,
   DialogContent,
@@ -77,32 +78,28 @@ export function RoomsPageClient() {
   }), [debouncedSearch, typeFilter])
 
   const { data, isLoading, isError, error, refetch } = useRooms(params)
-  // Requête non filtrée pour les KPIs (le `data` ci-dessus est filtré par type/recherche).
-  const { data: allRoomsData } = useRooms({ size: 100 })
+  const { data: summary } = useAdminSummary()
   const { data: classesData } = useClasses({ size: 100 })
   const deleteMutation = useDeleteRoom()
   const rooms = data?.items ?? []
-  const allRooms = useMemo(() => allRoomsData?.items ?? [], [allRoomsData])
   const allClasses = classesData?.items ?? []
 
-  // Classes without a room
+  // Classes without a room (bannière actionnable)
   const classesWithoutRoom = useMemo(() => {
     const roomClassIds = new Set(rooms.filter((r) => r.class_id).map((r) => r.class_id))
     return allClasses.filter((c) => !c.room_id && !roomClassIds.has(c.id))
   }, [allClasses, rooms])
 
   const roomsKpis: KpiItem[] = useMemo(() => {
-    const totalCapacity = allRooms.reduce((s, r) => s + (r.capacity ?? 0), 0)
-    const classrooms = allRooms.filter((r) => r.room_type === "classroom").length
-    const noRoomClassIds = new Set(allRooms.filter((r) => r.class_id).map((r) => r.class_id))
-    const noRoom = allClasses.filter((c) => !c.room_id && !noRoomClassIds.has(c.id)).length
+    const r = summary?.rooms
+    const noRoom = r?.classes_without_room ?? 0
     return [
-      { label: "Salles", value: allRooms.length, icon: DoorOpen, tone: "primary" },
-      { label: "Capacité totale", value: totalCapacity, icon: Users, tone: "default" },
-      { label: "Salles de classe", value: classrooms, icon: School, tone: "default" },
+      { label: "Salles", value: r?.total ?? 0, icon: DoorOpen, tone: "primary" },
+      { label: "Capacité totale", value: r?.capacity ?? 0, icon: Users, tone: "default" },
+      { label: "Salles de classe", value: r?.classrooms ?? 0, icon: School, tone: "default" },
       { label: "Classes sans salle", value: noRoom, icon: AlertTriangle, tone: noRoom > 0 ? "accent" : "default" },
     ]
-  }, [allRooms, allClasses])
+  }, [summary])
 
   // Batch create mutation
   const batchMutation = useMutation({

--- a/components/admin/staff/StaffPageClient.tsx
+++ b/components/admin/staff/StaffPageClient.tsx
@@ -6,20 +6,17 @@ import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
 import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { StaffTable } from "./StaffTable"
 import { StaffCreateModal } from "./StaffCreateModal"
-import { useStaffList } from "@/lib/hooks/useStaff"
+import { useAdminSummary } from "@/lib/hooks/useDashboard"
 
 function StaffKpis() {
-  const { data } = useStaffList({ size: 100 })
+  const { data } = useAdminSummary()
   const kpis: KpiItem[] = useMemo(() => {
-    const items = data?.items ?? []
-    const total = data?.total ?? items.length
-    const distinctPositions = new Set(items.map((s) => s.position?.trim()).filter(Boolean)).size
-    const withPhone = items.filter((s) => s.phone?.trim()).length
-    const withoutPosition = items.filter((s) => !s.position?.trim()).length
+    const s = data?.staff
+    const withoutPosition = s?.without_position ?? 0
     return [
-      { label: "Personnel", value: total, icon: Users, tone: "primary" },
-      { label: "Postes distincts", value: distinctPositions, icon: BadgeCheck, tone: "default" },
-      { label: "Avec téléphone", value: withPhone, icon: Phone, tone: "default" },
+      { label: "Personnel", value: s?.total ?? 0, icon: Users, tone: "primary" },
+      { label: "Postes distincts", value: s?.distinct_positions ?? 0, icon: BadgeCheck, tone: "default" },
+      { label: "Avec téléphone", value: s?.with_phone ?? 0, icon: Phone, tone: "default" },
       { label: "Sans poste", value: withoutPosition, icon: UserX, tone: withoutPosition > 0 ? "accent" : "default" },
     ]
   }, [data])

--- a/components/admin/subjects/SubjectsPageClient.tsx
+++ b/components/admin/subjects/SubjectsPageClient.tsx
@@ -4,24 +4,21 @@ import { useMemo, useState } from "react"
 import { BookMarked, Plus, LayoutGrid, List, Layers, UserX, Clock } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
-import { useSubjects } from "@/lib/hooks/useSubjects"
+import { useAdminSummary } from "@/lib/hooks/useDashboard"
 import { SubjectsTable } from "./SubjectsTable"
 import { SubjectsKanbanView } from "./SubjectsKanbanView"
 import { SubjectCreateModal } from "./SubjectCreateModal"
 
 function SubjectsKpis() {
-  const { data } = useSubjects({ size: 100 })
+  const { data } = useAdminSummary()
   const kpis: KpiItem[] = useMemo(() => {
-    const items = data?.items ?? []
-    const uniqueNames = new Set(items.map((s) => s.name)).size
-    const instances = items.filter((s) => s.level_id !== null)
-    const withoutTeacher = instances.filter((s) => !s.teacher_id).length
-    const hours = instances.reduce((sum, s) => sum + (s.hours_per_week ?? 0), 0)
+    const s = data?.subjects
+    const withoutTeacher = s?.without_teacher ?? 0
     return [
-      { label: "Matières uniques", value: uniqueNames, icon: BookMarked, tone: "primary" },
-      { label: "Instances par niveau", value: instances.length, icon: Layers, tone: "default" },
+      { label: "Matières uniques", value: s?.unique_names ?? 0, icon: BookMarked, tone: "primary" },
+      { label: "Instances par niveau", value: s?.instances ?? 0, icon: Layers, tone: "default" },
       { label: "Sans enseignant", value: withoutTeacher, icon: UserX, tone: withoutTeacher > 0 ? "accent" : "default" },
-      { label: "Heures / semaine", value: `${hours}h`, icon: Clock, tone: "default" },
+      { label: "Heures / semaine", value: `${s?.total_hours ?? 0}h`, icon: Clock, tone: "default" },
     ]
   }, [data])
   return <KpiStrip items={kpis} />

--- a/components/admin/teachers/TeachersPageClient.tsx
+++ b/components/admin/teachers/TeachersPageClient.tsx
@@ -6,20 +6,17 @@ import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
 import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { TeachersTable } from "./TeachersTable"
 import { TeacherCreateModal } from "./TeacherCreateModal"
-import { useTeachers } from "@/lib/hooks/useTeachers"
+import { useAdminSummary } from "@/lib/hooks/useDashboard"
 
 function TeacherKpis() {
-  const { data } = useTeachers({ size: 100 })
+  const { data } = useAdminSummary()
   const kpis: KpiItem[] = useMemo(() => {
-    const items = data?.items ?? []
-    const total = data?.total ?? items.length
-    const withSpeciality = items.filter((t) => t.speciality?.trim()).length
-    const withPhone = items.filter((t) => t.phone?.trim()).length
-    const withoutSpeciality = items.length - withSpeciality
+    const t = data?.teachers
+    const withoutSpeciality = t?.without_speciality ?? 0
     return [
-      { label: "Enseignants", value: total, icon: Users, tone: "primary" },
-      { label: "Avec spécialité", value: withSpeciality, icon: Award, tone: "default" },
-      { label: "Avec téléphone", value: withPhone, icon: Phone, tone: "default" },
+      { label: "Enseignants", value: t?.total ?? 0, icon: Users, tone: "primary" },
+      { label: "Avec spécialité", value: t?.with_speciality ?? 0, icon: Award, tone: "default" },
+      { label: "Avec téléphone", value: t?.with_phone ?? 0, icon: Phone, tone: "default" },
       { label: "Sans spécialité", value: withoutSpeciality, icon: UserX, tone: withoutSpeciality > 0 ? "accent" : "default" },
     ]
   }, [data])

--- a/lib/api/dashboard.ts
+++ b/lib/api/dashboard.ts
@@ -1,8 +1,10 @@
 import {
   DashboardStatsSchema,
   DashboardActivitySchema,
+  AdminSummarySchema,
   type DashboardStats,
   type DashboardActivity,
+  type AdminSummary,
 } from "@/lib/contracts/dashboard"
 import { apiFetch } from "./client"
 
@@ -12,4 +14,7 @@ export const dashboardApi = {
 
   activity: async (): Promise<DashboardActivity> =>
     apiFetch("/dashboard/activity", { schema: DashboardActivitySchema }),
+
+  summary: async (): Promise<AdminSummary> =>
+    apiFetch("/dashboard/summary", { schema: AdminSummarySchema }),
 }

--- a/lib/contracts/dashboard.ts
+++ b/lib/contracts/dashboard.ts
@@ -27,3 +27,52 @@ export const DashboardActivitySchema = z.object({
 
 export type ActivityItem = z.infer<typeof ActivityItemSchema>
 export type DashboardActivity = z.infer<typeof DashboardActivitySchema>
+
+// Agrégats KPI calculés côté serveur (GET /dashboard/summary). Justes quelle
+// que soit la volumétrie (pas de cap pagination size<=100).
+export const AdminSummarySchema = z.object({
+  classes: z.object({
+    total: z.number().default(0),
+    enrolled: z.number().default(0),
+    capacity: z.number().default(0),
+    full: z.number().default(0),
+  }),
+  teachers: z.object({
+    total: z.number().default(0),
+    with_speciality: z.number().default(0),
+    with_phone: z.number().default(0),
+    without_speciality: z.number().default(0),
+  }),
+  staff: z.object({
+    total: z.number().default(0),
+    distinct_positions: z.number().default(0),
+    with_phone: z.number().default(0),
+    without_position: z.number().default(0),
+  }),
+  parents: z.object({
+    total: z.number().default(0),
+    with_account: z.number().default(0),
+    with_email: z.number().default(0),
+    without_account: z.number().default(0),
+  }),
+  rooms: z.object({
+    total: z.number().default(0),
+    capacity: z.number().default(0),
+    classrooms: z.number().default(0),
+    classes_without_room: z.number().default(0),
+  }),
+  subjects: z.object({
+    unique_names: z.number().default(0),
+    instances: z.number().default(0),
+    without_teacher: z.number().default(0),
+    total_hours: z.number().default(0),
+  }),
+  enrollments: z.object({
+    total: z.number().default(0),
+    valid: z.number().default(0),
+    pending: z.number().default(0),
+    closed: z.number().default(0),
+  }),
+})
+
+export type AdminSummary = z.infer<typeof AdminSummarySchema>

--- a/lib/hooks/useDashboard.ts
+++ b/lib/hooks/useDashboard.ts
@@ -6,6 +6,20 @@ import { dashboardApi } from "@/lib/api/dashboard"
 export const dashboardKeys = {
   stats: ["dashboard", "stats"] as const,
   activity: ["dashboard", "activity"] as const,
+  summary: ["dashboard", "summary"] as const,
+}
+
+/**
+ * Agrégats KPI serveur (corrects quelle que soit la volumétrie). Partagé entre
+ * toutes les pages admin via une seule requête mise en cache.
+ */
+export function useAdminSummary() {
+  return useQuery({
+    queryKey: dashboardKeys.summary,
+    queryFn: dashboardApi.summary,
+    staleTime: 1000 * 60 * 2,
+    retry: 1,
+  })
 }
 
 export function useDashboardStats() {


### PR DESCRIPTION
Câble les bandeaux KPI (Classes, Matières, Enseignants, Personnel, Parents, Salles, Inscriptions) sur le nouvel endpoint serveur `GET /dashboard/summary` (BE #166) via un hook partagé `useAdminSummary` mis en cache. Les compteurs restent exacts au-delà de 100 lignes (l'ancien comptage chargeait des listes plafonnées à size<=100). Une seule requête partagée remplace les multiples fetchs de liste. Élèves conserve `useStudentFilters` (déjà serveur). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)