### PR TITLE
fix(auth): inactivity-based session + portal-aware dictee mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- La session ne se ferme plus pendant l'utilisation : tant que vous êtes actif, elle reste ouverte et se prolonge automatiquement. Elle n'expire désormais qu'après une période d'inactivité (mode veille), pas après un délai fixe *(tous)*.
+- Mode dictée des notes : le bouton « Mode dictée » de la saisie déléguée admin renvoyait vers le tableau de bord au lieu d'ouvrir la dictée. Il ouvre désormais la saisie vocale et revient à la bonne page en sortie *(admin, enseignant)*.
 - Page Frais de l'élève et du parent : la liste restait en chargement infini puis en erreur pour un élève inscrit. Les montants, le total payé, le reste à payer et le statut de chaque frais s'affichent désormais correctement *(élève, parent)*.
 
 ### Added

--- a/app/(admin)/admin/grades/[evaluationId]/dictee/page.tsx
+++ b/app/(admin)/admin/grades/[evaluationId]/dictee/page.tsx
@@ -1,0 +1,33 @@
+import { DicteeMode } from "@/components/teacher/grades/DicteeMode"
+
+interface AdminDicteePageProps {
+  params: Promise<{ evaluationId: string }>
+  searchParams: Promise<{ classId?: string }>
+}
+
+export const metadata = { title: "Mode dictée — KLASSCI" }
+
+/**
+ * Mode dictée en saisie déléguée (admin). Réutilise le composant DicteeMode du
+ * portail enseignant, mais revient vers la supervision admin à la sortie —
+ * rester dans le portail /admin évite la redirection middleware vers le
+ * tableau de bord (un admin ne peut pas atterrir sur /teacher/*).
+ *
+ * classId vient en query param depuis la page de saisie admin pour charger les
+ * métadonnées de l'évaluation (nom, matière) via le cache TanStack Query.
+ */
+export default async function AdminDicteePage({
+  params,
+  searchParams,
+}: AdminDicteePageProps) {
+  const { evaluationId } = await params
+  const { classId } = await searchParams
+
+  return (
+    <DicteeMode
+      classId={classId ? Number(classId) : 0}
+      evaluationId={Number(evaluationId)}
+      returnHref={`/admin/grades/${evaluationId}${classId ? `?classId=${classId}` : ""}`}
+    />
+  )
+}

--- a/app/(admin)/admin/grades/[evaluationId]/page.tsx
+++ b/app/(admin)/admin/grades/[evaluationId]/page.tsx
@@ -55,6 +55,11 @@ export default async function AdminGradeEntryPage({
       <GradeEntryGrid
         evaluationId={Number(evaluationId)}
         classId={classId ? Number(classId) : undefined}
+        dicteeHref={
+          classId
+            ? `/admin/grades/${evaluationId}/dictee?classId=${classId}`
+            : undefined
+        }
       />
     </div>
   )

--- a/auth.ts
+++ b/auth.ts
@@ -1,7 +1,24 @@
 import NextAuth from "next-auth"
 import Credentials from "next-auth/providers/credentials"
 import { authApi } from "@/lib/api/auth"
-import { isTokenExpired } from "@/lib/utils/jwt"
+import { getTokenTenant, isTokenExpired } from "@/lib/utils/jwt"
+
+/**
+ * Fenêtre d'inactivité avant expiration de la session (mode veille). La
+ * session NextAuth est glissante : tant que l'utilisateur est actif, elle se
+ * prolonge ; après IDLE_TIMEOUT sans interaction, le cookie expire et la
+ * déconnexion est forcée. Voir SessionKeepAlive pour le déclencheur côté
+ * client (déconnexion proactive + maintien de l'access token frais).
+ */
+const IDLE_TIMEOUT_SECONDS = 30 * 60 // 30 minutes
+/** Re-rotation du cookie de session au plus une fois par cette fenêtre. */
+const SESSION_UPDATE_SECONDS = 5 * 60 // 5 minutes
+/**
+ * Marge avant l'expiration de l'access token BE (15 min) à partir de laquelle
+ * on déclenche un refresh. 5 min : large devant l'intervalle de poll client
+ * (2 min) pour qu'aucune requête ne parte avec un token déjà expiré.
+ */
+const ACCESS_TOKEN_REFRESH_MARGIN_SECONDS = 5 * 60
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   pages: {
@@ -34,6 +51,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             email: data.user.email,
             role: data.user.role,
             accessToken: data.access_token,
+            refreshToken: data.refreshToken ?? undefined,
           }
         } catch {
           return null
@@ -49,17 +67,41 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         token.email = user.email!
         token.role = user.role
         token.accessToken = user.accessToken
+        token.refreshToken = user.refreshToken
+        token.error = undefined
         return token
       }
 
