### PR TITLE
feat(ui): KLASSCI gradient-hero design system (blue + orange) across all pages

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,6 +105,7 @@ npm run test:e2e
 @rules/auth-architecture.md
 @rules/ux-target-user-reality.md
 @rules/redesign-premium.md
+@rules/premium-design-system.md
 @rules/deploy.md
 @rules/git.md
 @rules/changelog.md

--- a/.claude/rules/premium-design-system.md
+++ b/.claude/rules/premium-design-system.md
@@ -1,0 +1,235 @@
+# Premium Design System — KLASSCI College (shadcn/ui + Tailwind)
+
+## Quand s'active
+
+Cette rule s'active **dès qu'on crée ou redesign une page, un composant, un
+modal ou un sous‑élément** dans `klassci-frontend` (Next.js + shadcn/ui +
+Tailwind). Elle régit l'identité visuelle de bout en bout : du hero d'en‑tête
+jusqu'au plus petit bouton imbriqué, **sur les 10 couches de profondeur**.
+
+> Différence avec KLASSCIv2 (`premium-redesign.md`, supérieur) : KLASSCIv2 est
+> **monochrome bleu** (2 couleurs). **KLASSCI College est bi‑chromatique
+> bleu + orange** : l'orange du logo (#F58220, le « K ») doit *ressortir*,
+> mais avec discipline (1 point focal orange par contexte, jamais l'arc‑en‑ciel).
+
+---
+
+## 1. La marque : bleu + orange + blanc
+
+### Tokens (déjà dans `app/globals.css`, ne pas hardcoder)
+
+| Token | Hex | Rôle |
+|---|---|---|
+| `--primary` | `#0F3F8C` | Bleu KLASSCI — structure, navigation, actions par défaut, texte fort |
+| `--accent` | `#F58220` | **Orange KLASSCI — accent focal** (la chose à regarder/cliquer) |
+| `--muted` / `--card` / `--border` | — | Surfaces et profondeur |
+| `--background` / `--foreground` | — | Fond de page / texte |
+
+### Les 3 bleus du dégradé hero (signature)
+
+```
+#0a3d8f  →  #0453cb  →  #3b7ddb
+```
+Utilisés **uniquement** dans le `PageHero` (`bg-gradient-to-br from-[#0a3d8f] via-[#0453cb] to-[#3b7ddb]`).
+
+### Couleurs sémantiques (statut uniquement, jamais décoratif)
+
+| Token Tailwind | Sens |
+|---|---|
+| `emerald-600` / `emerald-500` | Succès, payé, validé, présent |
+| `amber-500` / `amber-600` | Alerte, en attente, à surveiller |
+| `destructive` / `rose-600` | Erreur, impayé, rejeté, suppression |
+
+**Règle d'or couleur** : si la couleur porte une info que l'œil doit capter en
+< 1 s (statut, alerte, action focale), elle est autorisée. Sinon → bleu/neutre.
+
+### Le rôle de l'orange (à respecter absolument)
+
+L'orange `accent` = **l'accent focal, UN par contexte** : l'élément le plus
+important à regarder ou cliquer dans une zone donnée. Exemples corrects :
+
+- Repère de l'item de menu **actif** (barre orange).
+- Le **CTA principal** d'un hero ou d'une carte (1 bouton orange max par carte).
+- La **métrique clé** d'un bandeau (« Reste à payer », le solde).
+- Un **onglet/chip sélectionné**, un **état actif**.
+- Le **dot focal** d'une liste (l'élément qui requiert une action).
+
+❌ **Interdit** : colorer chaque KPI d'une couleur différente, des catégories
+neutres en orange « pour décorer », plusieurs oranges concurrents dans la même
+carte (le focal se dilue). Voir anti‑patterns § 6.
+
+---
+
+## 2. La signature : `PageHero` (Couche 1)
+
+**Toute page listing/dashboard commence par `<PageHero>`** (`components/shared/PageHero.tsx`).
+Ne jamais réinventer un en‑tête. Les **formulaires (create/edit)** n'ont **pas**
+de hero : ils utilisent l'en‑tête standard (icône `bg-primary` + titre).
+
+Structure :
+- Dégradé bleu 3 stops, texte blanc, icône en pastille verre (`bg-white/10 border-white/15`).
+- **1 accent orange focal** : le CTA principal en orange (`bg-accent`) OU un trait/badge orange.
+- **KPIs intégrés dans le hero** en cartes verre blanches (`bg-white/10 border-white/15`),
+  monochrome blanc (jamais une couleur par KPI). Layout d'une carte KPI :
+  **label petit en haut** (`text-[11px] uppercase text-white/65`) + icône discrète à
+  droite, **grande valeur en dessous** (`text-2xl font-bold`), hint optionnel.
+  Hero compact (`p-5 sm:p-6`, KPIs `mt-4`). La valeur clé peut passer en orange si focale.
+
+```tsx
+<PageHero
+  icon={Wallet}
+  title="Frais scolaires"
+  subtitle="Configuration des frais par niveau"
+  actions={
+    <>
+      <button className={heroGlassBtn}>Nouvelle variante</button>
+      <button className={heroAccentBtn}>Nouvelle catégorie</button>  {/* orange focal */}
+    </>
+  }
+  kpis={[ { label: "Obligatoires", value: 5, icon: Shield }, /* … */ ]}
+/>
+```
+
+Boutons du hero (exports de `PageHero.tsx`) :
+- `heroAccentBtn` — **orange plein** (`bg-accent text-accent-foreground`) : l'action focale.
+- `heroPrimaryBtn` — blanc plein (texte bleu) : action principale alternative.
+- `heroGlassBtn` — verre (`bg-white/15 border-white/25`) : actions secondaires.
+
+Autres exports partagés de `PageHero.tsx` :
+- `SectionTitle` (couche 4) — titre de sous-section avec icône carrée au dégradé bleu.
+- `premiumCardHover` — hover premium des cartes (couches 2-3) : `-translate-y-0.5` +
+  ombre bleue `shadow-[0_10px_30px_-12px_rgba(4,83,203,0.35)]`. À ajouter sur toute
+  carte survolable/cliquable.
+
+---
+
+## 3. Système de profondeur — les 10 couches
+
+**Principe** : la page est lisible jusqu'à 10 niveaux d'imbrication parce que
+chaque couche **alterne son élévation** (surélevée ↔ encaissée), **réduit son
+rayon et son padding**, et **n'introduit la couleur que par sémantique ou par
+le focal orange**. Une carte dans une carte dans une carte reste lisible.
+
+| # | Couche | Surface (tokens, clair+sombre) | Bordure | Radius | Ombre | Padding | Primitive shadcn | Couleur |
+|---|--------|-------------------------------|---------|--------|-------|---------|------------------|---------|
+| 0 | Page | `bg-background` | — | — | — | `space-y-6 p-4 md:p-6` | layout | — |
+| 1 | **Hero** | dégradé bleu, `text-white` | — | `rounded-2xl` | `shadow-sm` | `PageHero` | **1 orange focal** |
+| 2 | **Section card** | `bg-card` | `border` | `rounded-xl` | `shadow-sm` | `Card` | titre bleu + 1 action |
+| 3 | **Sub-card** (carte dans carte) | `bg-muted/40` | `border-border/60` | `rounded-lg` | — | `p-4` | `Card`/`div` | — |
+| 4 | **Section-bar** (en‑tête interne) | section-icon dégradé + titre | `border-b` | — | — | `pb-3` | `CardHeader` | icône dégradé bleu |
+| 5 | **Row / list item** | `bg-background`, hover `bg-muted/50` | `border-b last:border-0` | — | — | `px-3 py-2.5` | `TableRow` / `div` | statut (badge) |
+| 6 | **Inline group** (groupe dans une ligne) | `bg-muted/60` | `border` | `rounded-md` | — | `p-2` | `div` | — |
+| 7 | **Control** (input/select) | `bg-background` | `border-input` | `rounded-md` | — | `h-9 px-3` | `Input`/`Select` | ring `--ring` au focus |
+| 8 | **Button** | primary `bg-primary` / `outline` / `ghost` ; **focal = `bg-accent`** | — | `rounded-md` | `shadow-sm` | `h-9 px-3.5` | `Button` | **orange = CTA focal** |
+| 9 | **Chip / badge** (dans un bouton/contrôle) | `Badge` (`secondary` ou tone sémantique) | — | `rounded-full`/`rounded` | — | `px-2 py-0.5` | `Badge` | statut |
+| 10 | **Micro** (dot, helper, icône) | `text-muted-foreground` ; dot focal `bg-accent` | — | `rounded-full` | — | — | `span`/`svg` | dot orange = focal |
+
+### Règle d'alternance d'élévation (la clé de la lisibilité 10 couches)
+
+```
+Couche paire profonde  → ENCAISSÉE : bg-muted/40 → /50 → /60 (de plus en plus)
+Couche impaire         → SURÉLEVÉE  : bg-card / bg-background + border + shadow-sm
+```
+À chaque niveau plus profond : `rounded` d'un cran plus petit
+(`2xl → xl → lg → md`), `padding` d'un cran plus petit (`p-6 → p-5 → p-4 → p-3 → p-2`),
+opacité de surface qui monte. Jamais deux `bg-card` adjacents sans séparation
+(sinon les cartes fusionnent visuellement).
+
+### Recette « bouton dans une carte dans une carte » (couches 2→3→8)
+
+```tsx
+<Card className="border shadow-sm rounded-xl">                 {/* couche 2 */}
+  <CardContent className="p-5 space-y-4">
+    <div className="rounded-lg border border-border/60 bg-muted/40 p-4">  {/* couche 3 */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">Détail du frais</p>
+        <Button size="sm" className="bg-accent text-accent-foreground hover:bg-accent/90 shadow-sm">
+          Encaisser                                            {/* couche 8 — CTA focal orange */}
+        </Button>
+      </div>
+    </div>
+  </CardContent>
+</Card>
+```
+
+### Section-bar interne (couche 4) — section-icon dégradé
+
+```tsx
+<div className="flex items-center gap-2.5 border-b pb-3">
+  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-[#3b7ddb] text-white shadow-sm">
+    <Icon className="h-4 w-4" />
+  </span>
+  <h2 className="text-sm font-semibold">Montants par niveau</h2>
+</div>
+```
+
+---
+
+## 4. Composants shadcn par couche (ne rien recréer)
+
+| Besoin | Composant shadcn | Jamais |
+|---|---|---|
+| Carte (couches 2,3) | `Card`, `CardHeader`, `CardContent` | un `<div>` custom avec ombre maison |
+| Bouton (couche 8) | `Button` (variantes `default`/`outline`/`ghost`/`secondary`) | `<button>` brut stylé à la main |
+| Statut (couche 9) | `Badge` | un span coloré ad hoc |
+| Champ (couche 7) | `Input`, `Select`, `Textarea`, `Checkbox`, `Switch` | `<select>` natif |
+| Onglets | `Tabs` | des liens custom |
+| Tableau (couche 5) | `Table`, `TableRow`, `TableCell` | une grille CSS maison |
+| Dialog/confirm | `Dialog`, `AlertDialog` | `window.confirm`/`alert` |
+| Progression | `Progress` | une barre `<div>` maison |
+| Avatar | `Avatar` + `AvatarFallback` | `<img>` sans fallback 404‑safe |
+| Skeleton | `Skeleton` | un spinner global |
+
+Customisation **uniquement via Tailwind** (className), jamais en réécrivant le
+composant `components/ui/*`.
+
+---
+
+## 5. Dark / light (non négociable)
+
+- **Tout** via tokens (`bg-card`, `bg-muted`, `text-foreground`, `border`,
+  `bg-primary`, `bg-accent`) ou variantes `emerald-600 dark:emerald-400`.
+- Aucune couleur claire en dur (`bg-blue-50`, `bg-rose-50`, `text-blue-600`…) :
+  cassée en sombre.
+- Le hero (dégradé bleu + texte blanc) est **identique** dans les 2 thèmes — c'est
+  un bandeau coloré, c'est voulu.
+- Vérifier chaque livrable en **clair ET sombre** (toggle thème) avant de merger.
+
+---
+
+## 6. Anti‑patterns à bloquer en review
+
+1. ❌ KPIs/cartes avec **une couleur différente par item** (bleu/orange/vert/rouge décoratif) → tout en bleu/neutre, l'orange réservé au focal.
+2. ❌ **Plusieurs oranges** concurrents dans la même carte → 1 focal orange max.
+3. ❌ Orange sur une **catégorie neutre** « pour décorer » (ex : type de frais) → tons bleus par opacité ou neutre.
+4. ❌ **Hero sur un formulaire** create/edit → en‑tête standard seulement.
+5. ❌ **Deux `bg-card` adjacents** sans bordure/élévation distincte → ils fusionnent ; alterner encaissé/surélevé.
+6. ❌ Couleur claire **hardcodée** (`bg-blue-50`…) → tokens, sinon dark cassé.
+7. ❌ Recréer un `Button`/`Card`/`Badge` à la main → shadcn.
+8. ❌ Profondeur sans réduction de `radius`/`padding` → les couches deviennent illisibles.
+9. ❌ `window.confirm`/`alert` → `AlertDialog`.
+10. ❌ Tiret long `—` en français, accents manquants, contenu UI en anglais.
+
+---
+
+## 7. Checklist avant de livrer une page
+
+- [ ] Page démarre par `<PageHero>` (listing/dashboard) **avec 1 accent orange focal**.
+- [ ] KPIs intégrés au hero, en cartes verre monochrome.
+- [ ] Chaque couche imbriquée alterne élévation + réduit radius/padding (lisible jusqu'à 10).
+- [ ] Orange = focal uniquement (1 par contexte) ; statut = sémantique ; reste = bleu/neutre.
+- [ ] Tous les composants sont des primitives shadcn (className Tailwind).
+- [ ] Rendu vérifié en **clair ET sombre**.
+- [ ] Touch targets `h-11` sur mobile (persona Mme Diallo, cf. `ux-target-user-reality.md`).
+- [ ] États gérés : loading (Skeleton), empty (par rôle), error, success (toast).
+- [ ] Français propre, pas de tiret long, accents corrects.
+
+---
+
+## 8. Références canoniques
+
+- `components/shared/PageHero.tsx` — hero signature (dégradé + KPIs + boutons orange/verre).
+- `components/shared/fees/FeeSummaryHero.tsx` — bandeau bleu + « Reste à payer » orange focal.
+- KLASSCIv2 `premium-redesign.md` — l'ancêtre monochrome (supérieur), à **adapter** ici (ajout orange).
+- `ux-target-user-reality.md`, `redesign-premium.md`, `components.md` — persona + patterns.
+- Rule globale `~/.claude/rules/marcel-global-preferences.md` — no AI slop, mobile‑first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
-- Identité visuelle KLASSCI franchement présente : les indicateurs clés affichent désormais des pastilles pleines bleu / orange / vert et une carte teintée assortie, les en-têtes de page ont une pastille bleu marque, et la page active du menu porte un repère orange. On ressent enfin les trois couleurs sur chaque page. Vérifié en clair et sombre *(tous)*.
+- Identité visuelle KLASSCI plus présente dans toute l'application : la page active du menu est signalée par un repère orange, les indicateurs clés portent un liseré bleu ou orange, et la couleur orange de la marque ressort enfin au lieu d'un bleu uniforme. Rendu vérifié en mode clair et sombre *(tous)*.
 - Pages Frais (élève, parent) refondues avec un bandeau de synthèse bleu marque : total attendu, montant payé en vert et « Reste à payer » mis en avant en orange, avec barre de progression. Plus lisible d'un coup d'œil *(élève, parent)*.
 - Page Frais admin : les cartes de catégories adoptent les couleurs de la marque (obligatoire en bleu, optionnel en orange) et s'affichent correctement en mode sombre, là où elles restaient en tons clairs *(admin)*.
 - Indicateurs clés des pages de gestion désormais alimentés par un calcul serveur : les chiffres restent exacts même au-delà de 100 lignes (grands établissements), là où ils étaient auparavant tronqués *(admin)*.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
-- Identité visuelle KLASSCI plus présente dans toute l'application : la page active du menu est signalée par un repère orange, les indicateurs clés portent un liseré bleu ou orange, et la couleur orange de la marque ressort enfin au lieu d'un bleu uniforme. Rendu vérifié en mode clair et sombre *(tous)*.
-- Pages Frais (élève, parent) refondues avec un bandeau de synthèse bleu marque : total attendu, montant payé en vert et « Reste à payer » mis en avant en orange, avec barre de progression. Plus lisible d'un coup d'œil *(élève, parent)*.
-- Page Frais admin : les cartes de catégories adoptent les couleurs de la marque (obligatoire en bleu, optionnel en orange) et s'affichent correctement en mode sombre, là où elles restaient en tons clairs *(admin)*.
+- Refonte visuelle de toute l'application : chaque page (tableau de bord, listes d'administration, portails enseignant et parent) s'ouvre désormais sur un bandeau au dégradé bleu KLASSCI, avec les indicateurs clés intégrés en blanc et l'action principale mise en avant en orange, la couleur du logo. Identité de marque cohérente du haut de page jusqu'aux moindres détails, vérifiée en mode clair et sombre *(tous)*.
+- Pages Frais (élève, parent) avec un bandeau de synthèse bleu marque : total attendu, montant payé en vert et « Reste à payer » mis en avant en orange, avec barre de progression. Plus lisible d'un coup d'œil *(élève, parent)*.
+- Page Frais admin refondue : bandeau dégradé bleu, cartes de catégories sobres et lisibles aussi bien en clair qu'en sombre *(admin)*.
 - Indicateurs clés des pages de gestion désormais alimentés par un calcul serveur : les chiffres restent exacts même au-delà de 100 lignes (grands établissements), là où ils étaient auparavant tronqués *(admin)*.
 
 ### Fixed

