### PR TITLE
feat(classes): redesign class detail page with tabs + PDF downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Fiche de classe repensée en page à onglets (Aperçu, Élèves, Emploi du temps, Matières, Enseignants) avec bandeau bleu-orange et indicateurs clés. Téléchargement en un tap de la liste de classe et du rapport de synthèse (PDF), liste des élèves, emploi du temps par jour, et matières et enseignants déduits de l'emploi du temps *(admin)*.
 - Page publique de vérification d'un document scolaire : en scannant le cachet électronique (CEV) d'un certificat, d'une attestation ou d'un bulletin, ou en saisissant son code, n'importe qui confirme en un instant l'authenticité du document (établissement, type, élève, classe, année, date), sans aucun compte *(tous)*.
 
 ### Changed

--- a/components/admin/classes/ClassDetailClient.tsx
+++ b/components/admin/classes/ClassDetailClient.tsx
@@ -1,12 +1,22 @@
 "use client"
 
+import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { ArrowLeft, Pencil, Trash2, Users, School, DoorOpen } from "lucide-react"
+import {
+  ArrowLeft,
+  BookOpen,
+  CalendarDays,
+  GraduationCap,
+  Pencil,
+  School,
+  Trash2,
+  Users,
+} from "lucide-react"
 import { useClass, useDeleteClass } from "@/lib/hooks/useClasses"
+import { useTimetable } from "@/lib/hooks/useTimetable"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   Dialog,
   DialogContent,
@@ -16,8 +26,14 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { DataError } from "@/components/shared/DataError"
+import { PageHero, heroGlassBtn, heroAccentBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { ClassEditModal } from "./ClassEditModal"
-import { useState } from "react"
+import { OverviewTab } from "./detail/OverviewTab"
+import { StudentsTab } from "./detail/StudentsTab"
+import { TimetableTab } from "./detail/TimetableTab"
+import { SubjectsTab } from "./detail/SubjectsTab"
+import { TeachersTab } from "./detail/TeachersTab"
+import { deriveSubjects, deriveTeachers } from "./detail/class-helpers"
 
 interface ClassDetailClientProps {
   classId: number
@@ -26,126 +42,136 @@ interface ClassDetailClientProps {
 export function ClassDetailClient({ classId }: ClassDetailClientProps) {
   const router = useRouter()
   const { data: classData, isLoading, isError, error, refetch } = useClass(classId)
+  // Les slots EDT alimentent les KPIs du hero + l'onglet Aperçu (matières / profs).
+  const { data: slots } = useTimetable(classId)
   const deleteMutation = useDeleteClass()
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <Skeleton className="h-8 w-64" />
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-28 w-full rounded-lg" />
-          ))}
-        </div>
+      <div className="space-y-6 p-4 md:p-6">
+        <Skeleton className="h-40 w-full rounded-2xl" />
+        <Skeleton className="h-10 w-full max-w-md rounded-md" />
+        <Skeleton className="h-64 w-full rounded-xl" />
       </div>
     )
   }
 
   if (isError || !classData) {
-    return <DataError message={error?.message ?? "Classe introuvable"} error={error} onRetry={refetch} />
+    return (
+      <div className="p-4 md:p-6">
+        <DataError message={error?.message ?? "Classe introuvable"} error={error} onRetry={refetch} />
+      </div>
+    )
   }
 
+  const allSlots = slots ?? []
   const enrolled = classData.enrolled_count ?? 0
   const max = classData.max_students ?? 0
   const ratio = max > 0 ? Math.round((enrolled / max) * 100) : 0
 
