### PR TITLE
feat(dashboard): teacher performance score + staff activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Score de performance des enseignants et suivi d'activité du personnel : l'enseignant consulte « Ma performance » depuis son portail, une note sur 100 avec le détail de chaque critère (assiduité, saisie des notes, prise de l'appel) et son évaluation. La direction dispose d'une page « Performance » avec le classement des enseignants et un tableau d'activité du personnel (versements encaissés, inscriptions traitées). Un critère sans donnée est affiché « données insuffisantes » plutôt que noté zéro *(admin, enseignant)*.
 - L'enseignant peut faire l'appel numérique des élèves depuis son portail : un onglet « Faire l'appel » (et un accès rapide sur le tableau de bord) affiche les élèves de la classe, tous présents par défaut ; il suffit de basculer les absents, retards ou excusés puis d'enregistrer. Pensé mobile, gros boutons, lisible en plein soleil *(enseignant)*.
 - Gestion des congés et jours fériés dans les Paramètres (onglet « Calendrier », sous les trimestres) : on ajoute ou supprime des périodes (libellé + date de début et de fin). Ces jours n'apparaissent plus dans le cahier de texte, même en plein trimestre *(admin)*.
 - Bouton « Ajouter les jours fériés civils » dans la section Congés : pré-remplit en un clic les jours fériés civils fixes ivoiriens qui tombent pendant l'année scolaire en cours (à relire puis enregistrer). Les vacances scolaires et les fêtes religieuses mobiles restent en saisie manuelle *(admin)*.

--- a/app/(admin)/admin/performance/page.tsx
+++ b/app/(admin)/admin/performance/page.tsx
@@ -1,0 +1,7 @@
+import { PerformancePageClient } from "@/components/admin/performance/PerformancePageClient"
+
+export const metadata = { title: "Performance | KLASSCI" }
+
+export default function PerformancePage() {
+  return <PerformancePageClient />
+}

--- a/app/(teacher)/teacher/performance/page.tsx
+++ b/app/(teacher)/teacher/performance/page.tsx
@@ -1,0 +1,7 @@
+import { TeacherPerformanceClient } from "@/components/teacher/TeacherPerformanceClient"
+
+export const metadata = { title: "Ma performance | KLASSCI" }
+
+export default function TeacherPerformancePage() {
+  return <TeacherPerformanceClient />
+}

--- a/components/admin/performance/PerformancePageClient.tsx
+++ b/components/admin/performance/PerformancePageClient.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { Gauge, Users, Star, AlertCircle, UserCog, Info } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { DataError } from "@/components/shared/DataError"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
+import { useStaffActivity, useTeachersPerformance } from "@/lib/hooks/usePerformance"
+import { formatScore } from "@/lib/utils/performance"
+import { TeachersPerformanceTable } from "./TeachersPerformanceTable"
+import { StaffActivityTable } from "./StaffActivityTable"
+
+export function PerformancePageClient() {
+  const teachersQuery = useTeachersPerformance()
+  const staffQuery = useStaffActivity()
+
+  if (teachersQuery.isLoading) return <PerformanceSkeleton />
+
+  if (teachersQuery.isError || !teachersQuery.data) {
+    return (
+      <div className="space-y-6">
+        <PageHero icon={Gauge} title="Performance" subtitle="Enseignants et personnel" />
+        <DataError
+          message="Impossible de charger la performance."
+          onRetry={() => teachersQuery.refetch()}
+        />
+      </div>
+    )
+  }
+
+  const { teachers, summary, academic_year_name } = teachersQuery.data
+
+  const heroKpis: HeroKpi[] = [
+    {
+      label: "Enseignants notés",
+      value: `${summary.teachers_scored}/${summary.teachers_total}`,
+      icon: Users,
+    },
+    {
+      label: "Score moyen",
+      value: formatScore(summary.teachers_avg_score),
+      icon: Star,
+    },
+    {
+      label: "À compléter",
+      value: summary.teachers_insufficient,
+      icon: AlertCircle,
+      hint: "données manquantes",
+    },
+    {
+      label: "Personnel actif",
+      value: `${summary.staff_active}/${summary.staff_total}`,
+      icon: UserCog,
+    },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        icon={Gauge}
+        title="Performance"
+        subtitle={`Enseignants et personnel · Année ${academic_year_name}`}
+        kpis={heroKpis}
+      />
+
+      <Tabs defaultValue="teachers" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="teachers">Enseignants</TabsTrigger>
+          <TabsTrigger value="staff">Personnel</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="teachers" className="space-y-3">
+          <div className="flex items-start gap-2 rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <p>
+              Score sur 100, moyenne pondérée de trois axes : assiduité (40%), saisie des notes
+              (35%) et prise de l'appel (25%). Un axe sans donnée n'est pas noté et n'abaisse pas le
+              score. Les résultats des élèves ne sont pas pris en compte.
+            </p>
+          </div>
+          <TeachersPerformanceTable teachers={teachers} />
+        </TabsContent>
+
+        <TabsContent value="staff" className="space-y-3">
+          <div className="flex items-start gap-2 rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <p>
+              Activité factuelle du personnel sur l'année (versements encaissés, inscriptions
+              traitées). Pas de note : ces indicateurs mesurent le volume d'activité, pas une
+              performance comparable.
+            </p>
+          </div>
+          {staffQuery.isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-14 rounded-lg" />
+              ))}
+            </div>
+          ) : staffQuery.isError || !staffQuery.data ? (
+            <DataError
+              message="Impossible de charger l'activité du personnel."
+              onRetry={() => staffQuery.refetch()}
+            />
+          ) : (
+            <StaffActivityTable staff={staffQuery.data.staff} />
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function PerformanceSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-40 rounded-2xl" />
+      <Skeleton className="h-9 w-48 rounded-lg" />
+      <div className="space-y-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 rounded-lg" />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/admin/performance/StaffActivityTable.tsx
+++ b/components/admin/performance/StaffActivityTable.tsx
@@ -1,0 +1,105 @@
+import Link from "next/link"
+import { UserCog } from "lucide-react"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { StaffActivityItem } from "@/lib/contracts/performance"
+import { formatXof } from "@/lib/export/format"
+
+function lastLoginLabel(value: string | null | undefined): string {
+  if (!value) return "Jamais connecté"
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return "—"
+  return d.toLocaleDateString("fr-FR", { day: "2-digit", month: "short", year: "numeric" })
+}
+
+export function StaffActivityTable({ staff }: { staff: StaffActivityItem[] }) {
+  if (staff.length === 0) {
+    return (
+      <div className="rounded-xl border bg-card py-10 text-center">
+        <UserCog className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">Aucun membre du personnel enregistré.</p>
+        <Link href="/admin/staff" className="mt-1 inline-block text-sm font-medium text-accent">
+          Ajouter un membre du personnel
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {/* Desktop */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Membre</TableHead>
+              <TableHead>Poste</TableHead>
+              <TableHead className="text-center">Versements encaissés</TableHead>
+              <TableHead className="text-center">Inscriptions traitées</TableHead>
+              <TableHead className="text-right">Dernière connexion</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {staff.map((s) => (
+              <TableRow key={s.user_id}>
+                <TableCell className="font-medium">
+                  {s.last_name} {s.first_name}
+                </TableCell>
+                <TableCell className="text-muted-foreground">{s.position ?? "—"}</TableCell>
+                <TableCell className="text-center tabular-nums">
+                  <span className="font-semibold">{s.payments_count}</span>
+                  {s.payments_count > 0 && (
+                    <span className="ml-1 text-xs text-muted-foreground">
+                      · {formatXof(s.payments_amount)}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="text-center font-semibold tabular-nums">
+                  {s.enrollments_count}
+                </TableCell>
+                <TableCell className="text-right text-sm text-muted-foreground">
+                  {lastLoginLabel(s.last_login)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile */}
+      <div className="space-y-2 md:hidden">
+        {staff.map((s) => (
+          <div key={s.user_id} className="rounded-lg border bg-card p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">
+                  {s.last_name} {s.first_name}
+                </p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {s.position ?? "Personnel"}
+                </p>
+              </div>
+              <p className="shrink-0 text-xs text-muted-foreground">{lastLoginLabel(s.last_login)}</p>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-muted-foreground tabular-nums">
+              <span>
+                <span className="font-medium text-foreground">{s.payments_count}</span> versements
+                {s.payments_count > 0 && ` · ${formatXof(s.payments_amount)}`}
+              </span>
+              <span>
+                <span className="font-medium text-foreground">{s.enrollments_count}</span>{" "}
+                inscriptions
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/components/admin/performance/TeachersPerformanceTable.tsx
+++ b/components/admin/performance/TeachersPerformanceTable.tsx
@@ -1,0 +1,136 @@
+import Link from "next/link"
+import { Users } from "lucide-react"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { cn } from "@/lib/utils"
+import type { PerformanceAxis, TeacherPerformanceItem } from "@/lib/contracts/performance"
+import { formatScore, ratingConfig, scoreColorClass } from "@/lib/utils/performance"
+import { RatingPill } from "@/components/shared/performance/PerformanceParts"
+
+const AXIS_KEYS = ["assiduite", "notes", "appel"] as const
+const AXIS_SHORT: Record<string, string> = {
+  assiduite: "Assiduité",
+  notes: "Notes",
+  appel: "Appel",
+}
+
+function axisOf(teacher: TeacherPerformanceItem, key: string): PerformanceAxis | undefined {
+  return teacher.axes.find((a) => a.key === key)
+}
+
+function AxisScore({ axis }: { axis: PerformanceAxis | undefined }) {
+  if (!axis || !axis.sufficient || axis.score === null) {
+    return <span className="text-muted-foreground">—</span>
+  }
+  return (
+    <span className={cn("font-semibold tabular-nums", scoreColorClass(axis.score))}>
+      {formatScore(axis.score)}
+    </span>
+  )
+}
+
+function GlobalScore({ teacher }: { teacher: TeacherPerformanceItem }) {
+  const cfg = ratingConfig(teacher.rating)
+  return (
+    <span
+      className="inline-flex h-9 min-w-9 items-center justify-center rounded-lg px-2 text-base font-bold tabular-nums"
+      style={{ color: cfg.ringColor, backgroundColor: `${cfg.ringColor}1a` }}
+    >
+      {formatScore(teacher.global_score)}
+    </span>
+  )
+}
+
+export function TeachersPerformanceTable({ teachers }: { teachers: TeacherPerformanceItem[] }) {
+  if (teachers.length === 0) {
+    return (
+      <div className="rounded-xl border bg-card py-10 text-center">
+        <Users className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">Aucun enseignant enregistré.</p>
+        <Link href="/admin/teachers" className="mt-1 inline-block text-sm font-medium text-accent">
+          Ajouter un enseignant
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {/* Desktop */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Enseignant</TableHead>
+              <TableHead className="text-center">Score global</TableHead>
+              <TableHead className="text-center">Assiduité</TableHead>
+              <TableHead className="text-center">Notes</TableHead>
+              <TableHead className="text-center">Appel</TableHead>
+              <TableHead className="text-right">Appréciation</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {teachers.map((t) => (
+              <TableRow key={t.teacher_id}>
+                <TableCell>
+                  <p className="font-medium">
+                    {t.last_name} {t.first_name}
+                  </p>
+                  {t.speciality && (
+                    <p className="text-xs text-muted-foreground">{t.speciality}</p>
+                  )}
+                </TableCell>
+                <TableCell className="text-center">
+                  <GlobalScore teacher={t} />
+                </TableCell>
+                {AXIS_KEYS.map((key) => (
+                  <TableCell key={key} className="text-center">
+                    <AxisScore axis={axisOf(t, key)} />
+                  </TableCell>
+                ))}
+                <TableCell className="text-right">
+                  <RatingPill rating={t.rating} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Mobile */}
+      <div className="space-y-2 md:hidden">
+        {teachers.map((t) => (
+          <div key={t.teacher_id} className="rounded-lg border bg-card p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">
+                  {t.last_name} {t.first_name}
+                </p>
+                {t.speciality && (
+                  <p className="truncate text-xs text-muted-foreground">{t.speciality}</p>
+                )}
+              </div>
+              <GlobalScore teacher={t} />
+            </div>
+            <div className="mt-2 flex items-center justify-between gap-2">
+              <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                {AXIS_KEYS.map((key) => (
+                  <span key={key}>
+                    {AXIS_SHORT[key]} <AxisScore axis={axisOf(t, key)} />
+                  </span>
+                ))}
+              </div>
+              <RatingPill rating={t.rating} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   HeartHandshake,
   UserCheck,
   FileText,
+  Gauge,
   Bell,
   ShieldCheck,
   Settings,
@@ -85,6 +86,7 @@ const navigation: NavSection[] = [
       { label: "Notes", href: "/admin/grades", icon: ClipboardList },
       { label: "Présences", href: "/admin/attendance", icon: UserCheck },
       { label: "Bulletins", href: "/admin/reports", icon: FileText },
+      { label: "Performance", href: "/admin/performance" as Route, icon: Gauge },
     ],
   },
   {

--- a/components/shared/TeacherNav.tsx
+++ b/components/shared/TeacherNav.tsx
@@ -5,7 +5,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { signOut } from "next-auth/react"
-import { LayoutDashboard, CalendarDays, ClipboardList, UserCheck, LogOut, type LucideIcon } from "lucide-react"
+import { LayoutDashboard, CalendarDays, ClipboardList, UserCheck, Gauge, LogOut, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const navItems: { label: string; href: Route; icon: LucideIcon }[] = [
@@ -13,6 +13,7 @@ const navItems: { label: string; href: Route; icon: LucideIcon }[] = [
   { label: "Mon EDT", href: "/teacher/timetable", icon: CalendarDays },
   { label: "Notes", href: "/teacher/grades" as Route, icon: ClipboardList },
   { label: "Appel", href: "/teacher/attendance" as Route, icon: UserCheck },
+  { label: "Ma perf", href: "/teacher/performance" as Route, icon: Gauge },
 ]
 
 export function TeacherNav() {

--- a/components/shared/performance/PerformanceParts.tsx
+++ b/components/shared/performance/PerformanceParts.tsx
@@ -1,0 +1,103 @@
+import { cn } from "@/lib/utils"
+import type { PerformanceAxis } from "@/lib/contracts/performance"
+import { axisDescription, formatScore, ratingConfig, scoreColorClass } from "@/lib/utils/performance"
+
+// Libellés FR des compteurs bruts de chaque axe (justification du score).
+const DETAIL_LABELS: Record<string, string> = {
+  total_sessions: "Séances pointées",
+  present: "Présent",
+  late: "Retards",
+  absent_excused: "Absences justifiées",
+  absent_unexcused: "Absences non justifiées",
+  late_minutes: "Minutes de retard",
+  pending_validation: "En attente de validation",
+  total_evaluations: "Évaluations créées",
+  fully_graded: "Entièrement notées",
+  entered_grades: "Notes saisies",
+  expected_grades: "Notes attendues",
+  pending_grades: "Notes restantes",
+  appels_taken: "Appels effectués",
+  expected_sessions: "Séances planifiées",
+}
+
+// Ordre d'affichage préféré par axe (les clés absentes sont ignorées).
+const DETAIL_ORDER: Record<string, string[]> = {
+  assiduite: [
+    "total_sessions",
+    "present",
+    "late",
+    "absent_excused",
+    "absent_unexcused",
+    "late_minutes",
+    "pending_validation",
+  ],
+  notes: ["total_evaluations", "fully_graded", "entered_grades", "expected_grades", "pending_grades"],
+  appel: ["appels_taken", "expected_sessions"],
+}
+
+/** Pastille de notation (Excellent / Bon / À améliorer / Données insuffisantes). */
+export function RatingPill({ rating, className }: { rating: string; className?: string }) {
+  const cfg = ratingConfig(rating)
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold",
+        cfg.pillClass,
+        className,
+      )}
+    >
+      {cfg.label}
+    </span>
+  )
+}
+
+function orderedDetail(axis: PerformanceAxis): [string, number][] {
+  const order = DETAIL_ORDER[axis.key] ?? Object.keys(axis.detail)
+  const out: [string, number][] = []
+  for (const key of order) {
+    const raw = axis.detail[key]
+    if (typeof raw === "number" && DETAIL_LABELS[key]) {
+      out.push([key, raw])
+    }
+  }
+  return out
+}
+
+/** Carte d'un axe : sous-score, description de ce qui est mesuré, et compteurs. */
+export function PerformanceAxisCard({ axis }: { axis: PerformanceAxis }) {
+  const weightPct = Math.round(axis.weight * 100)
+  const details = orderedDetail(axis)
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold">{axis.label}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {axisDescription(axis.key)} · pèse {weightPct}%
+          </p>
+        </div>
+        <div className="shrink-0 text-right">
+          <p className={cn("text-2xl font-bold leading-none tabular-nums", scoreColorClass(axis.score))}>
+            {formatScore(axis.score)}
+          </p>
+          <p className="mt-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">/ 100</p>
+        </div>
+      </div>
+
+      {axis.sufficient && details.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground tabular-nums">
+          {details.map(([key, value]) => (
+            <span key={key}>
+              <span className="font-medium text-foreground">{value}</span> {DETAIL_LABELS[key]}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-3 text-xs text-muted-foreground">
+          Données insuffisantes pour noter cet axe pour le moment.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import type { Route } from "next"
 import Link from "next/link"
 import {
   CalendarDays,
@@ -9,6 +10,7 @@ import {
   ClipboardList,
   ChevronRight,
   CalendarX,
+  Gauge,
 } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -112,6 +114,22 @@ export function TeacherDashboardClient() {
             <div className="min-w-0 flex-1">
               <p className="text-sm font-semibold">Faire l&apos;appel</p>
               <p className="text-xs text-muted-foreground">Saisir les présences des élèves</p>
+            </div>
+            <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          </CardContent>
+        </Card>
+      </Link>
+
+      {/* Accès rapide — ma performance */}
+      <Link href={"/teacher/performance" as Route} className="group block">
+        <Card className="shadow-sm transition-colors group-hover:border-primary/40">
+          <CardContent className="flex items-center gap-3 p-4">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+              <Gauge className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold">Ma performance</p>
+              <p className="text-xs text-muted-foreground">Mon score et son détail</p>
             </div>
             <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           </CardContent>

--- a/components/teacher/TeacherPerformanceClient.tsx
+++ b/components/teacher/TeacherPerformanceClient.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { Gauge, Info } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { DataError } from "@/components/shared/DataError"
+import { PageHero } from "@/components/shared/PageHero"
+import { CircularProgress } from "@/components/shared/CircularProgress"
+import { PerformanceAxisCard, RatingPill } from "@/components/shared/performance/PerformanceParts"
+import { useMyPerformance } from "@/lib/hooks/usePerformance"
+import { formatScore, ratingConfig } from "@/lib/utils/performance"
+
+export function TeacherPerformanceClient() {
+  const { data, isLoading, isError, refetch } = useMyPerformance()
+
+  if (isLoading) return <PerformanceSkeleton />
+
+  if (isError) {
+    return (
+      <div className="space-y-6">
+        <PageHero icon={Gauge} title="Ma performance" subtitle="Votre score et son détail" />
+        <DataError message="Impossible de charger votre performance." onRetry={() => refetch()} />
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div className="space-y-6">
+        <PageHero icon={Gauge} title="Ma performance" subtitle="Votre score et son détail" />
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          Aucune donnée disponible.
+        </div>
+      </div>
+    )
+  }
+
+  const perf = data.performance
+  const cfg = ratingConfig(perf.rating)
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        icon={Gauge}
+        title="Ma performance"
+        subtitle={`Année ${data.academic_year_name}`}
+      />
+
+      {/* Score global */}
+      <Card className="border-0 shadow-sm ring-1 ring-border">
+        <CardContent className="flex flex-col items-center gap-4 p-6 sm:flex-row sm:justify-between">
+          <div className="flex items-center gap-4">
+            <CircularProgress
+              value={perf.global_score ?? 0}
+              size={92}
+              strokeWidth={7}
+              color={perf.global_score === null ? "#94a3b8" : cfg.ringColor}
+              label={`${formatScore(perf.global_score)}${perf.global_score !== null ? " / 100" : ""}`}
+              sublabel="Score global"
+            />
+          </div>
+          <div className="flex flex-col items-center gap-2 sm:items-end">
+            <RatingPill rating={perf.rating} />
+            <p className="max-w-xs text-center text-xs text-muted-foreground sm:text-right">
+              Moyenne pondérée des axes mesurables. Les résultats de vos élèves ne sont pas pris en
+              compte.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Détail par axe */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold">Détail par critère</h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {perf.axes.map((axis) => (
+            <PerformanceAxisCard key={axis.key} axis={axis} />
+          ))}
+        </div>
+      </section>
+
+      {/* Note explicative */}
+      <div className="flex items-start gap-2 rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+        <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+        <p>
+          Un critère marqué « données insuffisantes » n'est pas encore mesurable (aucune séance
+          pointée, aucune évaluation, ou aucun créneau planifié) : il n'abaisse pas votre score.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function PerformanceSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-28 rounded-2xl" />
+      <Skeleton className="h-40 rounded-xl" />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <Skeleton className="h-32 rounded-lg" />
+        <Skeleton className="h-32 rounded-lg" />
+        <Skeleton className="h-32 rounded-lg" />
+      </div>
+    </div>
+  )
+}

--- a/lib/api/performance.ts
+++ b/lib/api/performance.ts
@@ -1,0 +1,37 @@
+import { apiFetch, safeValidate } from "./client"
+import {
+  StaffActivityListSchema,
+  TeacherPerformanceListSchema,
+  TeacherSelfPerformanceSchema,
+  type StaffActivityList,
+  type TeacherPerformanceList,
+  type TeacherSelfPerformance,
+} from "@/lib/contracts/performance"
+
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object") {
+    const obj = json as Record<string, unknown>
+    if (obj.data !== undefined) return obj.data
+  }
+  return json
+}
+
+export const performanceApi = {
+  // Score de performance de tous les enseignants (vue direction)
+  getTeachers: async (): Promise<TeacherPerformanceList> => {
+    const json = await apiFetch<unknown>("/admin/performance/teachers")
+    return safeValidate(TeacherPerformanceListSchema, unwrap(json), "GET /admin/performance/teachers")
+  },
+
+  // Tableau d'activité du personnel (vue direction)
+  getStaff: async (): Promise<StaffActivityList> => {
+    const json = await apiFetch<unknown>("/admin/performance/staff")
+    return safeValidate(StaffActivityListSchema, unwrap(json), "GET /admin/performance/staff")
+  },
+
+  // Ma performance — enseignant connecté
+  getMyPerformance: async (): Promise<TeacherSelfPerformance> => {
+    const json = await apiFetch<unknown>("/teacher/performance/me")
+    return safeValidate(TeacherSelfPerformanceSchema, unwrap(json), "GET /teacher/performance/me")
+  },
+}

--- a/lib/contracts/performance.ts
+++ b/lib/contracts/performance.ts
@@ -1,0 +1,74 @@
+import { z } from "zod"
+
+// Contrats pour la performance enseignant + activité personnel — endpoints
+// /admin/performance/* et /teacher/performance/me.
+
+export const PerformanceAxisSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  weight: z.number(),
+  score: z.number().nullable(),
+  sufficient: z.boolean(),
+  detail: z.record(z.string(), z.unknown()),
+})
+
+export const TeacherPerformanceItemSchema = z.object({
+  teacher_id: z.number(),
+  user_id: z.number().nullable(),
+  first_name: z.string(),
+  last_name: z.string(),
+  speciality: z.string().nullish(),
+  photo_url: z.string().nullish(),
+  global_score: z.number().nullable(),
+  rating: z.string(),
+  sufficient: z.boolean(),
+  axes: z.array(PerformanceAxisSchema),
+})
+
+export const PerformanceSummarySchema = z.object({
+  teachers_total: z.number(),
+  teachers_scored: z.number(),
+  teachers_insufficient: z.number(),
+  teachers_avg_score: z.number().nullable(),
+  staff_total: z.number(),
+  staff_active: z.number(),
+})
+
+export const TeacherPerformanceListSchema = z.object({
+  academic_year_id: z.number(),
+  academic_year_name: z.string(),
+  teachers: z.array(TeacherPerformanceItemSchema),
+  summary: PerformanceSummarySchema,
+})
+
+export const TeacherSelfPerformanceSchema = z.object({
+  academic_year_id: z.number(),
+  academic_year_name: z.string(),
+  performance: TeacherPerformanceItemSchema,
+})
+
+export const StaffActivityItemSchema = z.object({
+  user_id: z.number(),
+  first_name: z.string(),
+  last_name: z.string(),
+  position: z.string().nullish(),
+  photo_url: z.string().nullish(),
+  payments_count: z.number(),
+  payments_amount: z.coerce.number(),
+  enrollments_count: z.number(),
+  last_login: z.string().nullish(),
+})
+
+export const StaffActivityListSchema = z.object({
+  academic_year_id: z.number(),
+  academic_year_name: z.string(),
+  staff: z.array(StaffActivityItemSchema),
+})
+
+export type PerformanceAxis = z.infer<typeof PerformanceAxisSchema>
+export type TeacherPerformanceItem = z.infer<typeof TeacherPerformanceItemSchema>
+export type PerformanceSummary = z.infer<typeof PerformanceSummarySchema>
+export type TeacherPerformanceList = z.infer<typeof TeacherPerformanceListSchema>
+export type TeacherSelfPerformance = z.infer<typeof TeacherSelfPerformanceSchema>
+export type StaffActivityItem = z.infer<typeof StaffActivityItemSchema>
+export type StaffActivityList = z.infer<typeof StaffActivityListSchema>

--- a/lib/hooks/usePerformance.ts
+++ b/lib/hooks/usePerformance.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { performanceApi } from "@/lib/api/performance"
+
+export const performanceKeys = {
+  all: ["performance"] as const,
+  teachers: () => ["performance", "teachers"] as const,
+  staff: () => ["performance", "staff"] as const,
+  me: () => ["performance", "me"] as const,
+}
+
+export function useTeachersPerformance() {
+  return useQuery({
+    queryKey: performanceKeys.teachers(),
+    queryFn: () => performanceApi.getTeachers(),
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useStaffActivity() {
+  return useQuery({
+    queryKey: performanceKeys.staff(),
+    queryFn: () => performanceApi.getStaff(),
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useMyPerformance() {
+  return useQuery({
+    queryKey: performanceKeys.me(),
+    queryFn: () => performanceApi.getMyPerformance(),
+    staleTime: 1000 * 60 * 2,
+  })
+}

--- a/lib/utils/performance.ts
+++ b/lib/utils/performance.ts
@@ -1,0 +1,60 @@
+// Helpers d'affichage partagés entre la vue admin et la vue « Ma performance ».
+
+export interface RatingConfig {
+  label: string
+  // Classes Tailwind via tokens/sémantique (dark-safe)
+  pillClass: string
+  ringColor: string // hex pour CircularProgress
+}
+
+export const RATING_CONFIG: Record<string, RatingConfig> = {
+  excellent: {
+    label: "Excellent",
+    pillClass: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300",
+    ringColor: "#10b981",
+  },
+  bon: {
+    label: "Bon",
+    pillClass: "bg-primary/10 text-primary",
+    ringColor: "#0453cb",
+  },
+  a_ameliorer: {
+    label: "À améliorer",
+    pillClass: "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300",
+    ringColor: "#f59e0b",
+  },
+  insuffisant_donnees: {
+    label: "Données insuffisantes",
+    pillClass: "bg-muted text-muted-foreground",
+    ringColor: "#94a3b8",
+  },
+}
+
+export function ratingConfig(rating: string): RatingConfig {
+  return RATING_CONFIG[rating] ?? RATING_CONFIG.insuffisant_donnees
+}
+
+// Ce que mesure chaque axe (pour la vue enseignant + tooltip admin).
+export const AXIS_DESCRIPTION: Record<string, string> = {
+  assiduite: "Votre présence aux séances pointées (présent, retard, absence).",
+  notes: "Part des notes saisies sur les évaluations que vous avez créées.",
+  appel: "Part des séances planifiées où l'appel des élèves a été fait.",
+}
+
+export function axisDescription(key: string): string {
+  return AXIS_DESCRIPTION[key] ?? ""
+}
+
+// Formate un score 0-100 : « 82 » ou « — » si non calculable.
+export function formatScore(score: number | null): string {
+  if (score === null || score === undefined) return "—"
+  return Number.isInteger(score) ? String(score) : score.toFixed(1)
+}
+
+// Couleur sémantique d'un score (par seuils), alignée sur CircularProgress.
+export function scoreColorClass(score: number | null): string {
+  if (score === null || score === undefined) return "text-muted-foreground"
+  if (score >= 80) return "text-emerald-600 dark:text-emerald-400"
+  if (score >= 60) return "text-primary"
+  return "text-amber-600 dark:text-amber-400"
+}


### PR DESCRIPTION
## Description
Interface du score de performance des enseignants et du suivi d'activité du personnel (côté BE : PR backend associée).

## Écrans ajoutés
**Enseignant — « Ma performance »** (`/teacher/performance`, + carte d'accès rapide sur le dashboard et entrée nav) : score global (anneau coloré), appréciation (Excellent / Bon / À améliorer / Données insuffisantes), et détail par axe (assiduité, saisie des notes, prise de l'appel) avec les compteurs bruts justifiant chaque sous-score.

**Admin — « Performance »** (`/admin/performance`, entrée sidebar « Suivi ») : hero + KPIs (enseignants notés, score moyen, à compléter, personnel actif), onglet **Enseignants** (tableau desktop + cartes mobile, score global + 3 axes + appréciation) et onglet **Personnel** (tableau d'activité : versements encaissés, inscriptions traitées, dernière connexion — pas de note fabriquée).

## Honnêteté des données
Un axe sans donnée affiche « données insuffisantes » (pas 0) et n'abaisse pas le score. Note explicative sur chaque vue. Les résultats des élèves sont exclus du score enseignant.

## Conformité
- API client via `apiFetch<unknown>` + `safeValidate` (Zod), zéro cast.
- Design system : PageHero bleu→orange, KPIs verre, composants shadcn, mobile-first (`hidden md:block` table + cartes `md:hidden`), dark-safe.
- `no-god-code` : orchestrateur + 2 tables + parts partagées séparés.
- tsc + eslint OK en local.

Dépend de la PR backend (endpoints `/admin/performance/*`, `/teacher/performance/me`).