### PR TITLE
feat(ui): extend KLASSCI hero to portal dashboards + remaining admin pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Tableaux de bord enseignant, élève et parent désormais en tête de page sur le bandeau bleu-orange KLASSCI, indicateurs clés intégrés. Pages Promotions, Paramètres, Conseil de classe et Statistiques DREN harmonisées sur le même bandeau *(tous)*.
 - Refonte visuelle de toute l'application : chaque page (tableau de bord, listes d'administration, portails enseignant et parent) s'ouvre désormais sur un bandeau au dégradé **bleu et orange** (les deux couleurs du logo KLASSCI), avec les indicateurs clés intégrés en blanc et l'action principale mise en avant en orange. Les en-têtes de section reprennent l'orange de la marque. Identité cohérente du haut de page jusqu'aux moindres détails, vérifiée en mode clair et sombre *(tous)*.
 - Pages Frais (élève, parent) avec un bandeau de synthèse bleu marque : total attendu, montant payé en vert et « Reste à payer » mis en avant en orange, avec barre de progression. Plus lisible d'un coup d'œil *(élève, parent)*.
 - Page Frais admin refondue : bandeau dégradé bleu, cartes de catégories sobres et lisibles aussi bien en clair qu'en sombre *(admin)*.

--- a/components/admin/promotions/PromotionsClient.tsx
+++ b/components/admin/promotions/PromotionsClient.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react"
 import { ArrowRight, ArrowUpFromLine, Check, RotateCcw, TriangleAlert } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { PageHero, heroGlassBtn } from "@/components/shared/PageHero"
 import {
   Select,
   SelectContent,
@@ -117,25 +118,19 @@ export function PromotionsClient() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <ArrowUpFromLine aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <h1 className="font-serif text-xl tracking-tight sm:text-2xl">Promotions</h1>
-            <p className="text-sm text-muted-foreground">
-              Promotion en masse pour préparer la rentrée
-            </p>
-          </div>
-        </div>
-        {step === "preview" && (
-          <Button variant="outline" onClick={reset} className="h-11 gap-2 sm:h-10">
-            <RotateCcw aria-hidden="true" className="h-4 w-4" />
-            Recommencer
-          </Button>
-        )}
-      </div>
+      <PageHero
+        icon={ArrowUpFromLine}
+        title="Promotions"
+        subtitle="Promotion en masse pour préparer la rentrée"
+        actions={
+          step === "preview" ? (
+            <button type="button" className={heroGlassBtn} onClick={reset}>
+              <RotateCcw aria-hidden="true" className="h-4 w-4" />
+              Recommencer
+            </button>
+          ) : undefined
+        }
+      />
 
       {step === "mapping" && (
         <Card>

--- a/components/admin/reports/council/CouncilPageClient.tsx
+++ b/components/admin/reports/council/CouncilPageClient.tsx
@@ -20,6 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { PageHero } from "@/components/shared/PageHero"
 import { CouncilDeliberationTable } from "./CouncilDeliberationTable"
 import { ReportsNav } from "../ReportsNav"
 import { useCouncilMinutes } from "@/lib/hooks/useCouncil"
@@ -77,17 +78,11 @@ export function CouncilPageClient() {
   return (
     <div className="space-y-6">
       {/* En-tête */}
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-          <Scale aria-hidden="true" className="h-5 w-5 text-primary" />
-        </div>
-        <div>
-          <h1 className="font-serif text-2xl tracking-tight">Conseil de classe</h1>
-          <p className="text-sm text-muted-foreground">
-            Procès-verbaux de délibération — décisions de passage par élève
-          </p>
-        </div>
-      </div>
+      <PageHero
+        icon={Scale}
+        title="Conseil de classe"
+        subtitle="Procès-verbaux de délibération, décisions de passage par élève"
+      />
 
       <ReportsNav current="council" />
 

--- a/components/admin/reports/dren/DrenPageClient.tsx
+++ b/components/admin/reports/dren/DrenPageClient.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback } from "react"
 import { Download, FileSpreadsheet, Loader2, Users, UserCheck, TrendingUp, BarChart3, Building } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -25,6 +24,7 @@ const SuccessRateChart = dynamic(() => import("./SuccessRateChart").then(m => m.
   loading: () => <Skeleton className="h-64 w-full" />,
 })
 import { LevelStatsTable } from "./LevelStatsTable"
+import { PageHero, heroAccentBtn, heroGlassBtn } from "@/components/shared/PageHero"
 import { ReportsNav } from "../ReportsNav"
 import { useDrenStats } from "@/lib/hooks/useDrenStats"
 import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
@@ -58,29 +58,33 @@ export function DrenPageClient() {
   return (
     <div className="space-y-6">
       {/* En-tête */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-            <Building aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="font-serif text-2xl tracking-tight">Statistiques DREN</h1>
-            <p className="text-sm text-muted-foreground">
-              Tableau de bord des indicateurs pour la Direction Régionale
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => handleDownload("excel")} disabled={downloading === "excel"}>
-            {downloading === "excel" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <FileSpreadsheet className="mr-2 h-4 w-4" />}
-            Excel
-          </Button>
-          <Button variant="outline" size="sm" onClick={() => handleDownload("pdf")} disabled={downloading === "pdf"}>
-            {downloading === "pdf" ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Download className="mr-2 h-4 w-4" />}
-            PDF
-          </Button>
-        </div>
-      </div>
+      <PageHero
+        icon={Building}
+        title="Statistiques DREN"
+        subtitle="Tableau de bord des indicateurs pour la Direction Régionale"
+        actions={
+          <>
+            <button
+              type="button"
+              className={`${heroGlassBtn} disabled:cursor-not-allowed disabled:opacity-50`}
+              onClick={() => handleDownload("excel")}
+              disabled={downloading === "excel"}
+            >
+              {downloading === "excel" ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileSpreadsheet className="h-4 w-4" />}
+              Excel
+            </button>
+            <button
+              type="button"
+              className={`${heroAccentBtn} disabled:cursor-not-allowed disabled:opacity-50`}
+              onClick={() => handleDownload("pdf")}
+              disabled={downloading === "pdf"}
+            >
+              {downloading === "pdf" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+              PDF
+            </button>
+          </>
+        }
+      />
 
       <ReportsNav current="dren" />
 

--- a/components/admin/settings/SettingsPageClient.tsx
+++ b/components/admin/settings/SettingsPageClient.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import { ArrowRight, Settings, Shield } from "lucide-react"
+import { PageHero } from "@/components/shared/PageHero"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { DataError } from "@/components/shared/DataError"
@@ -17,17 +18,11 @@ export function SettingsPageClient() {
   return (
     <div className="space-y-6">
       {/* En-tête */}
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-          <Settings aria-hidden="true" className="h-5 w-5 text-primary" />
-        </div>
-        <div>
-          <h1 className="font-serif text-2xl tracking-tight">Paramètres</h1>
-          <p className="text-sm text-muted-foreground">
-            Configuration de l&apos;établissement et des notifications
-          </p>
-        </div>
-      </div>
+      <PageHero
+        icon={Settings}
+        title="Paramètres"
+        subtitle="Configuration de l'établissement et des notifications"
+      />
 
       {/* Contenu */}
       {isLoading ? (

--- a/components/parent/ParentDashboardClient.tsx
+++ b/components/parent/ParentDashboardClient.tsx
@@ -1,14 +1,22 @@
 "use client"
 
 import Link from "next/link"
-import { Users, GraduationCap, Wallet, AlertCircle, ChevronRight } from "lucide-react"
+import {
+  Users,
+  GraduationCap,
+  Wallet,
+  AlertCircle,
+  ChevronRight,
+  UserCheck,
+  Clock,
+} from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
 import { NotEnrolledBanner } from "@/components/shared/NotEnrolledBanner"
 import { useParentDashboard } from "@/lib/hooks/useParentPortal"
@@ -35,7 +43,7 @@ export function ParentDashboardClient() {
   if (isError) {
     return (
       <div className="space-y-6">
-        <DashboardHeader name={null} />
+        <PageHero title="Espace Parent" subtitle="Résumé de vos enfants" />
         <DataError message="Impossible de charger le tableau de bord." onRetry={() => refetch()} />
       </div>
     )
@@ -44,7 +52,7 @@ export function ParentDashboardClient() {
   if (!data) {
     return (
       <div className="space-y-6">
-        <DashboardHeader name={null} />
+        <PageHero title="Espace Parent" subtitle="Résumé de vos enfants" />
         <div className="py-12 text-center text-sm text-muted-foreground">
           Aucune donnée disponible.
         </div>
@@ -54,38 +62,23 @@ export function ParentDashboardClient() {
 
   const enrollment = summarizeEnrollment(data.children)
 
+  // KPIs monochrome dans le hero. Le détail "en attente" garde sa couleur
+  // sémantique (amber) sur les cartes enfants en dessous, pas dans le hero.
+  const heroKpis: HeroKpi[] = [
+    { label: "Mes enfants", value: enrollment.total, icon: Users },
+    { label: "Inscrits", value: enrollment.enrolled, icon: UserCheck },
+    { label: "En attente", value: enrollment.pending, icon: Clock },
+  ]
+
   return (
     <div className="space-y-6">
-      <DashboardHeader name={data.parent_name} />
+      <PageHero
+        title={data.parent_name ? `Bonjour, ${data.parent_name.split(" ")[0]}` : "Espace Parent"}
+        subtitle="Résumé de vos enfants"
+        kpis={heroKpis}
+      />
 
       <AcademicYearBanner currentYear={data.current_academic_year} role="parent" />
-
-      {/* Résumé "Mes enfants" — seul accent primary. Le label compte les
-          enfants suivis, avec un breakdown inscrits / en attente. */}
-      <Card className="border-primary/30 bg-primary/5 shadow-sm">
-        <CardContent className="flex items-center gap-3 p-4">
-          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-            <Users className="h-5 w-5" aria-hidden="true" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="text-xs font-medium uppercase tracking-wider text-primary">Mes enfants</p>
-            <p className="text-2xl font-bold leading-tight tabular-nums">{enrollment.total}</p>
-            {enrollment.total > 0 && (
-              <p className="mt-0.5 text-xs text-muted-foreground">
-                {enrollment.enrolled} inscrit{enrollment.enrolled > 1 ? "s" : ""}
-                {enrollment.pending > 0 && (
-                  <>
-                    {" · "}
-                    <span className="font-medium text-amber-700 dark:text-amber-400">
-                      {enrollment.pending} en attente
-                    </span>
-                  </>
-                )}
-              </p>
-            )}
-          </div>
-        </CardContent>
-      </Card>
 
       {/* Cartes enfants */}
       {data.children.length === 0 ? (
@@ -104,20 +97,6 @@ export function ParentDashboardClient() {
           ))}
         </div>
       )}
-    </div>
-  )
-}
-
-function DashboardHeader({ name }: { name: string | null }) {
-  return (
-    <div className="space-y-4">
-      <div className="space-y-1">
-        <h1 className="font-serif text-2xl tracking-tight">
-          {name ? `Bonjour, ${name.split(" ")[0]}` : "Espace Parent"}
-        </h1>
-        <p className="text-sm text-muted-foreground">Résumé de vos enfants</p>
-      </div>
-      <Separator />
     </div>
   )
 }
@@ -259,11 +238,7 @@ function ChildKpi({
 function DashboardSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Skeleton className="h-7 w-48" />
-        <Skeleton className="h-4 w-32" />
-      </div>
-      <Skeleton className="h-20 rounded-lg" />
+      <Skeleton className="h-40 rounded-2xl" />
       {Array.from({ length: 2 }).map((_, i) => (
         <Skeleton key={i} className="h-44 rounded-lg" />
       ))}

--- a/components/student/StudentDashboardClient.tsx
+++ b/components/student/StudentDashboardClient.tsx
@@ -2,8 +2,8 @@
 
 import { CalendarDays, ClipboardList, Wallet, AlertCircle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
 import { NotEnrolledBanner } from "@/components/shared/NotEnrolledBanner"
 import { useStudentDashboard } from "@/lib/hooks/useStudentPortal"
@@ -17,7 +17,7 @@ export function StudentDashboardClient() {
   if (isError || !data) {
     return (
       <div className="space-y-6">
-        <DashboardHeader title="Espace Élève" subtitle="Votre résumé du jour" />
+        <PageHero title="Espace Élève" subtitle="Votre résumé du jour" />
         <div className="py-12 text-center text-sm text-muted-foreground">
           Impossible de charger le tableau de bord. Veuillez réessayer.
         </div>
@@ -33,11 +33,33 @@ export function StudentDashboardClient() {
     ? `${data.class_name} · Votre résumé du jour`
     : "Votre espace personnel"
 
+  // KPIs monochrome dans le hero. On garde la logique "non inscrit" : on
+  // affiche "—" tant que l'élève n'a pas d'inscription validée, plutôt que des
+  // zéros trompeurs (les couleurs sémantiques restent sur les statuts hors hero).
+  const heroKpis: HeroKpi[] = [
+    {
+      label: "Moyenne",
+      value: data.general_average !== null ? `${data.general_average.toFixed(2)}/20` : "—",
+      icon: ClipboardList,
+    },
+    {
+      label: "Frais restants",
+      value: isEnrolled ? `${data.fees_remaining.toLocaleString("fr-FR")} FCFA` : "—",
+      icon: Wallet,
+    },
+    {
+      label: "Absences",
+      value: isEnrolled ? String(data.total_absences) : "—",
+      icon: AlertCircle,
+    },
+  ]
+
   return (
     <div className="space-y-6">
-      <DashboardHeader
+      <PageHero
         title={`Bonjour, ${data.student_name.split(" ")[0]}`}
         subtitle={subtitle}
+        kpis={heroKpis}
       />
 
       <AcademicYearBanner currentYear={data.current_academic_year} role="student" />
@@ -72,98 +94,15 @@ export function StudentDashboardClient() {
           </div>
         </CardContent>
       </Card>
-
-      {/* KPIs — `—` muted quand non applicable pour éviter le faux signal
-          "0 FCFA vert = tout payé" alors qu'aucun frais n'est encore affecté. */}
-      <div className="grid grid-cols-3 gap-3">
-        <KpiTile
-          icon={ClipboardList}
-          label="Moyenne"
-          value={data.general_average !== null ? `${data.general_average.toFixed(2)}/20` : "—"}
-          valueClassName={
-            data.general_average === null
-              ? "text-muted-foreground"
-              : data.general_average >= 10
-                ? "text-emerald-600 dark:text-emerald-400"
-                : "text-amber-600"
-          }
-        />
-        <KpiTile
-          icon={Wallet}
-          label="Frais restants"
-          value={isEnrolled ? `${data.fees_remaining.toLocaleString("fr-FR")} FCFA` : "—"}
-          valueClassName={
-            !isEnrolled
-              ? "text-muted-foreground"
-              : data.fees_remaining === 0
-                ? "text-emerald-600 dark:text-emerald-400"
-                : "text-accent"
-          }
-        />
-        <KpiTile
-          icon={AlertCircle}
-          label="Absences"
-          value={isEnrolled ? String(data.total_absences) : "—"}
-          valueClassName={
-            !isEnrolled
-              ? "text-muted-foreground"
-              : data.total_absences > 5
-                ? "text-destructive"
-                : "text-foreground"
-          }
-        />
-      </div>
     </div>
-  )
-}
-
-function DashboardHeader({ title, subtitle }: { title: string; subtitle: string }) {
-  return (
-    <div className="space-y-4">
-      <div className="space-y-1">
-        <h1 className="font-serif text-2xl tracking-tight">{title}</h1>
-        <p className="text-sm text-muted-foreground">{subtitle}</p>
-      </div>
-      <Separator />
-    </div>
-  )
-}
-
-function KpiTile({
-  icon: Icon,
-  label,
-  value,
-  valueClassName,
-}: {
-  icon: React.ComponentType<{ className?: string }>
-  label: string
-  value: string
-  valueClassName?: string
-}) {
-  return (
-    <Card className="shadow-sm">
-      <CardContent className="p-3 text-center">
-        <Icon className="mx-auto mb-1 h-5 w-5 text-muted-foreground" aria-hidden="true" />
-        <p className={`text-lg font-bold tabular-nums ${valueClassName ?? ""}`}>{value}</p>
-        <p className="text-[10px] text-muted-foreground">{label}</p>
-      </CardContent>
-    </Card>
   )
 }
 
 function DashboardSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Skeleton className="h-7 w-48" />
-        <Skeleton className="h-4 w-64" />
-      </div>
+      <Skeleton className="h-44 rounded-2xl" />
       <Skeleton className="h-20 rounded-xl" />
-      <div className="grid grid-cols-3 gap-3">
-        <Skeleton className="h-24 rounded-lg" />
-        <Skeleton className="h-24 rounded-lg" />
-        <Skeleton className="h-24 rounded-lg" />
-      </div>
     </div>
   )
 }

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -12,11 +12,10 @@ import {
 } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
-import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
+import { PageHero, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
 import { useTeacherDashboard } from "@/lib/hooks/useTeacherPortal"
 import type { TeacherUpcomingEval } from "@/lib/contracts/teacher-portal"
@@ -31,7 +30,7 @@ export function TeacherDashboardClient() {
   if (isError) {
     return (
       <div className="space-y-6">
-        <DashboardHeader name={null} />
+        <PageHero title="Espace Enseignant" subtitle="Votre journée en un coup d'œil" />
         <DataError
           message="Impossible de charger le tableau de bord."
           onRetry={() => refetch()}
@@ -43,7 +42,7 @@ export function TeacherDashboardClient() {
   if (!data) {
     return (
       <div className="space-y-6">
-        <DashboardHeader name={null} />
+        <PageHero title="Espace Enseignant" subtitle="Votre journée en un coup d'œil" />
         <div className="py-12 text-center text-sm text-muted-foreground">
           Aucune donnée disponible.
         </div>
@@ -51,19 +50,28 @@ export function TeacherDashboardClient() {
     )
   }
 
+  const heroKpis: HeroKpi[] = [
+    { label: "Élèves", value: data.total_students, icon: Users },
+    { label: "Classes", value: data.total_classes, icon: BookOpen },
+  ]
+
   return (
     <div className="space-y-6">
-      <DashboardHeader name={data.teacher_name}>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setSelfDeclareOpen(true)}
-          className="h-11 sm:h-9"
-        >
-          <CalendarX className="mr-1.5 h-4 w-4" aria-hidden="true" />
-          Me déclarer absent
-        </Button>
-      </DashboardHeader>
+      <PageHero
+        title={data.teacher_name ? `Bonjour, ${data.teacher_name.split(" ")[0]}` : "Espace Enseignant"}
+        subtitle="Votre journée en un coup d'œil"
+        actions={
+          <button
+            type="button"
+            onClick={() => setSelfDeclareOpen(true)}
+            className={heroGlassBtn}
+          >
+            <CalendarX className="h-4 w-4" aria-hidden="true" />
+            Me déclarer absent
+          </button>
+        }
+        kpis={heroKpis}
+      />
 
       <AcademicYearBanner currentYear={data.current_academic_year} role="teacher" />
 
@@ -94,19 +102,23 @@ export function TeacherDashboardClient() {
         </CardContent>
       </Card>
 
-      {/* KPIs — Card neutres shadcn */}
-      <div className="grid grid-cols-2 gap-3">
-        <StatCard icon={Users} value={data.total_students} label="Élèves" />
-        <Link href="/teacher/classes" className="group">
-          <StatCard
-            icon={BookOpen}
-            value={data.total_classes}
-            label="Classes"
-            className="transition-colors group-hover:border-primary/40"
-            trailing={<ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />}
-          />
-        </Link>
-      </div>
+      {/* Accès rapide — mes classes */}
+      <Link href="/teacher/classes" className="group block">
+        <Card className="shadow-sm transition-colors group-hover:border-primary/40">
+          <CardContent className="flex items-center gap-3 p-4">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+              <BookOpen className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold">Mes classes</p>
+              <p className="text-xs text-muted-foreground">
+                {data.total_classes} classe{data.total_classes > 1 ? "s" : ""}
+              </p>
+            </div>
+            <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          </CardContent>
+        </Card>
+      </Link>
 
       {/* Évaluations à venir */}
       <section className="space-y-3">
@@ -135,58 +147,6 @@ export function TeacherDashboardClient() {
         onClose={() => setSelfDeclareOpen(false)}
       />
     </div>
-  )
-}
-
-function DashboardHeader({
-  name,
-  children,
-}: {
-  name: string | null
-  children?: React.ReactNode
-}) {
-  return (
-    <div className="space-y-4">
-      <div className="flex items-start justify-between gap-3">
-        <div className="space-y-1">
-          <h1 className="font-serif text-2xl tracking-tight">
-            {name ? `Bonjour, ${name.split(" ")[0]}` : "Espace Enseignant"}
-          </h1>
-          <p className="text-sm text-muted-foreground">Votre journée en un coup d&apos;œil</p>
-        </div>
-        {children}
-      </div>
-      <Separator />
-    </div>
-  )
-}
-
-function StatCard({
-  icon: Icon,
-  value,
-  label,
-  className,
-  trailing,
-}: {
-  icon: React.ComponentType<{ className?: string }>
-  value: React.ReactNode
-  label: string
-  className?: string
-  trailing?: React.ReactNode
-}) {
-  return (
-    <Card className={`shadow-sm ${className ?? ""}`}>
-      <CardContent className="flex items-center gap-3 p-4">
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-          <Icon className="h-5 w-5" aria-hidden="true" />
-        </span>
-        <div className="flex-1">
-          <p className="text-2xl font-bold tabular-nums">{value}</p>
-          <p className="text-xs text-muted-foreground">{label}</p>
-        </div>
-        {trailing}
-      </CardContent>
-    </Card>
   )
 }
 
@@ -234,15 +194,9 @@ function EvaluationCard({ evaluation }: { evaluation: TeacherUpcomingEval }) {
 function DashboardSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Skeleton className="h-7 w-48" />
-        <Skeleton className="h-4 w-64" />
-      </div>
+      <Skeleton className="h-40 rounded-2xl" />
       <Skeleton className="h-20 rounded-xl" />
-      <div className="grid grid-cols-2 gap-3">
-        <Skeleton className="h-20 rounded-lg" />
-        <Skeleton className="h-20 rounded-lg" />
-      </div>
+      <Skeleton className="h-20 rounded-lg" />
       <div className="space-y-2">
         <Skeleton className="h-4 w-36" />
         <Skeleton className="h-16 rounded-lg" />


### PR DESCRIPTION
Propagation finale du hero bleu-orange : tableaux de bord enseignant / élève / parent (avec KPIs intégrés, logique non-inscrit préservée) + Promotions, Paramètres, Conseil de classe, Statistiques DREN. Les pages de détail/formulaire gardent leur en-tête standard (conforme à la rule). tsc + build OK, vérifié clair/sombre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)