### PR TITLE
feat(ui): KLASSCI brand palette felt across app + fees pages redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Identité visuelle KLASSCI plus présente dans toute l'application : la page active du menu est signalée par un repère orange, les indicateurs clés portent un liseré bleu ou orange, et la couleur orange de la marque ressort enfin au lieu d'un bleu uniforme. Rendu vérifié en mode clair et sombre *(tous)*.
+- Pages Frais (élève, parent) refondues avec un bandeau de synthèse bleu marque : total attendu, montant payé en vert et « Reste à payer » mis en avant en orange, avec barre de progression. Plus lisible d'un coup d'œil *(élève, parent)*.
+- Page Frais admin : les cartes de catégories adoptent les couleurs de la marque (obligatoire en bleu, optionnel en orange) et s'affichent correctement en mode sombre, là où elles restaient en tons clairs *(admin)*.
 - Indicateurs clés des pages de gestion désormais alimentés par un calcul serveur : les chiffres restent exacts même au-delà de 100 lignes (grands établissements), là où ils étaient auparavant tronqués *(admin)*.
 
 ### Added

--- a/components/admin/fees/FeesPageClient.tsx
+++ b/components/admin/fees/FeesPageClient.tsx
@@ -29,9 +29,20 @@ import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { useLevels } from "@/lib/hooks/useLevels"
 import type { FeeCategory, FeeVariant } from "@/lib/contracts/fee"
 
-// Colors based on mandatory/optional type — semantic, not arbitrary
-const MANDATORY_COLOR = { bg: "bg-rose-50/60", border: "border-rose-200/80", icon: "bg-rose-100 text-rose-600" }
-const OPTIONAL_COLOR = { bg: "bg-blue-50/60", border: "border-blue-200/80", icon: "bg-blue-100 text-blue-600" }
+// Couleurs de marque KLASSCI, compatibles thème clair/sombre (tokens) :
+// obligatoire = bleu (primary), optionnel = orange (accent).
+const MANDATORY_COLOR = {
+  bg: "bg-primary/5",
+  border: "border-primary/20",
+  icon: "bg-primary/10 text-primary",
+  badge: "border-primary/30 bg-primary/10 text-primary",
+}
+const OPTIONAL_COLOR = {
+  bg: "bg-accent/5",
+  border: "border-accent/25",
+  icon: "bg-accent/10 text-accent",
+  badge: "border-accent/30 bg-accent/10 text-accent",
+}
 
 export function FeesPageClient() {
   const [categoryModalOpen, setCategoryModalOpen] = useState(false)
@@ -188,7 +199,7 @@ export function FeesPageClient() {
                           )}
                         </div>
                       </div>
-                      <Badge variant={cat.is_mandatory ? "destructive" : "secondary"} className="text-[10px] h-5">
+                      <Badge variant="outline" className={`text-[10px] h-5 ${color.badge}`}>
                         {cat.is_mandatory ? "Obligatoire" : "Optionnel"}
                       </Badge>
                     </div>

--- a/components/parent/ParentChildFeesClient.tsx
+++ b/components/parent/ParentChildFeesClient.tsx
@@ -3,8 +3,8 @@
 import { ArrowLeft, CheckCircle, Clock, AlertCircle } from "lucide-react"
 import Link from "next/link"
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { FeeSummaryHero } from "@/components/shared/fees/FeeSummaryHero"
 import {
   Table,
   TableBody,
@@ -63,43 +63,12 @@ export function ParentChildFeesClient({ childId }: ParentChildFeesClientProps) {
         </div>
       ) : (
         <>
-          {/* Résumé financier */}
-          <div className="grid grid-cols-3 gap-3">
-            <SummaryCard label="Total" value={`${data.total_expected.toLocaleString("fr-FR")} FCFA`} />
-            <SummaryCard
-              label="Payé"
-              value={`${data.total_paid.toLocaleString("fr-FR")} FCFA`}
-              className="text-emerald-600 dark:text-emerald-400"
-            />
-            <SummaryCard
-              label="Restant"
-              value={`${data.total_remaining.toLocaleString("fr-FR")} FCFA`}
-              className={data.total_remaining === 0 ? "text-emerald-600 dark:text-emerald-400" : "text-accent"}
-            />
-          </div>
-
-          {/* Barre de progression */}
-          {(() => {
-            const paymentPercent = data.total_expected > 0
-              ? Math.min(100, (data.total_paid / data.total_expected) * 100)
-              : 0
-            return (
-              <Card className="border-0 shadow-sm ring-1 ring-border">
-                <CardContent className="p-4">
-                  <div className="flex items-center justify-between mb-2">
-                    <span className="text-xs text-muted-foreground">Progression des paiements</span>
-                    <span className="text-xs font-medium">{paymentPercent.toFixed(0)}%</span>
-                  </div>
-                  <div className="h-2 rounded-full bg-muted overflow-hidden">
-                    <div
-                      className="h-full rounded-full bg-emerald-500 transition-all"
-                      style={{ width: `${paymentPercent}%` }}
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-            )
-          })()}
+          {/* Synthèse aux couleurs KLASSCI */}
+          <FeeSummaryHero
+            totalExpected={data.total_expected}
+            totalPaid={data.total_paid}
+            totalRemaining={data.total_remaining}
+          />
 
           {/* Détail par catégorie */}
           {data.fees.length === 0 ? (
@@ -144,25 +113,6 @@ export function ParentChildFeesClient({ childId }: ParentChildFeesClientProps) {
         </>
       )}
     </div>
-  )
-}
-
-function SummaryCard({
-  label,
-  value,
-  className,
-}: {
-  label: string
-  value: string
-  className?: string
-}) {
-  return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
-      <CardContent className="p-3 text-center">
-        <p className={`text-sm font-bold ${className ?? ""}`}>{value}</p>
-        <p className="text-[10px] text-muted-foreground">{label}</p>
-      </CardContent>
-    </Card>
   )
 }
 

