### PR TITLE
feat(profile): self-service 'Mon profil' page + self photo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Nouvel espace « Mon profil », accessible depuis le menu du compte dans tous les portails : sa photo (l'enseignant et le personnel la mettent eux-mêmes), ses informations et son téléphone modifiable en un clic. L'ajout de photo a été retiré des fiches enseignant et personnel côté admin, la photo étant désormais gérée par la personne elle-même *(tous)*.
 - Le rôle d'accès d'un membre du personnel (Personnel, Comptable, Directeur) se choisit à la création et se modifie ensuite ; il apparaît désormais clairement dans la liste, sur la fiche détail et dans les formulaires, en plus de son poste *(admin)*.
 - Fiches enseignant et élève (admin) dotées du même en-tête premium : photo, contact rapide et indicateurs clés en un coup d'œil (enseignant : nombre de classes, d'élèves et heures par semaine ; élève : classe, taux de présence et reste à payer), les onglets détaillés existants restant inchangés *(admin)*.
 - Fiche parent (admin) repensée : en-tête premium avec le récapitulatif financier du foyer (nombre d'enfants, total payé, reste à payer sur l'année), enfants liés présentés en cartes claires avec leur classe, leur statut d'inscription et leur solde de scolarité (barre de progression), boutons de contact rapides (Appeler, WhatsApp, Email) et possibilité de lier un enfant existant en un clic *(admin)*.

--- a/app/(admin)/admin/profile/page.tsx
+++ b/app/(admin)/admin/profile/page.tsx
@@ -1,0 +1,7 @@
+import { ProfilePageClient } from "@/components/shared/profile/ProfilePageClient"
+
+export const metadata = { title: "Mon profil | KLASSCI" }
+
+export default function AdminProfilePage() {
+  return <ProfilePageClient />
+}

--- a/app/(parent)/parent/profile/page.tsx
+++ b/app/(parent)/parent/profile/page.tsx
@@ -1,0 +1,7 @@
+import { ProfilePageClient } from "@/components/shared/profile/ProfilePageClient"
+
+export const metadata = { title: "Mon profil | KLASSCI" }
+
+export default function ParentProfilePage() {
+  return <ProfilePageClient />
+}

--- a/app/(student)/student/profile/page.tsx
+++ b/app/(student)/student/profile/page.tsx
@@ -1,0 +1,7 @@
+import { ProfilePageClient } from "@/components/shared/profile/ProfilePageClient"
+
+export const metadata = { title: "Mon profil | KLASSCI" }
+
+export default function StudentProfilePage() {
+  return <ProfilePageClient />
+}

--- a/app/(teacher)/teacher/profile/page.tsx
+++ b/app/(teacher)/teacher/profile/page.tsx
@@ -1,0 +1,7 @@
+import { ProfilePageClient } from "@/components/shared/profile/ProfilePageClient"
+
+export const metadata = { title: "Mon profil | KLASSCI" }
+
+export default function TeacherProfilePage() {
+  return <ProfilePageClient />
+}

--- a/components/admin/staff/StaffDetailClient.tsx
+++ b/components/admin/staff/StaffDetailClient.tsx
@@ -1,11 +1,8 @@
 "use client"
 