+  const kpis: HeroKpi[] = [
+    {
+      label: "Effectif",
+      value: max > 0 ? `${enrolled}/${max}` : enrolled,
+      icon: Users,
+      hint: max > 0 ? `${ratio}% rempli` : "Capacité non définie",
+    },
+    { label: "Niveau", value: classData.level_name ?? "—", icon: GraduationCap },
+    { label: "Matières", value: deriveSubjects(allSlots).length, icon: BookOpen },
+    { label: "Enseignants", value: deriveTeachers(allSlots).length, icon: School },
+  ]
+
+  const subtitle = (
+    <>
+      {classData.level_name}
+      {classData.series_name ? ` · Série ${classData.series_name}` : ""}
+      {classData.room_id ? ` · Salle ${classData.name}` : ""}
+    </>
+  )
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Retour à la liste des classes"
-            className="h-11 w-11 sm:h-10 sm:w-10"
-            onClick={() => router.push("/admin/classes")}
-          >
-            <ArrowLeft aria-hidden="true" className="h-5 w-5" />
-          </Button>
-          <div>
-            <h1 className="text-2xl font-bold">{classData.name}</h1>
-            <p className="text-sm text-muted-foreground">
-              {classData.level_name}
-              {classData.series_name && ` — Série ${classData.series_name}`}
-            </p>
-          </div>
+    <div className="space-y-6 p-4 md:p-6">
+      <PageHero
+        icon={School}
+        title={classData.name}
+        subtitle={subtitle}
+        actions={
+          <>
+            <button
+              type="button"
+              onClick={() => router.push("/admin/classes")}
+              className={heroGlassBtn}
+              aria-label="Retour à la liste des classes"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              Retour
+            </button>
+            <button
+              type="button"
+              onClick={() => setEditOpen(true)}
+              className={heroGlassBtn}
+            >
+              <Pencil className="h-4 w-4" aria-hidden="true" />
+              Modifier
+            </button>
+            <button
+              type="button"
+              onClick={() => setDeleteOpen(true)}
+              className={heroAccentBtn}
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+              Supprimer
+            </button>
+          </>
+        }
+        kpis={kpis}
+      />
+
+      <Tabs defaultValue="overview" className="space-y-4">
+        <div className="-mx-4 overflow-x-auto px-4 md:mx-0 md:px-0">
+          <TabsList className="inline-flex h-auto w-max gap-1 p-1">
+            <TabsTrigger value="overview" className="h-9 whitespace-nowrap">
+              <School className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              Aperçu
+            </TabsTrigger>
+            <TabsTrigger value="students" className="h-9 whitespace-nowrap">
+              <Users className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              Élèves
+            </TabsTrigger>
+            <TabsTrigger value="timetable" className="h-9 whitespace-nowrap">
+              <CalendarDays className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              <span className="hidden sm:inline">Emploi du temps</span>
+              <span className="sm:hidden">EDT</span>
+            </TabsTrigger>
+            <TabsTrigger value="subjects" className="h-9 whitespace-nowrap">
+              <BookOpen className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              Matières
+            </TabsTrigger>
+            <TabsTrigger value="teachers" className="h-9 whitespace-nowrap">
+              <GraduationCap className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              Enseignants
+            </TabsTrigger>
+          </TabsList>
         </div>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
-            <Pencil className="mr-2 h-4 w-4" />
-            Modifier
-          </Button>
-          <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)}>
-            <Trash2 className="mr-2 h-4 w-4" />
-            Supprimer
-          </Button>
-        </div>
-      </div>
 