--- a/app/(admin)/admin/dashboard/page.tsx
+++ b/app/(admin)/admin/dashboard/page.tsx
@@ -1,7 +1,6 @@
-import { DashboardKpis } from "@/components/admin/dashboard/DashboardKpis"
 import { QuickActions } from "@/components/admin/dashboard/QuickActions"
 import { DashboardCharts } from "@/components/admin/dashboard/DashboardChartsWrapper"
-import { WelcomeHeader } from "@/components/admin/dashboard/WelcomeHeader"
+import { DashboardHero } from "@/components/admin/dashboard/DashboardHero"
 import { RecentActivity } from "@/components/admin/dashboard/RecentActivity"
 
 export const metadata = { title: "Dashboard | KLASSCI" }
@@ -9,9 +8,7 @@ export const metadata = { title: "Dashboard | KLASSCI" }
 export default function DashboardPage() {
   return (
     <div className="space-y-6">
-      <WelcomeHeader />
-
-      <DashboardKpis />
+      <DashboardHero />
 
       <QuickActions />
 

--- a/components/admin/attendance/AttendancePageClient.tsx
+++ b/components/admin/attendance/AttendancePageClient.tsx
@@ -75,13 +75,13 @@ export function AttendancePageClient() {
       label: selectedClass ? "Créneaux de la classe" : "Créneaux",
       value: selectedClass ? (slots?.length ?? 0) : "—",
       icon: BookOpen,
-      tone: "emerald",
+      tone: "default",
     },
     {
       label: "Créneaux ce jour",
       value: selectedClass ? availableSlots.length : "—",
       icon: CalendarDays,
-      tone: "accent",
+      tone: selectedClass && availableSlots.length === 0 ? "accent" : "default",
     },
   ]
 
@@ -89,8 +89,8 @@ export function AttendancePageClient() {
     <div className="space-y-6">
       {/* En-tête */}
       <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-          <ClipboardCheck aria-hidden="true" className="h-5 w-5" />
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+          <ClipboardCheck aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
         <div className="min-w-0">
           <h1 className="font-serif text-2xl tracking-tight">Présences</h1>

--- a/components/admin/attendance/AttendancePageClient.tsx
+++ b/components/admin/attendance/AttendancePageClient.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/select"
 import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
 import { AttendanceGrid } from "./AttendanceGrid"
 import { AttendanceHistory } from "./AttendanceHistory"
 import { AttendanceStats } from "./AttendanceStats"
@@ -69,36 +69,29 @@ export function AttendancePageClient() {
     ? `Classe ${selectedClass.name}${dayOfWeek ? ` · ${dayOfWeek}` : ""}`
     : "Pointage des présences par session de cours, historique et statistiques"
 
-  const kpis: KpiItem[] = [
-    { label: "Classes", value: classes.length, icon: School, tone: "primary" },
+  const kpis: HeroKpi[] = [
+    { label: "Classes", value: classes.length, icon: School },
     {
       label: selectedClass ? "Créneaux de la classe" : "Créneaux",
       value: selectedClass ? (slots?.length ?? 0) : "—",
       icon: BookOpen,
-      tone: "default",
     },
     {
       label: "Créneaux ce jour",
       value: selectedClass ? availableSlots.length : "—",
       icon: CalendarDays,
-      tone: selectedClass && availableSlots.length === 0 ? "accent" : "default",
     },
   ]
 
   return (
     <div className="space-y-6">
-      {/* En-tête */}
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-          <ClipboardCheck aria-hidden="true" className="h-5 w-5 text-primary" />
-        </div>
-        <div className="min-w-0">
-          <h1 className="font-serif text-2xl tracking-tight">Présences</h1>
-          <p className="text-sm text-muted-foreground capitalize">{subtitle}</p>
-        </div>
-      </div>
-
-      <KpiStrip items={kpis} columns={3} />
+      {/* Hero signature KLASSCI (dégradé bleu + KPIs intégrés) */}
+      <PageHero
+        icon={ClipboardCheck}
+        title="Présences"
+        subtitle={<span className="capitalize">{subtitle}</span>}
+        kpis={kpis}
+      />
 
       {/* Filtres principaux */}
       <div className="flex flex-wrap items-end gap-3">

--- a/components/admin/classes/ClassesPageClient.tsx
+++ b/components/admin/classes/ClassesPageClient.tsx
@@ -2,82 +2,66 @@
 
 import { useMemo, useState } from "react"
 import { School, Plus, LayoutGrid, List, Users, Gauge, AlertTriangle } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroAccentBtn, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { useAdminSummary } from "@/lib/hooks/useDashboard"
 import { ClassesTable } from "./ClassesTable"
 import { ClassesTreeView } from "./ClassesTreeView"
 import { ClassCreateModal } from "./ClassCreateModal"
 
-function ClassesKpis() {
-  const { data } = useAdminSummary()
-  const kpis: KpiItem[] = useMemo(() => {
-    const c = data?.classes
-    const rate = c && c.capacity > 0 ? Math.round((c.enrolled / c.capacity) * 100) : 0
-    return [
-      { label: "Classes", value: c?.total ?? 0, icon: School, tone: "primary" },
-      { label: "Élèves inscrits", value: c?.enrolled ?? 0, icon: Users, tone: "default" },
-      { label: "Taux d'occupation", value: `${rate}%`, icon: Gauge, tone: rate >= 80 ? "accent" : "emerald" },
-      { label: "Classes pleines", value: c?.full ?? 0, icon: AlertTriangle, tone: (c?.full ?? 0) > 0 ? "destructive" : "default" },
-    ]
-  }, [data])
-  return <KpiStrip items={kpis} />
-}
-
 export function ClassesPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
   const [viewMode, setViewMode] = useState<"table" | "tree">("tree")
 
+  const { data } = useAdminSummary()
+  const kpis: HeroKpi[] = useMemo(() => {
+    const c = data?.classes
+    const rate = c && c.capacity > 0 ? Math.round((c.enrolled / c.capacity) * 100) : 0
+    return [
+      { label: "Classes", value: c?.total ?? 0, icon: School },
+      { label: "Élèves inscrits", value: c?.enrolled ?? 0, icon: Users },
+      { label: "Taux d'occupation", value: `${rate}%`, icon: Gauge },
+      { label: "Classes pleines", value: c?.full ?? 0, icon: AlertTriangle },
+    ]
+  }, [data])
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <School aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Classes</h1>
-            <p className="text-sm text-muted-foreground">Gestion des classes par niveau et série</p>
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          {/* View toggle : caché sur mobile (l'arbre n'est pas lisible sur 320px,
-              ClassesTable apporte automatiquement sa version mobile cards). */}
-          <div
-            role="group"
-            aria-label="Changer la vue"
-            className="hidden md:flex items-center rounded-lg border p-1"
-          >
-            <Button
-              variant={viewMode === "tree" ? "default" : "ghost"}
-              size="sm"
-              className="h-8 px-3"
-              aria-pressed={viewMode === "tree"}
-              onClick={() => setViewMode("tree")}
-            >
-              <LayoutGrid aria-hidden="true" className="mr-1.5 h-4 w-4" />
-              Arbre
-            </Button>
-            <Button
-              variant={viewMode === "table" ? "default" : "ghost"}
-              size="sm"
-              className="h-8 px-3"
-              aria-pressed={viewMode === "table"}
-              onClick={() => setViewMode("table")}
-            >
-              <List aria-hidden="true" className="mr-1.5 h-4 w-4" />
-              Table
-            </Button>
-          </div>
-          <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
-            <Plus aria-hidden="true" className="h-4 w-4" />
-            Nouvelle classe
-          </Button>
-        </div>
-      </div>
-
-      <ClassesKpis />
+      <PageHero
+        icon={School}
+        title="Classes"
+        subtitle="Gestion des classes par niveau et série"
+        actions={
+          <>
+            {/* View toggle : caché sur mobile (l'arbre n'est pas lisible sur 320px,
+                ClassesTable apporte automatiquement sa version mobile cards). */}
+            <div role="group" aria-label="Changer la vue" className="hidden md:flex items-center gap-1">
+              <button
+                type="button"
+                className={`${heroGlassBtn} ${viewMode === "tree" ? "" : "opacity-70"}`}
+                aria-pressed={viewMode === "tree"}
+                onClick={() => setViewMode("tree")}
+              >
+                <LayoutGrid aria-hidden="true" className="h-4 w-4" />
+                Arbre
+              </button>
+              <button
+                type="button"
+                className={`${heroGlassBtn} ${viewMode === "table" ? "" : "opacity-70"}`}
+                aria-pressed={viewMode === "table"}
+                onClick={() => setViewMode("table")}
+              >
+                <List aria-hidden="true" className="h-4 w-4" />
+                Table
+              </button>
+            </div>
+            <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+              <Plus aria-hidden="true" className="h-4 w-4" />
+              Nouvelle classe
+            </button>
+          </>
+        }
+        kpis={kpis}
+      />
 
       {/* Content : mobile force toujours table (qui contient cards mobile),
           desktop respecte le choix utilisateur (arbre par défaut). */}

--- a/components/admin/classes/ClassesPageClient.tsx
+++ b/components/admin/classes/ClassesPageClient.tsx
@@ -16,8 +16,8 @@ function ClassesKpis() {
     const rate = c && c.capacity > 0 ? Math.round((c.enrolled / c.capacity) * 100) : 0
     return [
       { label: "Classes", value: c?.total ?? 0, icon: School, tone: "primary" },
-      { label: "Élèves inscrits", value: c?.enrolled ?? 0, icon: Users, tone: "emerald" },
-      { label: "Taux d'occupation", value: `${rate}%`, icon: Gauge, tone: "accent" },
+      { label: "Élèves inscrits", value: c?.enrolled ?? 0, icon: Users, tone: "default" },
+      { label: "Taux d'occupation", value: `${rate}%`, icon: Gauge, tone: rate >= 80 ? "accent" : "emerald" },
       { label: "Classes pleines", value: c?.full ?? 0, icon: AlertTriangle, tone: (c?.full ?? 0) > 0 ? "destructive" : "default" },
     ]
   }, [data])
@@ -33,8 +33,8 @@ export function ClassesPageClient() {
       {/* Header */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <School aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <School aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Classes</h1>

--- a/components/admin/dashboard/DashboardHero.tsx
+++ b/components/admin/dashboard/DashboardHero.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { useSession } from "next-auth/react"
+import { GraduationCap, Wallet, CalendarDays, AlertTriangle } from "lucide-react"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
+import { useDashboardStats } from "@/lib/hooks/useDashboard"
+
+export function DashboardHero() {
+  const { data: session } = useSession()
+  const { data, isLoading } = useDashboardStats()
+
+  const today = new Date().toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  })
+  const rawName = session?.user?.email?.split("@")[0] ?? "Administrateur"
+  const firstName = rawName.split(/[._]/)[0].replace(/^\w/, (c) => c.toUpperCase())
+  const dash = (v: number | undefined) => (isLoading ? "—" : (v ?? 0))
+
+  const kpis: HeroKpi[] = [
+    {
+      label: "Élèves inscrits",
+      value: dash(data?.enrolled_students),
+      icon: GraduationCap,
+      hint: data
+        ? `${data.enrollment_validated ?? 0} validées · ${data.enrollment_pending ?? 0} en attente`
+        : undefined,
+    },
+    { label: "Paiements en attente", value: dash(data?.pending_payments), icon: Wallet, hint: "À traiter" },
+    { label: "Cours du jour", value: dash(data?.courses_today), icon: CalendarDays, hint: "Aujourd'hui" },
+    { label: "Alertes", value: dash(data?.alerts), icon: AlertTriangle, hint: "Évaluations sans notes" },
+  ]
+
+  return (
+    <PageHero
+      title={`Bonjour, ${firstName}`}
+      subtitle={
+        <span className="capitalize" suppressHydrationWarning>
+          {today}
+        </span>
+      }
+      kpis={kpis}
+    />
+  )
+}

--- a/components/admin/dashboard/KpiCard.tsx
+++ b/components/admin/dashboard/KpiCard.tsx
@@ -2,29 +2,19 @@ import { cn } from "@/lib/utils"
 import { Card, CardContent } from "@/components/ui/card"
 
 /**
- * Tons aux couleurs KLASSCI, franchement présents (carte teintée + pastille
- * d'icône pleine) tout en restant sémantiques. Compatibles clair/sombre.
- * - primary : bleu KLASSCI (métrique structurante)
- * - accent  : orange KLASSCI (action / argent)
- * - emerald : positif (payé, validé)
- * - destructive : alerte active
+ * Tons sémantiques restreints (règle "1 accent + monochrome") :
+ * - default : icône muted, base monochrome
+ * - primary : bleu KLASSCI, métrique structurante (élèves)
+ * - accent  : orange KLASSCI, action/argent (paiements)
+ * - destructive : alerte active (> 0)
  */
-type KpiTone = "default" | "primary" | "accent" | "destructive" | "emerald"
+type KpiTone = "default" | "primary" | "accent" | "destructive"
 
-const toneCard: Record<KpiTone, string> = {
-  default: "",
-  primary: "border-primary/25 bg-primary/[0.06]",
-  accent: "border-accent/30 bg-accent/[0.07]",
-  destructive: "border-destructive/30 bg-destructive/[0.07]",
-  emerald: "border-emerald-500/30 bg-emerald-500/[0.07]",
-}
-
-const toneIcon: Record<KpiTone, string> = {
+const toneStyles: Record<KpiTone, string> = {
   default: "bg-muted text-muted-foreground",
-  primary: "bg-primary text-primary-foreground",
-  accent: "bg-accent text-accent-foreground",
-  destructive: "bg-destructive text-destructive-foreground",
-  emerald: "bg-emerald-600 text-white",
+  primary: "bg-primary/10 text-primary",
+  accent: "bg-accent/10 text-accent",
+  destructive: "bg-destructive/10 text-destructive",
 }
 
 interface KpiCardProps {
@@ -55,7 +45,7 @@ export function KpiCard({
       aria-label={accessibleLabel}
       aria-live="polite"
       aria-atomic="true"
-      className={cn("shadow-sm", toneCard[tone], className)}
+      className={cn("shadow-sm", className)}
     >
       <CardContent className="flex items-start justify-between gap-4 p-6">
         <div className="space-y-1">
@@ -67,8 +57,8 @@ export function KpiCard({
         </div>
         <div
           className={cn(
-            "flex h-11 w-11 shrink-0 items-center justify-center rounded-lg shadow-sm",
-            toneIcon[tone],
+            "flex h-11 w-11 shrink-0 items-center justify-center rounded-lg",
+            toneStyles[tone],
           )}
         >
           <Icon aria-hidden="true" className="h-5 w-5" />

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -18,8 +18,8 @@ function EnrollmentsKpis() {
     return [
       { label: "Inscriptions", value: e?.total ?? 0, icon: ListChecks, tone: "primary" },
       { label: "Validées", value: e?.valid ?? 0, icon: CheckCircle2, tone: "emerald" },
-      { label: "À valider", value: pending, icon: Clock, tone: "accent" },
-      { label: "Rejetées / annulées", value: e?.closed ?? 0, icon: XCircle, tone: (e?.closed ?? 0) > 0 ? "destructive" : "default" },
+      { label: "À valider", value: pending, icon: Clock, tone: pending > 0 ? "accent" : "default" },
+      { label: "Rejetées / annulées", value: e?.closed ?? 0, icon: XCircle, tone: "default" },
     ]
   }, [data])
   return <KpiStrip items={kpis} />
@@ -64,8 +64,8 @@ export function EnrollmentsPageClient() {
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <GraduationCap aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <GraduationCap aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Inscriptions</h1>

--- a/components/admin/enrollments/EnrollmentsPageClient.tsx
+++ b/components/admin/enrollments/EnrollmentsPageClient.tsx
@@ -3,26 +3,23 @@
 import { useEffect, useMemo, useState } from "react"
 import { useSearchParams } from "next/navigation"
 import { GraduationCap, Plus, ListChecks, CheckCircle2, Clock, XCircle } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroAccentBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { EnrollmentsTable } from "./EnrollmentsTable"
 import { EnrollmentCreateModal } from "./EnrollmentCreateModal"
 import { useEnrollments } from "@/lib/hooks/useEnrollments"
 import { useAdminSummary } from "@/lib/hooks/useDashboard"
 
-function EnrollmentsKpis() {
+function useEnrollmentsKpis(): HeroKpi[] {
   const { data } = useAdminSummary()
-  const kpis: KpiItem[] = useMemo(() => {
+  return useMemo(() => {
     const e = data?.enrollments
-    const pending = e?.pending ?? 0
     return [
-      { label: "Inscriptions", value: e?.total ?? 0, icon: ListChecks, tone: "primary" },
-      { label: "Validées", value: e?.valid ?? 0, icon: CheckCircle2, tone: "emerald" },
-      { label: "À valider", value: pending, icon: Clock, tone: pending > 0 ? "accent" : "default" },
-      { label: "Rejetées / annulées", value: e?.closed ?? 0, icon: XCircle, tone: "default" },
+      { label: "Inscriptions", value: e?.total ?? 0, icon: ListChecks },
+      { label: "Validées", value: e?.valid ?? 0, icon: CheckCircle2 },
+      { label: "À valider", value: e?.pending ?? 0, icon: Clock },
+      { label: "Rejetées / annulées", value: e?.closed ?? 0, icon: XCircle },
     ]
   }, [data])
-  return <KpiStrip items={kpis} />
 }
 
 // Subtitle informatif sans redondance avec les chips. Le total renseigne
@@ -31,16 +28,16 @@ function EnrollmentsKpis() {
 function EnrollmentsSubtitle() {
   const { data, isLoading } = useEnrollments({ size: 1 })
   if (isLoading || !data) {
-    return <p className="text-sm text-muted-foreground">Gérez les inscriptions des élèves</p>
+    return <span>Gérez les inscriptions des élèves</span>
   }
   const total = data.total ?? 0
   if (total === 0) {
-    return <p className="text-sm text-muted-foreground">Aucune inscription pour le moment</p>
+    return <span>Aucune inscription pour le moment</span>
   }
   return (
-    <p className="text-sm text-muted-foreground">
+    <span>
       {total} inscription{total > 1 ? "s" : ""} au total
-    </p>
+    </span>
   )
 }
 
@@ -48,6 +45,7 @@ export function EnrollmentsPageClient() {
   const searchParams = useSearchParams()
   const [createOpen, setCreateOpen] = useState(false)
   const [preselectedStudentId, setPreselectedStudentId] = useState<number | undefined>(undefined)
+  const kpis = useEnrollmentsKpis()
 
   useEffect(() => {
     if (searchParams.get("action") === "create") {
@@ -62,23 +60,18 @@ export function EnrollmentsPageClient() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <GraduationCap aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Inscriptions</h1>
-            <EnrollmentsSubtitle />
-          </div>
-        </div>
-        <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
-          <Plus aria-hidden="true" className="h-4 w-4" />
-          Nouvelle inscription
-        </Button>
-      </div>
-
-      <EnrollmentsKpis />
+      <PageHero
+        icon={GraduationCap}
+        title="Inscriptions"
+        subtitle={<EnrollmentsSubtitle />}
+        actions={
+          <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4" />
+            Nouvelle inscription
+          </button>
+        }
+        kpis={kpis}
+      />
 
       <EnrollmentsTable />
 

--- a/components/admin/fees/FeesPageClient.tsx
+++ b/components/admin/fees/FeesPageClient.tsx
@@ -5,8 +5,8 @@ import { Plus, Pencil, Trash2, Wallet, Search, X, Shield, CircleDot, Layers, Coi
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { PageHero, heroGlassBtn, heroPrimaryBtn } from "@/components/shared/PageHero"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { PageHero, SectionTitle, heroGlassBtn, heroAccentBtn, premiumCardHover } from "@/components/shared/PageHero"
 import { FilterChips } from "@/components/shared/list/FilterChips"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -138,7 +138,7 @@ export function FeesPageClient() {
               <Layers className="h-4 w-4" />
               Nouvelle variante
             </button>
-            <button type="button" className={heroPrimaryBtn} onClick={() => setCategoryModalOpen(true)}>
+            <button type="button" className={heroAccentBtn} onClick={() => setCategoryModalOpen(true)}>
               <Plus className="h-4 w-4" />
               Nouvelle catégorie
             </button>
@@ -155,7 +155,7 @@ export function FeesPageClient() {
       {/* Categories as premium cards */}
       <div>
         <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">Catégories de frais</h2>
+          <SectionTitle icon={Wallet}>Catégories de frais</SectionTitle>
           <FilterChips
             aria-label="Filtrer les catégories"
             value={categoryFilter}
@@ -180,7 +180,7 @@ export function FeesPageClient() {
               const catVariants = variantsByCategory.get(cat.id) ?? []
               const totalAmount = catVariants.reduce((sum, v) => sum + v.amount, 0)
               return (
-                <Card key={cat.id} className={`border ${color.border} ${color.bg} shadow-sm hover:shadow-md transition-shadow`}>
+                <Card key={cat.id} className={`border ${color.border} ${color.bg} shadow-sm ${premiumCardHover}`}>
                   <CardContent className="p-4">
                     <div className="flex items-start justify-between mb-3">
                       <div className="flex items-center gap-2.5">
@@ -251,9 +251,7 @@ export function FeesPageClient() {
       {/* Variantes (montants par niveau) avec search */}
       <Card className="border-0 shadow-sm ring-1 ring-border overflow-hidden">
         <CardHeader className="flex flex-row items-center justify-between pb-3">
-          <CardTitle className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-            Montants par niveau
-          </CardTitle>
+          <SectionTitle icon={Coins}>Montants par niveau</SectionTitle>
           <div className="relative w-[220px]">
             <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input

--- a/components/admin/fees/FeesPageClient.tsx
+++ b/components/admin/fees/FeesPageClient.tsx
@@ -105,8 +105,8 @@ export function FeesPageClient() {
 
   const kpis: KpiItem[] = [
     { label: "Obligatoires", value: totalMandatory, icon: Shield, tone: "primary" },
-    { label: "Optionnels", value: totalOptional, icon: CircleDot, tone: "accent" },
-    { label: "Variantes", value: totalVariants, icon: Layers, tone: "emerald" },
+    { label: "Optionnels", value: totalOptional, icon: CircleDot, tone: "default" },
+    { label: "Variantes", value: totalVariants, icon: Layers, tone: "default" },
     { label: "Montant configuré", value: `${totalConfigured.toLocaleString("fr-FR")} F`, icon: Coins, tone: "accent" },
   ]
 
@@ -132,8 +132,8 @@ export function FeesPageClient() {
       {/* Header premium */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <Wallet aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Wallet aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Frais scolaires</h1>

--- a/components/admin/fees/FeesPageClient.tsx
+++ b/components/admin/fees/FeesPageClient.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroGlassBtn, heroPrimaryBtn } from "@/components/shared/PageHero"
 import { FilterChips } from "@/components/shared/list/FilterChips"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -29,19 +29,19 @@ import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { useLevels } from "@/lib/hooks/useLevels"
 import type { FeeCategory, FeeVariant } from "@/lib/contracts/fee"
 
-// Couleurs de marque KLASSCI, compatibles thème clair/sombre (tokens) :
-// obligatoire = bleu (primary), optionnel = orange (accent).
+// Monochrome KLASSCI : obligatoire = teinte bleue, optionnel = neutre.
+// (La couleur ne différencie pas des catégories — cf. rule premium-redesign.)
 const MANDATORY_COLOR = {
-  bg: "bg-primary/5",
+  bg: "bg-primary/[0.06]",
   border: "border-primary/20",
   icon: "bg-primary/10 text-primary",
-  badge: "border-primary/30 bg-primary/10 text-primary",
+  badge: "border-primary/25 bg-primary/10 text-primary",
 }
 const OPTIONAL_COLOR = {
-  bg: "bg-accent/5",
-  border: "border-accent/25",
-  icon: "bg-accent/10 text-accent",
-  badge: "border-accent/30 bg-accent/10 text-accent",
+  bg: "bg-muted/40",
+  border: "border-border",
+  icon: "bg-muted text-muted-foreground",
+  badge: "border-border bg-muted text-muted-foreground",
 }
 
 export function FeesPageClient() {
@@ -103,13 +103,6 @@ export function FeesPageClient() {
   const totalVariants = variants?.length ?? 0
   const totalConfigured = variants?.reduce((sum, v) => sum + v.amount, 0) ?? 0
 
-  const kpis: KpiItem[] = [
-    { label: "Obligatoires", value: totalMandatory, icon: Shield, tone: "primary" },
-    { label: "Optionnels", value: totalOptional, icon: CircleDot, tone: "default" },
-    { label: "Variantes", value: totalVariants, icon: Layers, tone: "default" },
-    { label: "Montant configuré", value: `${totalConfigured.toLocaleString("fr-FR")} F`, icon: Coins, tone: "accent" },
-  ]
-
   // Filtre obligatoire/optionnel sur les catégories affichées.
   const displayedCategories = (categories ?? []).filter((c) => {
     if (categoryFilter === "mandatory") return c.is_mandatory
@@ -129,33 +122,35 @@ export function FeesPageClient() {
 
   return (
     <div className="space-y-6">
-      {/* Header premium */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Wallet aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">Frais scolaires</h1>
-            <p className="text-sm text-muted-foreground">
-              Configuration des catégories de frais et montants par niveau
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => setVariantModalOpen(true)} disabled={!currentYearId}>
-            <Layers className="mr-2 h-4 w-4" />
-            Nouvelle variante
-          </Button>
-          <Button onClick={() => setCategoryModalOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Nouvelle catégorie
-          </Button>
-        </div>
-      </div>
-
-      {/* KPI summary */}
-      <KpiStrip items={kpis} />
+      {/* Hero signature KLASSCI (dégradé bleu + KPIs intégrés) */}
+      <PageHero
+        icon={Wallet}
+        title="Frais scolaires"
+        subtitle="Configuration des catégories de frais et montants par niveau"
+        actions={
+          <>
+            <button
+              type="button"
+              className={`${heroGlassBtn} disabled:cursor-not-allowed disabled:opacity-50`}
+              onClick={() => setVariantModalOpen(true)}
+              disabled={!currentYearId}
+            >
+              <Layers className="h-4 w-4" />
+              Nouvelle variante
+            </button>
+            <button type="button" className={heroPrimaryBtn} onClick={() => setCategoryModalOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Nouvelle catégorie
+            </button>
+          </>
+        }
+        kpis={[
+          { label: "Obligatoires", value: totalMandatory, icon: Shield },
+          { label: "Optionnels", value: totalOptional, icon: CircleDot },
+          { label: "Variantes", value: totalVariants, icon: Layers },
+          { label: "Montant configuré", value: `${totalConfigured.toLocaleString("fr-FR")} F`, icon: Coins },
+        ]}
+      />
 
       {/* Categories as premium cards */}
       <div>

--- a/components/admin/levels/LevelsAndSeriesPageClient.tsx
+++ b/components/admin/levels/LevelsAndSeriesPageClient.tsx
@@ -28,7 +28,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroGlassBtn, heroAccentBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { ListSearchBar } from "@/components/shared/list/ListSearchBar"
 import { matchesSearch } from "@/lib/utils/list-search"
 import { useLevels, useDeleteLevel } from "@/lib/hooks/useLevels"
@@ -98,11 +98,11 @@ export function LevelsAndSeriesPageClient() {
   // KPIs (données peu nombreuses : calcul direct à chaque render).
   const noSeriesCount = levels.filter((l) => (seriesByLevel.get(l.id)?.length ?? 0) === 0).length
   const avgSeries = levels.length > 0 ? (allSeries.length / levels.length).toFixed(1) : "0"
-  const kpis: KpiItem[] = [
-    { label: "Niveaux", value: levels.length, icon: GraduationCap, tone: "primary" },
-    { label: "Séries", value: allSeries.length, icon: BookOpen, tone: "default" },
-    { label: "Séries / niveau", value: avgSeries, icon: Layers, tone: "default" },
-    { label: "Niveaux sans série", value: noSeriesCount, icon: AlertTriangle, tone: noSeriesCount > 0 ? "accent" : "default" },
+  const kpis: HeroKpi[] = [
+    { label: "Niveaux", value: levels.length, icon: GraduationCap },
+    { label: "Séries", value: allSeries.length, icon: BookOpen },
+    { label: "Séries / niveau", value: avgSeries, icon: Layers },
+    { label: "Niveaux sans série", value: noSeriesCount, icon: AlertTriangle },
   ]
 
   // Recherche : filtre les niveaux par nom OU par nom de série. Quand un niveau
@@ -160,42 +160,35 @@ export function LevelsAndSeriesPageClient() {
 
   return (
     <div className="space-y-5">
-      {/* Header */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Layers aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="font-serif text-xl tracking-tight">Niveaux & Séries</h1>
-            <p className="text-sm text-muted-foreground">Structure académique de l&apos;établissement</p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-xs"
-            onClick={() => setExpanded(new Set(levels.map((l) => l.id)))}
-          >
-            Tout déplier
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-xs"
-            onClick={() => setExpanded(new Set())}
-          >
-            Tout replier
-          </Button>
-          <Button size="sm" onClick={() => setLevelCreateOpen(true)}>
-            <Plus className="mr-1.5 h-3.5 w-3.5" />
-            Nouveau niveau
-          </Button>
-        </div>
-      </div>
-
-      <KpiStrip items={kpis} />
+      {/* Hero signature KLASSCI (dégradé bleu + KPIs intégrés) */}
+      <PageHero
+        icon={Layers}
+        title="Niveaux & Séries"
+        subtitle="Structure académique de l'établissement"
+        actions={
+          <>
+            <button
+              type="button"
+              className={heroGlassBtn}
+              onClick={() => setExpanded(new Set(levels.map((l) => l.id)))}
+            >
+              Tout déplier
+            </button>
+            <button
+              type="button"
+              className={heroGlassBtn}
+              onClick={() => setExpanded(new Set())}
+            >
+              Tout replier
+            </button>
+            <button type="button" className={heroAccentBtn} onClick={() => setLevelCreateOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Nouveau niveau
+            </button>
+          </>
+        }
+        kpis={kpis}
+      />
 
       <ListSearchBar
         value={search}

--- a/components/admin/levels/LevelsAndSeriesPageClient.tsx
+++ b/components/admin/levels/LevelsAndSeriesPageClient.tsx
@@ -100,9 +100,9 @@ export function LevelsAndSeriesPageClient() {
   const avgSeries = levels.length > 0 ? (allSeries.length / levels.length).toFixed(1) : "0"
   const kpis: KpiItem[] = [
     { label: "Niveaux", value: levels.length, icon: GraduationCap, tone: "primary" },
-    { label: "Séries", value: allSeries.length, icon: BookOpen, tone: "emerald" },
-    { label: "Séries / niveau", value: avgSeries, icon: Layers, tone: "accent" },
-    { label: "Niveaux sans série", value: noSeriesCount, icon: AlertTriangle, tone: noSeriesCount > 0 ? "destructive" : "default" },
+    { label: "Séries", value: allSeries.length, icon: BookOpen, tone: "default" },
+    { label: "Séries / niveau", value: avgSeries, icon: Layers, tone: "default" },
+    { label: "Niveaux sans série", value: noSeriesCount, icon: AlertTriangle, tone: noSeriesCount > 0 ? "accent" : "default" },
   ]
 
   // Recherche : filtre les niveaux par nom OU par nom de série. Quand un niveau
@@ -163,8 +163,8 @@ export function LevelsAndSeriesPageClient() {
       {/* Header */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <Layers aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Layers aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-xl tracking-tight">Niveaux & Séries</h1>

--- a/components/admin/notifications/NotificationsPageClient.tsx
+++ b/components/admin/notifications/NotificationsPageClient.tsx
@@ -127,8 +127,8 @@ export function NotificationsPageClient() {
   const kpis: KpiItem[] = [
     { label: "Total", value: total, icon: Inbox, tone: "primary" },
     { label: "Non lues", value: unreadCount, icon: Mail, tone: unreadCount > 0 ? "accent" : "default" },
-    { label: "Lues", value: Math.max(total - unreadCount, 0), icon: MailOpen, tone: "emerald" },
-    { label: "Types actifs", value: distinctTypes, icon: Layers, tone: "accent" },
+    { label: "Lues", value: Math.max(total - unreadCount, 0), icon: MailOpen, tone: "default" },
+    { label: "Types actifs", value: distinctTypes, icon: Layers, tone: "default" },
   ]
 
   // Recherche client sur titre + corps (par-dessus les filtres serveur type/lu).
@@ -141,8 +141,8 @@ export function NotificationsPageClient() {
       {/* En-tête */}
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <Bell aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Bell aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Notifications</h1>

--- a/components/admin/notifications/NotificationsPageClient.tsx
+++ b/components/admin/notifications/NotificationsPageClient.tsx
@@ -21,7 +21,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { ListSearchBar } from "@/components/shared/list/ListSearchBar"
 import { matchesSearch } from "@/lib/utils/list-search"
 import {
@@ -124,11 +124,11 @@ export function NotificationsPageClient() {
   const all = allNotifications ?? []
   const total = all.length
   const distinctTypes = new Set(all.map((n) => n.type)).size
-  const kpis: KpiItem[] = [
-    { label: "Total", value: total, icon: Inbox, tone: "primary" },
-    { label: "Non lues", value: unreadCount, icon: Mail, tone: unreadCount > 0 ? "accent" : "default" },
-    { label: "Lues", value: Math.max(total - unreadCount, 0), icon: MailOpen, tone: "default" },
-    { label: "Types actifs", value: distinctTypes, icon: Layers, tone: "default" },
+  const kpis: HeroKpi[] = [
+    { label: "Total", value: total, icon: Inbox },
+    { label: "Non lues", value: unreadCount, icon: Mail },
+    { label: "Lues", value: Math.max(total - unreadCount, 0), icon: MailOpen },
+    { label: "Types actifs", value: distinctTypes, icon: Layers },
   ]
 
   // Recherche client sur titre + corps (par-dessus les filtres serveur type/lu).
@@ -138,35 +138,30 @@ export function NotificationsPageClient() {
 
   return (
     <div className="space-y-6">
-      {/* En-tête */}
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Bell aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">Notifications</h1>
-            <p className="text-sm text-muted-foreground">
-              {unreadCount > 0
-                ? `${unreadCount} notification${unreadCount > 1 ? "s" : ""} non lue${unreadCount > 1 ? "s" : ""}`
-                : "Toutes les notifications sont lues"}
-            </p>
-          </div>
-        </div>
-        {unreadCount > 0 && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => markAllAsRead.mutate()}
-            disabled={markAllAsRead.isPending}
-          >
-            <CheckCheck className="mr-2 h-4 w-4" />
-            Tout marquer comme lu
-          </Button>
-        )}
-      </div>
-
-      <KpiStrip items={kpis} />
+      {/* Hero signature KLASSCI (dégradé bleu + KPIs intégrés) */}
+      <PageHero
+        icon={Bell}
+        title="Notifications"
+        subtitle={
+          unreadCount > 0
+            ? `${unreadCount} notification${unreadCount > 1 ? "s" : ""} non lue${unreadCount > 1 ? "s" : ""}`
+            : "Toutes les notifications sont lues"
+        }
+        actions={
+          unreadCount > 0 ? (
+            <button
+              type="button"
+              className={`${heroGlassBtn} disabled:cursor-not-allowed disabled:opacity-50`}
+              onClick={() => markAllAsRead.mutate()}
+              disabled={markAllAsRead.isPending}
+            >
+              <CheckCheck className="h-4 w-4" />
+              Tout marquer comme lu
+            </button>
+          ) : undefined
+        }
+        kpis={kpis}
+      />
 
       {/* Recherche + Filtres */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/components/admin/parents/ParentsPageClient.tsx
+++ b/components/admin/parents/ParentsPageClient.tsx
@@ -19,8 +19,8 @@ export function ParentsPageClient() {
     return [
       { label: "Parents au total", value: total, icon: Users, tone: "primary" },
       { label: "Avec compte", value: p?.with_account ?? 0, icon: UserCheck, tone: "emerald" },
-      { label: "Sans compte", value: withoutAccount, icon: UserX, tone: withoutAccount > 0 ? "destructive" : "default" },
-      { label: "Avec email", value: p?.with_email ?? 0, icon: Mail, tone: "accent" },
+      { label: "Sans compte", value: withoutAccount, icon: UserX, tone: withoutAccount > 0 ? "accent" : "default" },
+      { label: "Avec email", value: p?.with_email ?? 0, icon: Mail, tone: "default" },
     ]
   }, [data, total])
 
@@ -28,8 +28,8 @@ export function ParentsPageClient() {
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <HeartHandshake aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <HeartHandshake aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Parents</h1>

--- a/components/admin/parents/ParentsPageClient.tsx
+++ b/components/admin/parents/ParentsPageClient.tsx
@@ -2,8 +2,7 @@
 
 import { useMemo, useState } from "react"
 import { HeartHandshake, Plus, Users, UserCheck, UserX, Mail } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroAccentBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { useAdminSummary } from "@/lib/hooks/useDashboard"
 import { ParentsTable } from "./ParentsTable"
 import { ParentCreateModal } from "./ParentCreateModal"
@@ -13,37 +12,30 @@ export function ParentsPageClient() {
   const { data } = useAdminSummary()
   const total = data?.parents.total ?? 0
 
-  const kpis: KpiItem[] = useMemo(() => {
+  const kpis: HeroKpi[] = useMemo(() => {
     const p = data?.parents
-    const withoutAccount = p?.without_account ?? 0
     return [
-      { label: "Parents au total", value: total, icon: Users, tone: "primary" },
-      { label: "Avec compte", value: p?.with_account ?? 0, icon: UserCheck, tone: "emerald" },
-      { label: "Sans compte", value: withoutAccount, icon: UserX, tone: withoutAccount > 0 ? "accent" : "default" },
-      { label: "Avec email", value: p?.with_email ?? 0, icon: Mail, tone: "default" },
+      { label: "Parents au total", value: total, icon: Users },
+      { label: "Avec compte", value: p?.with_account ?? 0, icon: UserCheck },
+      { label: "Sans compte", value: p?.without_account ?? 0, icon: UserX },
+      { label: "Avec email", value: p?.with_email ?? 0, icon: Mail },
     ]
   }, [data, total])
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <HeartHandshake aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Parents</h1>
-            <p className="text-sm text-muted-foreground">
-              {total} {total > 1 ? "parents au total" : "parent au total"}
-            </p>
-          </div>
-        </div>
-        <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
-          <Plus className="h-4 w-4" />
-          Nouveau parent
-        </Button>
-      </div>
-      <KpiStrip items={kpis} />
+      <PageHero
+        icon={HeartHandshake}
+        title="Parents"
+        subtitle={`${total} ${total > 1 ? "parents au total" : "parent au total"}`}
+        actions={
+          <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4" />
+            Nouveau parent
+          </button>
+        }
+        kpis={kpis}
+      />
       <ParentsTable />
       <ParentCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
     </div>

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -174,8 +174,8 @@ export function PaymentsPageClient() {
       {/* En-tête premium */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <CreditCard className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <CreditCard className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Paiements</h1>

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Card, CardContent } from "@/components/ui/card"
+import { PageHero, heroAccentBtn, type HeroKpi } from "@/components/shared/PageHero"
 import {
   Dialog,
   DialogContent,
@@ -98,7 +99,7 @@ export function PaymentsPageClient() {
   }
 
   const { data, isLoading } = usePayments(params)
-  const { data: summary, isLoading: loadingSummary } = useFinancialSummary()
+  const { data: summary } = useFinancialSummary()
   const { mutate: validatePayment, isPending: validating } = useValidatePayment()
   const { mutate: cancelPayment, isPending: cancelling } = useCancelPayment()
   const { data: feeCategories } = useFeeCategories()
@@ -169,65 +170,51 @@ export function PaymentsPageClient() {
     setSearch("")
   }
 
+  const heroKpis: HeroKpi[] | undefined = summary
+    ? [
+        {
+          label: "Attendu",
+          value: `${summary.total_expected.toLocaleString("fr-FR")} F`,
+          icon: Banknote,
+        },
+        {
+          label: "Collecté",
+          value: `${summary.total_paid.toLocaleString("fr-FR")} F`,
+          icon: Wallet,
+          hint: `${summary.payment_count} paiement(s)`,
+        },
+        {
+          label: "En attente",
+          value: `${summary.total_pending.toLocaleString("fr-FR")} F`,
+          icon: AlertCircle,
+        },
+        {
+          label: "Taux de recouvrement",
+          value: `${summary.completion_rate.toFixed(1)}%`,
+          icon: TrendingUp,
+          hint:
+            summary.total_cancelled > 0
+              ? `${summary.total_cancelled.toLocaleString("fr-FR")} FCFA annulés`
+              : undefined,
+        },
+      ]
+    : undefined
+
   return (
     <div className="space-y-6">
-      {/* En-tête premium */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <CreditCard className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">Paiements</h1>
-            <p className="text-sm text-muted-foreground">
-              Suivi des paiements et tableau de bord financier
-            </p>
-          </div>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Nouveau paiement
-        </Button>
-      </div>
-
-      {/* KPIs financiers premium */}
-      {loadingSummary ? (
-        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-28 rounded-xl" />
-          ))}
-        </div>
-      ) : summary ? (
-        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-          <KpiCard
-            icon={Banknote}
-            label="Attendu"
-            value={summary.total_expected}
-            color="blue"
-          />
-          <KpiCard
-            icon={Wallet}
-            label="Collecté"
-            value={summary.total_paid}
-            color="emerald"
-            subtext={`${summary.payment_count} paiement(s)`}
-          />
-          <KpiCard
-            icon={AlertCircle}
-            label="En attente"
-            value={summary.total_pending}
-            color="amber"
-          />
-          <KpiCard
-            icon={TrendingUp}
-            label="Taux de recouvrement"
-            value={summary.completion_rate}
-            isPercent
-            color={summary.completion_rate >= 70 ? "emerald" : "amber"}
-            subtext={summary.total_cancelled > 0 ? `${summary.total_cancelled.toLocaleString("fr-FR")} FCFA annulés` : undefined}
-          />
-        </div>
-      ) : null}
+      {/* Hero signature KLASSCI (dégradé bleu + KPIs financiers intégrés) */}
+      <PageHero
+        icon={CreditCard}
+        title="Paiements"
+        subtitle="Suivi des paiements et tableau de bord financier"
+        actions={
+          <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4" />
+            Nouveau paiement
+          </button>
+        }
+        kpis={heroKpis}
+      />
 
       {/* Barre de recherche + filtres */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
@@ -628,61 +615,5 @@ function StudentAvatar({ photoUrl, initials }: { photoUrl?: string | null; initi
     <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
       {initials}
     </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Premium KPI Card
-// ---------------------------------------------------------------------------
-
-const KPI_COLORS = {
-  blue: { bg: "bg-blue-50", icon: "text-blue-600 bg-blue-100", ring: "ring-blue-200/60" },
-  emerald: { bg: "bg-emerald-50", icon: "text-emerald-600 bg-emerald-100", ring: "ring-emerald-200/60" },
-  amber: { bg: "bg-amber-50", icon: "text-amber-600 bg-amber-100", ring: "ring-amber-200/60" },
-  rose: { bg: "bg-rose-50", icon: "text-rose-600 bg-rose-100", ring: "ring-rose-200/60" },
-  neutral: { bg: "bg-slate-50", icon: "text-slate-500 bg-slate-100", ring: "ring-slate-200/60" },
-}
-
-function KpiCard({
-  icon: Icon,
-  label,
-  value,
-  color,
-  isPercent,
-  subtext,
-}: {
-  icon: React.ComponentType<{ className?: string }>
-  label: string
-  value: number
-  color: keyof typeof KPI_COLORS
-  isPercent?: boolean
-  subtext?: string
-}) {
-  // Empty-state guard : value=0 doit etre neutre, pas un faux signal vert/amber.
-  // Cf. rule `not-enrolled-empty-state.md` : "0 FCFA Collecté" en vert suggère
-  // a tort "tout paye !" alors qu'il n'y a juste aucun paiement enregistre.
-  const effectiveColor: keyof typeof KPI_COLORS = value === 0 ? "neutral" : color
-  const c = KPI_COLORS[effectiveColor]
-  return (
-    <Card className={`border-0 shadow-sm ring-1 ${c.ring} overflow-hidden`}>
-      <CardContent className="p-4">
-        <div className="flex items-start justify-between">
-          <div className="space-y-2">
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{label}</p>
-            <p className="text-2xl font-bold tabular-nums tracking-tight">
-              {isPercent
-                ? `${value.toFixed(1)}%`
-                : `${value.toLocaleString("fr-FR")} FCFA`}
-            </p>
-            {subtext && (
-              <p className="text-[11px] text-muted-foreground">{subtext}</p>
-            )}
-          </div>
-          <div className={`flex h-9 w-9 items-center justify-center rounded-lg ${c.icon}`}>
-            <Icon className="h-4.5 w-4.5" />
-          </div>
-        </div>
-      </CardContent>
-    </Card>
   )
 }

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageHero } from "@/components/shared/PageHero"
 import { BulletinList } from "./BulletinList"
 import { BulletinGenerateButton } from "./BulletinGenerateButton"
 import { ReportsNav } from "./ReportsNav"
@@ -47,24 +48,18 @@ export function ReportsPageClient() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <FileText aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">Bulletins scolaires</h1>
-            <p className="text-sm text-muted-foreground">
-              Génération et consultation des bulletins par classe et trimestre
-            </p>
-          </div>
-        </div>
-        <BulletinGenerateButton
-          classId={classId}
-          trimester={trimester}
-          academicYearId={activeYearId}
-        />
-      </div>
+      <PageHero
+        icon={FileText}
+        title="Bulletins scolaires"
+        subtitle="Génération et consultation des bulletins par classe et trimestre"
+        actions={
+          <BulletinGenerateButton
+            classId={classId}
+            trimester={trimester}
+            academicYearId={activeYearId}
+          />
+        }
+      />
 
       <ReportsNav current="bulletins" />
 

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -49,8 +49,8 @@ export function ReportsPageClient() {
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <FileText aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <FileText aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Bulletins scolaires</h1>

--- a/components/admin/reports/council/CouncilPageClient.tsx
+++ b/components/admin/reports/council/CouncilPageClient.tsx
@@ -78,8 +78,8 @@ export function CouncilPageClient() {
     <div className="space-y-6">
       {/* En-tête */}
       <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-          <Scale aria-hidden="true" className="h-5 w-5" />
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+          <Scale aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
         <div>
           <h1 className="font-serif text-2xl tracking-tight">Conseil de classe</h1>

--- a/components/admin/reports/dren/DrenPageClient.tsx
+++ b/components/admin/reports/dren/DrenPageClient.tsx
@@ -60,8 +60,8 @@ export function DrenPageClient() {
       {/* En-tête */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <Building aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Building aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Statistiques DREN</h1>

--- a/components/admin/roles/RolesPageClient.tsx
+++ b/components/admin/roles/RolesPageClient.tsx
@@ -13,8 +13,8 @@ export function RolesPageClient() {
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <Shield aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Shield aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="font-serif text-2xl tracking-tight">Rôles &amp; Permissions</h1>

--- a/components/admin/roles/RolesPageClient.tsx
+++ b/components/admin/roles/RolesPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { Plus, Shield } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { PageHero, heroAccentBtn } from "@/components/shared/PageHero"
 import { RolesTable } from "./RolesTable"
 import { RoleCreateModal } from "./RoleCreateModal"
 
@@ -11,21 +11,17 @@ export function RolesPageClient() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Shield aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">Rôles &amp; Permissions</h1>
-            <p className="text-sm text-muted-foreground">Gérez les rôles et leurs permissions d&apos;accès</p>
-          </div>
-        </div>
-        <Button onClick={() => setCreateOpen(true)} className="h-11 gap-2 sm:h-10">
-          <Plus aria-hidden="true" className="h-4 w-4" />
-          Nouveau rôle
-        </Button>
-      </div>
+      <PageHero
+        icon={Shield}
+        title="Rôles & Permissions"
+        subtitle="Gérez les rôles et leurs permissions d'accès"
+        actions={
+          <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+            <Plus aria-hidden="true" className="h-4 w-4" />
+            Nouveau rôle
+          </button>
+        }
+      />
 
       <RolesTable />
 

--- a/components/admin/rooms/RoomsPageClient.tsx
+++ b/components/admin/rooms/RoomsPageClient.tsx
@@ -26,7 +26,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroAccentBtn, premiumCardHover, type HeroKpi } from "@/components/shared/PageHero"
 import { useAdminSummary } from "@/lib/hooks/useDashboard"
 import {
   Dialog,
@@ -90,14 +90,13 @@ export function RoomsPageClient() {
     return allClasses.filter((c) => !c.room_id && !roomClassIds.has(c.id))
   }, [allClasses, rooms])
 
-  const roomsKpis: KpiItem[] = useMemo(() => {
+  const roomsKpis: HeroKpi[] = useMemo(() => {
     const r = summary?.rooms
-    const noRoom = r?.classes_without_room ?? 0
     return [
-      { label: "Salles", value: r?.total ?? 0, icon: DoorOpen, tone: "primary" },
-      { label: "Capacité totale", value: r?.capacity ?? 0, icon: Users, tone: "default" },
-      { label: "Salles de classe", value: r?.classrooms ?? 0, icon: School, tone: "default" },
-      { label: "Classes sans salle", value: noRoom, icon: AlertTriangle, tone: noRoom > 0 ? "accent" : "default" },
+      { label: "Salles", value: r?.total ?? 0, icon: DoorOpen },
+      { label: "Capacité totale", value: r?.capacity ?? 0, icon: Users },
+      { label: "Salles de classe", value: r?.classrooms ?? 0, icon: School },
+      { label: "Classes sans salle", value: r?.classes_without_room ?? 0, icon: AlertTriangle },
     ]
   }, [summary])
 
@@ -129,26 +128,18 @@ export function RoomsPageClient() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <DoorOpen aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">Salles</h1>
-            <p className="text-sm text-muted-foreground">
-              {rooms.length} salle{rooms.length !== 1 ? "s" : ""} configurée{rooms.length !== 1 ? "s" : ""}
-            </p>
-          </div>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Nouvelle salle
-        </Button>
-      </div>
-
-      <KpiStrip items={roomsKpis} />
+      <PageHero
+        icon={DoorOpen}
+        title="Salles"
+        subtitle={`${rooms.length} salle${rooms.length !== 1 ? "s" : ""} configurée${rooms.length !== 1 ? "s" : ""}`}
+        actions={
+          <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+            <Plus aria-hidden="true" className="h-4 w-4" />
+            Nouvelle salle
+          </button>
+        }
+        kpis={roomsKpis}
+      />
 
       {/* Classes without room — banner */}
       {classesWithoutRoom.length > 0 && (
@@ -303,7 +294,7 @@ function RoomCard({
   const colorClass = typeColors[room.room_type] ?? typeColors.other
 
   return (
-    <Card className="group relative overflow-hidden hover:shadow-md transition-shadow">
+    <Card className={`group relative overflow-hidden ${premiumCardHover}`}>
       <CardContent className="p-5">
         {/* Icon + Type */}
         <div className="flex items-start justify-between mb-3">

--- a/components/admin/rooms/RoomsPageClient.tsx
+++ b/components/admin/rooms/RoomsPageClient.tsx
@@ -95,9 +95,9 @@ export function RoomsPageClient() {
     const noRoom = r?.classes_without_room ?? 0
     return [
       { label: "Salles", value: r?.total ?? 0, icon: DoorOpen, tone: "primary" },
-      { label: "Capacité totale", value: r?.capacity ?? 0, icon: Users, tone: "emerald" },
-      { label: "Salles de classe", value: r?.classrooms ?? 0, icon: School, tone: "accent" },
-      { label: "Classes sans salle", value: noRoom, icon: AlertTriangle, tone: noRoom > 0 ? "destructive" : "default" },
+      { label: "Capacité totale", value: r?.capacity ?? 0, icon: Users, tone: "default" },
+      { label: "Salles de classe", value: r?.classrooms ?? 0, icon: School, tone: "default" },
+      { label: "Classes sans salle", value: noRoom, icon: AlertTriangle, tone: noRoom > 0 ? "accent" : "default" },
     ]
   }, [summary])
 
@@ -132,8 +132,8 @@ export function RoomsPageClient() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <DoorOpen aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <DoorOpen aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Salles</h1>

--- a/components/admin/settings/SettingsPageClient.tsx
+++ b/components/admin/settings/SettingsPageClient.tsx
@@ -18,8 +18,8 @@ export function SettingsPageClient() {
     <div className="space-y-6">
       {/* En-tête */}
       <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-          <Settings aria-hidden="true" className="h-5 w-5" />
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+          <Settings aria-hidden="true" className="h-5 w-5 text-primary" />
         </div>
         <div>
           <h1 className="font-serif text-2xl tracking-tight">Paramètres</h1>

--- a/components/admin/staff/StaffPageClient.tsx
+++ b/components/admin/staff/StaffPageClient.tsx
@@ -15,9 +15,9 @@ function StaffKpis() {
     const withoutPosition = s?.without_position ?? 0
     return [
       { label: "Personnel", value: s?.total ?? 0, icon: Users, tone: "primary" },
-      { label: "Postes distincts", value: s?.distinct_positions ?? 0, icon: BadgeCheck, tone: "emerald" },
-      { label: "Avec téléphone", value: s?.with_phone ?? 0, icon: Phone, tone: "accent" },
-      { label: "Sans poste", value: withoutPosition, icon: UserX, tone: withoutPosition > 0 ? "destructive" : "default" },
+      { label: "Postes distincts", value: s?.distinct_positions ?? 0, icon: BadgeCheck, tone: "default" },
+      { label: "Avec téléphone", value: s?.with_phone ?? 0, icon: Phone, tone: "default" },
+      { label: "Sans poste", value: withoutPosition, icon: UserX, tone: withoutPosition > 0 ? "accent" : "default" },
     ]
   }, [data])
   return <KpiStrip items={kpis} />

--- a/components/admin/staff/StaffPageClient.tsx
+++ b/components/admin/staff/StaffPageClient.tsx
@@ -1,36 +1,29 @@
 "use client"
 
-import { useMemo } from "react"
 import { Briefcase, Users, BadgeCheck, Phone, UserX } from "lucide-react"
 import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { type HeroKpi } from "@/components/shared/PageHero"
 import { StaffTable } from "./StaffTable"
 import { StaffCreateModal } from "./StaffCreateModal"
 import { useAdminSummary } from "@/lib/hooks/useDashboard"
 
-function StaffKpis() {
-  const { data } = useAdminSummary()
-  const kpis: KpiItem[] = useMemo(() => {
-    const s = data?.staff
-    const withoutPosition = s?.without_position ?? 0
-    return [
-      { label: "Personnel", value: s?.total ?? 0, icon: Users, tone: "primary" },
-      { label: "Postes distincts", value: s?.distinct_positions ?? 0, icon: BadgeCheck, tone: "default" },
-      { label: "Avec téléphone", value: s?.with_phone ?? 0, icon: Phone, tone: "default" },
-      { label: "Sans poste", value: withoutPosition, icon: UserX, tone: withoutPosition > 0 ? "accent" : "default" },
-    ]
-  }, [data])
-  return <KpiStrip items={kpis} />
-}
-
 export function StaffPageClient() {
+  const { data } = useAdminSummary()
+  const s = data?.staff
+  const kpis: HeroKpi[] = [
+    { label: "Personnel", value: s?.total ?? 0, icon: Users },
+    { label: "Postes distincts", value: s?.distinct_positions ?? 0, icon: BadgeCheck },
+    { label: "Avec téléphone", value: s?.with_phone ?? 0, icon: Phone },
+    { label: "Sans poste", value: s?.without_position ?? 0, icon: UserX },
+  ]
+
   return (
     <CrudPageLayout
       title="Personnel"
       subtitle="Gestion du personnel administratif"
       createLabel="Nouveau personnel"
       icon={Briefcase}
-      kpiCards={<StaffKpis />}
+      kpis={kpis}
       table={<StaffTable />}
       createModal={(props) => <StaffCreateModal {...props} />}
     />

--- a/components/admin/students/StudentsPageClient.tsx
+++ b/components/admin/students/StudentsPageClient.tsx
@@ -2,8 +2,7 @@
 
 import { useRouter } from "next/navigation"
 import { Plus, Users, UserCheck, UserPlus, School } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroAccentBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { StudentsTable } from "./StudentsTable"
 import { useStudentFilters } from "@/lib/hooks/useStudents"
 import { useState } from "react"
@@ -29,48 +28,47 @@ export function StudentsPageClient() {
   const noCurrent = filters?.no_current_enrollment_count ?? 0
   const classesCount = filters?.by_class?.length ?? 0
 
-  const kpis: KpiItem[] = [
-    { label: "Élèves au total", value: total, icon: Users, tone: "primary" },
-    { label: "Inscrits", value: Math.max(total - noCurrent, 0), icon: UserCheck, tone: "emerald" },
-    { label: "À inscrire", value: noCurrent, icon: UserPlus, tone: noCurrent > 0 ? "accent" : "default" },
-    { label: "Classes", value: classesCount, icon: School, tone: "default" },
+  const kpis: HeroKpi[] = [
+    { label: "Élèves au total", value: total, icon: Users },
+    { label: "Inscrits", value: Math.max(total - noCurrent, 0), icon: UserCheck },
+    { label: "À inscrire", value: noCurrent, icon: UserPlus },
+    { label: "Classes", value: classesCount, icon: School },
   ]
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <Users aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Élèves</h1>
-            <p className="text-sm text-muted-foreground">
-              {total} {total > 1 ? "élèves au total" : "élève au total"}
-              {noCurrent > 0 && (
-                <>
-                  {" · "}
-                  <button
-                    type="button"
-                    className="text-amber-700 underline-offset-2 hover:underline"
-                    onClick={() => setUnenrolledChip(true)}
-                  >
-                    {noCurrent} à inscrire
-                  </button>
-                </>
-              )}
-            </p>
-          </div>
-        </div>
-        <Button
-          onClick={() => router.push("/admin/enrollments?action=create")}
-          className="h-11 gap-2 sm:h-10"
-        >
-          <Plus className="h-4 w-4" />
-          Nouvelle inscription
-        </Button>
-      </div>
-      <KpiStrip items={kpis} />
+      <PageHero
+        icon={Users}
+        title="Élèves"
+        subtitle={
+          <>
+            {total} {total > 1 ? "élèves au total" : "élève au total"}
+            {noCurrent > 0 && (
+              <>
+                {" · "}
+                <button
+                  type="button"
+                  className="font-medium text-white underline underline-offset-2 hover:text-white/90"
+                  onClick={() => setUnenrolledChip(true)}
+                >
+                  {noCurrent} à inscrire
+                </button>
+              </>
+            )}
+          </>
+        }
+        actions={
+          <button
+            type="button"
+            className={heroAccentBtn}
+            onClick={() => router.push("/admin/enrollments?action=create")}
+          >
+            <Plus className="h-4 w-4" />
+            Nouvelle inscription
+          </button>
+        }
+        kpis={kpis}
+      />
       <StudentsTable initialUnenrolledOnly={unenrolledChip} onChipsConsumed={() => setUnenrolledChip(false)} />
     </div>
   )

--- a/components/admin/students/StudentsPageClient.tsx
+++ b/components/admin/students/StudentsPageClient.tsx
@@ -33,15 +33,15 @@ export function StudentsPageClient() {
     { label: "Élèves au total", value: total, icon: Users, tone: "primary" },
     { label: "Inscrits", value: Math.max(total - noCurrent, 0), icon: UserCheck, tone: "emerald" },
     { label: "À inscrire", value: noCurrent, icon: UserPlus, tone: noCurrent > 0 ? "accent" : "default" },
-    { label: "Classes", value: classesCount, icon: School, tone: "accent" },
+    { label: "Classes", value: classesCount, icon: School, tone: "default" },
   ]
 
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <Users aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <Users aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
             <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Élèves</h1>

--- a/components/admin/subjects/SubjectsPageClient.tsx
+++ b/components/admin/subjects/SubjectsPageClient.tsx
@@ -16,9 +16,9 @@ function SubjectsKpis() {
     const withoutTeacher = s?.without_teacher ?? 0
     return [
       { label: "Matières uniques", value: s?.unique_names ?? 0, icon: BookMarked, tone: "primary" },
-      { label: "Instances par niveau", value: s?.instances ?? 0, icon: Layers, tone: "emerald" },
-      { label: "Sans enseignant", value: withoutTeacher, icon: UserX, tone: withoutTeacher > 0 ? "destructive" : "default" },
-      { label: "Heures / semaine", value: `${s?.total_hours ?? 0}h`, icon: Clock, tone: "accent" },
+      { label: "Instances par niveau", value: s?.instances ?? 0, icon: Layers, tone: "default" },
+      { label: "Sans enseignant", value: withoutTeacher, icon: UserX, tone: withoutTeacher > 0 ? "accent" : "default" },
+      { label: "Heures / semaine", value: `${s?.total_hours ?? 0}h`, icon: Clock, tone: "default" },
     ]
   }, [data])
   return <KpiStrip items={kpis} />
@@ -33,8 +33,8 @@ export function SubjectsPageClient() {
       {/* Header */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-            <BookMarked aria-hidden="true" className="h-5 w-5" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <BookMarked aria-hidden="true" className="h-5 w-5 text-primary" />
           </div>
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Matières</h1>

--- a/components/admin/subjects/SubjectsPageClient.tsx
+++ b/components/admin/subjects/SubjectsPageClient.tsx
@@ -2,82 +2,65 @@
 
 import { useMemo, useState } from "react"
 import { BookMarked, Plus, LayoutGrid, List, Layers, UserX, Clock } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, heroAccentBtn, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { useAdminSummary } from "@/lib/hooks/useDashboard"
 import { SubjectsTable } from "./SubjectsTable"
 import { SubjectsKanbanView } from "./SubjectsKanbanView"
 import { SubjectCreateModal } from "./SubjectCreateModal"
 
-function SubjectsKpis() {
-  const { data } = useAdminSummary()
-  const kpis: KpiItem[] = useMemo(() => {
-    const s = data?.subjects
-    const withoutTeacher = s?.without_teacher ?? 0
-    return [
-      { label: "Matières uniques", value: s?.unique_names ?? 0, icon: BookMarked, tone: "primary" },
-      { label: "Instances par niveau", value: s?.instances ?? 0, icon: Layers, tone: "default" },
-      { label: "Sans enseignant", value: withoutTeacher, icon: UserX, tone: withoutTeacher > 0 ? "accent" : "default" },
-      { label: "Heures / semaine", value: `${s?.total_hours ?? 0}h`, icon: Clock, tone: "default" },
-    ]
-  }, [data])
-  return <KpiStrip items={kpis} />
-}
-
 export function SubjectsPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
   const [viewMode, setViewMode] = useState<"kanban" | "table">("kanban")
 
+  const { data } = useAdminSummary()
+  const kpis: HeroKpi[] = useMemo(() => {
+    const s = data?.subjects
+    return [
+      { label: "Matières uniques", value: s?.unique_names ?? 0, icon: BookMarked },
+      { label: "Instances par niveau", value: s?.instances ?? 0, icon: Layers },
+      { label: "Sans enseignant", value: s?.without_teacher ?? 0, icon: UserX },
+      { label: "Heures / semaine", value: `${s?.total_hours ?? 0}h`, icon: Clock },
+    ]
+  }, [data])
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <BookMarked aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">Matières</h1>
-            <p className="text-sm text-muted-foreground">Gestion des matières par niveau</p>
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          {/* Kanban inadapté sous 320px (drag-drop entre colonnes impossible) :
-              toggle visible uniquement desktop, mobile force la vue table. */}
-          <div
-            role="group"
-            aria-label="Changer la vue"
-            className="hidden md:flex items-center rounded-lg border p-1"
-          >
-            <Button
-              variant={viewMode === "kanban" ? "default" : "ghost"}
-              size="sm"
-              className="h-8 px-3"
-              aria-pressed={viewMode === "kanban"}
-              onClick={() => setViewMode("kanban")}
-            >
-              <LayoutGrid aria-hidden="true" className="mr-1.5 h-4 w-4" />
-              Kanban
-            </Button>
-            <Button
-              variant={viewMode === "table" ? "default" : "ghost"}
-              size="sm"
-              className="h-8 px-3"
-              aria-pressed={viewMode === "table"}
-              onClick={() => setViewMode("table")}
-            >
-              <List aria-hidden="true" className="mr-1.5 h-4 w-4" />
-              Table
-            </Button>
-          </div>
-          <Button onClick={() => setCreateOpen(true)} className="h-11 sm:h-10">
-            <Plus aria-hidden="true" className="mr-2 h-4 w-4" />
-            Nouvelle matière
-          </Button>
-        </div>
-      </div>
-
-      <SubjectsKpis />
+      <PageHero
+        icon={BookMarked}
+        title="Matières"
+        subtitle="Gestion des matières par niveau"
+        actions={
+          <>
+            {/* Kanban inadapté sous 320px (drag-drop entre colonnes impossible) :
+                toggle visible uniquement desktop, mobile force la vue table. */}
+            <div role="group" aria-label="Changer la vue" className="hidden md:flex items-center gap-1">
+              <button
+                type="button"
+                className={`${heroGlassBtn} ${viewMode === "kanban" ? "" : "opacity-70"}`}
+                aria-pressed={viewMode === "kanban"}
+                onClick={() => setViewMode("kanban")}
+              >
+                <LayoutGrid aria-hidden="true" className="h-4 w-4" />
+                Kanban
+              </button>
+              <button
+                type="button"
+                className={`${heroGlassBtn} ${viewMode === "table" ? "" : "opacity-70"}`}
+                aria-pressed={viewMode === "table"}
+                onClick={() => setViewMode("table")}
+              >
+                <List aria-hidden="true" className="h-4 w-4" />
+                Table
+              </button>
+            </div>
+            <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+              <Plus aria-hidden="true" className="h-4 w-4" />
+              Nouvelle matière
+            </button>
+          </>
+        }
+        kpis={kpis}
+      />
 
       {/* Mobile : toujours table. Desktop : respecte le choix utilisateur. */}
       <div className="md:hidden">

--- a/components/admin/teachers/TeachersPageClient.tsx
+++ b/components/admin/teachers/TeachersPageClient.tsx
@@ -15,9 +15,9 @@ function TeacherKpis() {
     const withoutSpeciality = t?.without_speciality ?? 0
     return [
       { label: "Enseignants", value: t?.total ?? 0, icon: Users, tone: "primary" },
-      { label: "Avec spécialité", value: t?.with_speciality ?? 0, icon: Award, tone: "emerald" },
-      { label: "Avec téléphone", value: t?.with_phone ?? 0, icon: Phone, tone: "accent" },
-      { label: "Sans spécialité", value: withoutSpeciality, icon: UserX, tone: withoutSpeciality > 0 ? "destructive" : "default" },
+      { label: "Avec spécialité", value: t?.with_speciality ?? 0, icon: Award, tone: "default" },
+      { label: "Avec téléphone", value: t?.with_phone ?? 0, icon: Phone, tone: "default" },
+      { label: "Sans spécialité", value: withoutSpeciality, icon: UserX, tone: withoutSpeciality > 0 ? "accent" : "default" },
     ]
   }, [data])
   return <KpiStrip items={kpis} />

--- a/components/admin/teachers/TeachersPageClient.tsx
+++ b/components/admin/teachers/TeachersPageClient.tsx
@@ -1,36 +1,29 @@
 "use client"
 
-import { useMemo } from "react"
 import { BookOpen, Users, Award, Phone, UserX } from "lucide-react"
 import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { type HeroKpi } from "@/components/shared/PageHero"
 import { TeachersTable } from "./TeachersTable"
 import { TeacherCreateModal } from "./TeacherCreateModal"
 import { useAdminSummary } from "@/lib/hooks/useDashboard"
 
-function TeacherKpis() {
-  const { data } = useAdminSummary()
-  const kpis: KpiItem[] = useMemo(() => {
-    const t = data?.teachers
-    const withoutSpeciality = t?.without_speciality ?? 0
-    return [
-      { label: "Enseignants", value: t?.total ?? 0, icon: Users, tone: "primary" },
-      { label: "Avec spécialité", value: t?.with_speciality ?? 0, icon: Award, tone: "default" },
-      { label: "Avec téléphone", value: t?.with_phone ?? 0, icon: Phone, tone: "default" },
-      { label: "Sans spécialité", value: withoutSpeciality, icon: UserX, tone: withoutSpeciality > 0 ? "accent" : "default" },
-    ]
-  }, [data])
-  return <KpiStrip items={kpis} />
-}
-
 export function TeachersPageClient() {
+  const { data } = useAdminSummary()
+  const t = data?.teachers
+  const kpis: HeroKpi[] = [
+    { label: "Enseignants", value: t?.total ?? 0, icon: Users },
+    { label: "Avec spécialité", value: t?.with_speciality ?? 0, icon: Award },
+    { label: "Avec téléphone", value: t?.with_phone ?? 0, icon: Phone },
+    { label: "Sans spécialité", value: t?.without_speciality ?? 0, icon: UserX },
+  ]
+
   return (
     <CrudPageLayout
       title="Enseignants"
       subtitle="Gestion du corps enseignant"
       createLabel="Nouvel enseignant"
       icon={BookOpen}
-      kpiCards={<TeacherKpis />}
+      kpis={kpis}
       table={<TeachersTable />}
       createModal={(props) => <TeacherCreateModal {...props} />}
     />

--- a/components/parent/ParentChildrenClient.tsx
+++ b/components/parent/ParentChildrenClient.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, premiumCardHover, type HeroKpi } from "@/components/shared/PageHero"
 import { useParentChildren } from "@/lib/hooks/useParentPortal"
 import type { ParentChild } from "@/lib/contracts/parent-portal"
 import { isEnrolledFromClassName, summarizeEnrollment } from "@/lib/utils/enrollment-status"
@@ -32,12 +32,12 @@ export function ParentChildrenClient() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="font-serif text-xl tracking-tight">Mes enfants</h1>
-        {subtitle && <p className="text-sm text-muted-foreground">{subtitle}</p>}
-      </div>
-
-      {children && children.length > 0 && <ChildrenKpis childList={children} />}
+      <PageHero
+        icon={Users}
+        title="Mes enfants"
+        subtitle={subtitle ?? undefined}
+        kpis={children && children.length > 0 ? childrenKpis(children) : undefined}
+      />
 
       {isLoading ? (
         <ChildrenSkeleton />
@@ -64,30 +64,24 @@ export function ParentChildrenClient() {
   )
 }
 
-function ChildrenKpis({ childList }: { childList: ParentChild[] }) {
+function childrenKpis(childList: ParentChild[]): HeroKpi[] {
   const summary = summarizeEnrollment(childList)
   const remaining = childList
     .filter((c) => isEnrolledFromClassName(c.class_name))
     .reduce((s, c) => s + (c.fees_remaining ?? 0), 0)
-  const kpis: KpiItem[] = [
-    { label: "Enfants", value: summary.total, icon: Users, tone: "primary" },
-    { label: "Inscrits", value: summary.enrolled, icon: UserCheck, tone: "emerald" },
-    { label: "En attente", value: summary.pending, icon: Clock, tone: summary.pending > 0 ? "accent" : "default" },
-    {
-      label: "Restant total",
-      value: `${remaining.toLocaleString("fr-FR")} F`,
-      icon: Wallet,
-      tone: remaining > 0 ? "accent" : "default",
-    },
+  return [
+    { label: "Enfants", value: summary.total, icon: Users },
+    { label: "Inscrits", value: summary.enrolled, icon: UserCheck },
+    { label: "En attente", value: summary.pending, icon: Clock },
+    { label: "Restant total", value: `${remaining.toLocaleString("fr-FR")} F`, icon: Wallet },
   ]
-  return <KpiStrip items={kpis} />
 }
 
 function ChildDetailCard({ child }: { child: ParentChild }) {
   const isEnrolled = isEnrolledFromClassName(child.class_name)
 
   return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
+    <Card className={`border-0 shadow-sm ring-1 ring-border ${premiumCardHover}`}>
       <CardContent className="p-4">
         <div className="mb-3 flex items-start justify-between">
           <div className="flex items-center gap-3">

--- a/components/shared/CrudPageLayout.tsx
+++ b/components/shared/CrudPageLayout.tsx
@@ -22,8 +22,8 @@ export function CrudPageLayout({ title, subtitle, createLabel, icon: Icon, table
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           {Icon && (
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
-              <Icon aria-hidden="true" className="h-5 w-5" />
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+              <Icon aria-hidden="true" className="h-5 w-5 text-primary" />
             </div>
           )}
           <div>

--- a/components/shared/CrudPageLayout.tsx
+++ b/components/shared/CrudPageLayout.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import { useState } from "react"
-import { Button } from "@/components/ui/button"
 import { Plus, type LucideIcon } from "lucide-react"
+import { PageHero, heroAccentBtn, type HeroKpi } from "@/components/shared/PageHero"
 
 interface CrudPageLayoutProps {
   title: string
@@ -11,31 +11,26 @@ interface CrudPageLayoutProps {
   icon?: LucideIcon
   table: React.ReactNode
   createModal: (props: { open: boolean; onClose: () => void }) => React.ReactNode
-  kpiCards?: React.ReactNode
+  /** KPIs intégrés dans le hero (monochrome, cf. premium-design-system). */
+  kpis?: HeroKpi[]
 }
 
-export function CrudPageLayout({ title, subtitle, createLabel, icon: Icon, table, createModal, kpiCards }: CrudPageLayoutProps) {
+export function CrudPageLayout({ title, subtitle, createLabel, icon, table, createModal, kpis }: CrudPageLayoutProps) {
   const [createOpen, setCreateOpen] = useState(false)
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          {Icon && (
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-              <Icon aria-hidden="true" className="h-5 w-5 text-primary" />
-            </div>
-          )}
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">{title}</h1>
-            <p className="text-sm text-muted-foreground">{subtitle}</p>
-          </div>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" /> {createLabel}
-        </Button>
-      </div>
-      {kpiCards}
+      <PageHero
+        icon={icon}
+        title={title}
+        subtitle={subtitle}
+        kpis={kpis}
+        actions={
+          <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4" /> {createLabel}
+          </button>
+        }
+      />
       {table}
       {createModal({ open: createOpen, onClose: () => setCreateOpen(false) })}
     </div>

--- a/components/shared/PageHero.tsx
+++ b/components/shared/PageHero.tsx
@@ -1,0 +1,91 @@
+import type { LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+/**
+ * Hero signature KLASSCI : bandeau au dégradé bleu de marque (3 bleus :
+ * #0a3d8f -> #0453cb -> #3b7ddb), titre + icône en blanc, et KPIs intégrés
+ * en cartes blanches semi-transparentes (monochrome — pas de couleur par KPI,
+ * cf. rule premium-redesign). Réservé aux pages listing/dashboard.
+ *
+ * Identique en thème clair et sombre (c'est un bandeau coloré à texte blanc).
+ */
+export interface HeroKpi {
+  label: string
+  value: React.ReactNode
+  icon?: LucideIcon
+  hint?: React.ReactNode
+}
+
+interface PageHeroProps {
+  icon?: LucideIcon
+  title: string
+  subtitle?: React.ReactNode
+  actions?: React.ReactNode
+  kpis?: HeroKpi[]
+  className?: string
+}
+
+export function PageHero({ icon: Icon, title, subtitle, actions, kpis, className }: PageHeroProps) {
+  return (
+    <section
+      className={cn(
+        "rounded-2xl bg-gradient-to-br from-[#0a3d8f] via-[#0453cb] to-[#3b7ddb] p-5 text-white shadow-sm sm:p-6",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          {Icon && (
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/15 bg-white/10 backdrop-blur">
+              <Icon aria-hidden="true" className="h-6 w-6" />
+            </div>
+          )}
+          <div className="min-w-0">
+            <h1 className="font-serif text-xl font-bold tracking-tight sm:text-2xl">{title}</h1>
+            {subtitle && <div className="mt-0.5 text-sm text-white/70">{subtitle}</div>}
+          </div>
+        </div>
+        {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+      </div>
+
+      {kpis && kpis.length > 0 && (
+        <div className="mt-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {kpis.map((k, i) => {
+            const KIcon = k.icon
+            return (
+              <div
+                key={i}
+                className="rounded-xl border border-white/15 bg-white/10 p-3"
+                role="group"
+                aria-label={typeof k.value === "string" || typeof k.value === "number" ? `${k.label} : ${k.value}` : k.label}
+              >
+                <div className="flex items-center gap-2.5">
+                  {KIcon && (
+                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/15">
+                      <KIcon className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                  )}
+                  <div className="min-w-0">
+                    <div className="text-xl font-bold leading-tight tracking-tight tabular-nums">
+                      {k.value}
+                    </div>
+                    <p className="truncate text-[11px] text-white/65">{k.label}</p>
+                  </div>
+                </div>
+                {k.hint && <div className="mt-1.5 text-[11px] text-white/60">{k.hint}</div>}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}
+
+/** Bouton blanc plein pour action principale dans le hero (texte bleu). */
+export const heroPrimaryBtn =
+  "inline-flex h-9 items-center justify-center gap-2 rounded-lg bg-white px-3.5 text-sm font-semibold text-[#0453cb] shadow-sm transition-colors hover:bg-white/90"
+
+/** Bouton verre pour action secondaire dans le hero (texte blanc). */
+export const heroGlassBtn =
+  "inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-white/25 bg-white/15 px-3.5 text-sm font-semibold text-white transition-colors hover:bg-white/25"

--- a/components/shared/PageHero.tsx
+++ b/components/shared/PageHero.tsx
@@ -49,30 +49,26 @@ export function PageHero({ icon: Icon, title, subtitle, actions, kpis, className
       </div>
 
       {kpis && kpis.length > 0 && (
-        <div className="mt-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <div className="mt-4 grid grid-cols-2 gap-2.5 lg:grid-cols-4">
           {kpis.map((k, i) => {
             const KIcon = k.icon
             return (
               <div
                 key={i}
-                className="rounded-xl border border-white/15 bg-white/10 p-3"
+                className="rounded-xl border border-white/15 bg-white/10 px-3 py-2.5"
                 role="group"
                 aria-label={typeof k.value === "string" || typeof k.value === "number" ? `${k.label} : ${k.value}` : k.label}
               >
-                <div className="flex items-center gap-2.5">
-                  {KIcon && (
-                    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/15">
-                      <KIcon className="h-5 w-5" aria-hidden="true" />
-                    </span>
-                  )}
-                  <div className="min-w-0">
-                    <div className="text-xl font-bold leading-tight tracking-tight tabular-nums">
-                      {k.value}
-                    </div>
-                    <p className="truncate text-[11px] text-white/65">{k.label}</p>
-                  </div>
+                <div className="flex items-start justify-between gap-2">
+                  <p className="truncate text-[11px] font-medium uppercase tracking-wide text-white/65">
+                    {k.label}
+                  </p>
+                  {KIcon && <KIcon className="h-4 w-4 shrink-0 text-white/70" aria-hidden="true" />}
                 </div>
-                {k.hint && <div className="mt-1.5 text-[11px] text-white/60">{k.hint}</div>}
+                <div className="mt-1 text-2xl font-bold leading-none tracking-tight tabular-nums">
+                  {k.value}
+                </div>
+                {k.hint && <div className="mt-1 truncate text-[11px] text-white/60">{k.hint}</div>}
               </div>
             )
           })}
@@ -82,10 +78,46 @@ export function PageHero({ icon: Icon, title, subtitle, actions, kpis, className
   )
 }
 
-/** Bouton blanc plein pour action principale dans le hero (texte bleu). */
+/**
+ * Titre de sous-section (couche 4) avec la petite icône carrée au dégradé bleu
+ * KLASSCI. Cohérence du header de page jusqu'aux sous-blocs.
+ */
+export function SectionTitle({
+  icon: Icon,
+  children,
+  className,
+}: {
+  icon?: LucideIcon
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn("flex items-center gap-2.5", className)}>
+      {Icon && (
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-[#3b7ddb] text-white shadow-sm">
+          <Icon className="h-4 w-4" aria-hidden="true" />
+        </span>
+      )}
+      <h2 className="text-sm font-semibold tracking-tight">{children}</h2>
+    </div>
+  )
+}
+
+/** Bouton ORANGE plein — l'action focale du hero (accent KLASSCI). */
+export const heroAccentBtn =
+  "inline-flex h-9 items-center justify-center gap-2 rounded-lg bg-accent px-3.5 text-sm font-semibold text-accent-foreground shadow-sm transition-colors hover:bg-accent/90"
+
+/** Bouton blanc plein pour action principale alternative dans le hero (texte bleu). */
 export const heroPrimaryBtn =
   "inline-flex h-9 items-center justify-center gap-2 rounded-lg bg-white px-3.5 text-sm font-semibold text-[#0453cb] shadow-sm transition-colors hover:bg-white/90"
 
 /** Bouton verre pour action secondaire dans le hero (texte blanc). */
 export const heroGlassBtn =
   "inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-white/25 bg-white/15 px-3.5 text-sm font-semibold text-white transition-colors hover:bg-white/25"
+
+/**
+ * Hover premium pour les cartes (couches 2-3) : léger soulèvement + ombre bleue
+ * KLASSCI. À composer avec une carte shadcn cliquable/survolable.
+ */
+export const premiumCardHover =
+  "transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_10px_30px_-12px_rgba(4,83,203,0.35)]"

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -147,7 +147,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                   className={cn(
                     "relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
                     isActive
-                      ? "bg-primary/10 text-primary font-medium before:absolute before:left-0 before:top-1/2 before:h-6 before:w-1.5 before:-translate-y-1/2 before:rounded-r-full before:bg-accent before:content-['']"
+                      ? "bg-primary/10 text-primary font-medium before:absolute before:left-0 before:top-1/2 before:h-5 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-accent before:content-['']"
                       : "text-muted-foreground hover:bg-muted hover:text-foreground"
                   )}
                 >

--- a/components/shared/list/KpiStrip.tsx
+++ b/components/shared/list/KpiStrip.tsx
@@ -12,22 +12,22 @@ import { Card, CardContent } from "@/components/ui/card"
  */
 export type KpiTone = "default" | "primary" | "accent" | "destructive" | "emerald"
 
-// Couleurs de marque KLASSCI franchement présentes : carte teintée + pastille
-// d'icône pleine (bleu / orange / vert). Sémantique conservée, clair/sombre OK.
-const toneCard: Record<KpiTone, string> = {
-  default: "",
-  primary: "border-primary/25 bg-primary/[0.06]",
-  accent: "border-accent/30 bg-accent/[0.07]",
-  destructive: "border-destructive/30 bg-destructive/[0.07]",
-  emerald: "border-emerald-500/30 bg-emerald-500/[0.07]",
+const toneStyles: Record<KpiTone, string> = {
+  default: "bg-muted text-muted-foreground",
+  primary: "bg-primary/10 text-primary",
+  accent: "bg-accent/10 text-accent",
+  destructive: "bg-destructive/10 text-destructive",
+  emerald: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
 }
 
-const toneIcon: Record<KpiTone, string> = {
-  default: "bg-muted text-muted-foreground",
-  primary: "bg-primary text-primary-foreground",
-  accent: "bg-accent text-accent-foreground",
-  destructive: "bg-destructive text-destructive-foreground",
-  emerald: "bg-emerald-600 text-white",
+// Liseré de gauche aux couleurs de la marque KLASSCI (bleu / orange) pour que
+// l'identité se ressente sur chaque liste. Tons sémantiques conservés.
+const edgeStyles: Record<KpiTone, string> = {
+  default: "border-l-border",
+  primary: "border-l-primary",
+  accent: "border-l-accent",
+  destructive: "border-l-destructive",
+  emerald: "border-l-emerald-500",
 }
 
 export interface KpiItem {
@@ -66,7 +66,7 @@ export function KpiStrip({ items, columns = 4, className }: KpiStripProps) {
             key={i}
             role="group"
             aria-label={valueText ? `${item.label} : ${valueText}` : item.label}
-            className={cn("shadow-sm", toneCard[item.tone ?? "default"])}
+            className={cn("border-l-[3px] shadow-sm", edgeStyles[item.tone ?? "default"])}
           >
             <CardContent className="flex items-start justify-between gap-3 p-4">
               <div className="min-w-0 space-y-0.5">
@@ -83,8 +83,8 @@ export function KpiStrip({ items, columns = 4, className }: KpiStripProps) {
               {Icon && (
                 <span
                   className={cn(
-                    "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg shadow-sm",
-                    toneIcon[item.tone ?? "default"],
+                    "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+                    toneStyles[item.tone ?? "default"],
                   )}
                 >
                   <Icon className="h-5 w-5" aria-hidden="true" />

--- a/components/teacher/TeacherClassesClient.tsx
+++ b/components/teacher/TeacherClassesClient.tsx
@@ -14,7 +14,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
+import { PageHero, premiumCardHover, type HeroKpi } from "@/components/shared/PageHero"
 import { ListSearchBar } from "@/components/shared/list/ListSearchBar"
 import { matchesSearch } from "@/lib/utils/list-search"
 import { useTeacherClasses } from "@/lib/hooks/useTeacherPortal"
@@ -25,7 +25,7 @@ export function TeacherClassesClient() {
   const [search, setSearch] = useState("")
 
   const list = useMemo(() => classes ?? [], [classes])
-  const kpis: KpiItem[] = useMemo(() => {
+  const kpis: HeroKpi[] = useMemo(() => {
     const students = list.reduce((s, c) => s + (c.student_count ?? 0), 0)
     const evals = list.reduce((s, c) => s + (c.total_evaluations ?? 0), 0)
     const graded = list.filter((c) => c.general_average !== null && c.general_average !== undefined)
@@ -33,15 +33,10 @@ export function TeacherClassesClient() {
       ? graded.reduce((s, c) => s + (c.general_average ?? 0), 0) / graded.length
       : null
     return [
-      { label: "Classes", value: list.length, icon: School, tone: "primary" },
-      { label: "Élèves", value: students, icon: Users, tone: "default" },
-      { label: "Évaluations", value: evals, icon: ClipboardList, tone: "default" },
-      {
-        label: "Moyenne globale",
-        value: avg !== null ? avg.toFixed(2) : "—",
-        icon: GraduationCap,
-        tone: avg === null ? "default" : avg >= 10 ? "emerald" : "destructive",
-      },
+      { label: "Classes", value: list.length, icon: School },
+      { label: "Élèves", value: students, icon: Users },
+      { label: "Évaluations", value: evals, icon: ClipboardList },
+      { label: "Moyenne globale", value: avg !== null ? avg.toFixed(2) : "—", icon: GraduationCap },
     ]
   }, [list])
 
@@ -52,12 +47,12 @@ export function TeacherClassesClient() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="font-serif text-xl tracking-tight">Mes classes</h1>
-        <p className="text-sm text-muted-foreground">
-          Classes assignées et statistiques
-        </p>
-      </div>
+      <PageHero
+        icon={School}
+        title="Mes classes"
+        subtitle="Classes assignées et statistiques"
+        kpis={classes && classes.length > 0 ? kpis : undefined}
+      />
 
       {isLoading ? (
         <ClassesSkeleton />
@@ -78,7 +73,6 @@ export function TeacherClassesClient() {
         </div>
       ) : (
         <>
-          <KpiStrip items={kpis} />
           {list.length > 3 && (
             <ListSearchBar
               value={search}
@@ -108,7 +102,7 @@ function ClassCard({ cls }: { cls: TeacherClass }) {
   const average = cls.general_average ?? null
   const totalEvals = cls.total_evaluations ?? 0
   return (
-    <Card className="border-0 shadow-sm ring-1 ring-border">
+    <Card className={`border-0 shadow-sm ring-1 ring-border ${premiumCardHover}`}>
       <CardContent className="p-4 space-y-3">
         {/* En-tête */}
         <div className="flex items-start justify-between">


### PR DESCRIPTION
## Contexte

Après le retour « on ne ressent pas les trois couleurs », j'ai relu la rule de design KLASSCIv2. Le système est **monochrome bleu** et les « trois couleurs » sont les **trois bleus du dégradé du hero**. Pour klassci-college, Marcel veut en plus faire **ressortir l'orange du logo** (avec discipline : 1 point focal orange par contexte).

## Ce que fait cette PR

1. **Annule** le multicolore (KPIs bleu/orange/vert/rouge) de la tentative précédente.
2. **Nouvelle rule** `.claude/rules/premium-design-system.md` : système bleu + orange, shadcn/ui, **profondeur 10 couches** (du header au bouton dans une carte dans une carte jusqu'au bas de page), dark/light via tokens.
3. **Hero signature** `PageHero` : dégradé 3 bleus + KPIs verre intégrés (monochrome) + **CTA principal orange focal** + `SectionTitle` (icône dégradé) + `premiumCardHover`.
4. **Propagation** : tableau de bord, **toutes** les pages d'administration (élèves, classes, matières, parents, inscriptions, enseignants, personnel, salles, niveaux, notifications, présences, paiements, rôles, bulletins) + les pages liste des portails enseignant/parent. Page Frais (élève/parent/admin) cohérente.

## Vérifié
- `tsc --noEmit` + build de prod (typedRoutes) OK.
- Preview déployé sur le serveur Windows, contrôlé en clair et sombre (dashboard, Frais, Élèves, Enseignants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)