-import { useRef, useState } from "react"
+import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { useQueryClient } from "@tanstack/react-query"
-import { toast } from "sonner"
 import {
-  Camera,
   Pencil,
   Trash2,
   User,
@@ -43,55 +40,22 @@ import type { HeroKpi } from "@/components/shared/PageHero"
 import { StaffEditModal } from "./StaffEditModal"
 import { StaffProfileTab } from "./tabs/StaffProfileTab"
 import { StaffActivityTab } from "./tabs/StaffActivityTab"
-import { useStaffMember, useStaffFull, useDeleteStaff, staffKeys } from "@/lib/hooks/useStaff"
+import { useStaffMember, useStaffFull, useDeleteStaff } from "@/lib/hooks/useStaff"
 import { staffRoleLabel } from "@/lib/contracts/staff"
-import { staffApi } from "@/lib/api/staff"
 import { getUploadUrl } from "@/lib/utils"
 import { formatXof } from "@/lib/export/format"
 
 export function StaffDetailClient({ staffId }: { staffId: number }) {
   const router = useRouter()
-  const queryClient = useQueryClient()
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [photoPreview, setPhotoPreview] = useState(false)
-  const [uploading, setUploading] = useState(false)
   const [photoLoaded, setPhotoLoaded] = useState(false)
 
   const { data: staff, isLoading, isError, refetch } = useStaffMember(staffId)
   const { data: fullData } = useStaffFull(staffId)
   const { mutate: deleteStaff, isPending: deleting } = useDeleteStaff()
-
-  const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    setUploading(true)
-    try {
-      await staffApi.uploadPhoto(staffId, file)
-      queryClient.invalidateQueries({ queryKey: staffKeys.detail(staffId) })
-      queryClient.invalidateQueries({ queryKey: ["staff", staffId, "full"] })
-      toast.success("Photo mise à jour")
-    } catch {
-      toast.error("Erreur lors de l'upload")
-    } finally {
-      setUploading(false)
-      if (fileInputRef.current) fileInputRef.current.value = ""
-    }
-  }
-
-  const handleDeletePhoto = async () => {
-    try {
-      await staffApi.deletePhoto(staffId)
-      queryClient.invalidateQueries({ queryKey: staffKeys.detail(staffId) })
-      queryClient.invalidateQueries({ queryKey: ["staff", staffId, "full"] })
-      setPhotoPreview(false)
-      toast.success("Photo supprimée")
-    } catch {
-      toast.error("Erreur lors de la suppression de la photo")
-    }
-  }
 
   const handleDelete = () =>
     deleteStaff(staffId, { onSuccess: () => router.push("/admin/staff") })
@@ -155,16 +119,6 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
                 <Pencil className="mr-2 h-4 w-4" />
                 Modifier les infos
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => fileInputRef.current?.click()} disabled={uploading}>
-                <Camera className="mr-2 h-4 w-4" />
-                {photoSrc ? "Changer la photo" : "Ajouter une photo"}
-              </DropdownMenuItem>
-              {photoSrc && photoLoaded && (
-                <DropdownMenuItem onClick={handleDeletePhoto}>
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Supprimer la photo
-                </DropdownMenuItem>
-              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => setDeleteOpen(true)}
@@ -178,15 +132,7 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
         }
       />
 
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        className="hidden"
-        onChange={handlePhotoUpload}
-      />
-
-      {/* Photo preview dialog */}
+      {/* Photo preview (lecture seule — la photo est gérée par le membre lui-même) */}
       {photoSrc && (
         <Dialog open={photoPreview} onOpenChange={setPhotoPreview}>
           <DialogContent className="max-w-md p-2">
@@ -194,26 +140,7 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={photoSrc} alt={fullName} className="h-full w-full object-cover" />
             </div>
-            <div className="flex items-center justify-between px-2 pb-1">
-              <p className="text-sm font-medium">{fullName}</p>
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    setPhotoPreview(false)
-                    fileInputRef.current?.click()
-                  }}
-                >
-                  <Camera className="mr-1.5 h-3.5 w-3.5" />
-                  Changer
-                </Button>
-                <Button variant="destructive" size="sm" onClick={handleDeletePhoto}>
-                  <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-                  Supprimer
-                </Button>
-              </div>
-            </div>
+            <p className="px-2 pb-1 text-sm font-medium">{fullName}</p>
           </DialogContent>
         </Dialog>
       )}

--- a/components/admin/teachers/TeacherDetailClient.tsx
+++ b/components/admin/teachers/TeacherDetailClient.tsx
@@ -1,12 +1,9 @@
 "use client"
 
