### PR TITLE
refactor(timetable): retirer le sélecteur de semaine trompeur (EDT annuel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Emploi du temps : les flèches « Semaine précédente / suivante » sont retirées au profit d'un repère fixe « Semaine type · Année {en cours} ». L'emploi du temps vaut pour toute l'année scolaire ; l'ancien sélecteur laissait croire, à tort, que chaque semaine avait son propre planning *(admin)*.
 - Bandeau de synthèse des Frais (élève, parent) repassé au dégradé bleu-orange de la marque, et indicateurs de la page Années scolaires intégrés au bandeau d'en-tête *(tous)*.
 - Tableaux de bord enseignant, élève et parent désormais en tête de page sur le bandeau bleu-orange KLASSCI, indicateurs clés intégrés. Pages Promotions, Paramètres, Conseil de classe et Statistiques DREN harmonisées sur le même bandeau *(tous)*.
 - Refonte visuelle de toute l'application : chaque page (tableau de bord, listes d'administration, portails enseignant et parent) s'ouvre désormais sur un bandeau au dégradé **bleu et orange** (les deux couleurs du logo KLASSCI), avec les indicateurs clés intégrés en blanc et l'action principale mise en avant en orange. Les en-têtes de section reprennent l'orange de la marque. Identité cohérente du haut de page jusqu'aux moindres détails, vérifiée en mode clair et sombre *(tous)*.