-      // Return token if access token is still valid
-      if (!isTokenExpired(token.accessToken)) {
+      // Access token encore valide (hors marge de refresh) → on garde.
+      if (
+        token.accessToken &&
+        !isTokenExpired(token.accessToken, ACCESS_TOKEN_REFRESH_MARGIN_SECONDS)
+      ) {
         return token
       }
 
-      // Access token expired — refresh is handled by httpOnly cookie on the backend
-      // The frontend cannot read the refresh token (httpOnly).
-      // For now, force re-login when access token expires.
+      // Access token proche de l'expiration → refresh silencieux via le
+      // refresh token BE (rotation). Tant que l'utilisateur reste actif, le
+      // SessionKeepAlive déclenche ce callback assez tôt pour qu'aucune
+      // requête ne parte avec un token périmé.
+      if (token.refreshToken) {
+        try {
+          const refreshed = await authApi.refresh(
+            token.refreshToken,
+            getTokenTenant(token.accessToken) ?? undefined,
+          )
+          token.accessToken = refreshed.access_token
+          if (refreshed.refreshToken) token.refreshToken = refreshed.refreshToken
+          token.error = undefined
+          return token
+        } catch {
+          // Refresh token révoqué/expiré (inactivité prolongée) → re-login.
+          token.error = "RefreshTokenError"
+          return token
+        }
+      }
+
+      // Pas de refresh token (sessions d'avant cette feature) → re-login.
       token.error = "RefreshTokenError"
       return token
     },
@@ -88,5 +130,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   },
   session: {
     strategy: "jwt",
+    // Session glissante : expire IDLE_TIMEOUT après la DERNIÈRE activité
+    // (chaque lecture de session pendant que l'utilisateur est actif reporte
+    // l'échéance). C'est le comportement « mode veille » : actif → maintenue,
+    // inactif au-delà de la fenêtre → déconnexion.
+    maxAge: IDLE_TIMEOUT_SECONDS,
+    updateAge: SESSION_UPDATE_SECONDS,
   },
 })

