### PR TITLE
feat(dashboard): premium redesign of parent & staff detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Fiche parent (admin) repensée : en-tête premium avec le récapitulatif financier du foyer (nombre d'enfants, total payé, reste à payer sur l'année), enfants liés présentés en cartes claires avec leur classe, leur statut d'inscription et leur solde de scolarité (barre de progression), boutons de contact rapides (Appeler, WhatsApp, Email) et possibilité de lier un enfant existant en un clic *(admin)*.
+- Fiche personnel (admin) repensée : en-tête premium avec photo et contact rapide, plus un onglet « Activité » qui résume les versements encaissés, les inscriptions traitées et la dernière connexion du membre *(admin)*.
+
 - Score de performance des enseignants et suivi d'activité du personnel : l'enseignant consulte « Ma performance » depuis son portail, une note sur 100 avec le détail de chaque critère (assiduité, saisie des notes, prise de l'appel) et son évaluation. La direction dispose d'une page « Performance » avec le classement des enseignants et un tableau d'activité du personnel (versements encaissés, inscriptions traitées). Un critère sans donnée est affiché « données insuffisantes » plutôt que noté zéro *(admin, enseignant)*.
 - L'enseignant peut faire l'appel numérique des élèves depuis son portail : un onglet « Faire l'appel » (et un accès rapide sur le tableau de bord) affiche les élèves de la classe, tous présents par défaut ; il suffit de basculer les absents, retards ou excusés puis d'enregistrer. Pensé mobile, gros boutons, lisible en plein soleil *(enseignant)*.
 - Gestion des congés et jours fériés dans les Paramètres (onglet « Calendrier », sous les trimestres) : on ajoute ou supprime des périodes (libellé + date de début et de fin). Ces jours n'apparaissent plus dans le cahier de texte, même en plein trimestre *(admin)*.
@@ -34,6 +37,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Fiche parent : les enfants liés ne s'affichaient plus (lignes vides, « on ne voit rien ») ; ils réapparaissent avec leur nom, leur classe et leur situation *(admin)*.
 - La session ne se ferme plus pendant l'utilisation : tant que vous êtes actif, elle reste ouverte et se prolonge automatiquement. Elle n'expire désormais qu'après une période d'inactivité (mode veille), pas après un délai fixe *(tous)*.
 - Mode dictée des notes : le bouton « Mode dictée » de la saisie déléguée admin renvoyait vers le tableau de bord au lieu d'ouvrir la dictée. Il ouvre désormais la saisie vocale et revient à la bonne page en sortie *(admin, enseignant)*.
 - Page Frais de l'élève et du parent : la liste restait en chargement infini puis en erreur pour un élève inscrit. Les montants, le total payé, le reste à payer et le statut de chaque frais s'affichent désormais correctement *(élève, parent)*.

--- a/components/admin/parents/ParentChildCard.tsx
+++ b/components/admin/parents/ParentChildCard.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import Link from "next/link"
+import type { Route } from "next"
+import { GraduationCap, MoreVertical, Unlink, ArrowUpRight } from "lucide-react"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Progress } from "@/components/ui/progress"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import { getUploadUrl } from "@/lib/utils"
+import { formatXof } from "@/lib/export/format"
+import type { ParentChild } from "@/lib/contracts/parent"
+
+const RELATIONSHIP_LABEL: Record<string, string> = {
+  father: "Père",
+  mother: "Mère",
+  guardian: "Tuteur",
+  other: "Proche",
+}
+
+export function ParentChildCard({
+  child,
+  onUnlink,
+}: {
+  child: ParentChild
+  onUnlink: (child: ParentChild) => void
+}) {
+  const initials = `${child.last_name?.[0] ?? ""}${child.first_name?.[0] ?? ""}`.toUpperCase()
+  const photo = getUploadUrl(child.photo_url)
+  const rel = RELATIONSHIP_LABEL[child.relationship_type] ?? child.relationship_type
+  const paidRatio =
+    child.fees_expected > 0 ? Math.min(100, (child.fees_paid / child.fees_expected) * 100) : 0
+  const settled = child.fees_expected > 0 && child.fees_balance <= 0
+
+  return (
+    <div className="rounded-lg border bg-card p-3 transition-all hover:-translate-y-0.5 hover:shadow-[0_10px_30px_-12px_rgba(4,83,203,0.35)]">
+      <div className="flex items-start gap-3">
+        <Avatar className="h-11 w-11 shrink-0 rounded-xl">
+          {photo ? <AvatarImage src={photo} alt={child.student_name} className="object-cover" /> : null}
+          <AvatarFallback className="rounded-xl bg-primary/10 text-xs font-semibold text-primary">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold">
+            {child.last_name} {child.first_name}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {rel}
+            {child.matricule ? ` · N° ${child.matricule}` : ""}
+          </p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            {child.is_enrolled && child.class_name ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+                <GraduationCap className="h-3 w-3" aria-hidden="true" />
+                {child.class_name}
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
+                Pas inscrit cette année
+              </span>
+            )}
+          </div>
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted">
+            <MoreVertical className="h-4 w-4" />
+            <span className="sr-only">Actions sur l&apos;enfant</span>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem asChild>
+              <Link href={`/admin/students/${child.student_id}` as Route}>
+                <ArrowUpRight className="mr-2 h-4 w-4" />
+                Voir la fiche élève
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => onUnlink(child)}
+              className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+            >
+              <Unlink className="mr-2 h-4 w-4" />
+              Retirer de ce parent
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Situation financière (année courante) */}
+      {child.is_enrolled && child.fees_expected > 0 ? (
+        <div className="mt-3 rounded-md border border-border/60 bg-muted/40 p-2.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">Scolarité</span>
+            {settled ? (
+              <span className="font-semibold text-emerald-600 dark:text-emerald-400">À jour</span>
+            ) : (
+              <span className="font-semibold text-accent">
+                Reste {formatXof(child.fees_balance)}
+              </span>
+            )}
+          </div>
+          <Progress
+            value={paidRatio}
+            className={cn("mt-1.5 h-1.5", settled && "[&>*]:bg-emerald-500")}
+            aria-label={`${Math.round(paidRatio)}% payé`}
+          />
+          <p className="mt-1 text-[11px] tabular-nums text-muted-foreground">
+            {formatXof(child.fees_paid)} / {formatXof(child.fees_expected)}
+          </p>
+        </div>
+      ) : child.is_enrolled ? (
+        <p className="mt-2 text-[11px] text-muted-foreground">Aucun frais configuré.</p>
+      ) : null}
+    </div>
+  )
+}

