### PR TITLE
feat(staff): show and set staff access role everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Le rôle d'accès d'un membre du personnel (Personnel, Comptable, Directeur) se choisit à la création et se modifie ensuite ; il apparaît désormais clairement dans la liste, sur la fiche détail et dans les formulaires, en plus de son poste *(admin)*.
 - Fiches enseignant et élève (admin) dotées du même en-tête premium : photo, contact rapide et indicateurs clés en un coup d'œil (enseignant : nombre de classes, d'élèves et heures par semaine ; élève : classe, taux de présence et reste à payer), les onglets détaillés existants restant inchangés *(admin)*.
 - Fiche parent (admin) repensée : en-tête premium avec le récapitulatif financier du foyer (nombre d'enfants, total payé, reste à payer sur l'année), enfants liés présentés en cartes claires avec leur classe, leur statut d'inscription et leur solde de scolarité (barre de progression), boutons de contact rapides (Appeler, WhatsApp, Email) et possibilité de lier un enfant existant en un clic *(admin)*.
 - Fiche personnel (admin) repensée : en-tête premium avec photo et contact rapide, plus un onglet « Activité » qui résume les versements encaissés, les inscriptions traitées et la dernière connexion du membre *(admin)*.

--- a/components/admin/staff/StaffDetailClient.tsx
+++ b/components/admin/staff/StaffDetailClient.tsx
@@ -44,6 +44,7 @@ import { StaffEditModal } from "./StaffEditModal"
 import { StaffProfileTab } from "./tabs/StaffProfileTab"
 import { StaffActivityTab } from "./tabs/StaffActivityTab"
 import { useStaffMember, useStaffFull, useDeleteStaff, staffKeys } from "@/lib/hooks/useStaff"
+import { staffRoleLabel } from "@/lib/contracts/staff"
 import { staffApi } from "@/lib/api/staff"
 import { getUploadUrl } from "@/lib/utils"
 import { formatXof } from "@/lib/export/format"
@@ -133,7 +134,12 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
         photoUrl={photoSrc}
         initials={initials}
         name={fullName}
-        subtitle={staff.position ?? "Personnel"}
+        badge={
+          <span className="rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-medium text-white">
+            {staffRoleLabel(staff.role)}
+          </span>
+        }
+        subtitle={staff.position ?? "Poste non renseigné"}
         contact={<ContactActions phone={staff.phone} email={fullData?.user_email} variant="hero" />}
         kpis={kpis}
         onAvatarClick={() => photoLoaded && setPhotoPreview(true)}

--- a/components/admin/staff/StaffEditModal.tsx
+++ b/components/admin/staff/StaffEditModal.tsx
@@ -2,11 +2,18 @@
 
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { StaffUpdateSchema, type StaffUpdate } from "@/lib/contracts/staff"
+import { StaffUpdateSchema, STAFF_ROLE_OPTIONS, type StaffUpdate } from "@/lib/contracts/staff"
 import { useStaffMember, useUpdateStaff } from "@/lib/hooks/useStaff"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Form,
@@ -43,6 +50,7 @@ function EditForm({ staffId, onClose }: { staffId: number; onClose: () => void }
           last_name: staff.last_name,
           position: staff.position ?? undefined,
           phone: staff.phone ?? undefined,
+          role: staff.role ?? "staff",
         }
       : undefined,
   })
@@ -113,6 +121,31 @@ function EditForm({ staffId, onClose }: { staffId: number; onClose: () => void }
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="role"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Rôle d&apos;accès</FormLabel>
+              <Select value={field.value ?? "staff"} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger className="h-11">
+                    <SelectValue placeholder="Rôle d'accès" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {STAFF_ROLE_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         {error && (
           <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">

--- a/components/admin/staff/StaffTable.tsx
+++ b/components/admin/staff/StaffTable.tsx
@@ -7,6 +7,8 @@ import type { Route } from "next"
 import { Phone, MessageCircle, Mail } from "lucide-react"
 import { useStaffList, useDeleteStaff } from "@/lib/hooks/useStaff"
 import type { Staff } from "@/lib/contracts/staff"
+import { staffRoleLabel } from "@/lib/contracts/staff"
+import { Badge } from "@/components/ui/badge"
 import { CrudTable, type FilterConfig } from "@/components/shared/CrudTable"
 import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
 import { useDebounce } from "@/lib/hooks/useDebounce"
@@ -117,12 +119,21 @@ export function StaffTable() {
             <div className="min-w-0">
               <p className="font-medium truncate">{s.last_name} {s.first_name}</p>
               {s.position && (
-                <p className="text-[10px] text-muted-foreground">{s.position}</p>
+                <p className="text-xs text-muted-foreground truncate">{s.position}</p>
               )}
             </div>
           </div>
         )
       },
+    },
+    {
+      accessorKey: "role",
+      header: "Rôle",
+      cell: ({ row }) => (
+        <Badge variant="secondary" className="font-medium">
+          {staffRoleLabel(row.original.role)}
+        </Badge>
+      ),
     },
     {
       accessorKey: "phone",
@@ -192,6 +203,11 @@ export function StaffTable() {
               </>
             }
             secondary={s.position || (s.phone ? <span className="tabular-nums">{s.phone}</span> : null)}
+            status={
+              <Badge variant="secondary" className="text-[11px]">
+                {staffRoleLabel(s.role)}
+              </Badge>
+            }
           />
         ))}
       </div>