-import { useRef, useState } from "react"
+import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { useQueryClient } from "@tanstack/react-query"
-import { toast } from "sonner"
 import {
   BookOpen,
-  Camera,
   Pencil,
   Trash2,
   User,
@@ -18,7 +15,6 @@ import {
   Clock,
   MoreVertical,
 } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import {
   DropdownMenu,
@@ -51,8 +47,7 @@ import { TeacherEvaluationsTab } from "./tabs/TeacherEvaluationsTab"
 import { TeacherTimetableTab } from "./tabs/TeacherTimetableTab"
 import { TeacherAvailabilityTab } from "./tabs/TeacherAvailabilityTab"
 import { TeacherAttendanceTab } from "./tabs/TeacherAttendanceTab"
-import { useTeacher, useTeacherFull, useDeleteTeacher, teacherKeys } from "@/lib/hooks/useTeachers"
-import { teachersApi } from "@/lib/api/teachers"
+import { useTeacher, useTeacherFull, useDeleteTeacher } from "@/lib/hooks/useTeachers"
 import { getUploadUrl } from "@/lib/utils"
 
 interface TeacherDetailClientProps {
@@ -61,47 +56,16 @@ interface TeacherDetailClientProps {
 
 export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
   const router = useRouter()
-  const queryClient = useQueryClient()
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [photoPreview, setPhotoPreview] = useState(false)
-  const [uploading, setUploading] = useState(false)
   const [activeTab, setActiveTab] = useState("overview")
   const [photoLoaded, setPhotoLoaded] = useState(false)
 
   const { data: teacher, isLoading, isError, refetch } = useTeacher(teacherId)
   const { data: fullData } = useTeacherFull(teacherId)
   const { mutate: deleteTeacher, isPending: deleting } = useDeleteTeacher()
-
-  const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    setUploading(true)
-    try {
-      await teachersApi.uploadPhoto(teacherId, file)
-      queryClient.invalidateQueries({ queryKey: teacherKeys.detail(teacherId) })
-      toast.success("Photo mise à jour")
-    } catch {
-      toast.error("Erreur lors de l'upload")
-    } finally {
-      setUploading(false)
-      if (fileInputRef.current) fileInputRef.current.value = ""
-    }
-  }
-
-  const handleDeletePhoto = async () => {
-    try {
-      await teachersApi.deletePhoto(teacherId)
-      queryClient.invalidateQueries({ queryKey: teacherKeys.detail(teacherId) })
-      queryClient.invalidateQueries({ queryKey: teacherKeys.all })
-      setPhotoPreview(false)
-      toast.success("Photo supprimée")
-    } catch {
-      toast.error("Erreur lors de la suppression de la photo")
-    }
-  }
 
   const handleDelete = () => {
     deleteTeacher(teacherId, {
@@ -149,16 +113,6 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
                 <Pencil className="mr-2 h-4 w-4" />
                 Modifier les infos
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => fileInputRef.current?.click()} disabled={uploading}>
-                <Camera className="mr-2 h-4 w-4" />
-                {photoSrc ? "Changer la photo" : "Ajouter une photo"}
-              </DropdownMenuItem>
-              {photoSrc && photoLoaded && (
-                <DropdownMenuItem onClick={handleDeletePhoto}>
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Supprimer la photo
-                </DropdownMenuItem>
-              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => setDeleteOpen(true)}
@@ -172,49 +126,15 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
         }
       />
 
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        className="hidden"
-        onChange={handlePhotoUpload}
-      />
-
-      {/* Photo preview dialog */}
+      {/* Photo preview (lecture seule — gérée par l'enseignant sur son profil) */}
       {photoSrc && (
         <Dialog open={photoPreview} onOpenChange={setPhotoPreview}>
           <DialogContent className="max-w-md p-2">
             <div className="relative aspect-square w-full overflow-hidden rounded-lg">
-              <img
-                src={photoSrc}
-                alt={fullName}
-                className="h-full w-full object-cover"
-              />
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={photoSrc} alt={fullName} className="h-full w-full object-cover" />
             </div>
-            <div className="flex items-center justify-between px-2 pb-1">
-              <p className="text-sm font-medium">{fullName}</p>
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    setPhotoPreview(false)
-                    fileInputRef.current?.click()
-                  }}
-                >
-                  <Camera className="mr-1.5 h-3.5 w-3.5" />
-                  Changer
-                </Button>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={handleDeletePhoto}
-                >
-                  <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-                  Supprimer
-                </Button>
-              </div>
-            </div>
+            <p className="px-2 pb-1 text-sm font-medium">{fullName}</p>
           </DialogContent>
         </Dialog>
       )}

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import Link from "next/link"
+import type { Route } from "next"
 import { signOut, useSession } from "next-auth/react"
 import { useTheme } from "next-themes"
 import { Menu, LogOut, User, ChevronDown, Sun, Moon } from "lucide-react"
@@ -28,6 +30,11 @@ export function Navbar({ onMenuClick }: NavbarProps) {
     ?.split("@")[0]
     .slice(0, 2)
     .toUpperCase() ?? "AD"
+
+  const role = session?.user?.role
+  const profilePortal =
+    role === "teacher" ? "teacher" : role === "student" ? "student" : role === "parent" ? "parent" : "admin"
+  const profileHref = `/${profilePortal}/profile` as Route
 
   return (
     <header className="flex h-16 shrink-0 items-center border-b bg-card px-4 lg:px-6">
@@ -83,10 +90,11 @@ export function Navbar({ onMenuClick }: NavbarProps) {
           <DropdownMenuContent align="end" className="w-56">
             <DropdownMenuLabel>Mon compte</DropdownMenuLabel>
             <DropdownMenuSeparator />
-            {/* TODO: lier a /settings/profile */}
-            <DropdownMenuItem disabled>
-              <User className="mr-2 h-4 w-4" />
-              Profil
+            <DropdownMenuItem asChild>
+              <Link href={profileHref}>
+                <User className="mr-2 h-4 w-4" />
+                Profil
+              </Link>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/components/shared/profile/ProfileInfoCard.tsx
+++ b/components/shared/profile/ProfileInfoCard.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useState } from "react"
+import { Mail, Phone, Briefcase, ShieldCheck, CalendarDays, Pencil, Check, X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { SectionTitle } from "@/components/shared/PageHero"
+import { useUpdateMyProfile } from "@/lib/hooks/useProfile"
+import type { MyProfile } from "@/lib/contracts/profile"
+
+function InfoRow({
+  icon: Icon,
+  label,
+  children,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-1.5">
+        <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      </div>
+      <div className="text-sm font-medium">{children}</div>
+    </div>
+  )
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—"
+  return new Date(value).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })
+}
+
+export function ProfileInfoCard({ profile }: { profile: MyProfile }) {
+  const [editingPhone, setEditingPhone] = useState(false)
+  const [phone, setPhone] = useState(profile.phone ?? "")
+  const { mutate: update, isPending } = useUpdateMyProfile()
+
+  const job = profile.position || profile.speciality || null
+
+  const savePhone = () =>
+    update({ phone: phone.trim() }, { onSuccess: () => setEditingPhone(false) })
+
+  return (
+    <Card className="border shadow-sm rounded-xl">
+      <CardContent className="p-5 sm:p-6 space-y-5">
+        <SectionTitle icon={ShieldCheck}>Mes informations</SectionTitle>
+
+        <div className="grid gap-5 sm:grid-cols-2">
+          <InfoRow icon={Mail} label="Email">
+            {profile.email}
+          </InfoRow>
+
+          <InfoRow icon={Phone} label="Téléphone">
+            {editingPhone ? (
+              <div className="flex items-center gap-2">
+                <Input
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value)}
+                  placeholder="Ex : +225 07 12 34 56 78"
+                  className="h-9 font-mono"
+                  autoFocus
+                />
+                <Button size="icon" className="h-9 w-9 shrink-0" onClick={savePhone} disabled={isPending} aria-label="Enregistrer">
+                  <Check className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-9 w-9 shrink-0"
+                  onClick={() => {
+                    setPhone(profile.phone ?? "")
+                    setEditingPhone(false)
+                  }}
+                  aria-label="Annuler"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <span className={profile.phone ? "font-mono" : "text-muted-foreground"}>
+                  {profile.phone || "Non renseigné"}
+                </span>
+                {profile.can_edit_phone && (
+                  <button
+                    type="button"
+                    onClick={() => setEditingPhone(true)}
+                    className="text-primary hover:text-primary/80"
+                    aria-label="Modifier le téléphone"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            )}
+          </InfoRow>
+
+          {job && (
+            <InfoRow icon={Briefcase} label={profile.role === "teacher" ? "Spécialité" : "Poste"}>
+              {job}
+            </InfoRow>
+          )}
+
+          <InfoRow icon={CalendarDays} label="Membre depuis">
+            {formatDate(profile.created_at)}
+          </InfoRow>
+
+          <InfoRow icon={CalendarDays} label="Dernière connexion">
+            {profile.last_login
+              ? new Date(profile.last_login).toLocaleString("fr-FR", {
+                  day: "numeric",
+                  month: "long",
+                  year: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })
+              : "—"}
+          </InfoRow>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/shared/profile/ProfilePageClient.tsx
+++ b/components/shared/profile/ProfilePageClient.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { Camera, Trash2, Loader2, Bell } from "lucide-react"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardContent } from "@/components/ui/card"
+import { DataError } from "@/components/shared/DataError"
+import { ProfileInfoCard } from "./ProfileInfoCard"
+import { useMyProfile, profileKeys } from "@/lib/hooks/useProfile"
+import { profileApi } from "@/lib/api/profile"
+import { getUploadUrl } from "@/lib/utils"
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: "Administrateur",
+  staff: "Personnel",
+  teacher: "Enseignant",
+  student: "Élève",
+  parent: "Parent",
+  super_admin: "Super administrateur",
+}
+
+export function ProfilePageClient() {
+  const { data: profile, isLoading, isError, refetch } = useMyProfile()
+  const queryClient = useQueryClient()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [photoLoaded, setPhotoLoaded] = useState(false)
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    try {
+      await profileApi.uploadPhoto(file)
+      queryClient.invalidateQueries({ queryKey: profileKeys.me })
+      toast.success("Photo mise à jour")
+    } catch (err) {
+      toast.error("Erreur", { description: err instanceof Error ? err.message : "Envoi impossible" })
+    } finally {
+      setUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ""
+    }
+  }
+
+  const handleDelete = async () => {
+    try {
+      await profileApi.deletePhoto()
+      queryClient.invalidateQueries({ queryKey: profileKeys.me })
+      toast.success("Photo supprimée")
+    } catch {
+      toast.error("Erreur lors de la suppression de la photo")
+    }
+  }
+
+  if (isLoading) return <ProfileSkeleton />
+  if (isError || !profile)
+    return <DataError message="Impossible de charger votre profil." onRetry={() => refetch()} />
+
+  const fullName = `${profile.last_name} ${profile.first_name}`.trim() || profile.email
+  const initials = `${profile.first_name?.[0] ?? ""}${profile.last_name?.[0] ?? ""}`.toUpperCase() || "?"
+  const photoSrc = getUploadUrl(profile.photo_url)
+  const roleLabel = ROLE_LABELS[profile.role] ?? profile.role
+  const hasPhoto = Boolean(photoSrc && photoLoaded)
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl bg-[linear-gradient(135deg,#0a3d8f_0%,#0453cb_42%,#2a69cb_56%,#f5821f_92%)] p-5 text-white shadow-sm sm:p-6">
+        <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:text-left">
+          <div className="relative shrink-0">
+            <Avatar className="h-24 w-24 rounded-2xl border-2 border-white/25">
+              {photoSrc ? (
+                <AvatarImage
+                  src={photoSrc}
+                  alt={fullName}
+                  className="object-cover"
+                  onLoadingStatusChange={(s) => setPhotoLoaded(s === "loaded")}
+                />
+              ) : null}
+              <AvatarFallback className="rounded-2xl bg-white/15 text-2xl font-semibold text-white">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+            {profile.can_edit_photo && (
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                aria-label={hasPhoto ? "Changer la photo" : "Ajouter une photo"}
+                className="absolute -bottom-1 -right-1 flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-accent text-white shadow-sm transition-transform hover:scale-105 disabled:opacity-60"
+              >
+                {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Camera className="h-4 w-4" />}
+              </button>
+            )}
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
+              <h1 className="font-serif text-2xl font-bold tracking-tight">{fullName}</h1>
+              <span className="rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-medium text-white">
+                {roleLabel}
+              </span>
+            </div>
+            <p className="mt-1 text-sm text-white/75">{profile.email}</p>
+            {profile.can_edit_photo && hasPhoto && (
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-white/25 bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-white/20"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Retirer la photo
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleUpload} />
+
+      <ProfileInfoCard profile={profile} />
+
+      {/* Préférences de notifications — arrive prochainement (PR suivante) */}
+      <Card className="border border-dashed shadow-none rounded-xl">
+        <CardContent className="flex items-center gap-3 p-5 text-muted-foreground">
+          <Bell className="h-5 w-5 shrink-0" />
+          <p className="text-sm">
+            Les préférences de notifications arrivent bientôt : vous pourrez choisir comment être prévenu.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function ProfileSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-40 rounded-2xl" />
+      <Skeleton className="h-56 rounded-xl" />
+    </div>
+  )
+}

--- a/lib/api/profile.ts
+++ b/lib/api/profile.ts
@@ -1,0 +1,58 @@
+import { getSession } from "next-auth/react"
+import { z } from "zod"
+import { MyProfileSchema, type MyProfile, type MyProfileUpdate } from "@/lib/contracts/profile"
+import { apiFetch, handleExpiredSession, safeValidate } from "./client"
+
+function getBaseUrl(): string {
+  const url = process.env.NEXT_PUBLIC_API_URL
+  if (!url) throw new Error("NEXT_PUBLIC_API_URL is not defined")
+  return url
+}
+
+const PhotoResponseSchema = z.object({ photo_url: z.string().nullable() })
+
+export const profileApi = {
+  me: async (): Promise<MyProfile> => {
+    const json = await apiFetch<unknown>("/profile/me")
+    return safeValidate(MyProfileSchema, json, "GET /profile/me")
+  },
+
+  update: async (data: MyProfileUpdate): Promise<MyProfile> => {
+    const json = await apiFetch<unknown>("/profile/me", {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(MyProfileSchema, json, "PATCH /profile/me")
+  },
+
+  // Upload multipart : ne passe pas par apiFetch (JSON), on réplique le contrat 401.
+  uploadPhoto: async (file: File): Promise<{ photo_url: string | null }> => {
+    const session = await getSession()
+    if (session?.error === "RefreshTokenError") {
+      void handleExpiredSession()
+      throw new Error("Session expirée")
+    }
+    const formData = new FormData()
+    formData.append("file", file)
+    const headers: Record<string, string> = session?.accessToken
+      ? { Authorization: `Bearer ${session.accessToken}` }
+      : {}
+    const hadToken = "Authorization" in headers
+    const res = await fetch(`${getBaseUrl()}/profile/me/photo`, {
+      method: "POST",
+      headers,
+      body: formData,
+    })
+    if (res.status === 401) {
+      if (hadToken) void handleExpiredSession()
+      throw new Error("Session expirée")
+    }
+    if (!res.ok) throw new Error("Échec de l'envoi de la photo")
+    const data = await res.json()
+    return safeValidate(PhotoResponseSchema, data, "POST /profile/me/photo")
+  },
+
+  deletePhoto: async (): Promise<void> => {
+    await apiFetch<void>("/profile/me/photo", { method: "DELETE" })
+  },
+}

--- a/lib/contracts/profile.ts
+++ b/lib/contracts/profile.ts
@@ -1,0 +1,25 @@
+import { z } from "zod"
+
+// Miroir de app/schemas/profile.py::MyProfileResponse
+export const MyProfileSchema = z.object({
+  user_id: z.number(),
+  email: z.string(),
+  role: z.string(),
+  first_name: z.string(),
+  last_name: z.string(),
+  phone: z.string().nullish(),
+  photo_url: z.string().nullish(),
+  position: z.string().nullish(),
+  speciality: z.string().nullish(),
+  can_edit_photo: z.boolean(),
+  can_edit_phone: z.boolean(),
+  last_login: z.string().nullish(),
+  created_at: z.string().nullish(),
+})
+
+export const MyProfileUpdateSchema = z.object({
+  phone: z.string().optional(),
+})
+
+export type MyProfile = z.infer<typeof MyProfileSchema>
+export type MyProfileUpdate = z.infer<typeof MyProfileUpdateSchema>

--- a/lib/hooks/useProfile.ts
+++ b/lib/hooks/useProfile.ts
@@ -1,0 +1,30 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { profileApi } from "@/lib/api/profile"
+import type { MyProfile } from "@/lib/contracts/profile"
+
+export const profileKeys = {
+  me: ["profile", "me"] as const,
+}
+
+export function useMyProfile() {
+  return useQuery({
+    queryKey: profileKeys.me,
+    queryFn: profileApi.me,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useUpdateMyProfile() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: profileApi.update,
+    onSuccess: (data: MyProfile) => {
+      queryClient.setQueryData(profileKeys.me, data)
+      toast.success("Profil mis à jour")
+    },
+    onError: (err: Error) => toast.error("Erreur", { description: err.message }),
+  })
+}


### PR DESCRIPTION
Closes #258
Pairs with backend #206.

## Ajout
- Page « Mon profil » premium partagée (`ProfilePageClient`) : hero avec photo self-upload (enseignant/personnel), badge de rôle, email ; carte infos avec téléphone modifiable inline ; placeholder préférences de notifications (PR suivante).
- Montée dans chaque portail : /admin/profile, /teacher/profile, /student/profile, /parent/profile.
- Lien « Profil » de la navbar activé (route selon le rôle).
- Retrait de l'ajout / changement / suppression de photo sur les fiches admin enseignant et personnel (self-service désormais). Fiche élève inchangée (photo admin).

`tsc --noEmit` OK.