### PR TITLE
fix(fees): student & parent fees pages were broken by BE↔FE contract drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais admin : les cartes de catégories adoptent les couleurs de la marque (obligatoire en bleu, optionnel en orange) et s'affichent correctement en mode sombre, là où elles restaient en tons clairs *(admin)*.
 - Indicateurs clés des pages de gestion désormais alimentés par un calcul serveur : les chiffres restent exacts même au-delà de 100 lignes (grands établissements), là où ils étaient auparavant tronqués *(admin)*.
 
+### Fixed
+
+- Page Frais de l'élève et du parent : la liste restait en chargement infini puis en erreur pour un élève inscrit. Les montants, le total payé, le reste à payer et le statut de chaque frais s'affichent désormais correctement *(élève, parent)*.
+
 ### Added
 
 - Indicateurs clés (KPI), recherche instantanée et filtres ajoutés sur les pages de gestion qui en manquaient : Classes, Matières, Niveaux, Années scolaires, Inscriptions, Salles, Notifications, Frais, ainsi que les listes Élèves, Enseignants, Personnel et Parents. La recherche ignore les accents et la casse (taper « traore » trouve « Traoré ») *(admin)*.

--- a/components/parent/ParentChildFeesClient.tsx
+++ b/components/parent/ParentChildFeesClient.tsx
@@ -43,11 +43,12 @@ export function ParentChildFeesClient({ childId }: ParentChildFeesClientProps) {
         </Link>
         <div>
           <h1 className="font-serif text-xl tracking-tight">
-            {data ? `Frais — ${data.child_name}` : "Frais scolaires"}
+            {data?.child_name ? `Frais — ${data.child_name}` : "Frais scolaires"}
           </h1>
-          {data && (
+          {data?.class_name && (
             <p className="text-sm text-muted-foreground">
-              {data.class_name} • {data.academic_year}
+              {data.class_name}
+              {data.academic_year ? ` • ${data.academic_year}` : ""}
             </p>
           )}
         </div>

--- a/lib/api/parent-portal.ts
+++ b/lib/api/parent-portal.ts
@@ -1,14 +1,33 @@
+import { z } from "zod"
 import { apiFetch, apiFetchBlob, safeValidate } from "./client"
+import { mapFeeStatus } from "./student-portal"
 import {
   ParentDashboardSchema,
   ParentChildGradesResponseSchema,
-  ParentChildFeesResponseSchema,
   ParentChildBulletinsResponseSchema,
   type ParentDashboard,
   type ParentChildGradesResponse,
   type ParentChildFeesResponse,
   type ParentChildBulletinsResponse,
 } from "@/lib/contracts/parent-portal"
+
+// Le BE /parent/children/{id}/fees renvoie {student_id, enrollment_id,
+// total_due, total_paid, fees:[{id, category_name, amount, status, payments}]}.
+// On valide cette forme puis on la normalise vers le contrat UI.
+const ParentFeeRawSchema = z.object({
+  id: z.number(),
+  category_name: z.string(),
+  amount: z.coerce.number(),
+  status: z.string(),
+  payments: z.array(z.object({ amount: z.coerce.number() }).passthrough()).default([]),
+})
+const ParentChildFeesRawSchema = z.object({
+  student_id: z.number(),
+  enrollment_id: z.number().nullable().optional(),
+  total_due: z.coerce.number(),
+  total_paid: z.coerce.number(),
+  fees: z.array(ParentFeeRawSchema).default([]),
+})
 
 export interface ChildTimetableSlot {
   id: number
@@ -48,10 +67,30 @@ export const parentPortalApi = {
     return safeValidate(ParentChildGradesResponseSchema, unwrapResponse(res), `GET /parent/children/${childId}/grades`)
   },
 
-  // Frais d'un enfant
+  // Frais d'un enfant — normalise la réponse BE vers le contrat UI.
   getChildFees: async (childId: number): Promise<ParentChildFeesResponse> => {
     const res = await apiFetch<unknown>(`/parent/children/${childId}/fees`)
-    return safeValidate(ParentChildFeesResponseSchema, unwrapResponse(res), `GET /parent/children/${childId}/fees`)
+    const raw = safeValidate(ParentChildFeesRawSchema, unwrapResponse(res), `GET /parent/children/${childId}/fees`)
+    return {
+      child_name: null,
+      class_name: null,
+      academic_year: null,
+      total_expected: raw.total_due,
+      total_paid: raw.total_paid,
+      total_remaining: Math.max(0, raw.total_due - raw.total_paid),
+      fees: (raw.fees ?? []).map((f) => {
+        const paid = (f.payments ?? []).reduce((sum, p) => sum + p.amount, 0)
+        return {
+          id: f.id,
+          category_name: f.category_name,
+          total_amount: f.amount,
+          paid_amount: paid,
+          remaining: Math.max(0, f.amount - paid),
+          status: mapFeeStatus(f.status),
+          last_payment_date: null,
+        }
+      }),
+    }
   },
 
   // Bulletins d'un enfant

--- a/lib/api/student-portal.ts
+++ b/lib/api/student-portal.ts
@@ -3,7 +3,6 @@ import { apiFetch, apiFetchBlob, safeValidate } from "./client"
 import {
   StudentDashboardSchema,
   StudentGradesResponseSchema,
-  StudentFeesResponseSchema,
   StudentBulletinSchema,
   StudentAttendanceResponseSchema,
   type StudentDashboard,
@@ -19,6 +18,31 @@ import {
 
 const TimetableSlotArraySchema = z.array(TimetableSlotSchema)
 const StudentBulletinArraySchema = z.array(StudentBulletinSchema)
+
+// Le BE /student/fees renvoie {total_due, total_paid, balance, fees:[{id,
+// fee_category_name, amount, status: paid|partial|pending, payments}]}. On
+// valide cette forme réelle puis on la normalise vers le contrat consommé par
+// l'UI (total_expected/total_remaining/category_name/paye|partiel|impaye).
+const FeePaymentRawSchema = z.object({ amount: z.coerce.number() }).passthrough()
+const StudentFeeRawSchema = z.object({
+  id: z.number(),
+  fee_category_name: z.string(),
+  amount: z.coerce.number(),
+  status: z.string(),
+  payments: z.array(FeePaymentRawSchema).default([]),
+})
+const StudentFeesRawSchema = z.object({
+  total_due: z.coerce.number(),
+  total_paid: z.coerce.number(),
+  balance: z.coerce.number(),
+  fees: z.array(StudentFeeRawSchema).default([]),
+})
+
+export function mapFeeStatus(status: string): "paye" | "partiel" | "impaye" {
+  if (status === "paid" || status === "paye") return "paye"
+  if (status === "partial" || status === "partiel") return "partiel"
+  return "impaye"
+}
 
 // Extrait l'item de la réponse API, qu'elle soit { data: T } ou T directement
 function unwrapResponse<T>(res: unknown): T {
@@ -85,10 +109,28 @@ export const studentPortalApi = {
     return safeValidate(TimetableSlotArraySchema, mapped, "GET /student/timetable")
   },
 
-  // Frais et paiements
+  // Frais et paiements — normalise la réponse BE vers le contrat UI.
   getFees: async (): Promise<StudentFeesResponse> => {
     const res = await apiFetch<unknown>("/student/fees")
-    return safeValidate(StudentFeesResponseSchema, unwrapResponse(res), "GET /student/fees")
+    const raw = safeValidate(StudentFeesRawSchema, unwrapResponse(res), "GET /student/fees")
+    return {
+      academic_year: "",
+      total_expected: raw.total_due,
+      total_paid: raw.total_paid,
+      total_remaining: raw.balance,
+      fees: (raw.fees ?? []).map((f) => {
+        const paid = (f.payments ?? []).reduce((sum, p) => sum + p.amount, 0)
+        return {
+          id: f.id,
+          category_name: f.fee_category_name,
+          total_amount: f.amount,
+          paid_amount: paid,
+          remaining: Math.max(0, f.amount - paid),
+          status: mapFeeStatus(f.status),
+          last_payment_date: null,
+        }
+      }),
+    }
   },
 
   // Bulletins publiés

--- a/lib/contracts/parent-portal.ts
+++ b/lib/contracts/parent-portal.ts
@@ -63,9 +63,11 @@ export const ParentChildFeeItemSchema = z.object({
 })
 
 export const ParentChildFeesResponseSchema = z.object({
-  child_name: z.string(),
-  class_name: z.string(),
-  academic_year: z.string(),
+  // Le BE ne renvoie pas le nom/classe/année de l'enfant sur cet endpoint :
+  // champs optionnels, l'en-tête dégrade proprement si absents.
+  child_name: z.string().nullish(),
+  class_name: z.string().nullish(),
+  academic_year: z.string().nullish(),
   total_expected: z.coerce.number(),
   total_paid: z.coerce.number(),
   total_remaining: z.coerce.number(),


### PR DESCRIPTION
## Découvert pendant /klassci-e2e-test

En testant la page Frais sur le serveur Windows avec un élève réellement inscrit (`aminata.eleve@…`, 185 000 FCFA de frais), la page restait en **chargement infini puis erreur**.

## Cause

Le backend renvoie sur `/student/fees` et `/parent/children/{id}/fees` :
```json
{ "total_due": "185000.00", "total_paid": "0.00", "balance": "185000.00",
  "fees": [{ "id": 26, "fee_category_name": "Inscription", "amount": "25000.00", "status": "paid", "payments": [] }] }
```
…mais les contrats Zod du FE attendaient `total_expected` / `total_remaining` / `category_name` / `status: paye|partiel|impaye`. La validation échouait → la requête partait en erreur/retry → **squelette figé puis erreur** pour tout élève inscrit. Les pages Frais élève/parent n'ont jamais affiché de données.

## Fix (FE, conforme à la règle api-client-zod-validation)

Valider la **vraie forme BE** puis la normaliser dans le client API ( dérivé des paiements, mapping de statut). L'en-tête parent dégrade proprement car l'endpoint n'expose pas le nom/classe/année de l'enfant.

## Vérifié
- `tsc --noEmit` ✓
- Re-test E2E sur le serveur Windows après deploy (élève Aminata + parent).

## Suivi (hors scope)
- BE : enrichir `/parent/children/{id}/fees` avec child_name/class_name/année pour réafficher le nom dans l'en-tête.
- Données démo : un frais a le statut `paid` alors que `total_paid=0` (paiement non alloué) — à corriger côté seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)