### PR TITLE
feat(ui): bring KLASSCI orange into the hero background (blue to orange)

### DIFF
--- a/.claude/rules/premium-design-system.md
+++ b/.claude/rules/premium-design-system.md
@@ -25,12 +25,16 @@ jusqu'au plus petit bouton imbriqué, **sur les 10 couches de profondeur**.
 | `--muted` / `--card` / `--border` | — | Surfaces et profondeur |
 | `--background` / `--foreground` | — | Fond de page / texte |
 
-### Les 3 bleus du dégradé hero (signature)
+### Le dégradé bi-marque du hero (signature)
 
+Le hero glisse du **bleu** (titre, à gauche) vers **l'orange du logo** (coin bas-droite) :
+les DEUX couleurs de la marque dans le fond du hero.
 ```
-#0a3d8f  →  #0453cb  →  #3b7ddb
+bg-[linear-gradient(135deg,#0a3d8f_0%,#0453cb_42%,#2a69cb_56%,#f5821f_92%)]
 ```
-Utilisés **uniquement** dans le `PageHero` (`bg-gradient-to-br from-[#0a3d8f] via-[#0453cb] to-[#3b7ddb]`).
+Le titre et les actions restent sur la zone bleue (haut). L'orange occupe le coin
+bas-droite (derrière les derniers KPIs) → l'orange se voit dans le fond, pas juste
+sur un bouton. Réservé au `PageHero`.
 
 ### Couleurs sémantiques (statut uniquement, jamais décoratif)
 
@@ -67,8 +71,9 @@ Ne jamais réinventer un en‑tête. Les **formulaires (create/edit)** n'ont **p
 de hero : ils utilisent l'en‑tête standard (icône `bg-primary` + titre).
 
 Structure :
-- Dégradé bleu 3 stops, texte blanc, icône en pastille verre (`bg-white/10 border-white/15`).
-- **1 accent orange focal** : le CTA principal en orange (`bg-accent`) OU un trait/badge orange.
+- **Dégradé bleu→orange** (les 2 couleurs du logo), texte blanc, icône en pastille verre.
+- L'orange est présent **dans le fond** (coin bas-droite) ET sur le **CTA focal** (`heroAccentBtn`,
+  orange + ring blanc pour rester net sur la zone orange).
 - **KPIs intégrés dans le hero** en cartes verre blanches (`bg-white/10 border-white/15`),
   monochrome blanc (jamais une couleur par KPI). Layout d'une carte KPI :
   **label petit en haut** (`text-[11px] uppercase text-white/65`) + icône discrète à
@@ -116,7 +121,7 @@ le focal orange**. Une carte dans une carte dans une carte reste lisible.
 | 1 | **Hero** | dégradé bleu, `text-white` | — | `rounded-2xl` | `shadow-sm` | `PageHero` | **1 orange focal** |
 | 2 | **Section card** | `bg-card` | `border` | `rounded-xl` | `shadow-sm` | `Card` | titre bleu + 1 action |
 | 3 | **Sub-card** (carte dans carte) | `bg-muted/40` | `border-border/60` | `rounded-lg` | — | `p-4` | `Card`/`div` | — |
-| 4 | **Section-bar** (en‑tête interne) | section-icon dégradé + titre | `border-b` | — | — | `pb-3` | `CardHeader` | icône dégradé bleu |
+| 4 | **Section-bar** (en‑tête interne) | section-icon dégradé + titre | `border-b` | — | — | `pb-3` | `CardHeader` | icône dégradé **orange** |
 | 5 | **Row / list item** | `bg-background`, hover `bg-muted/50` | `border-b last:border-0` | — | — | `px-3 py-2.5` | `TableRow` / `div` | statut (badge) |
 | 6 | **Inline group** (groupe dans une ligne) | `bg-muted/60` | `border` | `rounded-md` | — | `p-2` | `div` | — |
 | 7 | **Control** (input/select) | `bg-background` | `border-input` | `rounded-md` | — | `h-9 px-3` | `Input`/`Select` | ring `--ring` au focus |
@@ -154,9 +159,11 @@ opacité de surface qui monte. Jamais deux `bg-card` adjacents sans séparation
 
 ### Section-bar interne (couche 4) — section-icon dégradé
 