--- a/components/admin/parents/ParentDetailClient.tsx
+++ b/components/admin/parents/ParentDetailClient.tsx
@@ -1,30 +1,29 @@
 "use client"
 
 import { useState } from "react"
-import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useQuery } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import {
-  ArrowLeft,
   Pencil,
   Trash2,
-  User,
   Users,
   Mail,
   MoreVertical,
-  Phone,
+  MapPin,
   CalendarDays,
-  ChevronRight,
   ShieldCheck,
+  UserPlus,
+  Wallet,
+  Coins,
 } from "lucide-react"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import type { Route } from "next"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -38,38 +37,29 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import { DataError } from "@/components/shared/DataError"
-import { useParent, useDeleteParent } from "@/lib/hooks/useParents"
-import { parentsApi } from "@/lib/api/parents"
+import { DetailHero } from "@/components/shared/DetailHero"
+import { ContactActions } from "@/components/shared/ContactActions"
+import type { HeroKpi } from "@/components/shared/PageHero"
+import { useParent, useParentFull, useDeleteParent, useUnlinkParent } from "@/lib/hooks/useParents"
+import { formatXof } from "@/lib/export/format"
+import type { ParentChild } from "@/lib/contracts/parent"
 import { ParentEditModal } from "./ParentEditModal"
-import type { Route } from "next"
+import { ParentLinkChildModal } from "./ParentLinkChildModal"
+import { ParentChildCard } from "./ParentChildCard"
 
-interface ParentDetailClientProps {
-  parentId: number
-}
-
-export function ParentDetailClient({ parentId }: ParentDetailClientProps) {
+export function ParentDetailClient({ parentId }: { parentId: number }) {
   const router = useRouter()
+  const queryClient = useQueryClient()
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
+  const [linkOpen, setLinkOpen] = useState(false)
+  const [unlinkTarget, setUnlinkTarget] = useState<ParentChild | null>(null)
 
   const { data: parent, isLoading, isError, refetch } = useParent(parentId)
-  const { data: fullData } = useQuery({
-    queryKey: ["parent", parentId, "full"],
-    queryFn: () => parentsApi.getFull(parentId),
-    enabled: !!parentId,
-    staleTime: 1000 * 60 * 5,
-  })
+  const { data: full } = useParentFull(parentId)
   const { mutate: deleteParent, isPending: deleting } = useDeleteParent()
-
-  const handleDelete = () => {
-    deleteParent(parentId, {
-      onSuccess: () => {
-        router.push("/admin/students" as Route)
-      },
-    })
-  }
+  const { mutate: unlink, isPending: unlinking } = useUnlinkParent()
 
   if (isLoading) return <DetailSkeleton />
   if (isError) return <DataError message="Impossible de charger la fiche parent." onRetry={() => refetch()} />
@@ -77,154 +67,169 @@ export function ParentDetailClient({ parentId }: ParentDetailClientProps) {
 
   const initials = `${parent.first_name?.[0] ?? ""}${parent.last_name?.[0] ?? ""}`.toUpperCase()
   const fullName = `${parent.last_name} ${parent.first_name}`
-  const children = (fullData?.children as Array<Record<string, unknown>>) ?? []
-  const userEmail = (fullData?.user_email as string | null | undefined) ?? parent.email
-  const userIsActive = fullData?.user_is_active as boolean | null | undefined
-  const userLastLogin = fullData?.user_last_login as string | null | undefined
+  const children = full?.children ?? []
+  const summary = full?.summary
+  const userEmail = full?.user_email ?? parent.email
   const createdAt = parent.created_at
     ? new Date(parent.created_at).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })
     : null
 
+  const kpis: HeroKpi[] = [
+    { label: "Enfants", value: summary?.children_count ?? children.length, icon: Users },
+    { label: "Total payé", value: formatXof(summary?.total_paid ?? 0), icon: Coins },
+    {
+      label: "Reste à payer",
+      value: formatXof(summary?.total_balance ?? 0),
+      icon: Wallet,
+      hint: summary?.academic_year_name ? `Année ${summary.academic_year_name}` : undefined,
+    },
+  ]
+
+  const handleDelete = () =>
+    deleteParent(parentId, { onSuccess: () => router.push("/admin/students" as Route) })
+
+  const confirmUnlink = () => {
+    if (!unlinkTarget) return
+    unlink(
+      { parentId, studentId: unlinkTarget.student_id },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["parent", parentId, "full"] })
+          setUnlinkTarget(null)
+        },
+      },
+    )
+  }
+
   return (
     <div className="space-y-6">
-      {/* Header — pattern cristallisé redesign-premium principes 13/14 */}
-      <div className="flex items-start gap-3">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          aria-label="Retour à la liste des parents"
-          className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
-        >
-          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
-        </button>
-
-        <Avatar className="h-16 w-16 shrink-0 rounded-2xl border-2 border-border sm:h-24 sm:w-24">
-          <AvatarFallback className="rounded-2xl bg-primary/10 text-xl font-semibold text-primary sm:text-2xl">
-            {initials}
-          </AvatarFallback>
-        </Avatar>
-
-        <div className="min-w-0 flex-1">
-          <h1 className="font-serif text-lg tracking-tight sm:text-2xl">{fullName}</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Parent {children.length > 0 ? `· ${children.length} enfant${children.length > 1 ? "s" : ""}` : ""}
-          </p>
-          {parent.phone && (
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <a
-                href={`tel:${parent.phone}`}
-                className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/5"
-              >
-                <Phone className="h-3 w-3" />
-                {parent.phone}
-              </a>
-            </div>
-          )}
-        </div>
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon" className="h-9 w-9 shrink-0">
+      <DetailHero
+        onBack={() => router.back()}
+        backLabel="Retour à la liste des parents"
+        initials={initials}
+        name={fullName}
+        subtitle={`Parent${children.length > 0 ? ` · ${children.length} enfant${children.length > 1 ? "s" : ""}` : ""}`}
+        contact={<ContactActions phone={parent.phone} email={userEmail} variant="hero" />}
+        kpis={kpis}
+        actions={
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/25 bg-white/10 text-white transition-colors hover:bg-white/20">
               <MoreVertical className="h-4 w-4" />
               <span className="sr-only">Actions sur le parent</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuItem onClick={() => setEditOpen(true)}>
-              <Pencil className="mr-2 h-4 w-4" />
-              Modifier
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => setDeleteOpen(true)}
-              className="text-destructive focus:text-destructive focus:bg-destructive/10"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Supprimer le parent
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuItem onClick={() => setEditOpen(true)}>
+                <Pencil className="mr-2 h-4 w-4" />
+                Modifier les infos
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setLinkOpen(true)}>
+                <UserPlus className="mr-2 h-4 w-4" />
+                Lier un enfant
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setDeleteOpen(true)}
+                className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Supprimer le parent
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        }
+      />
 