--- a/components/shared/ParentNav.tsx
+++ b/components/shared/ParentNav.tsx
@@ -25,9 +25,9 @@ export function ParentNav() {
               key={item.href}
               href={item.href}
               className={cn(
-                "flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
+                "relative flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
                 isActive
-                  ? "text-primary"
+                  ? "text-primary before:absolute before:top-0 before:left-1/2 before:h-1 before:w-6 before:-translate-x-1/2 before:rounded-full before:bg-accent before:content-['']"
                   : "text-muted-foreground"
               )}
             >

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -145,9 +145,9 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                   href={item.href}
                   onClick={onClose}
                   className={cn(
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
+                    "relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
                     isActive
-                      ? "bg-primary/10 text-primary font-medium"
+                      ? "bg-primary/10 text-primary font-medium before:absolute before:left-0 before:top-1/2 before:h-5 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-accent before:content-['']"
                       : "text-muted-foreground hover:bg-muted hover:text-foreground"
                   )}
                 >

--- a/components/shared/StudentNav.tsx
+++ b/components/shared/StudentNav.tsx
@@ -105,8 +105,10 @@ export function StudentNav() {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  "flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
-                  isActive ? "text-primary" : "text-muted-foreground",
+                  "relative flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
+                  isActive
+                    ? "text-primary before:absolute before:top-0 before:left-1/2 before:h-1 before:w-6 before:-translate-x-1/2 before:rounded-full before:bg-accent before:content-['']"
+                    : "text-muted-foreground",
                 )}
               >
                 <item.icon className={cn("h-5 w-5", isActive && "text-primary")} />
