### PR TITLE
feat(export): exports Excel/PDF sur élèves, paiements, notes, présences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Export en un tap des listes de gestion : bouton « Exporter » (Excel .xlsx ou PDF, aux couleurs de l'établissement) sur les pages Élèves, Paiements (avec total), Notes et Présences. L'export reprend exactement les lignes affichées, filtres compris *(admin)*.
 - Socle d'export de données réutilisable : les listes pourront bientôt être exportées en Excel (.xlsx) et en PDF, aux couleurs de l'établissement. L'Excel reste une vraie table exploitable (filtres, tri, colonnes typées), le PDF adopte la présentation sobre des documents officiels *(admin)*.
 - Vérification d'un document par saisie manuelle du code : sur la page de vérification, on peut maintenant taper le code « CEV-XXXX-XXXX-XXXX » imprimé au dos du document pour confirmer son authenticité, sans avoir à scanner *(tous)*.
 - Fiche de classe repensée en page à onglets (Aperçu, Élèves, Emploi du temps, Matières, Enseignants) avec bandeau bleu-orange et indicateurs clés. Téléchargement en un tap de la liste de classe et du rapport de synthèse (PDF), liste des élèves, emploi du temps par jour, et matières et enseignants déduits de l'emploi du temps *(admin)*.

--- a/components/admin/attendance/AttendancePageClient.tsx
+++ b/components/admin/attendance/AttendancePageClient.tsx
@@ -188,7 +188,7 @@ export function AttendancePageClient() {
         </TabsContent>
 
         <TabsContent value="statistiques">
-          <AttendanceStats classId={classId} />
+          <AttendanceStats classId={classId} className={selectedClass?.name} />
         </TabsContent>
       </Tabs>
     </div>

--- a/components/admin/attendance/AttendanceStats.tsx
+++ b/components/admin/attendance/AttendanceStats.tsx
@@ -9,10 +9,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { ExportMenu } from "@/components/export/ExportMenu"
 import { useAttendanceStats } from "@/lib/hooks/useAttendance"
+import { useSettings } from "@/lib/hooks/useSettings"
+import { buildAttendanceExportPayload } from "./attendance-export"
 
 interface AttendanceStatsProps {
   classId?: number
+  className?: string
 }
 
 function rateColor(rate: number): string {
@@ -22,8 +26,9 @@ function rateColor(rate: number): string {
 }
 
 
-export function AttendanceStats({ classId }: AttendanceStatsProps) {
+export function AttendanceStats({ classId, className }: AttendanceStatsProps) {
   const { data: stats, isLoading } = useAttendanceStats(classId)
+  const { data: settings } = useSettings()
 
   if (!classId) {
     return (
@@ -55,8 +60,16 @@ export function AttendanceStats({ classId }: AttendanceStatsProps) {
   const sorted = [...stats.students].sort((a, b) => a.attendance_rate - b.attendance_rate)
 
   return (
-    <div className="rounded-lg border">
-      <Table>
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <ExportMenu
+          filename="presences"
+          disabled={stats.students.length === 0}
+          getPayload={() => buildAttendanceExportPayload({ stats, settings, className })}
+        />
+      </div>
+      <div className="rounded-lg border">
+        <Table>
         <TableHeader>
           <TableRow>
             <TableHead>Élève</TableHead>
@@ -85,7 +98,8 @@ export function AttendanceStats({ classId }: AttendanceStatsProps) {
             </TableRow>
           ))}
         </TableBody>
-      </Table>
+        </Table>
+      </div>
     </div>
   )
 }

--- a/components/admin/attendance/attendance-export.ts
+++ b/components/admin/attendance/attendance-export.ts
@@ -1,0 +1,52 @@
+import type { ClassAttendanceStats } from "@/lib/api/attendance"
+import type { SchoolSettings } from "@/lib/contracts/settings"
+import type { ExportPayload } from "@/lib/export"
+import { brandingFromSettings } from "@/lib/export/branding"
+
+interface AttendanceExportArgs {
+  stats: ClassAttendanceStats
+  settings: SchoolSettings | undefined
+  /** Nom de la classe pour l'entête du document. */
+  className?: string
+}
+
+/**
+ * Construit la charge utile d'export des statistiques de présence par élève
+ * telles qu'affichées (tri par taux croissant). Colonnes calquées sur le
+ * tableau : élève, sessions, présent, absent, retard, excusé, taux.
+ */
+export function buildAttendanceExportPayload({
+  stats,
+  settings,
+  className,
+}: AttendanceExportArgs): ExportPayload {
+  const sorted = [...stats.students].sort((a, b) => a.attendance_rate - b.attendance_rate)
+  return {
+    branding: brandingFromSettings(settings),
+    meta: {
+      title: "Statistiques de présence",
+      subtitle: className
+        ? `Classe ${className} · ${stats.total_sessions} session(s)`
+        : `${stats.total_sessions} session(s)`,
+      date: new Date().toLocaleDateString("fr-FR"),
+    },
+    columns: [
+      { key: "eleve", header: "Élève" },
+      { key: "sessions", header: "Sessions", format: "number" },
+      { key: "present", header: "Présent", format: "number" },
+      { key: "absent", header: "Absent", format: "number" },
+      { key: "retard", header: "Retard", format: "number" },
+      { key: "excuse", header: "Excusé", format: "number" },
+      { key: "taux", header: "Taux (%)", format: "number" },
+    ],
+    rows: sorted.map((s) => ({
+      eleve: `${s.first_name} ${s.last_name}`.trim(),
+      sessions: stats.total_sessions,
+      present: s.present_count,
+      absent: s.absent_count,
+      retard: s.late_count,
+      excuse: s.excused_count,
+      taux: s.attendance_rate,
+    })),
+  }
+}

--- a/components/admin/grades/GradesSupervisor.tsx
+++ b/components/admin/grades/GradesSupervisor.tsx
@@ -22,7 +22,10 @@ import type { Evaluation } from "@/lib/contracts/grade"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { ExportMenu } from "@/components/export/ExportMenu"
+import { useSettings } from "@/lib/hooks/useSettings"
 import { EvaluationCreateModal } from "./EvaluationCreateModal"
+import { buildGradesExportPayload } from "./grades-export"
 import {
   Select,
   SelectContent,
@@ -66,6 +69,7 @@ export function GradesSupervisor() {
 
   const { has } = usePermissions()
   const canCreate = has("grades:write")
+  const { data: settings } = useSettings()
 
   const [classId, setClassId] = useState<number | null>(null)
   const [subjectId, setSubjectId] = useState<number | null>(null)
@@ -108,6 +112,25 @@ export function GradesSupervisor() {
   }
 
   const noClassSelected = classId === null
+
+  // Résumé lisible du contexte pour l'entête du document exporté.
+  const TAB_LABELS: Record<FilterTab, string> = {
+    all: "Toutes",
+    todo: "À saisir",
+    overdue: "En retard",
+    done: "Terminées",
+  }
+  const exportFilters = (() => {
+    const parts: string[] = []
+    const className = classes.find((c) => c.id === classId)?.name
+    if (className) parts.push(`Classe ${className}`)
+    const subjectName = subjects.find((s) => s.id === subjectId)?.name
+    if (subjectName) parts.push(subjectName)
+    if (trimester) parts.push(`T${trimester}`)
+    if (tab !== "all") parts.push(TAB_LABELS[tab])
+    return parts.length > 0 ? parts.join(" · ") : undefined
+  })()
+
   const tabsOrder: { key: FilterTab; label: string; count: number }[] = [
     { key: "all", label: "Toutes", count: stats.total },
     { key: "todo", label: "À saisir", count: stats.todo },
@@ -129,12 +152,21 @@ export function GradesSupervisor() {
               Suivez la progression des évaluations et saisissez au nom des enseignants si besoin.
             </p>
           </div>
-          {canCreate && (
-            <Button onClick={() => setCreateOpen(true)} className="shrink-0">
-              <Plus className="mr-2 h-4 w-4" />
-              Nouvelle évaluation
-            </Button>
-          )}
+          <div className="flex shrink-0 items-center gap-2">
+            <ExportMenu
+              filename="notes"
+              disabled={noClassSelected || filtered.length === 0}
+              getPayload={() =>
+                buildGradesExportPayload({ evaluations: filtered, settings, filters: exportFilters })
+              }
+            />
+            {canCreate && (
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Nouvelle évaluation
+              </Button>
+            )}
+          </div>
         </div>
 
         {!noClassSelected && (

--- a/components/admin/grades/grades-export.ts
+++ b/components/admin/grades/grades-export.ts
@@ -1,0 +1,73 @@
+import type { Evaluation } from "@/lib/contracts/grade"
+import type { SchoolSettings } from "@/lib/contracts/settings"
+import type { ExportPayload } from "@/lib/export"
+import { brandingFromSettings } from "@/lib/export/branding"
+
+const TYPE_LABELS: Record<string, string> = {
+  controle: "Contrôle",
+  devoir: "Devoir",
+  examen: "Examen",
+  oral: "Oral",
+}
+
+function isOverdue(e: Evaluation): boolean {
+  const daysAgo = (Date.now() - new Date(e.date).getTime()) / (1000 * 60 * 60 * 24)
+  return daysAgo > 3 && e.graded_students < e.total_students
+}
+
+function isDone(e: Evaluation): boolean {
+  return e.total_students > 0 && e.graded_students === e.total_students
+}
+
+function statusLabel(e: Evaluation): string {
+  if (isOverdue(e)) return "En retard"
+  if (isDone(e)) return "Complète"
+  return "En cours"
+}
+
+interface GradesExportArgs {
+  evaluations: Evaluation[]
+  settings: SchoolSettings | undefined
+  /** Résumé lisible du contexte (classe, matière, trimestre, vue). */
+  filters?: string
+}
+
+/**
+ * Construit la charge utile d'export du suivi des évaluations tel qu'affiché
+ * (classe sélectionnée, filtres appliqués). Colonnes calquées sur le tableau
+ * de supervision : évaluation, type, matière, date, coefficient, saisies,
+ * statut.
+ */
+export function buildGradesExportPayload({
+  evaluations,
+  settings,
+  filters,
+}: GradesExportArgs): ExportPayload {
+  return {
+    branding: brandingFromSettings(settings),
+    meta: {
+      title: "Suivi des évaluations",
+      subtitle: `${evaluations.length} évaluation(s) affichée(s)`,
+      filters,
+      date: new Date().toLocaleDateString("fr-FR"),
+    },
+    columns: [
+      { key: "evaluation", header: "Évaluation" },
+      { key: "type", header: "Type" },
+      { key: "matiere", header: "Matière" },
+      { key: "date", header: "Date", format: "date" },
+      { key: "coefficient", header: "Coeff.", format: "number" },
+      { key: "saisies", header: "Saisies" },
+      { key: "statut", header: "Statut" },
+    ],
+    rows: evaluations.map((e) => ({
+      evaluation: e.title,
+      type: TYPE_LABELS[e.type] ?? e.type,
+      matiere: e.subject_name,
+      date: e.date,
+      coefficient: e.coefficient,
+      saisies: `${e.graded_students}/${e.total_students}`,
+      statut: statusLabel(e),
+    })),
+  }
+}

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -45,12 +45,15 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { ExportMenu } from "@/components/export/ExportMenu"
 import { PaymentCreateWizard } from "./PaymentCreateWizard"
 import { usePayments, useFinancialSummary, useValidatePayment, useCancelPayment } from "@/lib/hooks/usePayments"
 import { useFeeCategories } from "@/lib/hooks/useFees"
+import { useSettings } from "@/lib/hooks/useSettings"
 import { paymentsApi } from "@/lib/api/payments"
 import { useDebounce } from "@/lib/hooks/useDebounce"
 import type { PaymentListParams, PaymentStatus, PaymentMethod, Payment } from "@/lib/contracts/payment"
+import { buildPaymentsExportPayload } from "./payments-export"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? ""
 
@@ -103,6 +106,7 @@ export function PaymentsPageClient() {
   const { mutate: validatePayment, isPending: validating } = useValidatePayment()
   const { mutate: cancelPayment, isPending: cancelling } = useCancelPayment()
   const { data: feeCategories } = useFeeCategories()
+  const { data: settings } = useSettings()
 
   // Client-side date filtering (BE doesn't support date params yet)
   const payments = useMemo(() => {
@@ -119,6 +123,20 @@ export function PaymentsPageClient() {
   }, [data, dateFrom, dateTo])
 
   const activeFilterCount = [statusFilter, methodFilter, categoryFilter, dateFrom, dateTo].filter(Boolean).length
+
+  // Résumé lisible des filtres actifs pour l'entête du document exporté.
+  const exportFilters = useMemo(() => {
+    const parts: string[] = []
+    if (statusFilter) parts.push(`Statut : ${STATUS_CONFIG[statusFilter].label}`)
+    if (methodFilter) parts.push(`Méthode : ${METHOD_LABELS[methodFilter]}`)
+    if (categoryFilter) {
+      const name = feeCategories?.find((c) => String(c.id) === categoryFilter)?.name
+      if (name) parts.push(`Catégorie : ${name}`)
+    }
+    if (dateFrom || dateTo) parts.push(`Période : ${dateFrom || "…"} au ${dateTo || "…"}`)
+    if (debouncedSearch) parts.push(`Recherche « ${debouncedSearch} »`)
+    return parts.length > 0 ? parts.join(" · ") : undefined
+  }, [statusFilter, methodFilter, categoryFilter, dateFrom, dateTo, debouncedSearch, feeCategories])
 
   const handlePreviewReceipt = useCallback(async (payment: Payment) => {
     setDownloadingId(payment.id)
@@ -208,10 +226,19 @@ export function PaymentsPageClient() {
         title="Paiements"
         subtitle="Suivi des paiements et tableau de bord financier"
         actions={
-          <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4" />
-            Nouveau paiement
-          </button>
+          <>
+            <ExportMenu
+              filename="paiements"
+              disabled={payments.length === 0}
+              getPayload={() =>
+                buildPaymentsExportPayload({ payments, settings, filters: exportFilters })
+              }
+            />
+            <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Nouveau paiement
+            </button>
+          </>
         }
         kpis={heroKpis}
       />

--- a/components/admin/payments/payments-export.ts
+++ b/components/admin/payments/payments-export.ts
@@ -1,0 +1,68 @@
+import type { Payment, PaymentMethod, PaymentStatus } from "@/lib/contracts/payment"
+import type { SchoolSettings } from "@/lib/contracts/settings"
+import type { ExportPayload } from "@/lib/export"
+import { brandingFromSettings } from "@/lib/export/branding"
+
+const METHOD_LABELS: Record<PaymentMethod, string> = {
+  cash: "Espèces",
+  mobile_money: "Mobile Money",
+  bank_transfer: "Virement",
+  cheque: "Chèque",
+}
+
+const STATUS_LABELS: Record<PaymentStatus, string> = {
+  pending: "En attente",
+  completed: "Validé",
+  failed: "Échoué",
+  refunded: "Remboursé",
+  cancelled: "Annulé",
+}
+
+interface PaymentsExportArgs {
+  payments: Payment[]
+  settings: SchoolSettings | undefined
+  /** Résumé lisible des filtres actifs (statut, méthode, période, recherche). */
+  filters?: string
+}
+
+/**
+ * Construit la charge utile d'export des paiements tels qu'affichés (page
+ * courante, filtres appliqués). Le montant total figure en ligne « Total ».
+ * Note : le tableau expose le frais alloué (`fee_name`), la classe n'étant pas
+ * portée par la ligne de paiement.
+ */
+export function buildPaymentsExportPayload({
+  payments,
+  settings,
+  filters,
+}: PaymentsExportArgs): ExportPayload {
+  const total = payments.reduce((sum, p) => sum + p.amount, 0)
+  return {
+    branding: brandingFromSettings(settings),
+    meta: {
+      title: "Liste des paiements",
+      subtitle: `${payments.length} paiement(s) affiché(s)`,
+      filters,
+      date: new Date().toLocaleDateString("fr-FR"),
+    },
+    columns: [
+      { key: "date", header: "Date", format: "date" },
+      { key: "reference", header: "Référence" },
+      { key: "eleve", header: "Élève" },
+      { key: "frais", header: "Frais" },
+      { key: "methode", header: "Méthode" },
+      { key: "statut", header: "Statut" },
+      { key: "montant", header: "Montant", format: "xof" },
+    ],
+    rows: payments.map((p) => ({
+      date: p.created_at,
+      reference: p.reference ?? "",
+      eleve: p.student_name ?? "",
+      frais: p.fee_name ?? "",
+      methode: METHOD_LABELS[p.method],
+      statut: STATUS_LABELS[p.status],
+      montant: p.amount,
+    })),
+    totalsRow: { eleve: "Total", montant: total },
+  }
+}

--- a/components/admin/students/StudentsTable.tsx
+++ b/components/admin/students/StudentsTable.tsx
@@ -10,9 +10,12 @@ import type { Student } from "@/lib/contracts/student"
 import { Badge } from "@/components/ui/badge"
 import { CrudTable } from "@/components/shared/CrudTable"
 import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
+import { ExportMenu } from "@/components/export/ExportMenu"
 import { getUploadUrl, cn } from "@/lib/utils"
 import { StudentEditModal } from "./StudentEditModal"
 import { useDebounce } from "@/lib/hooks/useDebounce"
+import { useSettings } from "@/lib/hooks/useSettings"
+import { buildStudentsExportPayload } from "./students-export"
 
 // Mini-icône genre inline à côté du nom (KEEP IN DATA pour DREN/bulletin compliance,
 // mais hidden de la colonne dédiée).
@@ -152,7 +155,22 @@ export function StudentsTable({
 
   const { data, isLoading, isError, error, refetch } = useStudents(params)
   const { data: filters } = useStudentFilters()
+  const { data: settings } = useSettings()
   const deleteMutation = useDeleteStudent()
+
+  // Résumé lisible des filtres actifs pour l'entête du document exporté.
+  const exportFilters = useMemo(() => {
+    const parts: string[] = []
+    if (activeChip === "unenrolled") {
+      parts.push("À inscrire")
+    } else if (activeChip.startsWith("class:")) {
+      const classId = Number(activeChip.split(":")[1])
+      const name = filters?.by_class?.find((c) => c.class_id === classId)?.class_name
+      parts.push(`Classe ${name ?? classId}`)
+    }
+    if (debouncedSearch) parts.push(`Recherche « ${debouncedSearch} »`)
+    return parts.length > 0 ? parts.join(" · ") : undefined
+  }, [activeChip, debouncedSearch, filters])
 
   const handleChipClick = useCallback((key: ChipKey) => {
     setActiveChip(key)
@@ -224,34 +242,43 @@ export function StudentsTable({
 
   return (
     <div className="space-y-4">
-      {/* Barre de filtre-chips. Horizontal-scroll sur mobile (Itel S661 320px ne
-          tient pas 14 chips wrap), wrap sur desktop. Le persona est mobile, on
-          design pour mobile d'abord. */}
-      <div className="flex gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-x-visible">
-        <FilterChip
-          label="Tous"
-          count={filters?.total ?? data?.total ?? 0}
-          isActive={activeChip === "all"}
-          onClick={() => handleChipClick("all")}
+      {/* Barre de filtre-chips + export. Horizontal-scroll sur mobile (Itel S661
+          320px ne tient pas 14 chips wrap), wrap sur desktop. Le persona est
+          mobile, on design pour mobile d'abord. */}
+      <div className="flex items-start gap-2">
+        <div className="flex flex-1 gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-x-visible">
+          <FilterChip
+            label="Tous"
+            count={filters?.total ?? data?.total ?? 0}
+            isActive={activeChip === "all"}
+            onClick={() => handleChipClick("all")}
+          />
+          {(filters?.no_current_enrollment_count ?? 0) > 0 && (
+            <FilterChip
+              label="À inscrire"
+              count={filters!.no_current_enrollment_count}
+              isActive={activeChip === "unenrolled"}
+              onClick={() => handleChipClick("unenrolled")}
+              tone="warning"
+            />
+          )}
+          {(filters?.by_class ?? []).map((c) => (
+            <FilterChip
+              key={c.class_id}
+              label={c.class_name}
+              count={c.count}
+              isActive={activeChip === `class:${c.class_id}`}
+              onClick={() => handleChipClick(`class:${c.class_id}`)}
+            />
+          ))}
+        </div>
+        <ExportMenu
+          filename="eleves"
+          disabled={items.length === 0}
+          getPayload={() =>
+            buildStudentsExportPayload({ students: items, settings, filters: exportFilters })
+          }
         />
-        {(filters?.no_current_enrollment_count ?? 0) > 0 && (
-          <FilterChip
-            label="À inscrire"
-            count={filters!.no_current_enrollment_count}
-            isActive={activeChip === "unenrolled"}
-            onClick={() => handleChipClick("unenrolled")}
-            tone="warning"
-          />
-        )}
-        {(filters?.by_class ?? []).map((c) => (
-          <FilterChip
-            key={c.class_id}
-            label={c.class_name}
-            count={c.count}
-            isActive={activeChip === `class:${c.class_id}`}
-            onClick={() => handleChipClick(`class:${c.class_id}`)}
-          />
-        ))}
       </div>
 
       {/* Desktop : table dense via CrudTable. Mobile : liste minimale via

--- a/components/admin/students/students-export.ts
+++ b/components/admin/students/students-export.ts
@@ -1,0 +1,50 @@
+import type { Student } from "@/lib/contracts/student"
+import type { SchoolSettings } from "@/lib/contracts/settings"
+import type { ExportPayload } from "@/lib/export"
+import { brandingFromSettings } from "@/lib/export/branding"
+
+const SEX_LABELS: Record<string, string> = { M: "Masculin", F: "Féminin" }
+
+interface StudentsExportArgs {
+  students: Student[]
+  settings: SchoolSettings | undefined
+  /** Résumé lisible des filtres actifs (chip cohorte, recherche). */
+  filters?: string
+}
+
+/**
+ * Construit la charge utile d'export de la liste des élèves telle qu'affichée
+ * (page courante, filtres appliqués). Colonnes calquées sur le tableau admin :
+ * matricule, nom, sexe, naissance, classe, statut.
+ */
+export function buildStudentsExportPayload({
+  students,
+  settings,
+  filters,
+}: StudentsExportArgs): ExportPayload {
+  return {
+    branding: brandingFromSettings(settings),
+    meta: {
+      title: "Liste des élèves",
+      subtitle: `${students.length} élève(s) affiché(s)`,
+      filters,
+      date: new Date().toLocaleDateString("fr-FR"),
+    },
+    columns: [
+      { key: "matricule", header: "Matricule" },
+      { key: "nom", header: "Nom" },
+      { key: "sexe", header: "Sexe" },
+      { key: "naissance", header: "Naissance", format: "date" },
+      { key: "classe", header: "Classe" },
+      { key: "statut", header: "Statut" },
+    ],
+    rows: students.map((s) => ({
+      matricule: s.enrollment_number ?? "",
+      nom: `${s.last_name} ${s.first_name}`.trim(),
+      sexe: s.genre ? (SEX_LABELS[s.genre] ?? s.genre) : "",
+      naissance: s.birth_date ?? "",
+      classe: s.current_enrollment?.class_name ?? "À inscrire",
+      statut: s.current_enrollment?.status ?? "Non inscrit",
+    })),
+  }
+}

--- a/lib/export/branding.ts
+++ b/lib/export/branding.ts
@@ -1,0 +1,22 @@
+/**
+ * Construit l'identité visuelle d'export à partir des paramètres du tenant.
+ *
+ * Centralise le mapping `SchoolSettings` -> `ExportBranding` pour éviter la
+ * répétition dans chaque page qui pose un `<ExportMenu>` (élèves, paiements,
+ * notes, présences...). Le logo n'est volontairement pas géré ici.
+ */
+
+import type { SchoolSettings } from "@/lib/contracts/settings"
+import type { ExportBranding } from "./types"
+import { DEFAULT_ACCENT_COLOR, DEFAULT_PRIMARY_COLOR } from "./types"
+
+/** Mappe les paramètres de l'établissement vers la marque d'export (fallback KLASSCI). */
+export function brandingFromSettings(
+  settings: SchoolSettings | undefined,
+): ExportBranding {
+  return {
+    schoolName: settings?.school_name ?? "Établissement",
+    primaryColor: settings?.primary_color ?? DEFAULT_PRIMARY_COLOR,
+    accentColor: settings?.accent_color ?? DEFAULT_ACCENT_COLOR,
+  }
+}


### PR DESCRIPTION
Closes #240 (câblage, PR finale des exports). S'appuie sur le socle #241.

## Câblage `<ExportMenu>` (Excel + PDF, marque tenant via useSettings)
- **Élèves** (`StudentsTable`) : matricule, nom, sexe, naissance, classe, statut.
- **Paiements** (`PaymentsPageClient`) : date, référence, élève, frais, méthode, statut, montant (XOF) + **ligne total**.
- **Notes** (`GradesSupervisor`) : liste d'évaluations (titre, type, matière, date, coeff., saisies, statut) ; désactivé tant qu'aucune classe choisie.
- **Présences** (`AttendanceStats`) : élève, sessions, présent/absent/retard/excusé, taux %.
- Helpers : `lib/export/branding.ts` (`brandingFromSettings`) + un `*-export.ts` de mapping par page (no-god-code).
- `getPayload` lazy → capture les lignes filtrées affichées ; `meta` reflète filtres + nb réel de lignes (pas de « toutes » trompeur sur les listes paginées).

**Hors scope** : `/admin/fees` (page de configuration, pas de dû/payé/solde) et `/admin/timetable` (grille).

## Validation
`pnpm type-check` = 0 erreur · `pnpm lint` = 0 erreur sur les fichiers touchés. Validation runtime (génération réelle Excel/PDF) via visual-check sur le serveur après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)