### PR TITLE
feat(documents): public document verification page (/verifier)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Added
+
+- Page publique de vérification d'un document scolaire : en scannant le cachet électronique (CEV) d'un certificat, d'une attestation ou d'un bulletin, ou en saisissant son code, n'importe qui confirme en un instant l'authenticité du document (établissement, type, élève, classe, année, date), sans aucun compte *(tous)*.
+
 ### Changed
 
 - Bandeau de synthèse des Frais (élève, parent) repassé au dégradé bleu-orange de la marque, et indicateurs de la page Années scolaires intégrés au bandeau d'en-tête *(tous)*.

--- a/app/verifier/[tenant]/[token]/loading.tsx
+++ b/app/verifier/[tenant]/[token]/loading.tsx
@@ -1,0 +1,24 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+// Affiché pendant que la vérification serveur se résout (streaming SSR).
+export default function VerifierLoading() {
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="space-y-3 bg-muted/40 p-6">
+        <Skeleton className="mx-auto h-12 w-12 rounded-full" />
+        <Skeleton className="mx-auto h-5 w-48" />
+        <Skeleton className="mx-auto h-4 w-32" />
+      </CardHeader>
+      <CardContent className="space-y-4 p-6">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between gap-4">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+        ))}
+        <Skeleton className="h-16 w-full rounded-lg" />
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/verifier/[tenant]/[token]/page.tsx
+++ b/app/verifier/[tenant]/[token]/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from "next"
+import { AlertTriangle, BadgeCheck, CalendarDays, GraduationCap, Hash, School, ShieldAlert, User } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { verifyDocument, type VerifiedDocument } from "@/lib/api/verify"
+
+// Jamais indexé : un document de vérification nominatif ne doit pas remonter
+// dans les moteurs de recherche.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+function formatIssuedAt(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(date)
+}
+
+function DetailRow({
+  icon: Icon,
+  label,
+  value,
+  mono,
+}: {
+  icon: typeof User
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 border-b border-border/60 py-3 last:border-0">
+      <span className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground/70" aria-hidden="true" />
+        {label}
+      </span>
+      <span
+        className={
+          mono
+            ? "text-right font-mono text-sm font-medium tracking-tight text-foreground"
+            : "text-right text-sm font-medium text-foreground"
+        }
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function AuthenticView({ doc }: { doc: VerifiedDocument }) {
+  return (
+    <Card className="overflow-hidden">
+      {/* Sceau de validité — vert réservé à l'authenticité, l'identité reste bleue. */}
+      <div className="flex flex-col items-center gap-3 bg-emerald-600 px-6 py-7 text-center text-white">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/30">
+          <BadgeCheck className="h-8 w-8" aria-hidden="true" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-lg font-semibold tracking-tight">Document authentique</p>
+          <p className="text-sm text-white/85">
+            Vérifié dans les registres de l&apos;établissement
+          </p>
+        </div>
+      </div>
+
+      <CardContent className="space-y-5 p-6">
+        {/* Établissement émetteur, mis en évidence (identité = bleu KLASSCI). */}
+        <div className="flex items-center gap-3 rounded-xl border border-primary/15 bg-primary/5 p-4">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground shadow-sm">
+            <School className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Établissement émetteur
+            </p>
+            <p className="truncate font-serif text-base font-semibold text-foreground">
+              {doc.school_name}
+            </p>
+          </div>
+        </div>
+
+        {/* Récapitulatif du document. */}
+        <div className="rounded-xl border bg-muted/30 px-4">
+          <DetailRow icon={GraduationCap} label="Type de document" value={doc.document_type} />
+          <DetailRow icon={User} label="Élève" value={doc.student_name} />
+          <DetailRow icon={School} label="Classe" value={doc.class_name ?? "Non précisée"} />
+          <DetailRow
+            icon={CalendarDays}
+            label="Année scolaire"
+            value={doc.academic_year ?? "Non précisée"}
+          />
+          <DetailRow
+            icon={CalendarDays}
+            label="Date d'émission"
+            value={formatIssuedAt(doc.issued_at)}
+          />
+          <DetailRow icon={Hash} label="Référence" value={doc.reference} mono />
+        </div>
+
+        {/* Mention légale. */}
+        <p className="text-[12px] leading-relaxed text-muted-foreground">
+          Ce document a été émis par {doc.school_name} via KLASSCI. Toute falsification est
+          passible de poursuites.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function NotRecognizedView() {
+  return (
+    <Card className="overflow-hidden border-amber-200">
+      <div className="flex flex-col items-center gap-3 bg-amber-500 px-6 py-7 text-center text-white">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/30">
+          <ShieldAlert className="h-8 w-8" aria-hidden="true" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-lg font-semibold tracking-tight">Document non reconnu</p>
+          <p className="text-sm text-white/90">
+            Ce document ne figure pas dans nos registres
+          </p>
+        </div>
+      </div>
+
+      <CardContent className="space-y-4 p-6">
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-200"
+        >
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" />
+          <p className="text-sm leading-relaxed">
+            Ce document pourrait être invalide ou falsifié. Aucune information ne lui est
+            associée dans nos registres.
+          </p>
+        </div>
+
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          Si vous pensez qu&apos;il s&apos;agit d&apos;une erreur, contactez directement
+          l&apos;établissement qui a délivré le document pour confirmer son authenticité.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default async function VerifierPage({
+  params,
+}: {
+  params: Promise<{ tenant: string; token: string }>
+}) {
+  const { tenant, token } = await params
+  const result = await verifyDocument(tenant, token)
+
+  if (result.status === "valid") {
+    return <AuthenticView doc={result.document} />
+  }
+
+  return <NotRecognizedView />
+}

--- a/app/verifier/layout.tsx
+++ b/app/verifier/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next"
+import Image from "next/image"
+
+// Page de vérification publique : ne doit jamais être indexée par les moteurs
+// de recherche (lien transactionnel rattaché à un document nominatif).
+export const metadata: Metadata = {
+  title: "Vérification de document — KLASSCI",
+  description: "Vérifiez l'authenticité d'un document scolaire émis via KLASSCI.",
+  robots: { index: false, follow: false },
+}
+
+export default function VerifierLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-muted/30">
+      <main className="flex flex-1 items-center justify-center px-4 py-10 sm:py-14">
+        <div className="w-full max-w-md">{children}</div>
+      </main>
+
+      {/* Pied de page minimal — identité KLASSCI discrète, pas de nav privée. */}
+      <footer className="border-t bg-background/60 py-5">
+        <div className="mx-auto flex max-w-md flex-col items-center gap-1 px-4 text-center">
+          <Image
+            src="/images/logo_klassci.png"
+            alt="KLASSCI"
+            width={104}
+            height={28}
+            className="opacity-80"
+          />
+          <p className="text-[11px] font-light text-muted-foreground/70">
+            Service de vérification de documents scolaires
+          </p>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/lib/api/verify.ts
+++ b/lib/api/verify.ts
@@ -1,0 +1,75 @@
+import { z } from "zod"
+
+/**
+ * Vérification publique d'authenticité de document scolaire.
+ *
+ * Cet appel est PUBLIC : aucun token d'auth, aucune session. Il est conçu pour
+ * tourner côté serveur (Server Component) afin d'avoir un rendu SSR propre.
+ *
+ * Résolution du BASE :
+ *   - côté serveur (le seul cas attendu ici) → backend interne direct
+ *     (INTERNAL_API_URL ou 127.0.0.1:8000), comme lib/api/client.ts.
+ *   - côté navigateur (fallback) → NEXT_PUBLIC_API_URL same-origin.
+ * On NE passe PAS par apiFetch() : pas de header Authorization, pas de getSession().
+ */
+function getBaseUrl(): string {
+  if (typeof window === "undefined") {
+    return process.env.INTERNAL_API_URL ?? "http://127.0.0.1:8000"
+  }
+  const url = process.env.NEXT_PUBLIC_API_URL
+  if (!url) throw new Error("NEXT_PUBLIC_API_URL is not defined — check your .env file")
+  return url
+}
+
+export const VerifiedDocumentSchema = z.object({
+  valid: z.literal(true),
+  document_type: z.string(),
+  reference: z.string(),
+  student_name: z.string(),
+  class_name: z.string().nullable().default(null),
+  academic_year: z.string().nullable().default(null),
+  issued_at: z.string(),
+  school_name: z.string(),
+})
+
+export type VerifiedDocument = z.infer<typeof VerifiedDocumentSchema>
+
+export type VerifyResult =
+  | { status: "valid"; document: VerifiedDocument }
+  | { status: "not_found" }
+
+/**
+ * Interroge GET {BASE}/public/verify/{tenant}/{token} sans authentification.
+ *
+ * Tout statut non-200, toute réponse au shape inattendu, toute erreur réseau →
+ * "not_found" (on traite un document non reconnu comme non authentique, jamais
+ * comme une erreur affichée au visiteur).
+ */
+export async function verifyDocument(tenant: string, token: string): Promise<VerifyResult> {
+  let res: Response
+  try {
+    res = await fetch(
+      `${getBaseUrl()}/public/verify/${encodeURIComponent(tenant)}/${encodeURIComponent(token)}`,
+      {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+        cache: "no-store",
+      },
+    )
+  } catch {
+    return { status: "not_found" }
+  }
+
+  if (!res.ok) {
+    return { status: "not_found" }
+  }
+
+  const json = (await res.json().catch(() => null)) as unknown
+  const parsed = VerifiedDocumentSchema.safeParse(json)
+  if (!parsed.success) {
+    console.error("[verify] réponse inattendue du serveur:", parsed.error.issues)
+    return { status: "not_found" }
+  }
+
+  return { status: "valid", document: parsed.data }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,6 +19,14 @@ function getPortalFromPath(pathname: string): Portal | null {
   return PORTALS.includes(segment as Portal) ? (segment as Portal) : null
 }
 
+// Routes publiques accessibles SANS authentification. Un parent/employeur qui
+// scanne le QR code d'un certificat papier arrive sur /verifier/* : il ne doit
+// jamais être redirigé vers /login, même s'il porte un cookie de session
+// expiré (RefreshTokenError) d'une visite précédente sur le même domaine.
+function isPublicRoute(pathname: string): boolean {
+  return pathname === "/login" || pathname.startsWith("/verifier")
+}
+
 function getDefaultRedirect(role: string | undefined): string {
   if (!role) return "/admin/dashboard"
   if (role === "super_admin") return "/super-admin/tenants"
@@ -61,7 +69,7 @@ const authMiddleware = auth((req) => {
   // logged in. session.id is the canonical authenticated marker.
   const isLoggedIn = !!session?.user?.id
 
-  if (session?.error === "RefreshTokenError" && pathname !== "/login") {
+  if (session?.error === "RefreshTokenError" && !isPublicRoute(pathname)) {
     return hostRedirect(req, "/login")
   }
 


### PR DESCRIPTION
## Résumé
Page publique de vérification d'authenticité d'un document scolaire (Phase 5 refonte PDF, côté FE). Complète le BE #174 (Cachet Électronique Visible signé).

## Ce que ça fait
Un parent / employeur scanne le Datamatrix d'un certificat, attestation ou bulletin (ou saisit le code CEV) et arrive sur `/verifier/{tenant}/{token}` :
- **Document authentique** : sceau vert + établissement + type + élève + classe + année + date + référence.
- **Non reconnu** : avertissement clair, conseil de contacter l'établissement.

## Implémentation
- Server Component (SSR) + skeleton de chargement, `robots: noindex`, layout public minimal (aucune nav privée).
- `lib/api/verify.ts` : appel **public** (sans session) à `GET /public/verify/{tenant}/{token}`, validation **Zod**, tout statut non-200 / shape inattendu → « non reconnu » (jamais d'erreur affichée).
- `middleware.ts` : `/verifier/*` exempté de la redirection `/login` (host allowlist conservé).

## Vérification
- `tsc --noEmit` OK.
- Contrat aligné sur l'endpoint BE (`valid`, `document_type`, `reference`, `student_name`, `class_name?`, `academic_year?`, `issued_at`, `school_name`).

## Dépendance
Nécessite le BE #174 déployé pour fonctionner de bout en bout.

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)