### PR TITLE
feat(teacher): écran d'appel numérique + accès dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- L'enseignant peut faire l'appel numérique des élèves depuis son portail : un onglet « Faire l'appel » (et un accès rapide sur le tableau de bord) affiche les élèves de la classe, tous présents par défaut ; il suffit de basculer les absents, retards ou excusés puis d'enregistrer. Pensé mobile, gros boutons, lisible en plein soleil *(enseignant)*.
 - Gestion des congés et jours fériés dans les Paramètres (onglet « Calendrier », sous les trimestres) : on ajoute ou supprime des périodes (libellé + date de début et de fin). Ces jours n'apparaissent plus dans le cahier de texte, même en plein trimestre *(admin)*.
 - Bouton « Ajouter les jours fériés civils » dans la section Congés : pré-remplit en un clic les jours fériés civils fixes ivoiriens qui tombent pendant l'année scolaire en cours (à relire puis enregistrer). Les vacances scolaires et les fêtes religieuses mobiles restent en saisie manuelle *(admin)*.
 - Relevé de notes rempli (PDF) téléchargeable et consultable en aperçu depuis la page Notes, une fois une classe, une matière et un trimestre choisis. Cahier de texte de la classe (semaine en cours) ajouté aux documents de la fiche de classe, en téléchargement et en aperçu *(admin, enseignant)*.