--- a/components/admin/staff/tabs/StaffProfileTab.tsx
+++ b/components/admin/staff/tabs/StaffProfileTab.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { User, Phone, CalendarDays, Mail, ShieldCheck } from "lucide-react"
+import { User, Phone, CalendarDays, Mail, ShieldCheck, Briefcase, KeyRound } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import type { Staff, StaffFull } from "@/lib/contracts/staff"
+import { staffRoleLabel } from "@/lib/contracts/staff"
 
 interface StaffProfileTabProps {
   staff: Staff
@@ -63,11 +64,20 @@ export function StaffProfileTab({ staff, fullData }: StaffProfileTabProps) {
           <h3 className="text-sm font-medium text-muted-foreground mb-4">
             Informations personnelles
           </h3>
-          {/* Drop Poste (déjà sub-title header) — principe 1 redesign-premium */}
           <div className="grid gap-5 sm:grid-cols-3">
             <InfoField label="Nom" value={staff.last_name} icon={User} />
             <InfoField label="Prénom" value={staff.first_name} icon={User} />
             <InfoField label="Téléphone" value={staff.phone} icon={Phone} />
+            <div className="space-y-1">
+              <div className="flex items-center gap-1.5">
+                <KeyRound className="h-3.5 w-3.5 text-muted-foreground" />
+                <p className="text-xs font-medium text-muted-foreground">Rôle d&apos;accès</p>
+              </div>
+              <Badge variant="secondary" className="font-medium">
+                {staffRoleLabel(staff.role)}
+              </Badge>
+            </div>
+            <InfoField label="Poste" value={staff.position} icon={Briefcase} />
             <InfoField label="Créé le" value={createdAt} icon={CalendarDays} />
           </div>
         </CardContent>

--- a/components/forms/StaffForm.tsx
+++ b/components/forms/StaffForm.tsx
@@ -4,10 +4,17 @@ import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Eye, EyeOff, KeyRound } from "lucide-react"
-import { StaffCreateSchema, type StaffCreate } from "@/lib/contracts/staff"
+import { StaffCreateSchema, STAFF_ROLE_OPTIONS, type StaffCreate } from "@/lib/contracts/staff"
 import { useCreateStaff } from "@/lib/hooks/useStaff"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   Form,
   FormControl,
@@ -33,6 +40,7 @@ export function StaffForm({ onSuccess }: StaffFormProps) {
       password: "",
       position: "",
       phone: "",
+      role: "staff",
     },
   })
 
@@ -109,6 +117,34 @@ export function StaffForm({ onSuccess }: StaffFormProps) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="role"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Rôle d&apos;accès *</FormLabel>
+              <Select value={field.value ?? "staff"} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger className="h-11">
+                    <SelectValue placeholder="Rôle d'accès" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {STAFF_ROLE_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription className="text-xs">
+                Détermine les droits d&apos;accès dans KLASSCI (le poste ci-dessus reste le libellé du métier).
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         {/* Compte de connexion — toujours obligatoire pour le staff
             (admin secondaire, secrétaire, comptable... doit accéder à un portail). */}

--- a/lib/contracts/staff.ts
+++ b/lib/contracts/staff.ts
@@ -1,5 +1,25 @@
 import { z } from "zod"
 
+// Rôles d'accès assignables à un membre du personnel (miroir de
+// STAFF_ASSIGNABLE_ROLES côté backend). Jamais admin / super_admin.
+export const STAFF_ROLE_OPTIONS = [
+  { value: "staff", label: "Personnel" },
+  { value: "accountant", label: "Comptable" },
+  { value: "director", label: "Directeur" },
+] as const
+
+const STAFF_ROLE_LABELS: Record<string, string> = {
+  staff: "Personnel",
+  accountant: "Comptable",
+  director: "Directeur",
+}
+
+/** Libellé français du rôle d'accès (défaut : Personnel). */
+export function staffRoleLabel(role?: string | null): string {
+  if (!role) return "Personnel"
+  return STAFF_ROLE_LABELS[role] ?? role
+}
+
 export const StaffSchema = z.object({
   id: z.number(),
   user_id: z.number(),
@@ -7,6 +27,7 @@ export const StaffSchema = z.object({
   last_name: z.string(),
   position: z.string().nullish(),
   phone: z.string().nullish(),
+  role: z.string().nullish(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 }).passthrough()
@@ -21,6 +42,7 @@ export const StaffCreateSchema = z.object({
   password: z.string({ required_error: "Le mot de passe est requis" }).min(8, "8 caractères minimum"),
   position: z.string().optional(),
   phone: z.string().optional(),
+  role: z.string().optional(),
 })
 
 // L'update n'envoie jamais email/password (changement compte = endpoint dédié)
@@ -29,6 +51,7 @@ export const StaffUpdateSchema = z.object({
   last_name: z.string().min(1).optional(),
   position: z.string().optional(),
   phone: z.string().optional(),
+  role: z.string().optional(),
 })
 
 export const StaffListParamsSchema = z.object({


### PR DESCRIPTION
Closes #256
Pairs with backend #204.

## Contexte
Sur /admin/staff, le rôle du personnel n'était visible nulle part.

## Changements
- Sélecteur `Rôle d'accès` (Personnel / Comptable / Directeur) dans les formulaires création et modification.
- Colonne Rôle en liste (desktop) + badge de rôle sur mobile.
- Rôle en badge dans l'en-tête de la fiche détail + rôle & poste restaurés dans l'onglet Profil.
- Contrat Zod : `role` sur `StaffSchema`/`StaffCreate`/`StaffUpdate`, helper `staffRoleLabel`.

## Tests
- `tsc --noEmit` OK, lint OK (seul warning `<img>` pré-existant).