### PR TITLE
feat(dashboard): premium hero on teacher & student detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Fiches enseignant et élève (admin) dotées du même en-tête premium : photo, contact rapide et indicateurs clés en un coup d'œil (enseignant : nombre de classes, d'élèves et heures par semaine ; élève : classe, taux de présence et reste à payer), les onglets détaillés existants restant inchangés *(admin)*.
 - Fiche parent (admin) repensée : en-tête premium avec le récapitulatif financier du foyer (nombre d'enfants, total payé, reste à payer sur l'année), enfants liés présentés en cartes claires avec leur classe, leur statut d'inscription et leur solde de scolarité (barre de progression), boutons de contact rapides (Appeler, WhatsApp, Email) et possibilité de lier un enfant existant en un clic *(admin)*.
 - Fiche personnel (admin) repensée : en-tête premium avec photo et contact rapide, plus un onglet « Activité » qui résume les versements encaissés, les inscriptions traitées et la dernière connexion du membre *(admin)*.
 

--- a/components/admin/students/StudentDetailClient.tsx
+++ b/components/admin/students/StudentDetailClient.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import {
-  ArrowLeft,
   Camera,
   Pencil,
   Trash2,
@@ -22,8 +21,6 @@ import {
   ChevronRight,
   Sparkles,
 } from "lucide-react"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
@@ -47,6 +44,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
+import { DetailHero } from "@/components/shared/DetailHero"
+import type { HeroKpi } from "@/components/shared/PageHero"
 import { StudentEditModal } from "./StudentEditModal"
 import { StudentJourneyTimeline } from "./StudentJourneyTimeline"
 import { StudentAcademicCharts } from "./StudentAcademicCharts"
@@ -131,103 +130,78 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
   const initials = `${student.first_name?.[0] ?? ""}${student.last_name?.[0] ?? ""}`.toUpperCase()
   const fullName = `${student.last_name} ${student.first_name}`
   const photoSrc = getUploadUrl((student as Record<string, unknown>).photo_url as string | null | undefined)
+  const f = full as Record<string, unknown> | undefined
+  const heroKpis: HeroKpi[] = [
+    { label: "Classe", value: (f?.current_class_name as string | undefined) ?? "—", icon: GraduationCap },
+    { label: "Présence", value: `${(f?.attendance_rate as number | undefined) ?? 0}%`, icon: ClipboardCheck },
+    {
+      label: "Reste à payer",
+      value: formatFCFA((f?.fees_remaining as number | undefined) ?? 0),
+      icon: Wallet,
+      hint: (f?.current_academic_year as string | undefined)
+        ? `Année ${f?.current_academic_year as string}`
+        : undefined,
+    },
+  ]
+  const genreLabel = student.genre === "M" ? "Masculin" : student.genre === "F" ? "Féminin" : null
 
   return (
     <div className="space-y-6">
-      {/* Header — mobile-first stack, no horizontal overflow */}
-      <div className="flex items-start gap-3">
-        <Link
-          href="/admin/students"
-          aria-label="Retour à la liste des élèves"
-          className="mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-md border hover:bg-muted transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
-
-        {/* Avatar shadcn — handles 404 via AvatarImage onError → AvatarFallback */}
-        <button
-          type="button"
-          onClick={() => photoLoaded && setPhotoPreview(true)}
-          aria-label={photoLoaded ? "Voir la photo en grand" : "Photo de l'élève"}
-          className="shrink-0 overflow-hidden rounded-2xl border-2 border-border focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-default"
-          disabled={!photoLoaded}
-        >
-          <Avatar className="h-16 w-16 rounded-2xl sm:h-24 sm:w-24">
-            {photoSrc ? (
-              <AvatarImage
-                src={photoSrc}
-                alt={fullName}
-                className="object-cover"
-                onLoadingStatusChange={(status) => setPhotoLoaded(status === "loaded")}
-              />
-            ) : null}
-            <AvatarFallback className="rounded-2xl bg-primary/10 text-xl font-semibold text-primary sm:text-2xl">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
-        </button>
-
-        {/* Name + matricule + sex — flex-1 prevents overflow */}
-        <div className="min-w-0 flex-1">
-          <h1 className="font-serif text-lg tracking-tight sm:text-2xl">{fullName}</h1>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-            {student.enrollment_number && (
-              <span className="font-mono text-xs">{student.enrollment_number}</span>
-            )}
-            {student.genre && (
-              <Badge variant="outline" className="text-[10px]">
-                {student.genre === "M" ? "Masculin" : "Féminin"}
-              </Badge>
-            )}
-          </div>
-        </div>
-
-        {/* Actions — kebab DropdownMenu protects against touch-error on mobile */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon" className="h-9 w-9 shrink-0">
+      <DetailHero
+        onBack={() => router.push("/admin/students")}
+        backLabel="Retour à la liste des élèves"
+        photoUrl={photoSrc}
+        initials={initials}
+        name={fullName}
+        subtitle={
+          [student.enrollment_number, genreLabel, f?.current_class_name as string | undefined]
+            .filter(Boolean)
+            .join(" · ") || "Élève"
+        }
+        kpis={heroKpis}
+        onAvatarClick={() => photoLoaded && setPhotoPreview(true)}
+        onPhotoStatus={setPhotoLoaded}
+        actions={
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/25 bg-white/10 text-white transition-colors hover:bg-white/20">
               <MoreVertical className="h-4 w-4" />
               <span className="sr-only">Actions sur l&apos;élève</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuItem onClick={() => setEditOpen(true)}>
-              <Pencil className="mr-2 h-4 w-4" />
-              Modifier les infos
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => fileInputRef.current?.click()}
-              disabled={uploading}
-            >
-              <Camera className="mr-2 h-4 w-4" />
-              {photoSrc ? "Changer la photo" : "Ajouter une photo"}
-            </DropdownMenuItem>
-            {photoSrc && photoLoaded && (
-              <DropdownMenuItem onClick={handleDeletePhoto}>
-                <Trash2 className="mr-2 h-4 w-4" />
-                Supprimer la photo
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuItem onClick={() => setEditOpen(true)}>
+                <Pencil className="mr-2 h-4 w-4" />
+                Modifier les infos
               </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => setDeleteOpen(true)}
-              className="text-destructive focus:text-destructive focus:bg-destructive/10"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Supprimer l&apos;élève
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <DropdownMenuItem onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+                <Camera className="mr-2 h-4 w-4" />
+                {photoSrc ? "Changer la photo" : "Ajouter une photo"}
+              </DropdownMenuItem>
+              {photoSrc && photoLoaded && (
+                <DropdownMenuItem onClick={handleDeletePhoto}>
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Supprimer la photo
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setDeleteOpen(true)}
+                className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Supprimer l&apos;élève
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        }
+      />
 
-        {/* Hidden input for photo upload (triggered from DropdownMenu) */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          className="hidden"
-          onChange={handlePhotoUpload}
-        />
-      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handlePhotoUpload}
+      />
 
       {/* Photo preview dialog */}
       {photoSrc && (

--- a/components/admin/teachers/TeacherDetailClient.tsx
+++ b/components/admin/teachers/TeacherDetailClient.tsx
@@ -1,27 +1,23 @@
 "use client"
 
 import { useRef, useState } from "react"
-import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import {
-  ArrowLeft,
   BookOpen,
   Camera,
   Pencil,
   Trash2,
   User,
   GraduationCap,
-  Phone,
+  Users,
   FileText,
   CalendarDays,
   CalendarCheck,
   Clock,
   MoreVertical,
 } from "lucide-react"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import {
@@ -44,6 +40,9 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
+import { DetailHero } from "@/components/shared/DetailHero"
+import { ContactActions } from "@/components/shared/ContactActions"
+import type { HeroKpi } from "@/components/shared/PageHero"
 import { TeacherEditModal } from "./TeacherEditModal"
 import { TeacherOverviewTab } from "./tabs/TeacherOverviewTab"
 import { TeacherProfileTab } from "./tabs/TeacherProfileTab"
@@ -119,104 +118,67 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
   const initials = `${teacher.first_name?.[0] ?? ""}${teacher.last_name?.[0] ?? ""}`.toUpperCase()
   const fullName = `${teacher.last_name} ${teacher.first_name}`
   const photoSrc = getUploadUrl((teacher as Record<string, unknown>).photo_url as string | null | undefined)
+  const userEmail = fullData?.user_email as string | null | undefined
+  const heroKpis: HeroKpi[] = [
+    { label: "Classes", value: (fullData?.classes_count as number | undefined) ?? 0, icon: GraduationCap },
+    { label: "Élèves", value: (fullData?.students_count as number | undefined) ?? 0, icon: Users },
+    { label: "Heures / sem", value: (fullData?.hours_per_week as number | undefined) ?? 0, icon: Clock },
+  ]
 
   return (
     <div className="space-y-6">
-      {/* Header — mobile-first stack, AvatarImage gating, kebab actions
-          Pattern cristallisé dans redesign-premium.md principes 13 + 14 */}
-      <div className="flex items-start gap-3">
-        <Link
-          href="/admin/teachers"
-          aria-label="Retour à la liste des enseignants"
-          className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
-        >
-          <ArrowLeft aria-hidden="true" className="h-4 w-4" />
-        </Link>
-
-        <button
-          type="button"
-          onClick={() => photoLoaded && setPhotoPreview(true)}
-          aria-label={photoLoaded ? "Voir la photo en grand" : "Photo de l'enseignant"}
-          className="shrink-0 overflow-hidden rounded-2xl border-2 border-border focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-default"
-          disabled={!photoLoaded}
-        >
-          <Avatar className="h-16 w-16 rounded-2xl sm:h-24 sm:w-24">
-            {photoSrc ? (
-              <AvatarImage
-                src={photoSrc}
-                alt={fullName}
-                className="object-cover"
-                onLoadingStatusChange={(status) => setPhotoLoaded(status === "loaded")}
-              />
-            ) : null}
-            <AvatarFallback className="rounded-2xl bg-primary/10 text-xl font-semibold text-primary sm:text-2xl">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
-        </button>
-
-        <div className="min-w-0 flex-1">
-          <h1 className="font-serif text-lg tracking-tight sm:text-2xl">{fullName}</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {teacher.speciality ?? "Enseignant"}
-          </p>
-          {teacher.phone && (
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <a
-                href={`tel:${teacher.phone}`}
-                className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/5"
-              >
-                <Phone className="h-3 w-3" />
-                {teacher.phone}
-              </a>
-            </div>
-          )}
-        </div>
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon" className="h-9 w-9 shrink-0">
+      <DetailHero
+        onBack={() => router.push("/admin/teachers")}
+        backLabel="Retour à la liste des enseignants"
+        photoUrl={photoSrc}
+        initials={initials}
+        name={fullName}
+        subtitle={teacher.speciality ?? "Enseignant"}
+        contact={<ContactActions phone={teacher.phone} email={userEmail} variant="hero" />}
+        kpis={heroKpis}
+        onAvatarClick={() => photoLoaded && setPhotoPreview(true)}
+        onPhotoStatus={setPhotoLoaded}
+        actions={
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/25 bg-white/10 text-white transition-colors hover:bg-white/20">
               <MoreVertical className="h-4 w-4" />
               <span className="sr-only">Actions sur l&apos;enseignant</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuItem onClick={() => setEditOpen(true)}>
-              <Pencil className="mr-2 h-4 w-4" />
-              Modifier les infos
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => fileInputRef.current?.click()}
-              disabled={uploading}
-            >
-              <Camera className="mr-2 h-4 w-4" />
-              {photoSrc ? "Changer la photo" : "Ajouter une photo"}
-            </DropdownMenuItem>
-            {photoSrc && photoLoaded && (
-              <DropdownMenuItem onClick={handleDeletePhoto}>
-                <Trash2 className="mr-2 h-4 w-4" />
-                Supprimer la photo
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuItem onClick={() => setEditOpen(true)}>
+                <Pencil className="mr-2 h-4 w-4" />
+                Modifier les infos
               </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onClick={() => setDeleteOpen(true)}
-              className="text-destructive focus:text-destructive focus:bg-destructive/10"
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Supprimer l&apos;enseignant
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <DropdownMenuItem onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+                <Camera className="mr-2 h-4 w-4" />
+                {photoSrc ? "Changer la photo" : "Ajouter une photo"}
+              </DropdownMenuItem>
+              {photoSrc && photoLoaded && (
+                <DropdownMenuItem onClick={handleDeletePhoto}>
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Supprimer la photo
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setDeleteOpen(true)}
+                className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Supprimer l&apos;enseignant
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        }
+      />
 
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          className="hidden"
-          onChange={handlePhotoUpload}
-        />
-      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handlePhotoUpload}
+      />
 
       {/* Photo preview dialog */}
       {photoSrc && (


### PR DESCRIPTION
Applique le `DetailHero` premium (créé pour parent/personnel) aux fiches **enseignant** (`/admin/teachers/[id]`) et **élève** (`/admin/students/[id]`). En-tête dégradé avec photo, contact rapide (enseignant) et KPIs en un coup d'œil (enseignant : classes / élèves / heures ; élève : classe / présence / reste à payer). Les onglets existants sont conservés. FE-only, données déjà fournies par les endpoints `/full`. tsc + eslint OK.