-      {/* KPI Cards */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Élèves inscrits</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{enrolled}</div>
-            <p className="text-xs text-muted-foreground">sur {max || "—"} places</p>
-            {max > 0 && (
-              <div className="mt-2 h-2 rounded-full bg-muted">
-                <div
-                  className={`h-full rounded-full transition-all ${
-                    ratio > 95 ? "bg-rose-500" : ratio >= 80 ? "bg-amber-500" : "bg-emerald-500"
-                  }`}
-                  style={{ width: `${Math.min(ratio, 100)}%` }}
-                />
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Niveau</CardTitle>
-            <School className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{classData.level_name ?? "—"}</div>
-            {classData.series_name && (
-              <p className="text-xs text-muted-foreground">Série {classData.series_name}</p>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Taux de remplissage</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{ratio}%</div>
-            <p className="text-xs text-muted-foreground">
-              {max > 0 ? `${max - enrolled} places disponibles` : "Capacité non définie"}
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Salle</CardTitle>
-            <DoorOpen className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{classData.room_id ? `Salle #${classData.room_id}` : "—"}</div>
-            <p className="text-xs text-muted-foreground">
-              {classData.room_id ? "Salle assignée" : "Aucune salle assignée"}
-            </p>
-          </CardContent>
-        </Card>
-      </div>
+        <TabsContent value="overview">
+          <OverviewTab classData={classData} slots={allSlots} />
+        </TabsContent>
+        <TabsContent value="students">
+          <StudentsTab classId={classId} className={classData.name} />
+        </TabsContent>
+        <TabsContent value="timetable">
+          <TimetableTab classId={classId} />
+        </TabsContent>
+        <TabsContent value="subjects">
+          <SubjectsTab classId={classId} />
+        </TabsContent>
+        <TabsContent value="teachers">
+          <TeachersTab classId={classId} />
+        </TabsContent>
+      </Tabs>
 
       {/* Modals */}
       <ClassEditModal classId={editOpen ? classId : null} open={editOpen} onClose={() => setEditOpen(false)} />
@@ -155,11 +181,13 @@ export function ClassDetailClient({ classId }: ClassDetailClientProps) {
           <DialogHeader>
             <DialogTitle>Supprimer la classe</DialogTitle>
             <DialogDescription>
-              Cette action est irréversible. La classe "{classData.name}" sera définitivement supprimée.
+              Cette action est irréversible. La classe « {classData.name} » sera définitivement supprimée.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteOpen(false)}>Annuler</Button>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
+              Annuler
+            </Button>
             <Button
               variant="destructive"
               disabled={deleteMutation.isPending}

--- a/components/admin/classes/detail/OverviewTab.tsx
+++ b/components/admin/classes/detail/OverviewTab.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+import {
+  BookOpen,
+  Download,
+  DoorOpen,
+  FileText,
+  GraduationCap,
+  Loader2,
+  School,
+  Users,
+} from "lucide-react"
+import type { Class } from "@/lib/contracts/class"
+import type { TimetableSlot } from "@/lib/contracts/timetable"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { SectionCard } from "@/components/admin/students/tabs/_primitives"
+import { deriveSubjects, deriveTeachers } from "./class-helpers"
+import {
+  fetchClassRoster,
+  fetchClassSynthesis,
+  fileSafeName,
+  triggerBlobDownload,
+} from "./class-downloads"
+
+interface OverviewTabProps {
+  classData: Class
+  slots: TimetableSlot[]
+}
+
+function MetricTile({
+  icon: Icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: typeof Users
+  label: string
+  value: React.ReactNode
+  hint?: React.ReactNode
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </p>
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <div className="mt-1 text-2xl font-bold leading-none tracking-tight tabular-nums">
+        {value}
+      </div>
+      {hint && <div className="mt-1 text-[11px] text-muted-foreground">{hint}</div>}
+    </div>
+  )
+}
+
+export function OverviewTab({ classData, slots }: OverviewTabProps) {
+  const [trimester, setTrimester] = useState("1")
+  const [downloadingRoster, setDownloadingRoster] = useState(false)
+  const [downloadingSynthesis, setDownloadingSynthesis] = useState(false)
+
+  const enrolled = classData.enrolled_count ?? 0
+  const max = classData.max_students ?? 0
+  const ratio = max > 0 ? Math.round((enrolled / max) * 100) : 0
+  const available = max > 0 ? Math.max(max - enrolled, 0) : 0
+
+  const subjectsCount = deriveSubjects(slots).length
+  const teachersCount = deriveTeachers(slots).length
+  const academicYearId = slots[0]?.academic_year_id
+
+  const name = classData.name
+  const safeName = fileSafeName(name)
+
+  async function handleRoster() {
+    setDownloadingRoster(true)
+    try {
+      const blob = await fetchClassRoster(classData.id)
+      triggerBlobDownload(blob, `liste-classe-${safeName}.pdf`)
+    } catch (err) {
+      toast.error("Téléchargement impossible", {
+        description: err instanceof Error ? err.message : "Erreur lors de la génération du PDF",
+      })
+    } finally {
+      setDownloadingRoster(false)
+    }
+  }
+
+  async function handleSynthesis() {
+    if (!academicYearId) return
+    setDownloadingSynthesis(true)
+    try {
+      const blob = await fetchClassSynthesis(classData.id, Number(trimester), academicYearId)
+      triggerBlobDownload(blob, `synthese-${safeName}-T${trimester}.pdf`)
+    } catch (err) {
+      toast.error("Téléchargement impossible", {
+        description: err instanceof Error ? err.message : "Erreur lors de la génération du PDF",
+      })
+    } finally {
+      setDownloadingSynthesis(false)
+    }
+  }
+
+  const barTone =
+    ratio > 95 ? "bg-rose-500" : ratio >= 80 ? "bg-amber-500" : "bg-emerald-500"
+
+  return (
+    <div className="space-y-5">
+      <SectionCard icon={<School className="h-4 w-4" />} title="Synthèse de la classe">
+        {/* Capacité avec barre de remplissage */}
+        <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
+          <div className="flex items-end justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Effectif inscrit
+              </p>
+              <p className="mt-1 text-3xl font-bold leading-none tracking-tight tabular-nums">
+                {enrolled}
+                <span className="ml-1 text-base font-medium text-muted-foreground">
+                  / {max || "—"}
+                </span>
+              </p>
+            </div>
+            <span className="text-2xl font-bold tabular-nums text-[#F58220]">{ratio}%</span>
+          </div>
+          {max > 0 && (
+            <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-muted">
+              <div
+                className={`h-full rounded-full transition-all ${barTone}`}
+                style={{ width: `${Math.min(ratio, 100)}%` }}
+                role="progressbar"
+                aria-valuenow={ratio}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`Taux de remplissage : ${ratio}%`}
+              />
+            </div>
+          )}
+          <p className="mt-2 text-xs text-muted-foreground">
+            {max > 0 ? `${available} place${available > 1 ? "s" : ""} disponible${available > 1 ? "s" : ""}` : "Capacité non définie"}
+          </p>
+        </div>
+
+        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <MetricTile
+            icon={GraduationCap}
+            label="Niveau"
+            value={classData.level_name ?? "—"}
+            hint={classData.series_name ? `Série ${classData.series_name}` : undefined}
+          />
+          <MetricTile
+            icon={DoorOpen}
+            label="Salle"
+            value={classData.room_id ? `Salle ${name}` : "—"}
+            hint={classData.room_id ? "Salle attitrée" : "Aucune salle"}
+          />
+          <MetricTile
+            icon={BookOpen}
+            label="Matières"
+            value={subjectsCount}
+            hint="enseignées (via l'EDT)"
+          />
+          <MetricTile
+            icon={Users}
+            label="Enseignants"
+            value={teachersCount}
+            hint="intervenant dans la classe"
+          />
+        </div>
+      </SectionCard>
+
+      {/* Documents PDF */}
+      <SectionCard
+        icon={<FileText className="h-4 w-4" />}
+        title="Documents"
+        description="Générer les documents officiels de la classe au format PDF."
+      >
+        <div className="space-y-3">
+          {/* Liste de classe (roster) */}
+          <div className="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/40 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-medium">Liste de classe</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Les élèves inscrits, avec matricule et coordonnées.
+              </p>
+            </div>
+            <Button
+              onClick={handleRoster}
+              disabled={downloadingRoster}
+              className="h-11 w-full bg-accent text-accent-foreground shadow-sm hover:bg-accent/90 sm:h-10 sm:w-auto"
+            >
+              {downloadingRoster ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+              )}
+              Télécharger
+            </Button>
+          </div>
+
+          {/* Rapport de synthèse */}
+          {academicYearId ? (
+            <div className="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/40 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-medium">Rapport de synthèse</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Moyennes et classement de la classe pour un trimestre.
+                </p>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <Select value={trimester} onValueChange={setTrimester}>
+                  <SelectTrigger className="h-11 w-full sm:h-10 sm:w-[140px]" aria-label="Trimestre">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="1">Trimestre 1</SelectItem>
+                    <SelectItem value="2">Trimestre 2</SelectItem>
+                    <SelectItem value="3">Trimestre 3</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="outline"
+                  onClick={handleSynthesis}
+                  disabled={downloadingSynthesis}
+                  className="h-11 w-full sm:h-10 sm:w-auto"
+                >
+                  {downloadingSynthesis ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+                  )}
+                  Télécharger
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 p-4">
+              <p className="text-xs text-muted-foreground">
+                Le rapport de synthèse sera disponible dès qu'un emploi du temps sera défini pour la classe (année académique requise).
+              </p>
+            </div>
+          )}
+        </div>
+      </SectionCard>
+    </div>
+  )
+}

--- a/components/admin/classes/detail/StudentsTab.tsx
+++ b/components/admin/classes/detail/StudentsTab.tsx
@@ -1,0 +1,186 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+import { Download, Loader2, Users } from "lucide-react"
+import type { Route } from "next"
+import type { Student } from "@/lib/contracts/student"
+import { useStudents } from "@/lib/hooks/useStudents"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { DataError } from "@/components/shared/DataError"
+import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
+import { SectionCard, EmptyState, InitialsAvatar } from "@/components/admin/students/tabs/_primitives"
+import { getUploadUrl } from "@/lib/utils"
+import { fetchClassRoster, fileSafeName, triggerBlobDownload } from "./class-downloads"
+
+interface StudentsTabProps {
+  classId: number
+  className: string
+}
+
+function fullName(s: Student): string {
+  return `${s.last_name} ${s.first_name}`.trim()
+}
+
+function GenreMark({ genre }: { genre?: string | null }) {
+  if (genre !== "M" && genre !== "F") return null
+  return (
+    <span
+      className="ml-1.5 text-sm text-muted-foreground"
+      aria-label={genre === "F" ? "Fille" : "Garçon"}
+      title={genre === "F" ? "Fille" : "Garçon"}
+    >
+      {genre === "F" ? "♀" : "♂"}
+    </span>
+  )
+}
+
+function StudentAvatar({ student, size = "md" }: { student: Student; size?: "sm" | "md" }) {
+  const src = getUploadUrl(student.photo_url)
+  const dim = size === "sm" ? "h-9 w-9" : "h-10 w-10"
+  return (
+    <Avatar className={dim}>
+      {src ? <AvatarImage src={src} alt={fullName(student)} /> : null}
+      <AvatarFallback className="bg-primary/10 text-xs font-semibold text-primary">
+        {`${student.last_name?.[0] ?? ""}${student.first_name?.[0] ?? ""}`.toUpperCase() || "?"}
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
+export function StudentsTab({ classId, className }: StudentsTabProps) {
+  const { data, isLoading, isError, error, refetch } = useStudents({
+    class_id: classId,
+    page: 1,
+    size: 100,
+  })
+  const [downloading, setDownloading] = useState(false)
+
+  const students = data?.items ?? []
+
+  async function handleRoster() {
+    setDownloading(true)
+    try {
+      const blob = await fetchClassRoster(classId)
+      triggerBlobDownload(blob, `liste-classe-${fileSafeName(className)}.pdf`)
+    } catch (err) {
+      toast.error("Téléchargement impossible", {
+        description: err instanceof Error ? err.message : "Erreur lors de la génération du PDF",
+      })
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  const downloadBtn = (
+    <Button
+      onClick={handleRoster}
+      disabled={downloading || students.length === 0}
+      size="sm"
+      className="h-11 bg-accent text-accent-foreground shadow-sm hover:bg-accent/90 sm:h-9"
+    >
+      {downloading ? (
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+      ) : (
+        <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+      )}
+      Liste (PDF)
+    </Button>
+  )
+
+  return (
+    <SectionCard
+      icon={<Users className="h-4 w-4" />}
+      title="Élèves inscrits"
+      description={
+        isLoading ? undefined : `${students.length} élève${students.length > 1 ? "s" : ""} dans cette classe`
+      }
+      action={downloadBtn}
+    >
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full rounded-lg" />
+          ))}
+        </div>
+      ) : isError ? (
+        <DataError message={error?.message ?? "Erreur de chargement"} error={error} onRetry={refetch} />
+      ) : students.length === 0 ? (
+        <EmptyState
+          icon={<Users className="h-5 w-5" />}
+          title="Aucun élève inscrit"
+          message="Aucun élève n'est inscrit dans cette classe pour l'année en cours."
+        />
+      ) : (
+        <>
+          {/* Desktop */}
+          <div className="hidden md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Élève</TableHead>
+                  <TableHead>Matricule</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {students.map((s) => (
+                  <TableRow key={s.id}>
+                    <TableCell>
+                      <a
+                        href={`/admin/students/${s.id}`}
+                        className="flex items-center gap-3 hover:underline"
+                      >
+                        <StudentAvatar student={s} size="sm" />
+                        <span className="font-medium">
+                          {fullName(s)}
+                          <GenreMark genre={s.genre} />
+                        </span>
+                      </a>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-muted-foreground">
+                      {s.enrollment_number ?? "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Mobile */}
+          <div className="space-y-2 md:hidden">
+            {students.map((s) => (
+              <MobileEntityListItem
+                key={s.id}
+                href={`/admin/students/${s.id}` as Route}
+                avatar={
+                  getUploadUrl(s.photo_url) ? (
+                    <StudentAvatar student={s} size="sm" />
+                  ) : (
+                    <InitialsAvatar first={s.first_name} last={s.last_name} size="sm" />
+                  )
+                }
+                primary={
+                  <>
+                    {fullName(s)}
+                    <GenreMark genre={s.genre} />
+                  </>
+                }
+                secondary={s.enrollment_number ? `Matricule ${s.enrollment_number}` : "Sans matricule"}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </SectionCard>
+  )
+}

--- a/components/admin/classes/detail/SubjectsTab.tsx
+++ b/components/admin/classes/detail/SubjectsTab.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { BookOpen, User } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { DataError } from "@/components/shared/DataError"
+import { useTimetable } from "@/lib/hooks/useTimetable"
+import { SectionCard, EmptyState, StatusPill } from "@/components/admin/students/tabs/_primitives"
+import { deriveSubjects } from "./class-helpers"
+
+interface SubjectsTabProps {
+  classId: number
+}
+
+export function SubjectsTab({ classId }: SubjectsTabProps) {
+  const { data, isLoading, isError, error, refetch } = useTimetable(classId)
+  const subjects = deriveSubjects(data ?? [])
+
+  return (
+    <SectionCard
+      icon={<BookOpen className="h-4 w-4" />}
+      title="Matières"
+      description={isLoading ? undefined : `${subjects.length} matière${subjects.length > 1 ? "s" : ""} enseignée${subjects.length > 1 ? "s" : ""}`}
+    >
+      {isLoading ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-20 w-full rounded-lg" />
+          ))}
+        </div>
+      ) : isError ? (
+        <DataError message={error?.message ?? "Erreur de chargement"} error={error} onRetry={refetch} />
+      ) : subjects.length === 0 ? (
+        <EmptyState
+          icon={<BookOpen className="h-5 w-5" />}
+          title="Aucune matière"
+          message="Les matières apparaîtront ici dès qu'un emploi du temps sera défini pour la classe."
+        />
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {subjects.map((s) => (
+            <div
+              key={s.subject_id}
+              className="flex items-start gap-3 rounded-lg border border-border/60 bg-muted/40 p-4"
+            >
+              <span
+                className="mt-1 h-3.5 w-3.5 shrink-0 rounded-full"
+                style={{ backgroundColor: s.subject_color ?? "#0F3F8C" }}
+                aria-hidden="true"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="truncate text-sm font-medium">{s.subject_name}</p>
+                  <StatusPill tone="neutral">{s.slot_count} cours</StatusPill>
+                </div>
+                <div className="mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <User className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  <span className="truncate">
+                    {s.teacher_names.length > 0
+                      ? s.teacher_names.join(", ")
+                      : "Aucun enseignant affecté"}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  )
+}

--- a/components/admin/classes/detail/TeachersTab.tsx
+++ b/components/admin/classes/detail/TeachersTab.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { BookOpen, GraduationCap } from "lucide-react"
+import type { Route } from "next"
+import { Skeleton } from "@/components/ui/skeleton"
+import { DataError } from "@/components/shared/DataError"
+import { useTimetable } from "@/lib/hooks/useTimetable"
+import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
+import {
+  SectionCard,
+  EmptyState,
+  InitialsAvatar,
+  StatusPill,
+} from "@/components/admin/students/tabs/_primitives"
+import { deriveTeachers } from "./class-helpers"
+
+interface TeachersTabProps {
+  classId: number
+}
+
+function splitName(fullName: string): { first?: string; last?: string } {
+  const parts = fullName.trim().split(/\s+/)
+  if (parts.length === 1) return { first: parts[0] }
+  return { last: parts[0], first: parts.slice(1).join(" ") }
+}
+
+export function TeachersTab({ classId }: TeachersTabProps) {
+  const { data, isLoading, isError, error, refetch } = useTimetable(classId)
+  const teachers = deriveTeachers(data ?? [])
+
+  return (
+    <SectionCard
+      icon={<GraduationCap className="h-4 w-4" />}
+      title="Enseignants"
+      description={isLoading ? undefined : `${teachers.length} enseignant${teachers.length > 1 ? "s" : ""} dans cette classe`}
+    >
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-lg" />
+          ))}
+        </div>
+      ) : isError ? (
+        <DataError message={error?.message ?? "Erreur de chargement"} error={error} onRetry={refetch} />
+      ) : teachers.length === 0 ? (
+        <EmptyState
+          icon={<GraduationCap className="h-5 w-5" />}
+          title="Aucun enseignant"
+          message="Les enseignants apparaîtront ici dès qu'un emploi du temps sera défini (le lien se fait via les créneaux)."
+        />
+      ) : (
+        <>
+          {/* Desktop */}
+          <div className="hidden space-y-2 md:block">
+            {teachers.map((t) => {
+              const { first, last } = splitName(t.teacher_name)
+              return (
+                <a
+                  key={t.teacher_id}
+                  href={`/admin/teachers/${t.teacher_id}`}
+                  className="flex items-center gap-3 rounded-lg border border-border/60 bg-muted/40 p-3 transition-colors hover:bg-accent/40"
+                >
+                  <InitialsAvatar first={first} last={last} size="md" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{t.teacher_name}</p>
+                    <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                      <BookOpen className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      <span className="truncate">
+                        {t.subject_names.length > 0 ? t.subject_names.join(", ") : "—"}
+                      </span>
+                    </div>
+                  </div>
+                  <StatusPill tone="neutral">{t.slot_count} cours</StatusPill>
+                </a>
+              )
+            })}
+          </div>
+
+          {/* Mobile */}
+          <div className="space-y-2 md:hidden">
+            {teachers.map((t) => {
+              const { first, last } = splitName(t.teacher_name)
+              return (
+                <MobileEntityListItem
+                  key={t.teacher_id}
+                  href={`/admin/teachers/${t.teacher_id}` as Route}
+                  avatar={<InitialsAvatar first={first} last={last} size="sm" />}
+                  primary={t.teacher_name}
+                  secondary={t.subject_names.length > 0 ? t.subject_names.join(", ") : "Aucune matière"}
+                  status={<StatusPill tone="neutral">{t.slot_count}</StatusPill>}
+                />
+              )
+            })}
+          </div>
+        </>
+      )}
+    </SectionCard>
+  )
+}

--- a/components/admin/classes/detail/TimetableTab.tsx
+++ b/components/admin/classes/detail/TimetableTab.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import { CalendarDays, Clock, DoorClosed, User } from "lucide-react"
+import type { TimetableSlot } from "@/lib/contracts/timetable"
+import { Skeleton } from "@/components/ui/skeleton"
+import { DataError } from "@/components/shared/DataError"
+import { useTimetable } from "@/lib/hooks/useTimetable"
+import { SectionCard, EmptyState } from "@/components/admin/students/tabs/_primitives"
+import { dayLabel, formatTime, groupSlotsByDay } from "./class-helpers"
+
+interface TimetableTabProps {
+  classId: number
+}
+
+function SlotCard({ slot }: { slot: TimetableSlot }) {
+  const color = slot.subject_color ?? "#0F3F8C"
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-border/60 bg-background p-3">
+      <span
+        className="mt-1 h-3 w-3 shrink-0 rounded-full"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{slot.subject_name}</p>
+        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+            {formatTime(slot.start_time)}–{formatTime(slot.end_time)}
+          </span>
+          {slot.teacher_name && (
+            <span className="inline-flex items-center gap-1">
+              <User className="h-3.5 w-3.5" aria-hidden="true" />
+              {slot.teacher_name}
+            </span>
+          )}
+          {slot.room && (
+            <span className="inline-flex items-center gap-1">
+              <DoorClosed className="h-3.5 w-3.5" aria-hidden="true" />
+              {slot.room}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function TimetableTab({ classId }: TimetableTabProps) {
+  const { data, isLoading, isError, error, refetch } = useTimetable(classId)
+  const slots = data ?? []
+  const grouped = groupSlotsByDay(slots)
+
+  return (
+    <SectionCard
+      icon={<CalendarDays className="h-4 w-4" />}
+      title="Emploi du temps"
+      description={isLoading ? undefined : `${slots.length} créneau${slots.length > 1 ? "x" : ""} programmé${slots.length > 1 ? "s" : ""}`}
+    >
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-20 w-full rounded-lg" />
+          ))}
+        </div>
+      ) : isError ? (
+        <DataError message={error?.message ?? "Erreur de chargement"} error={error} onRetry={refetch} />
+      ) : grouped.length === 0 ? (
+        <EmptyState
+          icon={<CalendarDays className="h-5 w-5" />}
+          title="Aucun emploi du temps"
+          message="Aucun créneau n'a encore été défini pour cette classe."
+        />
+      ) : (
+        <div className="space-y-5">
+          {grouped.map(({ day, slots: daySlots }) => (
+            <div key={day}>
+              <div className="mb-2 flex items-center gap-2.5 border-b pb-2">
+                <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
+                  <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                </span>
+                <h4 className="text-sm font-semibold">{dayLabel(day)}</h4>
+                <span className="text-xs text-muted-foreground">
+                  {daySlots.length} cours
+                </span>
+              </div>
+              <div className="space-y-2">
+                {daySlots.map((slot) => (
+                  <SlotCard key={slot.id} slot={slot} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </SectionCard>
+  )
+}

--- a/components/admin/classes/detail/class-downloads.ts
+++ b/components/admin/classes/detail/class-downloads.ts
@@ -1,0 +1,49 @@
+import { apiFetchBlob } from "@/lib/api/client"
+
+/**
+ * Téléchargements PDF d'une classe (liste / synthèse).
+ *
+ * Réutilise `apiFetchBlob` (Bearer token + contrat 401 → handleExpiredSession).
+ * Exception légitime à la validation Zod (réponse binaire Blob), cf.
+ * `.claude/rules/api-client-zod-validation.md`.
+ */
+
+/** Liste de classe (roster) — PDF. */
+export function fetchClassRoster(classId: number): Promise<Blob> {
+  return apiFetchBlob(`/admin/classes/${classId}/roster`)
+}
+
+/** Rapport de synthèse de la classe pour un trimestre — PDF. */
+export function fetchClassSynthesis(
+  classId: number,
+  trimester: number,
+  academicYearId: number,
+): Promise<Blob> {
+  return apiFetchBlob(
+    `/reports/classes/${classId}/synthesis?trimester=${trimester}&academic_year_id=${academicYearId}`,
+  )
+}
+
+/**
+ * Déclenche le téléchargement d'un Blob côté navigateur (création d'un
+ * `<a download>` éphémère + revokeObjectURL). Pattern identique à
+ * PdfIdentitySection / PaymentsPageClient.
+ */
+export function triggerBlobDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename
+  a.click()
+  setTimeout(() => URL.revokeObjectURL(url), 60_000)
+}
+
+/** Nettoie un nom de classe pour un nom de fichier (espaces → tirets). */
+export function fileSafeName(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase()
+}

--- a/components/admin/classes/detail/class-helpers.ts
+++ b/components/admin/classes/detail/class-helpers.ts
@@ -1,0 +1,149 @@
+import type { Day, TimetableSlot } from "@/lib/contracts/timetable"
+
+/**
+ * Helpers purs pour la fiche classe : ordre des jours, libellés FR, et
+ * dérivation matières / enseignants à partir des créneaux EDT.
+ *
+ * Rappel métier (cf. rules projet) : le lien prof↔classe et matière↔classe
+ * est IMPLICITE via l'emploi du temps. On dérive donc ces listes des slots.
+ */
+
+// Ordre canonique d'affichage (le BE renvoie soit les jours FR soit EN).
+export const DAY_ORDER: Day[] = [
+  "lundi",
+  "mardi",
+  "mercredi",
+  "jeudi",
+  "vendredi",
+  "samedi",
+]
+
+const DAY_LABELS: Record<Day, string> = {
+  lundi: "Lundi",
+  mardi: "Mardi",
+  mercredi: "Mercredi",
+  jeudi: "Jeudi",
+  vendredi: "Vendredi",
+  samedi: "Samedi",
+  monday: "Lundi",
+  tuesday: "Mardi",
+  wednesday: "Mercredi",
+  thursday: "Jeudi",
+  friday: "Vendredi",
+  saturday: "Samedi",
+}
+
+// Normalise un jour (FR ou EN) vers sa clé FR canonique.
+const DAY_TO_FR: Record<Day, Day> = {
+  lundi: "lundi",
+  mardi: "mardi",
+  mercredi: "mercredi",
+  jeudi: "jeudi",
+  vendredi: "vendredi",
+  samedi: "samedi",
+  monday: "lundi",
+  tuesday: "mardi",
+  wednesday: "mercredi",
+  thursday: "jeudi",
+  friday: "vendredi",
+  saturday: "samedi",
+}
+
+export function dayLabel(day: Day): string {
+  return DAY_LABELS[day] ?? day
+}
+
+export function normalizeDay(day: Day): Day {
+  return DAY_TO_FR[day] ?? day
+}
+
+/** Heure "08:00:00" → "08:00". */
+export function formatTime(time: string): string {
+  return time.slice(0, 5)
+}
+
+export interface SlotsByDay {
+  day: Day
+  slots: TimetableSlot[]
+}
+
+/** Regroupe les créneaux par jour, triés par jour puis par heure de début. */
+export function groupSlotsByDay(slots: TimetableSlot[]): SlotsByDay[] {
+  const byDay = new Map<Day, TimetableSlot[]>()
+  for (const slot of slots) {
+    const key = normalizeDay(slot.day)
+    const bucket = byDay.get(key) ?? []
+    bucket.push(slot)
+    byDay.set(key, bucket)
+  }
+  return DAY_ORDER.filter((d) => byDay.has(d)).map((day) => ({
+    day,
+    slots: (byDay.get(day) ?? []).sort((a, b) =>
+      a.start_time.localeCompare(b.start_time),
+    ),
+  }))
+}
+
+export interface DerivedSubject {
+  subject_id: number
+  subject_name: string
+  subject_color?: string | null
+  teacher_names: string[]
+  slot_count: number
+}
+
+/** Matières distinctes enseignées dans la classe (dérivées des slots). */
+export function deriveSubjects(slots: TimetableSlot[]): DerivedSubject[] {
+  const map = new Map<number, DerivedSubject>()
+  for (const slot of slots) {
+    const existing = map.get(slot.subject_id)
+    if (existing) {
+      existing.slot_count += 1
+      if (slot.teacher_name && !existing.teacher_names.includes(slot.teacher_name)) {
+        existing.teacher_names.push(slot.teacher_name)
+      }
+    } else {
+      map.set(slot.subject_id, {
+        subject_id: slot.subject_id,
+        subject_name: slot.subject_name,
+        subject_color: slot.subject_color,
+        teacher_names: slot.teacher_name ? [slot.teacher_name] : [],
+        slot_count: 1,
+      })
+    }
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.subject_name.localeCompare(b.subject_name, "fr"),
+  )
+}
+
+export interface DerivedTeacher {
+  teacher_id: number
+  teacher_name: string
+  subject_names: string[]
+  slot_count: number
+}
+
+/** Enseignants distincts intervenant dans la classe (dérivés des slots). */
+export function deriveTeachers(slots: TimetableSlot[]): DerivedTeacher[] {
+  const map = new Map<number, DerivedTeacher>()
+  for (const slot of slots) {
+    const existing = map.get(slot.teacher_id)
+    if (existing) {
+      existing.slot_count += 1
+      if (slot.subject_name && !existing.subject_names.includes(slot.subject_name)) {
+        existing.subject_names.push(slot.subject_name)
+      }
+    } else {
+      map.set(slot.teacher_id, {
+        teacher_id: slot.teacher_id,
+        teacher_name: slot.teacher_name,
+        subject_names: slot.subject_name ? [slot.subject_name] : [],
+        slot_count: 1,
+      })
+    }
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    a.teacher_name.localeCompare(b.teacher_name, "fr"),
+  )
+}


### PR DESCRIPTION
## Résumé
Plan B′ Phase 4b (FE) : la fiche de classe devient une page premium à onglets, avec téléchargement de la liste de classe et du **rapport de synthèse** (BE #182).

## Onglets
- **Aperçu** : KPIs (effectif/capacité, niveau, matières, enseignants) + boutons PDF **Liste de classe** et **Rapport de synthèse** (sélecteur trimestre).
- **Élèves** : table desktop + `MobileEntityListItem` mobile, matricule/sexe, roster PDF.
- **Emploi du temps** : créneaux groupés par jour (pastille matière, prof, heures, salle).
- **Matières** / **Enseignants** : dérivés des créneaux EDT (lien implicite prof↔classe).

## Implémentation
- `ClassDetailClient` = orchestrateur PageHero + Tabs (< 220 LOC), modals Modifier/Supprimer conservées.
- no-god-code : 7 fichiers sous `detail/` (tabs + helpers download/dérivation).
- Téléchargements via `apiFetchBlob` (endpoints existants `/admin/classes/{id}/roster` et `/reports/classes/{id}/synthesis`).

## Vérifié
`tsc --noEmit` + eslint clean. Bleu+orange, mobile-first `h-11`, clair/sombre via tokens.

## Dépendance
Le bouton synthèse utilise le BE #182 (déjà déployé).

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)