@@ -119,8 +121,10 @@ export function StudentNav() {
             aria-haspopup="true"
             onClick={() => setMoreOpen((prev) => !prev)}
             className={cn(
-              "flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
-              isMoreActive || moreOpen ? "text-primary" : "text-muted-foreground",
+              "relative flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
+              isMoreActive || moreOpen
+                ? "text-primary before:absolute before:top-0 before:left-1/2 before:h-1 before:w-6 before:-translate-x-1/2 before:rounded-full before:bg-accent before:content-['']"
+                : "text-muted-foreground",
             )}
           >
             <MoreHorizontal className={cn("h-5 w-5", (isMoreActive || moreOpen) && "text-primary")} />

--- a/components/shared/TeacherNav.tsx
+++ b/components/shared/TeacherNav.tsx
@@ -28,9 +28,9 @@ export function TeacherNav() {
               key={item.href}
               href={item.href}
               className={cn(
-                "flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
+                "relative flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium transition-colors min-w-[56px]",
                 isActive
-                  ? "text-primary"
+                  ? "text-primary before:absolute before:top-0 before:left-1/2 before:h-1 before:w-6 before:-translate-x-1/2 before:rounded-full before:bg-accent before:content-['']"
                   : "text-muted-foreground"
               )}
             >
@@ -82,9 +82,9 @@ export function TeacherSidebar() {
               key={item.href}
               href={item.href}
               className={cn(
-                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                "relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                 isActive
-                  ? "bg-primary/10 text-primary"
+                  ? "bg-primary/10 text-primary before:absolute before:left-0 before:top-1/2 before:h-5 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-accent before:content-['']"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground"
               )}
             >

--- a/components/shared/fees/FeeSummaryHero.tsx
+++ b/components/shared/fees/FeeSummaryHero.tsx
@@ -1,0 +1,92 @@
+import { cn } from "@/lib/utils"
+
+/**
+ * Bandeau de synthèse des frais aux couleurs KLASSCI : panneau bleu marque
+ * (primary), chiffres en blanc, « Reste à payer » mis en avant en orange
+ * (accent). Compatible thème clair et sombre (tokens primary/-foreground).
+ *
+ * Cas « rien à payer » (total attendu = 0) : neutralisé en blanc/gris pour ne
+ * pas afficher un faux signal positif (cf. rule not-enrolled-empty-state).
+ */
+interface FeeSummaryHeroProps {
+  totalExpected: number
+  totalPaid: number
+  totalRemaining: number
+  className?: string
+}
+
+const fmt = (n: number) => `${n.toLocaleString("fr-FR")} FCFA`
+
+export function FeeSummaryHero({
+  totalExpected,
+  totalPaid,
+  totalRemaining,
+  className,
+}: FeeSummaryHeroProps) {
+  const hasExpected = totalExpected > 0
+  const pct = hasExpected ? Math.min(100, Math.round((totalPaid / totalExpected) * 100)) : 0
+  const settled = hasExpected && totalRemaining <= 0
+
+  return (
+    <section
+      aria-label="Résumé des frais"
+      className={cn(
+        "rounded-2xl bg-primary p-5 text-primary-foreground shadow-sm sm:p-6",
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-wider text-primary-foreground/70">
+            Total attendu
+          </p>
+          <p className="mt-1 text-2xl font-bold tabular-nums sm:text-3xl">
+            {hasExpected ? fmt(totalExpected) : "—"}
+          </p>
+        </div>
+        {hasExpected && (
+          <span
+            className={cn(
+              "shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold",
+              settled ? "bg-emerald-400/20 text-emerald-100" : "bg-accent/25 text-amber-100",
+            )}
+          >
+            {settled ? "Soldé" : `${pct}% payé`}
+          </span>
+        )}
+      </div>
+
+      {/* Progression — piste blanche translucide, remplissage vert (montant payé) */}
+      <div className="mt-4 h-2 overflow-hidden rounded-full bg-primary-foreground/15">
+        <div
+          className="h-full rounded-full bg-emerald-400 transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-xl bg-primary-foreground/10 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-primary-foreground/70">Payé</p>
+          <p className="mt-0.5 text-lg font-bold tabular-nums text-emerald-300">{fmt(totalPaid)}</p>
+        </div>
+        <div className="rounded-xl bg-primary-foreground/10 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-primary-foreground/70">
+            Reste à payer
+          </p>
+          <p
+            className={cn(
+              "mt-0.5 text-lg font-bold tabular-nums",
+              !hasExpected
+                ? "text-primary-foreground/80"
+                : settled
+                  ? "text-emerald-300"
+                  : "text-accent",
+            )}
+          >
+            {hasExpected ? fmt(totalRemaining) : "—"}
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/shared/list/KpiStrip.tsx
+++ b/components/shared/list/KpiStrip.tsx
@@ -20,6 +20,16 @@ const toneStyles: Record<KpiTone, string> = {
   emerald: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
 }
 
+// Liseré de gauche aux couleurs de la marque KLASSCI (bleu / orange) pour que
+// l'identité se ressente sur chaque liste. Tons sémantiques conservés.
+const edgeStyles: Record<KpiTone, string> = {
+  default: "border-l-border",
+  primary: "border-l-primary",
+  accent: "border-l-accent",
+  destructive: "border-l-destructive",
+  emerald: "border-l-emerald-500",
+}
+
 export interface KpiItem {
   label: string
   value: React.ReactNode
@@ -56,7 +66,7 @@ export function KpiStrip({ items, columns = 4, className }: KpiStripProps) {
             key={i}
             role="group"
             aria-label={valueText ? `${item.label} : ${valueText}` : item.label}
-            className="shadow-sm"
+            className={cn("border-l-[3px] shadow-sm", edgeStyles[item.tone ?? "default"])}
           >
             <CardContent className="flex items-start justify-between gap-3 p-4">
               <div className="min-w-0 space-y-0.5">

--- a/components/student/StudentFeesClient.tsx
+++ b/components/student/StudentFeesClient.tsx
@@ -2,8 +2,8 @@
 
 import { CheckCircle, Clock, AlertCircle } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { FeeSummaryHero } from "@/components/shared/fees/FeeSummaryHero"
 import {
   Table,
   TableBody,
@@ -45,53 +45,13 @@ export function StudentFeesClient() {
         </div>
       ) : (
         <>
-          {/* Résumé financier — Wave-style 3 KPIs amount-first.
-              Neutralisé en gris si total_expected=0 (signal vert "—FCFA payé"
-              quand rien à payer = faux signal — cf. rule not-enrolled-empty-state). */}
-          <div className="grid grid-cols-3 gap-3">
-            <SummaryCard
-              label="Total"
-              value={`${data.total_expected.toLocaleString("fr-FR")} FCFA`}
-            />
-            <SummaryCard
-              label="Payé"
-              value={`${data.total_paid.toLocaleString("fr-FR")} FCFA`}
-              className={data.total_expected > 0 ? "text-emerald-600 dark:text-emerald-400" : "text-muted-foreground"}
-            />
-            <SummaryCard
-              label="Restant"
-              value={`${data.total_remaining.toLocaleString("fr-FR")} FCFA`}
-              className={
-                data.total_expected === 0
-                  ? "text-muted-foreground"
-                  : data.total_remaining === 0
-                    ? "text-emerald-600 dark:text-emerald-400"
-                    : "text-accent"
-              }
-            />
-          </div>
-
-          {/* Barre de progression */}
-          <Card className="border-0 shadow-sm ring-1 ring-border">
-            <CardContent className="p-4">
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-xs text-muted-foreground">Progression des paiements</span>
-                <span className="text-xs font-medium">
-                  {data.total_expected > 0
-                    ? `${Math.min(100, (data.total_paid / data.total_expected) * 100).toFixed(0)}%`
-                    : "0%"}
-                </span>
-              </div>
-              <div className="h-2 rounded-full bg-muted overflow-hidden">
-                <div
-                  className="h-full rounded-full bg-emerald-500 transition-all"
-                  style={{
-                    width: `${data.total_expected > 0 ? Math.min(100, (data.total_paid / data.total_expected) * 100) : 0}%`,
-                  }}
-                />
-              </div>
-            </CardContent>
-          </Card>
+          {/* Synthèse aux couleurs KLASSCI. Neutralisé si rien à payer
+              (cf. rule not-enrolled-empty-state). */}
+          <FeeSummaryHero
+            totalExpected={data.total_expected}
+            totalPaid={data.total_paid}
+            totalRemaining={data.total_remaining}
+          />
 
           {/* Détail par catégorie */}
           {data.fees.length === 0 ? (
@@ -136,25 +96,6 @@ export function StudentFeesClient() {
         </>
       )}
     </div>
-  )
-}
-
-function SummaryCard({
-  label,
-  value,
-  className,
-}: {
-  label: string
-  value: string
-  className?: string
-}) {
-  return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
-      <CardContent className="p-3 text-center">
-        <p className={`text-sm font-bold ${className ?? ""}`}>{value}</p>
-        <p className="text-[10px] text-muted-foreground">{label}</p>
-      </CardContent>
-    </Card>
   )
 }
 


### PR DESCRIPTION
## Pourquoi

Les trois couleurs de la marque KLASSCI (bleu, orange, blanc) n'étaient pas "senties" : l'app paraissait monochrome bleu et l'orange était quasi invisible. La page Frais utilisait des couleurs en dur (`bg-blue-50`, `bg-rose-50`) cassées en mode sombre.

## Ce que ça change (shadcn uniquement, clair + sombre)

**Identité ressentie sur toutes les pages, via la couche partagée :**
- Repère **orange** sur l'item de menu actif (sidebar admin + bottom-navs élève/enseignant/parent).
- Liseré coloré (bleu/orange/emerald) sur chaque tuile KPI.

**Pages Frais (showcase) :**
- Nouveau `FeeSummaryHero` partagé : panneau **bleu marque**, montant payé en vert, **« Reste à payer » en orange**, barre de progression. Réutilisé par les portails élève + parent.
- Page Frais admin : cartes catégories en tokens de marque (obligatoire = bleu, optionnel = orange), **enfin correctes en mode sombre**.

Cas "rien à payer" neutralisé (pas de faux signal vert) conformément à la règle not-enrolled-empty-state.

## Vérifications
- `tsc --noEmit` ✓
- Visual-check (clair + sombre) sur le serveur Windows après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)