--- a/app/(admin)/admin/timetable/page.tsx
+++ b/app/(admin)/admin/timetable/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect, useRef, useMemo, useCallback } from "react"
-import { Calendar, ChevronLeft, ChevronRight, FileDown, Wand2, Loader2 } from "lucide-react"
+import { Calendar, CalendarRange, FileDown, Wand2, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -14,6 +14,7 @@ import {
 import { useTimetableStore } from "@/lib/stores/useTimetableStore"
 import { useGenerateTimetable } from "@/lib/hooks/useTimetable"
 import { useClasses } from "@/lib/hooks/useClasses"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { timetableApi } from "@/lib/api/timetable"
 import { downloadBlob } from "@/lib/utils"
 import { useQueryClient } from "@tanstack/react-query"
@@ -25,7 +26,7 @@ import { GenerateDiagnosticModal } from "@/components/admin/timetable/GenerateDi
 import type { TimetableDiagnostic } from "@/lib/contracts/timetable"
 
 export default function TimetablePage() {
-  const { selectedClassId, setSelectedClassId, weekOffset, nextWeek, prevWeek, resetWeek } = useTimetableStore()
+  const { selectedClassId, setSelectedClassId } = useTimetableStore()
   const generateMutation = useGenerateTimetable()
   const queryClient = useQueryClient()
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -41,6 +42,12 @@ export default function TimetablePage() {
 
   const { data: classesData } = useClasses({ size: 100 })
   const classes = useMemo(() => classesData?.items ?? [], [classesData])
+
+  const { data: yearsData } = useAcademicYears()
+  const currentYearName =
+    (yearsData?.items ?? []).find((y) => y.is_current)?.name ??
+    (yearsData?.items ?? [])[0]?.name ??
+    ""
 
   // Cleanup polling on unmount or class change
   useEffect(() => {
@@ -129,7 +136,7 @@ export default function TimetablePage() {
     if (!selectedClassId) return
     setExportingPdf(true)
     try {
-      const blob = await timetableApi.exportPdf(selectedClassId, weekOffset)
+      const blob = await timetableApi.exportPdf(selectedClassId)
       const className = classes.find((c) => c.id === selectedClassId)?.name ?? "classe"
       downloadBlob(blob, `emploi-du-temps-${className}.pdf`)
       toast.success("PDF exporté avec succès")
@@ -157,7 +164,7 @@ export default function TimetablePage() {
         </div>
         <div className="flex flex-wrap gap-2">
           <PdfPreviewButton
-            fetchBlob={() => timetableApi.exportPdf(selectedClassId as number, weekOffset)}
+            fetchBlob={() => timetableApi.exportPdf(selectedClassId as number)}
             label="l'emploi du temps"
             disabled={!selectedClassId}
             className="h-11 sm:h-10"
@@ -218,34 +225,20 @@ export default function TimetablePage() {
           </Select>
         </div>
 
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="icon"
-            aria-label="Semaine précédente"
-            className="h-11 w-11 sm:h-9 sm:w-9"
-            onClick={prevWeek}
-          >
-            <ChevronLeft aria-hidden="true" className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={resetWeek}
-            aria-label="Revenir à cette semaine"
-            className="h-11 text-sm min-w-[120px] sm:h-9"
-          >
-            {weekOffset === 0 ? "Cette semaine" : `Semaine ${weekOffset > 0 ? "+" : ""}${weekOffset}`}
-          </Button>
-          <Button
-            variant="outline"
-            size="icon"
-            aria-label="Semaine suivante"
-            className="h-11 w-11 sm:h-9 sm:w-9"
-            onClick={nextWeek}
-          >
-            <ChevronRight aria-hidden="true" className="h-4 w-4" />
-          </Button>
+        <div
+          className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-1.5 text-sm text-muted-foreground"
+          title="L'emploi du temps est un modèle hebdomadaire valable toute l'année scolaire."
+        >
+          <CalendarRange aria-hidden="true" className="h-4 w-4 text-primary" />
+          <span>
+            Semaine type
+            {currentYearName ? (
+              <>
+                {" · "}
+                <span className="font-medium text-foreground">Année {currentYearName}</span>
+              </>
+            ) : null}
+          </span>
         </div>
       </div>
 
@@ -273,9 +266,9 @@ export default function TimetablePage() {
       {selectedClassId ? (
         <div className="flex gap-4 items-start">
           <div className="flex-1 min-w-0">
-            <TimetableGrid classId={selectedClassId} weekOffset={weekOffset} />
+            <TimetableGrid classId={selectedClassId} />
           </div>
-          <TimetableHoursSidebar classId={selectedClassId} weekOffset={weekOffset} />
+          <TimetableHoursSidebar classId={selectedClassId} />
         </div>
       ) : (
         <div className="flex h-64 items-center justify-center rounded-lg border border-dashed bg-muted/20">

--- a/components/admin/timetable/TimetableGrid.tsx
+++ b/components/admin/timetable/TimetableGrid.tsx
@@ -67,12 +67,11 @@ function minutesToPx(minutes: number): number {
 
 interface TimetableGridProps {
   classId: number
-  weekOffset?: number
 }
 
-export function TimetableGrid({ classId, weekOffset = 0 }: TimetableGridProps) {
+export function TimetableGrid({ classId }: TimetableGridProps) {
   const queryClient = useQueryClient()
-  const { data: slots, isLoading } = useTimetable(classId, weekOffset)
+  const { data: slots, isLoading } = useTimetable(classId)
   const deleteMutation = useDeleteSlot()
   const [createModal, setCreateModal] = useState<{ day: string; time: string; endTime?: string } | null>(null)
   const [selectedSlot, setSelectedSlot] = useState<TimetableSlot | null>(null)

--- a/components/admin/timetable/TimetableHoursSidebar.tsx
+++ b/components/admin/timetable/TimetableHoursSidebar.tsx
@@ -13,7 +13,6 @@ import type { Subject } from "@/lib/contracts/subject"
 
 interface TimetableHoursSidebarProps {
   classId: number
-  weekOffset?: number
 }
 
 interface SubjectHours {
@@ -68,8 +67,8 @@ function formatHours(h: number): string {
   return `${hours}h${String(minutes).padStart(2, "0")}`
 }
 
-export function TimetableHoursSidebar({ classId, weekOffset = 0 }: TimetableHoursSidebarProps) {
-  const { data: slots, isLoading: slotsLoading } = useTimetable(classId, weekOffset)
+export function TimetableHoursSidebar({ classId }: TimetableHoursSidebarProps) {
+  const { data: slots, isLoading: slotsLoading } = useTimetable(classId)
   const { data: classDetail } = useClass(classId)
   const levelId = classDetail?.level_id
   const { data: subjectsData, isLoading: subjectsLoading } = useSubjects(

--- a/lib/api/timetable.ts
+++ b/lib/api/timetable.ts
@@ -44,11 +44,8 @@ function slotsToFr<T extends { day: string }>(slots: T[]): T[] {
 }
 
 export const timetableApi = {
-  listByClass: async (classId: number, weekOffset?: number): Promise<TimetableSlot[]> => {
+  listByClass: async (classId: number): Promise<TimetableSlot[]> => {
     const params = new URLSearchParams({ class_id: String(classId) })
-    if (weekOffset !== undefined && weekOffset !== 0) {
-      params.set("week_offset", String(weekOffset))
-    }
     const json = await apiFetch<{ data?: TimetableSlot[] } | TimetableSlot[]>(
       `/timetable?${params}`,
     )
@@ -177,12 +174,9 @@ export const timetableApi = {
     await apiFetch<void>(`/teacher-availabilities/${availabilityId}`, { method: "DELETE" })
   },
 
-  exportPdf: async (classId: number, weekOffset?: number): Promise<Blob> => {
+  exportPdf: async (classId: number): Promise<Blob> => {
     const session = await getSession()
     const params = new URLSearchParams({ class_id: String(classId) })
-    if (weekOffset !== undefined && weekOffset !== 0) {
-      params.set("week_offset", String(weekOffset))
-    }
     const base = process.env.NEXT_PUBLIC_API_URL ?? ""
     const res = await fetch(`${base}/timetable/export-pdf?${params}`, {
       headers: {

--- a/lib/hooks/useTimetable.ts
+++ b/lib/hooks/useTimetable.ts
@@ -13,18 +13,17 @@ import type {
 
 export const timetableKeys = {
   all: ["timetable"] as const,
-  byClass: (classId: number, weekOffset?: number) =>
-    ["timetable", "class", classId, weekOffset ?? 0] as const,
+  byClass: (classId: number) => ["timetable", "class", classId] as const,
   byTeacher: (teacherId: number) => ["timetable", "teacher", teacherId] as const,
   mine: () => ["timetable", "mine"] as const,
   availabilities: (teacherId: number) =>
     ["timetable", "availabilities", teacherId] as const,
 }
 
-export function useTimetable(classId: number, weekOffset: number = 0) {
+export function useTimetable(classId: number) {
   return useQuery({
-    queryKey: timetableKeys.byClass(classId, weekOffset),
-    queryFn: () => timetableApi.listByClass(classId, weekOffset),
+    queryKey: timetableKeys.byClass(classId),
+    queryFn: () => timetableApi.listByClass(classId),
     enabled: !!classId,
     staleTime: 1000 * 60 * 5,
   })

--- a/lib/stores/useTimetableStore.ts
+++ b/lib/stores/useTimetableStore.ts
@@ -3,21 +3,13 @@ import { create } from "zustand"
 interface TimetableState {
   selectedClassId: number | null
   view: "week" | "day"
-  weekOffset: number
   setSelectedClassId: (id: number | null) => void
   setView: (view: "week" | "day") => void
-  nextWeek: () => void
-  prevWeek: () => void
-  resetWeek: () => void
 }
 
 export const useTimetableStore = create<TimetableState>((set) => ({
   selectedClassId: null,
   view: "week",
-  weekOffset: 0,
   setSelectedClassId: (id) => set({ selectedClassId: id }),
   setView: (view) => set({ view }),
-  nextWeek: () => set((s) => ({ weekOffset: s.weekOffset + 1 })),
-  prevWeek: () => set((s) => ({ weekOffset: s.weekOffset - 1 })),
-  resetWeek: () => set({ weekOffset: 0 }),
 }))


### PR DESCRIPTION
## Contexte

L'emploi du temps est un **modèle hebdomadaire récurrent rattaché à une année** : un créneau porte un jour de la semaine, pas une date. Le sélecteur « Semaine précédente / suivante » (`weekOffset`) envoyait un `week_offset` que le backend **n'a jamais utilisé** → quelle que soit la semaine, la grille était identique. Le contrôle induisait faussement en erreur.

## Changements

- Retrait de `weekOffset` / `nextWeek` / `prevWeek` / `resetWeek` du store, du hook `useTimetable`, de l'API (`listByClass`, `exportPdf`), de `TimetableGrid` et `TimetableHoursSidebar`.
- Remplacement des flèches par une puce fixe **« Semaine type · Année {courante} »** (année via `useAcademicYears` `is_current`).

## Tests

- `pnpm tsc --noEmit` : OK (exit 0).
- `eslint` sur les fichiers modifiés : 0 erreur (warnings préexistants uniquement).
- `grep` : plus aucune référence à `weekOffset` / `week_offset` dans le FE.

Voir aussi backend #193/#194 (retrait du paramètre mort côté endpoints).

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)