-      {/* Section Enfants liés — Wave-style 1-tap action vers la fiche élève */}
+      {/* Enfants liés */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardContent className="p-4">
-          <div className="mb-3 flex items-center justify-between">
-            <h3 className="flex items-center gap-2 text-sm font-medium">
-              <Users className="h-4 w-4 text-muted-foreground" />
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <h2 className="flex items-center gap-2 text-sm font-semibold">
+              <Users className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
               Enfants liés
-            </h3>
-            {children.length > 0 && (
-              <span className="text-xs text-muted-foreground">{children.length} liés</span>
-            )}
+            </h2>
+            <button
+              type="button"
+              onClick={() => setLinkOpen(true)}
+              className="inline-flex h-9 items-center gap-1.5 rounded-lg bg-accent px-3 text-sm font-semibold text-accent-foreground shadow-sm transition-colors hover:bg-accent/90"
+            >
+              <UserPlus className="h-4 w-4" aria-hidden="true" />
+              Lier un enfant
+            </button>
           </div>
+
           {children.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Aucun enfant lié à ce parent.</p>
+            <div className="rounded-lg border border-dashed py-8 text-center">
+              <Users className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" aria-hidden="true" />
+              <p className="text-sm text-muted-foreground">Aucun enfant lié à ce parent.</p>
+              <button
+                type="button"
+                onClick={() => setLinkOpen(true)}
+                className="mt-1 text-sm font-medium text-accent"
+              >
+                Lier un enfant maintenant
+              </button>
+            </div>
           ) : (
-            <ul className="space-y-2">
-              {children.map((child) => {
-                const ln = String(child.last_name ?? "")
-                const fn = String(child.first_name ?? "")
-                const className = (child.class_name as string | null) ?? null
-                const cid = child.id as number
-                const ci = `${ln[0] ?? ""}${fn[0] ?? ""}`.toUpperCase()
-                return (
-                  <li key={cid}>
-                    <Link
-                      href={`/admin/students/${cid}` as Route}
-                      className="flex items-center gap-3 rounded-lg border bg-card p-3 hover:bg-muted/50 hover:ring-1 hover:ring-primary transition-all"
-                    >
-                      <Avatar className="h-9 w-9 shrink-0">
-                        <AvatarFallback className="bg-primary/10 text-xs font-semibold text-primary">
-                          {ci}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium">{ln} {fn}</p>
-                        {className && <p className="text-xs text-muted-foreground">{className}</p>}
-                      </div>
-                      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    </Link>
-                  </li>
-                )
-              })}
-            </ul>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {children.map((child) => (
+                <ParentChildCard key={child.student_id} child={child} onUnlink={setUnlinkTarget} />
+              ))}
+            </div>
           )}
         </CardContent>
       </Card>
 
-      {/* Section Contact & compte — tri-état badge principe 14 */}
+      {/* Contact & compte */}
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardContent className="p-6">
-          <h3 className="text-sm font-medium text-muted-foreground mb-4">
-            Contact &amp; compte
-          </h3>
+          <h2 className="mb-4 text-sm font-semibold text-muted-foreground">Contact &amp; compte</h2>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <InfoItem icon={<Mail className="h-4 w-4" />} label="Email" value={userEmail ?? "Non renseigné"} />
             <InfoItem
-              icon={<Mail className="h-4 w-4" />}
-              label="Email"
-              value={userEmail ?? "Non renseigné"}
-            />
-            <InfoItem
-              icon={<User className="h-4 w-4" />}
+              icon={<MapPin className="h-4 w-4" />}
               label="Ville / Commune"
               value={[parent.city, parent.commune].filter(Boolean).join(" / ") || "Non renseigné"}
             />
-            <AccountStatusItem isActive={userIsActive} lastLogin={userLastLogin} />
-            <InfoItem
-              icon={<CalendarDays className="h-4 w-4" />}
-              label="Créé le"
-              value={createdAt ?? "—"}
+            <AccountStatusItem
+              hasAccount={!!(full?.user_email || parent.user_id)}
+              isActive={full?.user_is_active}
+              lastLogin={full?.user_last_login}
             />
+            <InfoItem icon={<CalendarDays className="h-4 w-4" />} label="Créé le" value={createdAt ?? "—"} />
           </div>
         </CardContent>
       </Card>
 
-      <ParentEditModal
+      <ParentEditModal parentId={parentId} open={editOpen} onClose={() => setEditOpen(false)} />
+      <ParentLinkChildModal
         parentId={parentId}
-        open={editOpen}
-        onClose={() => setEditOpen(false)}
+        linkedStudentIds={children.map((c) => c.student_id)}
+        open={linkOpen}
+        onClose={() => setLinkOpen(false)}
       />
+
+      {/* Unlink confirmation */}
+      <AlertDialog open={!!unlinkTarget} onOpenChange={(o) => !o && setUnlinkTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Retirer cet enfant ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Le lien entre {fullName} et {unlinkTarget?.student_name} sera retiré. L&apos;élève ne
+              sera pas supprimé.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmUnlink}
+              disabled={unlinking}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {unlinking ? "Retrait..." : "Retirer le lien"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Delete confirmation */}
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
@@ -232,8 +237,8 @@ export function ParentDetailClient({ parentId }: ParentDetailClientProps) {
           <AlertDialogHeader>
             <AlertDialogTitle>Supprimer ce parent ?</AlertDialogTitle>
             <AlertDialogDescription>
-              Cette action est irréversible. Le parent {fullName} sera définitivement supprimé.
-              Les liens avec les enfants seront retirés.
+              Cette action est irréversible. Le parent {fullName} sera définitivement supprimé. Les
+              liens avec les enfants seront retirés.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -252,15 +257,7 @@ export function ParentDetailClient({ parentId }: ParentDetailClientProps) {
   )
 }
 
