### PR TITLE
feat(ui): align fees summary panel to blue-orange + Academic Years KPIs in hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Bandeau de synthèse des Frais (élève, parent) repassé au dégradé bleu-orange de la marque, et indicateurs de la page Années scolaires intégrés au bandeau d'en-tête *(tous)*.
 - Tableaux de bord enseignant, élève et parent désormais en tête de page sur le bandeau bleu-orange KLASSCI, indicateurs clés intégrés. Pages Promotions, Paramètres, Conseil de classe et Statistiques DREN harmonisées sur le même bandeau *(tous)*.
 - Refonte visuelle de toute l'application : chaque page (tableau de bord, listes d'administration, portails enseignant et parent) s'ouvre désormais sur un bandeau au dégradé **bleu et orange** (les deux couleurs du logo KLASSCI), avec les indicateurs clés intégrés en blanc et l'action principale mise en avant en orange. Les en-têtes de section reprennent l'orange de la marque. Identité cohérente du haut de page jusqu'aux moindres détails, vérifiée en mode clair et sombre *(tous)*.
 - Pages Frais (élève, parent) avec un bandeau de synthèse bleu marque : total attendu, montant payé en vert et « Reste à payer » mis en avant en orange, avec barre de progression. Plus lisible d'un coup d'œil *(élève, parent)*.

--- a/components/admin/academic-years/AcademicYearsPageClient.tsx
+++ b/components/admin/academic-years/AcademicYearsPageClient.tsx
@@ -1,17 +1,34 @@
 "use client"
 
-import { Calendar } from "lucide-react"
+import { Calendar, CalendarRange, CalendarCheck, History, CalendarClock } from "lucide-react"
 import { CrudPageLayout } from "@/components/shared/CrudPageLayout"
+import { type HeroKpi } from "@/components/shared/PageHero"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { AcademicYearsTable } from "./AcademicYearsTable"
 import { AcademicYearCreateModal } from "./AcademicYearCreateModal"
 
 export function AcademicYearsPageClient() {
+  const { data } = useAcademicYears({ size: 100 })
+  const items = data?.items ?? []
+  const now = Date.now()
+  const current = items.find((y) => y.is_current)
+  const past = items.filter((y) => !y.is_current && new Date(y.end_date).getTime() < now).length
+  const upcoming = items.filter((y) => !y.is_current && new Date(y.start_date).getTime() > now).length
+
+  const kpis: HeroKpi[] = [
+    { label: "Années", value: items.length, icon: CalendarRange },
+    { label: "Année courante", value: current?.name ?? "—", icon: CalendarCheck },
+    { label: "Passées", value: past, icon: History },
+    { label: "À venir", value: upcoming, icon: CalendarClock },
+  ]
+
   return (
     <CrudPageLayout
       title="Annees academiques"
       subtitle="Gestion des annees scolaires et definition de l'annee courante"
       createLabel="Nouvelle annee"
       icon={Calendar}
+      kpis={kpis}
       table={<AcademicYearsTable />}
       createModal={(props) => <AcademicYearCreateModal {...props} />}
     />

--- a/components/admin/academic-years/AcademicYearsTable.tsx
+++ b/components/admin/academic-years/AcademicYearsTable.tsx
@@ -2,12 +2,11 @@
 
 import { useMemo, useState } from "react"
 import type { ColumnDef } from "@tanstack/react-table"
-import { CheckCircle2, Circle, CalendarRange, CalendarCheck, History, CalendarClock } from "lucide-react"
+import { CheckCircle2, Circle } from "lucide-react"
 import { useAcademicYears, useDeleteAcademicYear, useSetCurrentYear } from "@/lib/hooks/useAcademicYears"
 import type { AcademicYear } from "@/lib/contracts/academic-year"
 import type { PaginatedResponse } from "@/lib/contracts"
 import { CrudTable, type FilterConfig } from "@/components/shared/CrudTable"
-import { KpiStrip, type KpiItem } from "@/components/shared/list/KpiStrip"
 import { AcademicYearEditModal } from "./AcademicYearEditModal"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -34,18 +33,6 @@ export function AcademicYearsTable() {
 
   const allItems = useMemo(() => data?.items ?? [], [data])
   const now = Date.now()
-
-  const kpis: KpiItem[] = useMemo(() => {
-    const current = allItems.find((y) => y.is_current)
-    const past = allItems.filter((y) => !y.is_current && new Date(y.end_date).getTime() < now).length
-    const upcoming = allItems.filter((y) => !y.is_current && new Date(y.start_date).getTime() > now).length
-    return [
-      { label: "Années", value: allItems.length, icon: CalendarRange, tone: "primary" },
-      { label: "Année courante", value: current?.name ?? "—", icon: CalendarCheck, tone: current ? "emerald" : "default" },
-      { label: "Passées", value: past, icon: History, tone: "default" },
-      { label: "À venir", value: upcoming, icon: CalendarClock, tone: "default" },
-    ]
-  }, [allItems, now])
 
   const filtered = useMemo(() => {
     return allItems.filter((y) => {
@@ -126,7 +113,6 @@ export function AcademicYearsTable() {
 
   return (
     <div className="space-y-4">
-      <KpiStrip items={kpis} />
       <CrudTable<AcademicYear>
         data={tableData}
         columns={columns}

--- a/components/shared/fees/FeeSummaryHero.tsx
+++ b/components/shared/fees/FeeSummaryHero.tsx
@@ -31,7 +31,7 @@ export function FeeSummaryHero({
     <section
       aria-label="Résumé des frais"
       className={cn(
-        "rounded-2xl bg-primary p-5 text-primary-foreground shadow-sm sm:p-6",
+        "rounded-2xl bg-[linear-gradient(135deg,#0a3d8f_0%,#0453cb_42%,#2a69cb_56%,#f5821f_92%)] p-5 text-primary-foreground shadow-sm sm:p-6",
         className,
       )}
     >
@@ -79,8 +79,8 @@ export function FeeSummaryHero({
               !hasExpected
                 ? "text-primary-foreground/80"
                 : settled
-                  ? "text-emerald-300"
-                  : "text-accent",
+                  ? "text-emerald-200"
+                  : "text-white",
             )}
           >
             {hasExpected ? fmt(totalRemaining) : "—"}


### PR DESCRIPTION
Les deux finitions : le bandeau de synthèse des Frais (élève/parent) passe au dégradé bleu-orange (reste à payer sur la zone orange, en blanc) ; les indicateurs de la page Années scolaires sont remontés dans le bandeau d'en-tête. tsc + build OK, vérifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)