+L'icône de section est au **dégradé orange** (l'orange de la marque, qui se diffuse
+ainsi sur chaque sous-section de la page, pas seulement dans le hero) :
 ```tsx
 <div className="flex items-center gap-2.5 border-b pb-3">
-  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-[#3b7ddb] text-white shadow-sm">
+  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
     <Icon className="h-4 w-4" />
   </span>
   <h2 className="text-sm font-semibold">Montants par niveau</h2>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
-- Refonte visuelle de toute l'application : chaque page (tableau de bord, listes d'administration, portails enseignant et parent) s'ouvre désormais sur un bandeau au dégradé bleu KLASSCI, avec les indicateurs clés intégrés en blanc et l'action principale mise en avant en orange, la couleur du logo. Identité de marque cohérente du haut de page jusqu'aux moindres détails, vérifiée en mode clair et sombre *(tous)*.
+- Refonte visuelle de toute l'application : chaque page (tableau de bord, listes d'administration, portails enseignant et parent) s'ouvre désormais sur un bandeau au dégradé **bleu et orange** (les deux couleurs du logo KLASSCI), avec les indicateurs clés intégrés en blanc et l'action principale mise en avant en orange. Les en-têtes de section reprennent l'orange de la marque. Identité cohérente du haut de page jusqu'aux moindres détails, vérifiée en mode clair et sombre *(tous)*.
 - Pages Frais (élève, parent) avec un bandeau de synthèse bleu marque : total attendu, montant payé en vert et « Reste à payer » mis en avant en orange, avec barre de progression. Plus lisible d'un coup d'œil *(élève, parent)*.
 - Page Frais admin refondue : bandeau dégradé bleu, cartes de catégories sobres et lisibles aussi bien en clair qu'en sombre *(admin)*.
 - Indicateurs clés des pages de gestion désormais alimentés par un calcul serveur : les chiffres restent exacts même au-delà de 100 lignes (grands établissements), là où ils étaient auparavant tronqués *(admin)*.

--- a/components/shared/PageHero.tsx
+++ b/components/shared/PageHero.tsx
@@ -29,7 +29,9 @@ export function PageHero({ icon: Icon, title, subtitle, actions, kpis, className
   return (
     <section
       className={cn(
-        "rounded-2xl bg-gradient-to-br from-[#0a3d8f] via-[#0453cb] to-[#3b7ddb] p-5 text-white shadow-sm sm:p-6",
+        // Dégradé bi-marque KLASSCI : bleu (titre, à gauche) -> orange du logo
+        // (à droite). Les deux couleurs de la marque dans le fond du hero.
+        "rounded-2xl bg-[linear-gradient(135deg,#0a3d8f_0%,#0453cb_42%,#2a69cb_56%,#f5821f_92%)] p-5 text-white shadow-sm sm:p-6",
         className,
       )}
     >
@@ -55,7 +57,7 @@ export function PageHero({ icon: Icon, title, subtitle, actions, kpis, className
             return (
               <div
                 key={i}
-                className="rounded-xl border border-white/15 bg-white/10 px-3 py-2.5"
+                className="rounded-xl border border-white/20 bg-white/15 px-3 py-2.5 backdrop-blur-sm"
                 role="group"
                 aria-label={typeof k.value === "string" || typeof k.value === "number" ? `${k.label} : ${k.value}` : k.label}
               >
@@ -94,7 +96,7 @@ export function SectionTitle({
   return (
     <div className={cn("flex items-center gap-2.5", className)}>
       {Icon && (
-        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-primary to-[#3b7ddb] text-white shadow-sm">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
           <Icon className="h-4 w-4" aria-hidden="true" />
         </span>
       )}

--- a/components/shared/PageHero.tsx
+++ b/components/shared/PageHero.tsx
@@ -105,9 +105,10 @@ export function SectionTitle({
   )
 }
 
-/** Bouton ORANGE plein — l'action focale du hero (accent KLASSCI). */
+/** Bouton ORANGE plein — l'action focale du hero. Ring blanc pour rester net
+ * même sur la zone orange du dégradé du hero. */
 export const heroAccentBtn =
-  "inline-flex h-9 items-center justify-center gap-2 rounded-lg bg-accent px-3.5 text-sm font-semibold text-accent-foreground shadow-sm transition-colors hover:bg-accent/90"
+  "inline-flex h-9 items-center justify-center gap-2 rounded-lg bg-accent px-3.5 text-sm font-semibold text-accent-foreground shadow-sm ring-1 ring-white/35 transition-colors hover:bg-accent/90"
 
 /** Bouton blanc plein pour action principale alternative dans le hero (texte bleu). */
 export const heroPrimaryBtn =


### PR DESCRIPTION
Suite au retour « dans les bg je ne vois pas la couleur orange du tout ». L'orange n'apparaissait que sur le bouton.

- Le hero passe d'un dégradé tout-bleu à un dégradé **bleu → orange** (les 2 couleurs du logo) : le titre/les actions restent sur le bleu (haut), l'orange occupe le coin bas-droite. L'orange se voit enfin **dans le fond**.
- Les **icônes de section** passent au dégradé orange → l'orange se diffuse sur chaque sous-section, pas juste le hero.
- Le CTA orange du hero reçoit un liseré blanc pour rester net sur la zone orange.
- Rule `premium-design-system.md` mise à jour.

Vérifié clair + sombre (dashboard, Frais).

🤖 Generated with [Claude Code](https://claude.com/claude-code)