### PR TITLE
feat(pdf): boutons Relevé de notes + Cahier de texte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Relevé de notes rempli (PDF) téléchargeable et consultable en aperçu depuis la page Notes, une fois une classe, une matière et un trimestre choisis. Cahier de texte de la classe (semaine en cours) ajouté aux documents de la fiche de classe, en téléchargement et en aperçu *(admin, enseignant)*.
 - Aperçu PDF sur tous les documents : à côté de chaque bouton « Télécharger », un bouton « Aperçu » ouvre le document dans un nouvel onglet sans le télécharger (bulletins, certificats et attestations, reçus de paiement, liste de classe, rapport de synthèse, PV de conseil, emploi du temps, statistiques DREN). Deux nouveaux documents de classe, la feuille d'appel et la feuille de notes vierges, sont aussi téléchargeables et consultables en aperçu depuis la fiche de classe *(admin, enseignant, parent, élève)*.
 - Export en un tap des listes de gestion : bouton « Exporter » (Excel .xlsx ou PDF, aux couleurs de l'établissement) sur les pages Élèves, Paiements (avec total), Notes et Présences. L'export reprend exactement les lignes affichées, filtres compris *(admin)*.
 - Socle d'export de données réutilisable : les listes pourront bientôt être exportées en Excel (.xlsx) et en PDF, aux couleurs de l'établissement. L'Excel reste une vraie table exploitable (filtres, tri, colonnes typées), le PDF adopte la présentation sobre des documents officiels *(admin)*.

--- a/components/admin/classes/detail/OverviewTab.tsx
+++ b/components/admin/classes/detail/OverviewTab.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils"
 import { deriveSubjects, deriveTeachers } from "./class-helpers"
 import {
   fetchClassAttendanceSheet,
+  fetchClassCahierTexte,
   fetchClassGradeSheet,
   fetchClassRoster,
   fetchClassSynthesis,
@@ -270,6 +271,15 @@ export function OverviewTab({ classData, slots }: OverviewTabProps) {
             fetchBlob={() => fetchClassGradeSheet(classData.id)}
             filename={`feuille-notes-${safeName}.pdf`}
             label={`la feuille de notes de la classe ${name}`}
+          />
+
+          {/* Cahier de texte (semaine en cours) */}
+          <DocRow
+            title="Cahier de texte"
+            description="Le cahier de texte de la classe pour la semaine en cours."
+            fetchBlob={() => fetchClassCahierTexte(classData.id)}
+            filename={`cahier-texte-${safeName}.pdf`}
+            label={`le cahier de texte de la classe ${name}`}
           />
 
           {/* Rapport de synthèse */}

--- a/components/admin/classes/detail/class-downloads.ts
+++ b/components/admin/classes/detail/class-downloads.ts
@@ -34,6 +34,11 @@ export function fetchClassGradeSheet(classId: number): Promise<Blob> {
   return apiFetchBlob(`/admin/classes/${classId}/grade-sheet`)
 }
 
+/** Cahier de texte de la classe (semaine en cours par défaut) — PDF. */
+export function fetchClassCahierTexte(classId: number): Promise<Blob> {
+  return apiFetchBlob(`/admin/classes/${classId}/cahier-texte`)
+}
+
 /**
  * Déclenche le téléchargement d'un Blob côté navigateur (création d'un
  * `<a download>` éphémère + revokeObjectURL). Pattern identique à

--- a/components/admin/grades/GradesSupervisor.tsx
+++ b/components/admin/grades/GradesSupervisor.tsx
@@ -3,13 +3,16 @@
 import { useState, useMemo } from "react"
 import Link from "next/link"
 import type { Route } from "next"
+import { toast } from "sonner"
 import {
   AlertTriangle,
   CheckCircle2,
   ClipboardList,
   Edit3,
+  FileText,
   Hourglass,
   Info,
+  Loader2,
   Plus,
   TrendingUp,
 } from "lucide-react"
@@ -17,12 +20,19 @@ import { cn } from "@/lib/utils"
 import { useEvaluations } from "@/lib/hooks/useGrades"
 import { useClasses } from "@/lib/hooks/useClasses"
 import { useSubjects } from "@/lib/hooks/useSubjects"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { usePermissions } from "@/lib/hooks/usePermissions"
 import type { Evaluation } from "@/lib/contracts/grade"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { ExportMenu } from "@/components/export/ExportMenu"
+import { PdfPreviewButton } from "@/components/shared/PdfPreviewButton"
+import { apiFetchBlob } from "@/lib/api/client"
+import {
+  fileSafeName,
+  triggerBlobDownload,
+} from "@/components/admin/classes/detail/class-downloads"
 import { useSettings } from "@/lib/hooks/useSettings"
 import { EvaluationCreateModal } from "./EvaluationCreateModal"
 import { buildGradesExportPayload } from "./grades-export"
@@ -67,6 +77,11 @@ export function GradesSupervisor() {
   const { data: subjectsData } = useSubjects({ size: 100 })
   const subjects = subjectsData?.items ?? []
 
+  const { data: yearsData } = useAcademicYears()
+  const years = yearsData?.items ?? []
+  const currentYear = years.find((y) => y.is_current) ?? years[0]
+  const ayId = currentYear?.id
+
   const { has } = usePermissions()
   const canCreate = has("grades:write")
   const { data: settings } = useSettings()
@@ -76,6 +91,7 @@ export function GradesSupervisor() {
   const [trimester, setTrimester] = useState<number | null>(null)
   const [tab, setTab] = useState<FilterTab>("all")
   const [createOpen, setCreateOpen] = useState(false)
+  const [downloadingReport, setDownloadingReport] = useState(false)
 
   const { data: evaluations, isLoading, error } = useEvaluations(classId ?? 0)
 
@@ -131,6 +147,41 @@ export function GradesSupervisor() {
     return parts.length > 0 ? parts.join(" · ") : undefined
   })()
 
+  // Relevé de notes rempli : n'a de sens que par matière ET trimestre précis.
+  const reportReady =
+    classId != null && subjectId != null && trimester != null && ayId != null
+  const reportClassName = classes.find((c) => c.id === classId)?.name
+  const reportSubjectName = subjects.find((s) => s.id === subjectId)?.name
+  const reportLabel = `le relevé de notes${
+    reportClassName ? ` de la classe ${reportClassName}` : ""
+  }${reportSubjectName ? ` en ${reportSubjectName}` : ""}${
+    trimester ? ` (T${trimester})` : ""
+  }`
+  const reportFilename = `releve-notes-${fileSafeName(
+    reportClassName ?? "classe",
+  )}-${fileSafeName(reportSubjectName ?? "matiere")}-T${trimester}.pdf`
+  const fetchGradeReport = () =>
+    apiFetchBlob(
+      `/reports/classes/${classId}/grade-report?subject_id=${subjectId}&trimester=${trimester}&academic_year_id=${ayId}`,
+    )
+
+  async function handleGradeReport() {
+    if (!reportReady) return
+    setDownloadingReport(true)
+    try {
+      triggerBlobDownload(await fetchGradeReport(), reportFilename)
+    } catch (err) {
+      toast.error("Téléchargement impossible", {
+        description:
+          err instanceof Error ? err.message : "Erreur lors de la génération du PDF",
+      })
+    } finally {
+      setDownloadingReport(false)
+    }
+  }
+
+  const reportHint = "Choisir une classe, une matière et un trimestre"
+
   const tabsOrder: { key: FilterTab; label: string; count: number }[] = [
     { key: "all", label: "Toutes", count: stats.total },
     { key: "todo", label: "À saisir", count: stats.todo },
@@ -152,7 +203,33 @@ export function GradesSupervisor() {
               Suivez la progression des évaluations et saisissez au nom des enseignants si besoin.
             </p>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            <div
+              className="flex items-center gap-2"
+              title={reportReady ? undefined : reportHint}
+            >
+              <PdfPreviewButton
+                fetchBlob={fetchGradeReport}
+                label={reportLabel}
+                disabled={!reportReady}
+                className="h-11 sm:h-10"
+              />
+              <Button
+                variant="outline"
+                onClick={handleGradeReport}
+                disabled={!reportReady || downloadingReport}
+                aria-label="Télécharger le relevé de notes"
+                title={reportReady ? undefined : reportHint}
+                className="h-11 sm:h-10"
+              >
+                {downloadingReport ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <FileText className="mr-2 h-4 w-4" aria-hidden="true" />
+                )}
+                Relevé de notes (PDF)
+              </Button>
+            </div>
             <ExportMenu
               filename="notes"
               disabled={noClassSelected || filtered.length === 0}


### PR DESCRIPTION
Câblage FE des 2 documents remplis (endpoints BE #192 déployés).

- **Relevé de notes** sur la page Notes (`GradesSupervisor`) : Télécharger + Aperçu, activé seulement quand classe + matière + trimestre sont choisis. `academic_year_id` via `useAcademicYears()` (année `is_current`). Endpoint `/reports/classes/{id}/grade-report`.
- **Cahier de texte** en `DocRow` sur la page de classe (onglet Aperçu, section Documents) : Télécharger + Aperçu. Endpoint `/admin/classes/{id}/cahier-texte` (semaine courante).

Réutilise `apiFetchBlob` + `openPdfPreview` + `PdfPreviewButton` + `triggerBlobDownload`. `pnpm type-check`/`lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)