--- a/components/teacher/AppelSheet.tsx
+++ b/components/teacher/AppelSheet.tsx
@@ -1,0 +1,246 @@
+"use client"
+
+import { useState, useEffect, useMemo } from "react"
+import { toast } from "sonner"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { CalendarCheck, Loader2, Users } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  useTeacherClasses,
+  useTeacherClassRoster,
+  teacherPortalKeys,
+} from "@/lib/hooks/useTeacherPortal"
+import { attendanceApi } from "@/lib/api/attendance"
+
+type Status = "present" | "absent" | "late" | "excused"
+
+const STATUSES: { key: Status; label: string; short: string; on: string }[] = [
+  { key: "present", label: "Présent", short: "P", on: "bg-emerald-600 text-white border-emerald-600" },
+  { key: "absent", label: "Absent", short: "A", on: "bg-rose-600 text-white border-rose-600" },
+  { key: "late", label: "Retard", short: "R", on: "bg-amber-500 text-white border-amber-500" },
+  { key: "excused", label: "Excusé", short: "E", on: "bg-blue-600 text-white border-blue-600" },
+]
+
+function todayISO(): string {
+  const d = new Date()
+  const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000)
+  return local.toISOString().slice(0, 10)
+}
+
+function initials(first: string, last: string): string {
+  return `${first.charAt(0)}${last.charAt(0)}`.toUpperCase()
+}
+
+export function AppelSheet() {
+  const queryClient = useQueryClient()
+  const { data: classes, isLoading: classesLoading } = useTeacherClasses()
+  const [classId, setClassId] = useState<number | undefined>(undefined)
+  const [date, setDate] = useState<string>(todayISO())
+  const [statuses, setStatuses] = useState<Record<number, Status>>({})
+
+  const { data: roster, isLoading: rosterLoading } = useTeacherClassRoster(classId)
+
+  // Défaut : tous présents (l'enseignant ne bascule que les absents)
+  useEffect(() => {
+    if (roster) {
+      setStatuses(Object.fromEntries(roster.students.map((s) => [s.student_id, "present" as Status])))
+    }
+  }, [roster])
+
+  const counts = useMemo(() => {
+    const c = { present: 0, absent: 0, late: 0, excused: 0 }
+    Object.values(statuses).forEach((s) => (c[s] += 1))
+    return c
+  }, [statuses])
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!roster) throw new Error("Aucune classe sélectionnée")
+      return attendanceApi.createSession({
+        entity_type: "class",
+        context_id: roster.class_id,
+        date,
+        academic_year_id: roster.academic_year_id,
+        records: roster.students.map((s) => ({
+          student_id: s.student_id,
+          status: statuses[s.student_id] ?? "present",
+        })),
+      })
+    },
+    onSuccess: () => {
+      toast.success("Appel enregistré", {
+        description: `${counts.present} présent(s), ${counts.absent} absent(s).`,
+      })
+      if (classId) {
+        queryClient.invalidateQueries({ queryKey: teacherPortalKeys.classAttendance(classId) })
+      }
+    },
+    onError: (err) => {
+      toast.error("Erreur", { description: err instanceof Error ? err.message : "Enregistrement impossible" })
+    },
+  })
+
+  function setAll(status: Status) {
+    if (!roster) return
+    setStatuses(Object.fromEntries(roster.students.map((s) => [s.student_id, status])))
+  }
+
+  // --- Class picker ---
+  const classList = classes ?? []
+
+  return (
+    <div className="space-y-4">
+      {/* Sélection de la classe */}
+      <div>
+        <p className="mb-2 text-sm font-medium text-muted-foreground">Classe</p>
+        {classesLoading ? (
+          <div className="flex gap-2">
+            <Skeleton className="h-11 w-28" />
+            <Skeleton className="h-11 w-28" />
+          </div>
+        ) : classList.length === 0 ? (
+          <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            Aucune classe assignée. Contactez l&apos;administration.
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {classList.map((c) => (
+              <button
+                key={c.class_id}
+                type="button"
+                onClick={() => setClassId(c.class_id)}
+                className={`h-11 rounded-lg border px-4 text-sm font-medium transition-colors ${
+                  classId === c.class_id
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "bg-muted hover:bg-muted/70 text-foreground"
+                }`}
+              >
+                {c.class_name}
+                <span className="ml-1.5 text-xs opacity-70">{c.subject_name}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {classId && (
+        <>
+          {/* Date + résumé + tout présent */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <label htmlFor="appel-date" className="mb-1 block text-sm font-medium text-muted-foreground">
+                Date
+              </label>
+              <input
+                id="appel-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                className="h-11 rounded-md border border-input bg-background px-3 text-sm"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-11 sm:h-10"
+              onClick={() => setAll("present")}
+              disabled={rosterLoading || !roster?.students.length}
+            >
+              <Users className="mr-2 h-4 w-4" />
+              Tout présent
+            </Button>
+          </div>
+
+          {/* Liste des élèves */}
+          {rosterLoading ? (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-16 w-full" />
+              ))}
+            </div>
+          ) : !roster?.students.length ? (
+            <p className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Aucun élève inscrit dans cette classe pour l&apos;année en cours.
+            </p>
+          ) : (
+            <Card>
+              <CardContent className="divide-y p-0">
+                {roster.students.map((s) => {
+                  const current = statuses[s.student_id] ?? "present"
+                  return (
+                    <div
+                      key={s.student_id}
+                      className="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-9 w-9">
+                          {s.photo_url ? <AvatarImage src={s.photo_url} alt={`${s.first_name} ${s.last_name}`} /> : null}
+                          <AvatarFallback className="text-xs">{initials(s.first_name, s.last_name)}</AvatarFallback>
+                        </Avatar>
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium">
+                            {s.last_name} {s.first_name}
+                          </p>
+                          {s.matricule ? (
+                            <p className="truncate text-xs text-muted-foreground">{s.matricule}</p>
+                          ) : null}
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-4 gap-1.5 sm:flex">
+                        {STATUSES.map((st) => (
+                          <button
+                            key={st.key}
+                            type="button"
+                            aria-label={`${st.label} — ${s.first_name} ${s.last_name}`}
+                            onClick={() => setStatuses((prev) => ({ ...prev, [s.student_id]: st.key }))}
+                            className={`h-11 rounded-md border text-xs font-semibold transition-colors sm:h-9 sm:w-14 ${
+                              current === st.key
+                                ? st.on
+                                : "border-input bg-background text-muted-foreground hover:bg-muted"
+                            }`}
+                          >
+                            <span className="sm:hidden">{st.short}</span>
+                            <span className="hidden sm:inline">{st.label}</span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )
+                })}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Barre de soumission */}
+          {roster?.students.length ? (
+            <div className="sticky bottom-0 flex flex-col gap-2 border-t bg-background/95 py-3 backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-emerald-600">{counts.present} présent(s)</span>
+                {" · "}
+                <span className="font-medium text-rose-600">{counts.absent} absent(s)</span>
+                {counts.late ? <span className="text-amber-600"> · {counts.late} retard(s)</span> : null}
+                {counts.excused ? <span className="text-blue-600"> · {counts.excused} excusé(s)</span> : null}
+              </p>
+              <Button
+                type="button"
+                className="h-11 sm:h-10"
+                onClick={() => mutation.mutate()}
+                disabled={mutation.isPending}
+              >
+                {mutation.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <CalendarCheck className="mr-2 h-4 w-4" />
+                )}
+                Enregistrer l&apos;appel
+              </Button>
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/teacher/TeacherAttendanceClient.tsx
+++ b/components/teacher/TeacherAttendanceClient.tsx
@@ -20,7 +20,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { DataError } from "@/components/shared/DataError"
+import { AppelSheet } from "@/components/teacher/AppelSheet"
 import { useTeacherClasses, useTeacherClassAttendance } from "@/lib/hooks/useTeacherPortal"
 
 export function TeacherAttendanceClient() {
@@ -40,6 +42,17 @@ export function TeacherAttendanceClient() {
         </div>
       </div>
 
+      <Tabs defaultValue="appel" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="appel">Faire l&apos;appel</TabsTrigger>
+          <TabsTrigger value="stats">Statistiques</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="appel">
+          <AppelSheet />
+        </TabsContent>
+
+        <TabsContent value="stats" className="space-y-6">
       {/* Sélection de classe */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardHeader className="pb-4">
@@ -158,6 +171,8 @@ export function TeacherAttendanceClient() {
           </CardContent>
         </Card>
       )}
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -102,6 +102,22 @@ export function TeacherDashboardClient() {
         </CardContent>
       </Card>
 
+      {/* Accès rapide — faire l'appel */}
+      <Link href="/teacher/attendance" className="group block">
+        <Card className="border-primary/30 shadow-sm transition-colors group-hover:border-primary">
+          <CardContent className="flex items-center gap-3 p-4">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <ClipboardList className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold">Faire l&apos;appel</p>
+              <p className="text-xs text-muted-foreground">Saisir les présences des élèves</p>
+            </div>
+            <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          </CardContent>
+        </Card>
+      </Link>
+
       {/* Accès rapide — mes classes */}
       <Link href="/teacher/classes" className="group block">
         <Card className="shadow-sm transition-colors group-hover:border-primary/40">

--- a/lib/api/teacher-portal.ts
+++ b/lib/api/teacher-portal.ts
@@ -4,10 +4,12 @@ import {
   TeacherDashboardSchema,
   TeacherClassSchema,
   TeacherClassAttendanceStatsSchema,
+  TeacherClassRosterSchema,
   TeacherUpcomingEvalSchema,
   type TeacherDashboard,
   type TeacherClass,
   type TeacherClassAttendanceStats,
+  type TeacherClassRoster,
   type TeacherUpcomingEval,
 } from "@/lib/contracts/teacher-portal"
 
@@ -36,6 +38,16 @@ export const teacherPortalApi = {
     const res = await apiFetch<unknown>("/teacher/classes")
     const arr = Array.isArray(res) ? res : unwrapResponse<TeacherClass[]>(res)
     return safeValidate(TeacherClassArraySchema, arr, "GET /teacher/classes")
+  },
+
+  // Liste des élèves d'une classe (pour l'appel)
+  getClassRoster: async (classId: number): Promise<TeacherClassRoster> => {
+    const res = await apiFetch<unknown>(`/teacher/classes/${classId}/students`)
+    return safeValidate(
+      TeacherClassRosterSchema,
+      unwrapResponse(res),
+      `GET /teacher/classes/${classId}/students`,
+    )
   },
 
   // Stats de présence pour une classe

--- a/lib/contracts/teacher-portal.ts
+++ b/lib/contracts/teacher-portal.ts
@@ -68,6 +68,25 @@ export const TeacherClassAttendanceStatsSchema = z.object({
   students: z.array(TeacherStudentAttendanceSummarySchema),
 })
 
+// Roster d'une classe pour l'appel
+export const TeacherRosterStudentSchema = z.object({
+  student_id: z.number(),
+  first_name: z.string(),
+  last_name: z.string(),
+  matricule: z.string().nullish(),
+  photo_url: z.string().nullish(),
+})
+
+export const TeacherClassRosterSchema = z.object({
+  class_id: z.number(),
+  class_name: z.string(),
+  academic_year_id: z.number(),
+  students: z.array(TeacherRosterStudentSchema),
+})
+
+export type TeacherRosterStudent = z.infer<typeof TeacherRosterStudentSchema>
+export type TeacherClassRoster = z.infer<typeof TeacherClassRosterSchema>
+
 export type TeacherNextCourse = z.infer<typeof TeacherNextCourseSchema>
 export type TeacherClass = z.infer<typeof TeacherClassSchema>
 export type TeacherUpcomingEval = z.infer<typeof TeacherUpcomingEvalSchema>

--- a/lib/hooks/useTeacherPortal.ts
+++ b/lib/hooks/useTeacherPortal.ts
@@ -8,6 +8,7 @@ export const teacherPortalKeys = {
   dashboard: () => ["teacher-portal", "dashboard"] as const,
   classes: () => ["teacher-portal", "classes"] as const,
   classAttendance: (classId: number) => ["teacher-portal", "class-attendance", classId] as const,
+  classRoster: (classId: number) => ["teacher-portal", "class-roster", classId] as const,
   evaluations: () => ["teacher-portal", "evaluations"] as const,
 }
 
@@ -31,6 +32,15 @@ export function useTeacherClassAttendance(classId: number | undefined) {
   return useQuery({
     queryKey: teacherPortalKeys.classAttendance(classId as number),
     queryFn: () => teacherPortalApi.getClassAttendance(classId as number),
+    enabled: classId !== undefined && classId > 0,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useTeacherClassRoster(classId: number | undefined) {
+  return useQuery({
+    queryKey: teacherPortalKeys.classRoster(classId as number),
+    queryFn: () => teacherPortalApi.getClassRoster(classId as number),
     enabled: classId !== undefined && classId > 0,
     staleTime: 1000 * 60 * 5,
   })


### PR DESCRIPTION
## Contexte

Suite de BE #200. Les enseignants pouvaient consulter les stats de présence mais pas **saisir** l'appel. On ajoute l'écran de saisie.

## Changements

- `AppelSheet.tsx` : choisir une classe (chips), élèves **tous présents par défaut**, bascule par élève (Présent/Absent/Retard/Excusé), résumé + « Enregistrer l'appel » via `POST /attendance/sessions`. Mobile-first (persona Mme Diallo : gros boutons `h-11`, bascule des absents seulement).
- `/teacher/attendance` : onglets **« Faire l'appel »** (par défaut) / « Statistiques » (existant).
- Dashboard enseignant : carte d'accès rapide **« Faire l'appel »**.
- Contrat + API + hook `useTeacherClassRoster`.

## Tests

- `pnpm tsc --noEmit` OK, `eslint` OK.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)