### PR TITLE
feat(settings): gestion des congés / jours fériés (onglet Calendrier)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Gestion des congés et jours fériés dans les Paramètres (onglet « Calendrier », sous les trimestres) : on ajoute ou supprime des périodes (libellé + date de début et de fin). Ces jours n'apparaissent plus dans le cahier de texte, même en plein trimestre *(admin)*.
 - Relevé de notes rempli (PDF) téléchargeable et consultable en aperçu depuis la page Notes, une fois une classe, une matière et un trimestre choisis. Cahier de texte de la classe (semaine en cours) ajouté aux documents de la fiche de classe, en téléchargement et en aperçu *(admin, enseignant)*.
 - Aperçu PDF sur tous les documents : à côté de chaque bouton « Télécharger », un bouton « Aperçu » ouvre le document dans un nouvel onglet sans le télécharger (bulletins, certificats et attestations, reçus de paiement, liste de classe, rapport de synthèse, PV de conseil, emploi du temps, statistiques DREN). Deux nouveaux documents de classe, la feuille d'appel et la feuille de notes vierges, sont aussi téléchargeables et consultables en aperçu depuis la fiche de classe *(admin, enseignant, parent, élève)*.
 - Export en un tap des listes de gestion : bouton « Exporter » (Excel .xlsx ou PDF, aux couleurs de l'établissement) sur les pages Élèves, Paiements (avec total), Notes et Présences. L'export reprend exactement les lignes affichées, filtres compris *(admin)*.

--- a/components/admin/settings/HolidaySection.tsx
+++ b/components/admin/settings/HolidaySection.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useForm, useFieldArray } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { CalendarOff, Loader2, Plus, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { HolidaysUpdateSchema, type HolidaysUpdate, type SchoolSettings } from "@/lib/contracts/settings"
+import { useUpdateHolidays } from "@/lib/hooks/useSettings"
+
+interface HolidaySectionProps {
+  settings: SchoolSettings
+}
+
+export function HolidaySection({ settings }: HolidaySectionProps) {
+  const { mutate, isPending } = useUpdateHolidays()
+
+  const form = useForm<HolidaysUpdate>({
+    resolver: zodResolver(HolidaysUpdateSchema),
+    defaultValues: { holidays: settings.holidays ?? [] },
+  })
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "holidays",
+  })
+
+  function onSubmit(data: HolidaysUpdate) {
+    mutate(data)
+  }
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardHeader className="pb-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <CalendarOff className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle className="text-base">Congés &amp; jours fériés</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Congés de Toussaint, fêtes, jours fériés. Ces jours sont exclus du cahier de texte.
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            {fields.length === 0 ? (
+              <p className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                Aucun congé enregistré. Ajoutez les vacances et jours fériés de l&apos;année pour
+                qu&apos;ils n&apos;apparaissent pas dans le cahier de texte.
+              </p>
+            ) : (
+              fields.map((field, index) => (
+                <div key={field.id} className="rounded-lg border p-4">
+                  <div className="grid gap-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end">
+                    <FormField
+                      control={form.control}
+                      name={`holidays.${index}.label`}
+                      render={({ field: f }) => (
+                        <FormItem>
+                          <FormLabel>Libellé</FormLabel>
+                          <FormControl>
+                            <Input placeholder="ex : Congés de Toussaint" className="h-11 sm:h-10" {...f} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`holidays.${index}.start_date`}
+                      render={({ field: f }) => (
+                        <FormItem>
+                          <FormLabel>Début</FormLabel>
+                          <FormControl>
+                            <Input type="date" className="h-11 sm:h-10" {...f} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`holidays.${index}.end_date`}
+                      render={({ field: f }) => (
+                        <FormItem>
+                          <FormLabel>Fin</FormLabel>
+                          <FormControl>
+                            <Input type="date" className="h-11 sm:h-10" {...f} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Supprimer le congé ${index + 1}`}
+                      className="h-11 w-11 shrink-0 text-muted-foreground hover:text-destructive sm:h-10 sm:w-10"
+                      onClick={() => remove(index)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))
+            )}
+
+            <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:items-center sm:justify-between">
+              <Button
+                type="button"
+                variant="outline"
+                className="h-11 sm:h-10"
+                onClick={() => append({ label: "", start_date: "", end_date: "" })}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Ajouter un congé
+              </Button>
+              <Button type="submit" disabled={isPending} className="h-11 sm:h-10">
+                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Enregistrer
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/settings/SettingsPageClient.tsx
+++ b/components/admin/settings/SettingsPageClient.tsx
@@ -9,6 +9,7 @@ import { DataError } from "@/components/shared/DataError"
 import { useSettings } from "@/lib/hooks/useSettings"
 import { SchoolInfoSection } from "./SchoolInfoSection"
 import { TrimesterSection } from "./TrimesterSection"
+import { HolidaySection } from "./HolidaySection"
 import { NotificationSection } from "./NotificationSection"
 import { PdfIdentitySection } from "./PdfIdentitySection"
 
@@ -34,7 +35,7 @@ export function SettingsPageClient() {
           <TabsList>
             <TabsTrigger value="school">Établissement</TabsTrigger>
             <TabsTrigger value="identity">Identité visuelle</TabsTrigger>
-            <TabsTrigger value="trimesters">Trimestres</TabsTrigger>
+            <TabsTrigger value="trimesters">Calendrier</TabsTrigger>
             <TabsTrigger value="notifications">Notifications</TabsTrigger>
           </TabsList>
 
@@ -46,8 +47,9 @@ export function SettingsPageClient() {
             <PdfIdentitySection settings={settings} isLoading={isLoading} />
           </TabsContent>
 
-          <TabsContent value="trimesters">
+          <TabsContent value="trimesters" className="space-y-6">
             <TrimesterSection settings={settings} />
+            <HolidaySection settings={settings} />
           </TabsContent>
 
           <TabsContent value="notifications">

--- a/lib/api/settings.ts
+++ b/lib/api/settings.ts
@@ -4,6 +4,7 @@ import {
   type SchoolSettings,
   type SchoolInfoUpdate,
   type TrimesterUpdate,
+  type HolidaysUpdate,
   type NotificationUpdate,
 } from "@/lib/contracts/settings"
 
@@ -44,6 +45,14 @@ export const settingsApi = {
       body: JSON.stringify(data),
     })
     return parseSettings(json, "PUT /admin/settings/trimesters")
+  },
+
+  updateHolidays: async (data: HolidaysUpdate): Promise<SchoolSettings> => {
+    const json = await apiFetch<unknown>("/admin/settings/holidays", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    })
+    return parseSettings(json, "PUT /admin/settings/holidays")
   },
 
   updateNotifications: async (data: NotificationUpdate): Promise<SchoolSettings> => {

--- a/lib/contracts/settings.ts
+++ b/lib/contracts/settings.ts
@@ -10,6 +10,12 @@ export const TrimesterConfigSchema = z.object({
   end_date: z.string(),
 })
 
+export const SchoolHolidaySchema = z.object({
+  label: z.string(),
+  start_date: z.string(),
+  end_date: z.string(),
+})
+
 export const SchoolSettingsSchema = z.object({
   id: z.number().optional(),
   // --- Fields from backend ---
@@ -33,6 +39,7 @@ export const SchoolSettingsSchema = z.object({
   // --- UI-only fields ---
   active_academic_year: z.string().nullable().optional().default(null),
   trimesters: z.array(TrimesterConfigSchema).optional().default([]),
+  holidays: z.array(SchoolHolidaySchema).optional().default([]),
   // Notification preferences (now backed by BE columns on school_settings — see migration 0027)
   notify_by_email: z.boolean().optional().default(false),
   notify_by_sms: z.boolean().optional().default(false),
@@ -61,6 +68,21 @@ export const TrimesterUpdateSchema = z.object({
   trimesters: z.array(TrimesterConfigSchema).length(3, "3 trimestres requis"),
 })
 
+export const HolidayInputSchema = z
+  .object({
+    label: z.string().min(1, "Libellé requis"),
+    start_date: z.string().min(1, "Date de début requise"),
+    end_date: z.string().min(1, "Date de fin requise"),
+  })
+  .refine((h) => !h.start_date || !h.end_date || h.end_date >= h.start_date, {
+    message: "La date de fin doit être après le début",
+    path: ["end_date"],
+  })
+
+export const HolidaysUpdateSchema = z.object({
+  holidays: z.array(HolidayInputSchema),
+})
+
 export const NotificationUpdateSchema = z.object({
   notify_by_email: z.boolean(),
   notify_by_sms: z.boolean(),
@@ -72,7 +94,9 @@ export const NotificationUpdateSchema = z.object({
 })
 
 export type TrimesterConfig = z.infer<typeof TrimesterConfigSchema>
+export type SchoolHoliday = z.infer<typeof SchoolHolidaySchema>
 export type SchoolSettings = z.infer<typeof SchoolSettingsSchema>
 export type SchoolInfoUpdate = z.infer<typeof SchoolInfoUpdateSchema>
 export type TrimesterUpdate = z.infer<typeof TrimesterUpdateSchema>
+export type HolidaysUpdate = z.infer<typeof HolidaysUpdateSchema>
 export type NotificationUpdate = z.infer<typeof NotificationUpdateSchema>

--- a/lib/hooks/useSettings.ts
+++ b/lib/hooks/useSettings.ts
@@ -3,7 +3,12 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { settingsApi } from "@/lib/api/settings"
-import type { SchoolInfoUpdate, TrimesterUpdate, NotificationUpdate } from "@/lib/contracts/settings"
+import type {
+  SchoolInfoUpdate,
+  TrimesterUpdate,
+  HolidaysUpdate,
+  NotificationUpdate,
+} from "@/lib/contracts/settings"
 
 export const settingsKeys = {
   all: ["settings"] as const,
@@ -38,6 +43,20 @@ export function useUpdateTrimesters() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: settingsKeys.all })
       toast.success("Trimestres mis à jour")
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Erreur lors de la mise à jour")
+    },
+  })
+}
+
+export function useUpdateHolidays() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: HolidaysUpdate) => settingsApi.updateHolidays(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.all })
+      toast.success("Congés mis à jour")
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Erreur lors de la mise à jour")


### PR DESCRIPTION
## Contexte

Phase 2 de l'alternative B (backend #196). Interface admin pour saisir les congés/jours fériés que le cahier de texte doit exclure.

## Changements

- `lib/contracts/settings.ts` : `SchoolHolidaySchema`, `holidays` dans le contrat settings, `HolidaysUpdateSchema` (validation libellé + dates + fin ≥ début).
- `lib/api/settings.ts` + `lib/hooks/useSettings.ts` : `updateHolidays` (Zod) + `useUpdateHolidays`.
- `components/admin/settings/HolidaySection.tsx` : liste variable (`useFieldArray`) libellé + début + fin, ajout/suppression, empty state, touch targets `h-11`.
- Câblé dans l'onglet Paramètres renommé **Trimestres → Calendrier** (trimestres + congés).

## Tests

- `pnpm tsc --noEmit` : OK. `eslint` : 0 erreur.

Voir aussi backend #196.

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)