-function InfoItem({
-  icon,
-  label,
-  value,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: string
-}) {
+function InfoItem({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
   return (
     <div className="flex items-start gap-3">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
@@ -275,26 +272,24 @@ function InfoItem({
 }
 
 function AccountStatusItem({
+  hasAccount,
   isActive,
   lastLogin,
 }: {
+  hasAccount: boolean
   isActive: boolean | null | undefined
   lastLogin: string | null | undefined
 }) {
-  // Tri-état sémantique principe 14 redesign-premium.
-  let badge: { label: string; className: string; variant: "outline" | "destructive" }
-  if (!lastLogin) {
-    badge = {
-      label: "En attente",
-      className: "border-amber-500 text-amber-700 dark:text-amber-400",
-      variant: "outline",
-    }
+  let badge: { label: string; className: string; variant: "outline" | "destructive" | "secondary" }
+  if (!hasAccount) {
+    badge = { label: "Sans compte", className: "", variant: "secondary" }
+  } else if (!lastLogin) {
+    badge = { label: "En attente", className: "border-amber-500 text-amber-700 dark:text-amber-400", variant: "outline" }
   } else if (isActive === false) {
     badge = { label: "Désactivé", className: "", variant: "destructive" }
   } else {
     badge = { label: "Actif", className: "border-emerald-500 text-emerald-600", variant: "outline" }
   }
-
   return (
     <div className="flex items-start gap-3">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
@@ -313,16 +308,9 @@ function AccountStatusItem({
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="flex items-start gap-3">
-        <Skeleton className="h-9 w-9 rounded-md" />
-        <Skeleton className="h-16 w-16 rounded-2xl sm:h-24 sm:w-24" />
-        <div className="flex-1 space-y-2">
-          <Skeleton className="h-7 w-48" />
-          <Skeleton className="h-4 w-32" />
-        </div>
-      </div>
-      <Skeleton className="h-32 rounded-lg" />
-      <Skeleton className="h-32 rounded-lg" />
+      <Skeleton className="h-52 rounded-2xl" />
+      <Skeleton className="h-40 rounded-xl" />
+      <Skeleton className="h-32 rounded-xl" />
     </div>
   )
 }

--- a/components/admin/parents/ParentLinkChildModal.tsx
+++ b/components/admin/parents/ParentLinkChildModal.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Label } from "@/components/ui/label"
+import { useStudents } from "@/lib/hooks/useStudents"
+import { useLinkParent } from "@/lib/hooks/useParents"
+import type { Student } from "@/lib/contracts/student"
+
+const RELATIONSHIPS = [
+  { value: "guardian", label: "Tuteur / Tutrice" },
+  { value: "father", label: "Père" },
+  { value: "mother", label: "Mère" },
+  { value: "other", label: "Autre proche" },
+]
+
+export function ParentLinkChildModal({
+  parentId,
+  linkedStudentIds,
+  open,
+  onClose,
+}: {
+  parentId: number
+  linkedStudentIds: number[]
+  open: boolean
+  onClose: () => void
+}) {
+  const queryClient = useQueryClient()
+  const [studentId, setStudentId] = useState("")
+  const [relationship, setRelationship] = useState("guardian")
+
+  const { data, isLoading } = useStudents({ size: 100 })
+  const { mutate: link, isPending } = useLinkParent()
+
+  const students: Student[] = (data as { items?: Student[] } | undefined)?.items ?? []
+  const available = students.filter((s) => !linkedStudentIds.includes(s.id))
+
+  const submit = () => {
+    if (!studentId) return
+    link(
+      { parentId, studentId: Number(studentId), relationshipType: relationship },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["parent", parentId, "full"] })
+          setStudentId("")
+          setRelationship("guardian")
+          onClose()
+        },
+      },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Lier un enfant</DialogTitle>
+          <DialogDescription>
+            Associez un élève existant à ce parent et précisez le lien de parenté.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="child-select">Élève</Label>
+            <Select value={studentId} onValueChange={setStudentId}>
+              <SelectTrigger id="child-select" className="h-11 sm:h-10">
+                <SelectValue placeholder={isLoading ? "Chargement..." : "Choisir un élève"} />
+              </SelectTrigger>
+              <SelectContent>
+                {available.map((s) => (
+                  <SelectItem key={s.id} value={String(s.id)}>
+                    {s.last_name} {s.first_name}
+                    {s.enrollment_number ? ` · ${s.enrollment_number}` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {!isLoading && available.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                Tous les élèves sont déjà liés à ce parent.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="rel-select">Lien de parenté</Label>
+            <Select value={relationship} onValueChange={setRelationship}>
+              <SelectTrigger id="rel-select" className="h-11 sm:h-10">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RELATIONSHIPS.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={isPending}>
+            Annuler
+          </Button>
+          <Button onClick={submit} disabled={!studentId || isPending}>
+            {isPending ? "Liaison..." : "Lier l'enfant"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/staff/StaffDetailClient.tsx
+++ b/components/admin/staff/StaffDetailClient.tsx
@@ -1,12 +1,20 @@
 "use client"
 
 import { useRef, useState } from "react"
-import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { ArrowLeft, Camera, Pencil, Trash2, User, MoreVertical } from "lucide-react"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import {
+  Camera,
+  Pencil,
+  Trash2,
+  User,
+  Activity,
+  MoreVertical,
+  Coins,
+  UserPlus,
+  Clock,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import {
@@ -29,18 +37,18 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
+import { DetailHero } from "@/components/shared/DetailHero"
+import { ContactActions } from "@/components/shared/ContactActions"
+import type { HeroKpi } from "@/components/shared/PageHero"
 import { StaffEditModal } from "./StaffEditModal"
 import { StaffProfileTab } from "./tabs/StaffProfileTab"
+import { StaffActivityTab } from "./tabs/StaffActivityTab"
 import { useStaffMember, useStaffFull, useDeleteStaff, staffKeys } from "@/lib/hooks/useStaff"
 import { staffApi } from "@/lib/api/staff"
 import { getUploadUrl } from "@/lib/utils"
+import { formatXof } from "@/lib/export/format"
 
-// ---------- Main component ----------
-interface StaffDetailClientProps {
-  staffId: number
-}
-
-export function StaffDetailClient({ staffId }: StaffDetailClientProps) {
+export function StaffDetailClient({ staffId }: { staffId: number }) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -62,6 +70,7 @@ export function StaffDetailClient({ staffId }: StaffDetailClientProps) {
     try {
       await staffApi.uploadPhoto(staffId, file)
       queryClient.invalidateQueries({ queryKey: staffKeys.detail(staffId) })
+      queryClient.invalidateQueries({ queryKey: ["staff", staffId, "full"] })
       toast.success("Photo mise à jour")
     } catch {
       toast.error("Erreur lors de l'upload")
@@ -75,7 +84,7 @@ export function StaffDetailClient({ staffId }: StaffDetailClientProps) {
     try {
       await staffApi.deletePhoto(staffId)
       queryClient.invalidateQueries({ queryKey: staffKeys.detail(staffId) })
-      queryClient.invalidateQueries({ queryKey: staffKeys.all })
+      queryClient.invalidateQueries({ queryKey: ["staff", staffId, "full"] })
       setPhotoPreview(false)
       toast.success("Photo supprimée")
     } catch {
@@ -83,125 +92,101 @@ export function StaffDetailClient({ staffId }: StaffDetailClientProps) {
     }
   }
 
-  const handleDelete = () => {
-    deleteStaff(staffId, {
-      onSuccess: () => {
-        router.push("/admin/staff")
-      },
-    })
-  }
+  const handleDelete = () =>
+    deleteStaff(staffId, { onSuccess: () => router.push("/admin/staff") })
 
   if (isLoading) return <DetailSkeleton />
   if (isError)
-    return (
-      <DataError
-        message="Impossible de charger la fiche du personnel."
-        onRetry={() => refetch()}
-      />
-    )
+    return <DataError message="Impossible de charger la fiche du personnel." onRetry={() => refetch()} />
   if (!staff) return <DataError message="Personnel introuvable." />
 
-  const initials =
-    `${staff.first_name?.[0] ?? ""}${staff.last_name?.[0] ?? ""}`.toUpperCase()
+  const initials = `${staff.first_name?.[0] ?? ""}${staff.last_name?.[0] ?? ""}`.toUpperCase()
   const fullName = `${staff.last_name} ${staff.first_name}`
-  const photoSrc = getUploadUrl((staff as Record<string, unknown>).photo_url as string | null | undefined)
+  const photoSrc = getUploadUrl(
+    (fullData?.photo_url ?? (staff as Record<string, unknown>).photo_url) as string | null | undefined,
+  )
+  const activity = fullData?.activity
+  const lastLoginLabel = fullData?.user_last_login
+    ? new Date(fullData.user_last_login).toLocaleDateString("fr-FR", {
+        day: "2-digit",
+        month: "short",
+        year: "numeric",
+      })
+    : "Jamais"
+
+  const kpis: HeroKpi[] = [
+    {
+      label: "Versements encaissés",
+      value: activity?.payments_count ?? 0,
+      icon: Coins,
+      hint: activity && activity.payments_count > 0 ? formatXof(activity.payments_amount) : undefined,
+    },
+    { label: "Inscriptions traitées", value: activity?.enrollments_count ?? 0, icon: UserPlus },
+    { label: "Dernière connexion", value: lastLoginLabel, icon: Clock },
+  ]
 
   return (
     <div className="space-y-6">
-      {/* Header — pattern cristallisé redesign-premium principes 13 + 14 */}
-      <div className="flex items-start gap-3">
-        <Link
-          href="/admin/staff"
-          aria-label="Retour à la liste du personnel"
-          className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
-        >
-          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
-        </Link>
-
-        <button
-          type="button"
-          onClick={() => photoLoaded && setPhotoPreview(true)}
-          aria-label={photoLoaded ? "Voir la photo en grand" : "Photo du personnel"}
-          className="shrink-0 overflow-hidden rounded-2xl border-2 border-border focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-default"
-          disabled={!photoLoaded}
-        >
-          <Avatar className="h-16 w-16 rounded-2xl sm:h-24 sm:w-24">
-            {photoSrc ? (
-              <AvatarImage
-                src={photoSrc}
-                alt={fullName}
-                className="object-cover"
-                onLoadingStatusChange={(status) => setPhotoLoaded(status === "loaded")}
-              />
-            ) : null}
-            <AvatarFallback className="rounded-2xl bg-primary/10 text-xl font-semibold text-primary sm:text-2xl">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
-        </button>
-
-        <div className="min-w-0 flex-1">
-          <h1 className="font-serif text-lg tracking-tight sm:text-2xl">{fullName}</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {staff.position ?? "Personnel"}
-          </p>
-        </div>
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon" className="h-9 w-9 shrink-0">
+      <DetailHero
+        onBack={() => router.push("/admin/staff")}
+        backLabel="Retour à la liste du personnel"
+        photoUrl={photoSrc}
+        initials={initials}
+        name={fullName}
+        subtitle={staff.position ?? "Personnel"}
+        contact={<ContactActions phone={staff.phone} email={fullData?.user_email} variant="hero" />}
+        kpis={kpis}
+        onAvatarClick={() => photoLoaded && setPhotoPreview(true)}
+        onPhotoStatus={setPhotoLoaded}
+        actions={
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/25 bg-white/10 text-white transition-colors hover:bg-white/20">
               <MoreVertical className="h-4 w-4" />
               <span className="sr-only">Actions sur le membre du personnel</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuItem onClick={() => setEditOpen(true)}>
-              <Pencil className="mr-2 h-4 w-4" />
-              Modifier les infos
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => fileInputRef.current?.click()}
-              disabled={uploading}
-            >
-              <Camera className="mr-2 h-4 w-4" />
-              {photoSrc ? "Changer la photo" : "Ajouter une photo"}
-            </DropdownMenuItem>
-            {photoSrc && photoLoaded && (
-              <DropdownMenuItem onClick={handleDeletePhoto}>
-                <Trash2 className="mr-2 h-4 w-4" />
-                Supprimer la photo
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuItem onClick={() => setEditOpen(true)}>
+                <Pencil className="mr-2 h-4 w-4" />
+                Modifier les infos
               </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => setDeleteOpen(true)}
-              className="text-destructive focus:text-destructive focus:bg-destructive/10"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Supprimer le personnel
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <DropdownMenuItem onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+                <Camera className="mr-2 h-4 w-4" />
+                {photoSrc ? "Changer la photo" : "Ajouter une photo"}
+              </DropdownMenuItem>
+              {photoSrc && photoLoaded && (
+                <DropdownMenuItem onClick={handleDeletePhoto}>
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Supprimer la photo
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setDeleteOpen(true)}
+                className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Supprimer le personnel
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        }
+      />
 
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          className="hidden"
-          onChange={handlePhotoUpload}
-        />
-      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handlePhotoUpload}
+      />
 
       {/* Photo preview dialog */}
       {photoSrc && (
         <Dialog open={photoPreview} onOpenChange={setPhotoPreview}>
           <DialogContent className="max-w-md p-2">
             <div className="relative aspect-square w-full overflow-hidden rounded-lg">
-              <img
-                src={photoSrc}
-                alt={fullName}
-                className="h-full w-full object-cover"
-              />
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={photoSrc} alt={fullName} className="h-full w-full object-cover" />
             </div>
             <div className="flex items-center justify-between px-2 pb-1">
               <p className="text-sm font-medium">{fullName}</p>
@@ -217,11 +202,7 @@ export function StaffDetailClient({ staffId }: StaffDetailClientProps) {
                   <Camera className="mr-1.5 h-3.5 w-3.5" />
                   Changer
                 </Button>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={handleDeletePhoto}
-                >
+                <Button variant="destructive" size="sm" onClick={handleDeletePhoto}>
                   <Trash2 className="mr-1.5 h-3.5 w-3.5" />
                   Supprimer
                 </Button>
@@ -238,30 +219,28 @@ export function StaffDetailClient({ staffId }: StaffDetailClientProps) {
             <User className="mr-1.5 h-3.5 w-3.5" />
             Profil
           </TabsTrigger>
+          <TabsTrigger value="activite">
+            <Activity className="mr-1.5 h-3.5 w-3.5" />
+            Activité
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="profil">
           <StaffProfileTab staff={staff} fullData={fullData} />
         </TabsContent>
+        <TabsContent value="activite">
+          <StaffActivityTab fullData={fullData} />
+        </TabsContent>
       </Tabs>
 
-      {/* Edit modal */}
-      <StaffEditModal
-        staffId={staffId}
-        open={editOpen}
-        onClose={() => setEditOpen(false)}
-      />
+      <StaffEditModal staffId={staffId} open={editOpen} onClose={() => setEditOpen(false)} />
 
-      {/* Delete confirmation */}
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>
-              Supprimer ce membre du personnel ?
-            </AlertDialogTitle>
+            <AlertDialogTitle>Supprimer ce membre du personnel ?</AlertDialogTitle>
             <AlertDialogDescription>
-              Cette action est irréversible. {fullName} sera définitivement
-              supprimé.
+              Cette action est irréversible. {fullName} sera définitivement supprimé.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -280,20 +259,12 @@ export function StaffDetailClient({ staffId }: StaffDetailClientProps) {
   )
 }
 
-// ---------- Skeleton ----------
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="flex items-start gap-4">
-        <Skeleton className="h-8 w-8 rounded-md" />
-        <Skeleton className="h-28 w-28 rounded-2xl" />
-        <div className="space-y-2">
-          <Skeleton className="h-7 w-48" />
-          <Skeleton className="h-4 w-32" />
-        </div>
-      </div>
-      <Skeleton className="h-10 w-40 rounded-lg" />
-      <Skeleton className="h-48 rounded-lg" />
+      <Skeleton className="h-52 rounded-2xl" />
+      <Skeleton className="h-10 w-48 rounded-lg" />
+      <Skeleton className="h-48 rounded-xl" />
     </div>
   )
 }

--- a/components/admin/staff/tabs/StaffActivityTab.tsx
+++ b/components/admin/staff/tabs/StaffActivityTab.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { Coins, UserPlus, Clock, Info } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { formatXof } from "@/lib/export/format"
+import type { StaffFull } from "@/lib/contracts/staff"
+
+function StatTile({
+  icon: Icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: React.ReactNode
+  hint?: string
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <p className="mt-1.5 text-2xl font-bold leading-none tabular-nums">{value}</p>
+      {hint && <p className="mt-1 text-[11px] text-muted-foreground">{hint}</p>}
+    </div>
+  )
+}
+
+export function StaffActivityTab({ fullData }: { fullData?: StaffFull }) {
+  const activity = fullData?.activity
+  const lastLogin = fullData?.user_last_login
+  const lastLoginLabel = lastLogin
+    ? new Date(lastLogin).toLocaleDateString("fr-FR", { day: "2-digit", month: "short", year: "numeric" })
+    : "Jamais connecté"
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardContent className="space-y-4 p-6">
+        <div>
+          <h2 className="text-sm font-semibold">Activité de l&apos;année</h2>
+          {activity?.academic_year_name && (
+            <p className="text-xs text-muted-foreground">Année {activity.academic_year_name}</p>
+          )}
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <StatTile
+            icon={Coins}
+            label="Versements encaissés"
+            value={activity?.payments_count ?? 0}
+            hint={
+              activity && activity.payments_count > 0
+                ? formatXof(activity.payments_amount)
+                : "Aucun encaissement"
+            }
+          />
+          <StatTile
+            icon={UserPlus}
+            label="Inscriptions traitées"
+            value={activity?.enrollments_count ?? 0}
+          />
+          <StatTile icon={Clock} label="Dernière connexion" value={lastLoginLabel} />
+        </div>
+
+        <div className="flex items-start gap-2 rounded-lg border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+          <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <p>
+            Ces indicateurs reflètent le volume d&apos;activité de ce membre du personnel sur
+            l&apos;année en cours (versements qu&apos;il a encaissés, inscriptions qu&apos;il a
+            enregistrées). Ce n&apos;est pas une note de performance.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/staff/tabs/StaffProfileTab.tsx
+++ b/components/admin/staff/tabs/StaffProfileTab.tsx
@@ -3,11 +3,11 @@
 import { User, Phone, CalendarDays, Mail, ShieldCheck } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
-import type { Staff } from "@/lib/contracts/staff"
+import type { Staff, StaffFull } from "@/lib/contracts/staff"
 
 interface StaffProfileTabProps {
   staff: Staff
-  fullData?: Record<string, unknown>
+  fullData?: StaffFull
 }
 
 function InfoField({

--- a/components/shared/ContactActions.tsx
+++ b/components/shared/ContactActions.tsx
@@ -1,0 +1,56 @@
+import { Phone, MessageCircle, Mail } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+/**
+ * Actions de contact « Wave-style » (persona Mme Diallo) : Appeler / WhatsApp /
+ * Email, gros boutons tactiles (h-11), réutilisables sur une fiche détail.
+ * `variant="hero"` = boutons verre sur le dégradé foncé du hero ;
+ * `variant="card"` = boutons outline sur fond clair.
+ */
+interface ContactActionsProps {
+  phone?: string | null
+  email?: string | null
+  variant?: "hero" | "card"
+  className?: string
+}
+
+const heroBtn =
+  "inline-flex h-11 items-center justify-center gap-1.5 rounded-lg border border-white/25 bg-white/15 px-3 text-sm font-semibold text-white transition-colors hover:bg-white/25 sm:h-10"
+const cardBtn =
+  "inline-flex h-11 items-center justify-center gap-1.5 rounded-lg border bg-background px-3 text-sm font-medium transition-colors hover:bg-muted sm:h-10"
+
+export function ContactActions({ phone, email, variant = "card", className }: ContactActionsProps) {
+  const btn = variant === "hero" ? heroBtn : cardBtn
+  const waNumber = phone ? phone.replace(/[^\d]/g, "") : ""
+
+  if (!phone && !email) return null
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      {phone && (
+        <a href={`tel:${phone}`} className={btn} aria-label={`Appeler ${phone}`}>
+          <Phone className="h-4 w-4" aria-hidden="true" />
+          Appeler
+        </a>
+      )}
+      {waNumber && (
+        <a
+          href={`https://wa.me/${waNumber}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={btn}
+          aria-label="Contacter par WhatsApp"
+        >
+          <MessageCircle className="h-4 w-4" aria-hidden="true" />
+          WhatsApp
+        </a>
+      )}
+      {email && (
+        <a href={`mailto:${email}`} className={btn} aria-label={`Envoyer un email à ${email}`}>
+          <Mail className="h-4 w-4" aria-hidden="true" />
+          Email
+        </a>
+      )}
+    </div>
+  )
+}

--- a/components/shared/DetailHero.tsx
+++ b/components/shared/DetailHero.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { ArrowLeft } from "lucide-react"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { cn } from "@/lib/utils"
+import type { HeroKpi } from "@/components/shared/PageHero"
+
+/**
+ * Hero premium unifié pour les fiches détail (parent, personnel, et à terme
+ * élève/enseignant). Même dégradé bleu→orange que `PageHero`, mais avec avatar
+ * (photo 404-safe), bouton retour, actions de contact et une bande de KPIs.
+ * Un seul bloc sombre en tête qui porte toute la synthèse.
+ */
+interface DetailHeroProps {
+  onBack?: () => void
+  backLabel?: string
+  photoUrl?: string | null
+  initials: string
+  name: string
+  subtitle?: React.ReactNode
+  badge?: React.ReactNode
+  contact?: React.ReactNode
+  kpis?: HeroKpi[]
+  actions?: React.ReactNode
+  onAvatarClick?: () => void
+  onPhotoStatus?: (loaded: boolean) => void
+}
+
+export function DetailHero({
+  onBack,
+  backLabel = "Retour",
+  photoUrl,
+  initials,
+  name,
+  subtitle,
+  badge,
+  contact,
+  kpis,
+  actions,
+  onAvatarClick,
+  onPhotoStatus,
+}: DetailHeroProps) {
+  const avatar = (
+    <Avatar className="h-16 w-16 rounded-2xl border-2 border-white/25 sm:h-20 sm:w-20">
+      {photoUrl ? (
+        <AvatarImage
+          src={photoUrl}
+          alt={name}
+          className="object-cover"
+          onLoadingStatusChange={(s) => onPhotoStatus?.(s === "loaded")}
+        />
+      ) : null}
+      <AvatarFallback className="rounded-2xl bg-white/15 text-lg font-semibold text-white sm:text-xl">
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  )
+
+  return (
+    <section className="rounded-2xl bg-[linear-gradient(135deg,#0a3d8f_0%,#0453cb_42%,#2a69cb_56%,#f5821f_92%)] p-5 text-white shadow-sm sm:p-6">
+      <div className="flex items-start gap-3">
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label={backLabel}
+            className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/25 bg-white/10 transition-colors hover:bg-white/20"
+          >
+            <ArrowLeft aria-hidden="true" className="h-4 w-4" />
+          </button>
+        )}
+
+        {onAvatarClick ? (
+          <button
+            type="button"
+            onClick={onAvatarClick}
+            aria-label="Voir la photo"
+            className="shrink-0 rounded-2xl focus:outline-none focus:ring-2 focus:ring-white/60"
+          >
+            {avatar}
+          </button>
+        ) : (
+          <div className="shrink-0">{avatar}</div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="font-serif text-xl font-bold tracking-tight sm:text-2xl">{name}</h1>
+            {badge}
+          </div>
+          {subtitle && <div className="mt-0.5 text-sm text-white/75">{subtitle}</div>}
+          {contact && <div className="mt-3">{contact}</div>}
+        </div>
+
+        {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+      </div>
+
+      {kpis && kpis.length > 0 && (
+        <div
+          className={cn(
+            "mt-5 grid gap-2.5",
+            kpis.length >= 3 ? "grid-cols-2 lg:grid-cols-3" : "grid-cols-2",
+          )}
+        >
+          {kpis.map((k, i) => {
+            const KIcon = k.icon
+            return (
+              <div
+                key={i}
+                className="rounded-xl border border-white/20 bg-white/15 px-3 py-2.5 backdrop-blur-sm"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="truncate text-[11px] font-medium uppercase tracking-wide text-white/65">
+                    {k.label}
+                  </p>
+                  {KIcon && <KIcon className="h-4 w-4 shrink-0 text-white/70" aria-hidden="true" />}
+                </div>
+                <div className="mt-1 text-xl font-bold leading-none tracking-tight tabular-nums sm:text-2xl">
+                  {k.value}
+                </div>
+                {k.hint && <div className="mt-1 truncate text-[11px] text-white/60">{k.hint}</div>}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/lib/api/parents.ts
+++ b/lib/api/parents.ts
@@ -1,13 +1,14 @@
-import { ParentSchema } from "@/lib/contracts/parent"
-import type { Parent, ParentCreate, ParentUpdate } from "@/lib/contracts/parent"
+import { ParentSchema, ParentFullSchema } from "@/lib/contracts/parent"
+import type { Parent, ParentCreate, ParentUpdate, ParentFull } from "@/lib/contracts/parent"
 import { createCrudApi } from "./createCrudApi"
-import { apiFetch } from "./client"
+import { apiFetch, safeValidate } from "./client"
 
 export const parentsApi = {
   ...createCrudApi<Parent, ParentCreate, ParentUpdate>("/admin/parents", ParentSchema),
 
-  getFull: async (id: number): Promise<Record<string, unknown>> => {
-    return apiFetch<Record<string, unknown>>(`/admin/parents/${id}/full`)
+  getFull: async (id: number): Promise<ParentFull> => {
+    const json = await apiFetch<unknown>(`/admin/parents/${id}/full`)
+    return safeValidate(ParentFullSchema, json, `GET /admin/parents/${id}/full`)
   },
 
   getStudentParents: async (studentId: number): Promise<Parent[]> => {

--- a/lib/api/staff.ts
+++ b/lib/api/staff.ts
@@ -1,7 +1,7 @@
 import { getSession } from "next-auth/react"
 import { z } from "zod"
-import { StaffSchema } from "@/lib/contracts/staff"
-import type { Staff, StaffCreate, StaffUpdate } from "@/lib/contracts/staff"
+import { StaffSchema, StaffFullSchema } from "@/lib/contracts/staff"
+import type { Staff, StaffCreate, StaffUpdate, StaffFull } from "@/lib/contracts/staff"
 import { createCrudApi } from "./createCrudApi"
 import { apiFetch, handleExpiredSession, safeValidate } from "./client"
 
@@ -19,8 +19,9 @@ export const staffApi = {
     StaffSchema,
   ),
 
-  getFull: async (id: number): Promise<Record<string, unknown>> => {
-    return apiFetch<Record<string, unknown>>(`/admin/staff/${id}/full`)
+  getFull: async (id: number): Promise<StaffFull> => {
+    const json = await apiFetch<unknown>(`/admin/staff/${id}/full`)
+    return safeValidate(StaffFullSchema, json, `GET /admin/staff/${id}/full`)
   },
 
   uploadPhoto: async (staffId: number, file: File): Promise<{ photo_url: string }> => {

--- a/lib/contracts/parent.ts
+++ b/lib/contracts/parent.ts
@@ -33,6 +33,43 @@ export const ParentUpdateSchema = z.object({
   commune: z.string().optional(),
 })
 
+// Enfant lié enrichi (endpoint /admin/parents/{id}/full). Pas de `.default()` :
+// le safeValidate du projet ne tolère pas la divergence input/output des defaults.
+export const ParentChildSchema = z.object({
+  student_id: z.number(),
+  first_name: z.string(),
+  last_name: z.string(),
+  student_name: z.string(),
+  matricule: z.string().nullish(),
+  photo_url: z.string().nullish(),
+  relationship_type: z.string(),
+  class_name: z.string().nullish(),
+  enrollment_status: z.string().nullish(),
+  is_enrolled: z.boolean(),
+  fees_expected: z.coerce.number(),
+  fees_paid: z.coerce.number(),
+  fees_balance: z.coerce.number(),
+})
+
+export const ParentSummarySchema = z.object({
+  children_count: z.number(),
+  enrolled_count: z.number(),
+  total_expected: z.coerce.number(),
+  total_paid: z.coerce.number(),
+  total_balance: z.coerce.number(),
+  academic_year_name: z.string().nullish(),
+})
+
+export const ParentFullSchema = ParentSchema.extend({
+  user_email: z.string().nullish(),
+  user_is_active: z.boolean().nullish(),
+  user_last_login: z.string().nullish(),
+  children: z.array(ParentChildSchema),
+  summary: ParentSummarySchema,
+})
+
 export type Parent = z.infer<typeof ParentSchema>
 export type ParentCreate = z.infer<typeof ParentCreateSchema>
 export type ParentUpdate = z.infer<typeof ParentUpdateSchema>
+export type ParentChild = z.infer<typeof ParentChildSchema>
+export type ParentFull = z.infer<typeof ParentFullSchema>

--- a/lib/contracts/staff.ts
+++ b/lib/contracts/staff.ts
@@ -38,7 +38,25 @@ export const StaffListParamsSchema = z.object({
   position: z.string().optional(),
 })
 
+export const StaffActivitySchema = z.object({
+  payments_count: z.number(),
+  payments_amount: z.coerce.number(),
+  enrollments_count: z.number(),
+  academic_year_name: z.string().nullish(),
+})
+
+export const StaffFullSchema = StaffSchema.extend({
+  photo_url: z.string().nullish(),
+  user_email: z.string().nullish(),
+  user_is_active: z.boolean().nullish(),
+  user_last_login: z.string().nullish(),
+  user_created_at: z.string().nullish(),
+  activity: StaffActivitySchema,
+})
+
 export type Staff = z.infer<typeof StaffSchema>
 export type StaffCreate = z.infer<typeof StaffCreateSchema>
 export type StaffUpdate = z.infer<typeof StaffUpdateSchema>
 export type StaffListParams = z.infer<typeof StaffListParamsSchema>
+export type StaffActivity = z.infer<typeof StaffActivitySchema>
+export type StaffFull = z.infer<typeof StaffFullSchema>

--- a/lib/hooks/useParents.ts
+++ b/lib/hooks/useParents.ts
@@ -26,6 +26,15 @@ export const useCreateParent = useCreate
 export const useUpdateParent = useUpdate
 export const useDeleteParent = useDelete
 
+export function useParentFull(parentId: number | undefined) {
+  return useQuery({
+    queryKey: ["parent", parentId, "full"],
+    queryFn: () => parentsApi.getFull(parentId as number),
+    enabled: !!parentId,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
 export function useStudentParents(studentId: number | undefined) {
   return useQuery({
     queryKey: ["student-parents", studentId],


### PR DESCRIPTION
## Description
Redesign premium des fiches détail **parent** (`/admin/parents/[id]`) et **personnel** (`/admin/staff/[id]`), avec correction d'un bug d'affichage et de nouvelles fonctionnalités. Dépend de la PR backend #202 (endpoints enrichis).

## Fix
Les enfants liés d'un parent ne s'affichaient plus (lignes vides) : le FE lisait `id/first_name/last_name/class_name` alors que le BE renvoyait `student_id/student_name`. Contrat aligné (Zod) + BE enrichi.

## Nouveautés
**Composants partagés réutilisables** : `DetailHero` (en-tête premium dégradé bleu→orange avec avatar/photo, contact, bande de KPIs, actions) et `ContactActions` (Appeler / WhatsApp / Email, gros boutons tactiles h-11, variantes hero/card).

**Fiche parent** : hero avec récap financier du foyer (enfants, total payé, reste à payer), enfants en cartes premium (classe, statut d'inscription, solde de scolarité + barre de progression, kebab voir la fiche / retirer le lien), action « Lier un enfant » (modal), contact & compte enrichi (statut compte tri-état + « Sans compte »).

**Fiche personnel** : hero premium (photo, poste, contact) + KPIs d'activité, nouvel onglet **Activité** (versements encaissés, inscriptions traitées, dernière connexion, avec note de cadrage).

## Conformité
- Tout `lib/api/*` via `apiFetch<unknown>` + `safeValidate` (Zod), zéro cast. Pas de `.default()` sur les schémas validés (gotcha projet input/output).
- Design system : dégradé signature, KPIs verre, shadcn, mobile-first (cartes 2 colonnes), touch h-11, dark-safe, un seul accent orange focal.
- `no-god-code` : hero + contact + child-card + link-modal + activity-tab séparés.
- tsc + eslint OK en local.