--- a/components/shared/Providers.tsx
+++ b/components/shared/Providers.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { SessionProvider } from "next-auth/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ThemeProvider } from "next-themes"
+import { SessionKeepAlive } from "./SessionKeepAlive"
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -19,7 +20,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
   )
 
   return (
-    <SessionProvider>
+    // refetchOnWindowFocus : revenir sur l'onglet re-lit la session (et
+    // rafraîchit l'access token si besoin). Le refresh périodique et la
+    // déconnexion sur inactivité sont pilotés par SessionKeepAlive.
+    <SessionProvider refetchOnWindowFocus>
+      <SessionKeepAlive />
       <QueryClientProvider client={queryClient}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           {children}

--- a/components/shared/SessionKeepAlive.tsx
+++ b/components/shared/SessionKeepAlive.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { signOut, useSession } from "next-auth/react"
+
+/**
+ * Gestionnaire d'inactivité (« mode veille ») de la session.
+ *
+ * Tant que l'utilisateur interagit (souris, clavier, tactile, scroll), on
+ * rafraîchit périodiquement la session : le callback jwt de NextAuth rotate
+ * alors l'access token BE (15 min) avant qu'il n'expire et reporte l'échéance
+ * du cookie de session. Résultat : la session NE expire PAS pendant qu'on
+ * utilise l'app.
+ *
+ * Après IDLE_TIMEOUT sans aucune interaction, on déconnecte proprement et on
+ * renvoie vers /login?expired=1. L'inactivité se compte à partir de la
+ * dernière interaction réelle, pas du temps total de connexion.
+ *
+ * Monté une seule fois (dans Providers) : inactif tant que l'utilisateur n'est
+ * pas authentifié, donc sans effet sur les pages publiques (login).
+ */
+
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000 // 30 min sans interaction → déconnexion
+const POLL_INTERVAL_MS = 2 * 60 * 1000 // vérifie / rafraîchit toutes les 2 min
+const ACTIVITY_EVENTS = [
+  "mousedown",
+  "keydown",
+  "touchstart",
+  "scroll",
+  "pointerdown",
+] as const
+
+export function SessionKeepAlive() {
+  const { status, update } = useSession()
+  const lastActivityRef = useRef(Date.now())
+
+  // Enregistre la dernière interaction utilisateur (ignore les onglets cachés
+  // pour que l'inactivité se mesure sur une présence réelle).
+  useEffect(() => {
+    const bump = () => {
+      if (typeof document !== "undefined" && document.visibilityState === "hidden") return
+      lastActivityRef.current = Date.now()
+    }
+    ACTIVITY_EVENTS.forEach((evt) =>
+      window.addEventListener(evt, bump, { passive: true }),
+    )
+    return () =>
+      ACTIVITY_EVENTS.forEach((evt) => window.removeEventListener(evt, bump))
+  }, [])
+
+  useEffect(() => {
+    if (status !== "authenticated") return
+
+    const tick = () => {
+      const idleMs = Date.now() - lastActivityRef.current
+      if (idleMs >= IDLE_TIMEOUT_MS) {
+        // Inactivité prolongée → déconnexion propre (mode veille). Full reload
+        // pour vider les caches client (TanStack Query / Zustand).
+        void signOut({ redirect: false }).finally(() => {
+          window.location.href = "/login?expired=1"
+        })
+        return
+      }
+      // Actif récemment → re-lit la session, ce qui déclenche le callback jwt
+      // (refresh de l'access token si proche de l'expiration) et reporte
+      // l'échéance du cookie.
+      void update()
+    }
+
+    const id = setInterval(tick, POLL_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [status, update])
+
+  return null
+}

--- a/components/teacher/grades/DicteeMode.tsx
+++ b/components/teacher/grades/DicteeMode.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
+import type { Route } from "next"
 import {
   Mic,
   MicOff,
@@ -35,6 +36,13 @@ type EntryValue = number | null | undefined // undefined = pas saisi, null = abs
 interface DicteeModeProps {
   evaluationId: number
   classId: number
+  /**
+   * Page vers laquelle revenir à la sortie/l'enregistrement. Par défaut la
+   * saisie enseignant. L'admin (saisie déléguée) passe sa propre page de
+   * supervision : sans ça, revenir vers `/teacher/...` ferait traverser les
+   * portails et le middleware redirigerait l'admin vers son tableau de bord.
+   */
+  returnHref?: string
 }
 
 /**
@@ -54,8 +62,9 @@ interface DicteeModeProps {
  *   - beep audio sur succès (feedback non-visuel pour saisie sans regarder)
  *   - fallback total au tap : tout est utilisable sans micro
  */
-export function DicteeMode({ evaluationId, classId }: DicteeModeProps) {
+export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProps) {
   const router = useRouter()
+  const backHref = returnHref ?? `/teacher/grades/${classId}/${evaluationId}`
   const { data: grades, isLoading } = useGrades(evaluationId)
   const { data: evals } = useEvaluations(classId)
   const evaluation = useMemo(
@@ -241,8 +250,8 @@ export function DicteeMode({ evaluationId, classId }: DicteeModeProps) {
 
   const performExit = useCallback(() => {
     speech.stop()
-    router.push(`/teacher/grades/${classId}/${evaluationId}`)
-  }, [speech, router, classId, evaluationId])
+    router.push(backHref as Route)
+  }, [speech, router, backHref])
 
   const requestExit = useCallback(() => {
     if (hasDirty) {
@@ -269,11 +278,11 @@ export function DicteeMode({ evaluationId, classId }: DicteeModeProps) {
             description: `${payload.filter((p) => p.value !== null).length} notes sur ${grades.length}`,
           })
           speech.stop()
-          router.push(`/teacher/grades/${classId}/${evaluationId}`)
+          router.push(backHref as Route)
         },
       },
     )
-  }, [grades, entries, updateMutation, speech, router, classId, evaluationId])
+  }, [grades, entries, updateMutation, speech, router, backHref])
 
   // ─── Rendu ─────────────────────────────────────────────────────────────
   if (isLoading || !grades) {

--- a/components/teacher/grades/GradeEntryGrid.tsx
+++ b/components/teacher/grades/GradeEntryGrid.tsx
@@ -27,6 +27,14 @@ interface GradeEntryGridProps {
   evaluationId: number
   /** Si fourni, affiche le hero card avec ces métadonnées */
   classId?: number
+  /**
+   * Lien du bouton « Mode dictée ». Dépend du portail : enseignant
+   * (`/teacher/...`) ou admin en saisie déléguée (`/admin/...`). À défaut, on
+   * tombe sur la route enseignant. Indispensable côté admin, sinon le bouton
+   * pointerait vers `/teacher/...` et le middleware redirigerait l'admin vers
+   * son tableau de bord (changement de portail interdit).
+   */
+  dicteeHref?: string
 }
 
 /**
@@ -40,7 +48,7 @@ const SAVE_DEBOUNCE_MS = 1500
  */
 const SAVED_INDICATOR_MS = 2500
 
-export function GradeEntryGrid({ evaluationId, classId }: GradeEntryGridProps) {
+export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntryGridProps) {
   const { data: grades, isLoading, error } = useGrades(evaluationId)
   // Métadonnées de l'éval — fetch la liste de la classe (cache 5 min)
   const { data: evals } = useEvaluations(classId ?? 0)
@@ -216,7 +224,8 @@ export function GradeEntryGrid({ evaluationId, classId }: GradeEntryGridProps) {
               <Button asChild size="sm" className="shrink-0 gap-2">
                 <Link
                   href={
-                    `/teacher/grades/${classId}/${evaluationId}/dictee` as Route
+                    (dicteeHref ??
+                      `/teacher/grades/${classId}/${evaluationId}/dictee`) as Route
                   }
                 >
                   <Mic className="h-4 w-4" />

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -21,6 +21,31 @@ function getBaseUrl(): string {
 
 export type { LoginResponse, RefreshResponse }
 
+/** Login/refresh enrichis du refresh token capté depuis le cookie BE. */
+export type LoginResult = LoginResponse & { refreshToken: string | null }
+export type RefreshResult = RefreshResponse & { refreshToken: string | null }
+
+/**
+ * Extrait la valeur du cookie `refresh_token` depuis les en-têtes Set-Cookie
+ * de la réponse BE. Ces appels tournent côté serveur (NextAuth authorize() et
+ * callback jwt, en Node) : le cookie httpOnly posé par le BE n'atteint jamais
+ * le navigateur, on le récupère donc ici pour le persister dans le JWT
+ * NextAuth chiffré et permettre le refresh silencieux.
+ */
+function extractRefreshToken(headers: Headers): string | null {
+  const raw =
+    typeof headers.getSetCookie === "function"
+      ? headers.getSetCookie()
+      : headers.get("set-cookie")
+        ? [headers.get("set-cookie") as string]
+        : []
+  for (const cookie of raw) {
+    const match = cookie.match(/(?:^|;\s*)refresh_token=([^;]+)/)
+    if (match) return decodeURIComponent(match[1])
+  }
+  return null
+}
+
 export const authApi = {
   /**
    * Authenticate against the BE.
@@ -35,7 +60,7 @@ export const authApi = {
     email: string,
     password: string,
     tenantSlug?: string,
-  ): Promise<LoginResponse> => {
+  ): Promise<LoginResult> => {
     const headers: Record<string, string> = { "Content-Type": "application/json" }
     if (tenantSlug) headers["X-Tenant-Slug"] = tenantSlug
 
@@ -49,20 +74,44 @@ export const authApi = {
       throw new Error(error.detail || "Identifiants invalides")
     }
     const data = await res.json()
-    return safeValidate(LoginResponseSchema, data, "/auth/login")
+    const validated = safeValidate(LoginResponseSchema, data, "/auth/login")
+    return { ...validated, refreshToken: extractRefreshToken(res.headers) }
   },
 
-  refresh: async (refreshToken: string): Promise<RefreshResponse> => {
+  /**
+   * Échange le refresh token contre un nouvel access token (rotation BE).
+   *
+   * Le BE lit le refresh token depuis le cookie `refresh_token`, on l'envoie
+   * donc via l'en-tête `Cookie`. `tenantSlug` (= le claim tenant_id du token,
+   * identique au slug) est forwardé en `X-Tenant-Slug` : sans Bearer, c'est
+   * ce header que le TenantMiddleware utilise pour scoper la bonne DB, sinon
+   * le refresh tombe sur le tenant local et `auth_service.refresh` rejette le
+   * mismatch tenant. Le BE pose un refresh token rotaté en Set-Cookie qu'on
+   * récupère pour le prochain cycle.
+   */
+  refresh: async (
+    refreshToken: string,
+    tenantSlug?: string,
+  ): Promise<RefreshResult> => {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Cookie: `refresh_token=${refreshToken}`,
+    }
+    if (tenantSlug) headers["X-Tenant-Slug"] = tenantSlug
+
     const res = await fetch(`${getBaseUrl()}/auth/refresh`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refresh_token: refreshToken }),
+      headers,
     })
     if (!res.ok) {
       throw new Error("Refresh token expired")
     }
     const data = await res.json()
-    return safeValidate(RefreshResponseSchema, data, "/auth/refresh")
+    const validated = safeValidate(RefreshResponseSchema, data, "/auth/refresh")
+    return {
+      ...validated,
+      refreshToken: extractRefreshToken(res.headers) ?? refreshToken,
+    }
   },
 
   myPermissions: async (): Promise<string[]> => {

--- a/lib/utils/jwt.ts
+++ b/lib/utils/jwt.ts
@@ -2,6 +2,7 @@ interface JwtPayload {
   exp?: number
   sub?: string
   role?: string
+  tenant_id?: string
   [key: string]: unknown
 }
 
@@ -20,5 +21,18 @@ export function isTokenExpired(token: string, bufferSeconds = 60): boolean {
     return Date.now() >= (exp - bufferSeconds) * 1000
   } catch {
     return true
+  }
+}
+
+/**
+ * Lit le claim `tenant_id` d'un JWT BE. Le slug tenant EST le tenant_id dans
+ * KLASSCI (le middleware le pose depuis X-Tenant-Slug au login), donc cette
+ * valeur sert à rescopée le refresh côté BE. Retourne null si illisible.
+ */
+export function getTokenTenant(token: string): string | null {
+  try {
+    return decodeJwtPayload(token).tenant_id ?? null
+  } catch {
+    return null
   }
 }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -9,6 +9,13 @@ declare module "next-auth" {
     email: string
     role: UserRole
     accessToken: string
+    /**
+     * Refresh token BE, capté côté serveur depuis le cookie httpOnly posé par
+     * /auth/login. Stocké uniquement dans le JWT NextAuth chiffré (jamais
+     * exposé au navigateur via la session) pour permettre le rafraîchissement
+     * silencieux de l'access token.
+     */
+    refreshToken?: string
   }
 
   interface Session {
@@ -28,6 +35,8 @@ declare module "next-auth/jwt" {
     email: string
     role: UserRole
     accessToken: string
+    /** Refresh token BE — server-side only, jamais propagé à la session client. */
+    refreshToken?: string
     error?: string
   }
 }


### PR DESCRIPTION
Closes #232

## 1. La session expire même en cours d'utilisation
Le token d'accès BE (15 min) était invalidé au bout de 15 min quoi qu'il arrive : le callback `jwt` posait `RefreshTokenError` sans jamais rafraîchir. On était déconnecté en pleine saisie.

**Fix** — refresh silencieux + session glissante (mode veille) :
- Le refresh token BE (cookie httpOnly posé sur `/auth/login`, capté côté serveur Node) est stocké dans le **JWT NextAuth chiffré** (jamais exposé au navigateur).
- Le callback `jwt` rotate l'access token via `/auth/refresh` à l'approche de l'expiration (marge 5 min). Slug tenant dérivé du token → `X-Tenant-Slug` (multi-tenant safe).
- Session NextAuth glissante : `maxAge` = 30 min d'**inactivité**, `updateAge` 5 min. `SessionKeepAlive` maintient le token frais tant qu'on interagit et déconnecte proprement après 30 min sans interaction.
- Zéro changement backend (`/auth/refresh` + rotation Redis existaient déjà).

Conforme à [Auth.js — Refresh Token Rotation](https://authjs.dev/guides/refresh-token-rotation).

## 2. Mode dictée renvoyait au tableau de bord
En saisie déléguée admin, le bouton « Mode dictée » pointait en dur vers `/teacher/...` → middleware bounce vers `/admin/dashboard`.

**Fix** : `GradeEntryGrid` accepte `dicteeHref` (la page admin passe `/admin/grades/[id]/dictee?classId=...`), nouvelle route dictée admin, `DicteeMode` accepte `returnHref` pour revenir à la bonne page de supervision.

## Tests
- `tsc --noEmit` ✅ · `eslint` ✅
- Validation E2E (session + dictée admin/enseignant) sur le serveur déployé après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)