### PR TITLE
feat(profile): notification preferences section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Section « Préférences de notifications » sur la page profil : activez ou désactivez l'email et le SMS d'un simple interrupteur ; la cloche dans l'application reste toujours active *(tous)*.
 - Nouvel espace « Mon profil », accessible depuis le menu du compte dans tous les portails : sa photo (l'enseignant et le personnel la mettent eux-mêmes), ses informations et son téléphone modifiable en un clic. L'ajout de photo a été retiré des fiches enseignant et personnel côté admin, la photo étant désormais gérée par la personne elle-même *(tous)*.
 - Le rôle d'accès d'un membre du personnel (Personnel, Comptable, Directeur) se choisit à la création et se modifie ensuite ; il apparaît désormais clairement dans la liste, sur la fiche détail et dans les formulaires, en plus de son poste *(admin)*.
 - Fiches enseignant et élève (admin) dotées du même en-tête premium : photo, contact rapide et indicateurs clés en un coup d'œil (enseignant : nombre de classes, d'élèves et heures par semaine ; élève : classe, taux de présence et reste à payer), les onglets détaillés existants restant inchangés *(admin)*.

--- a/components/shared/profile/NotificationPrefsCard.tsx
+++ b/components/shared/profile/NotificationPrefsCard.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { Bell, Mail, MessageSquare } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Switch } from "@/components/ui/switch"
+import { Skeleton } from "@/components/ui/skeleton"
+import { SectionTitle } from "@/components/shared/PageHero"
+import { useNotificationPrefs, useUpdateNotificationPrefs } from "@/lib/hooks/useProfile"
+
+function PrefRow({
+  icon: Icon,
+  title,
+  description,
+  checked,
+  disabled,
+  onCheckedChange,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  title: string
+  description: string
+  checked: boolean
+  disabled?: boolean
+  onCheckedChange?: (v: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 bg-muted/40 p-4">
+      <div className="flex items-start gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Icon className="h-4 w-4" />
+        </span>
+        <div>
+          <p className="text-sm font-medium">{title}</p>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+      </div>
+      <Switch checked={checked} disabled={disabled} onCheckedChange={onCheckedChange} />
+    </div>
+  )
+}
+
+export function NotificationPrefsCard() {
+  const { data: prefs, isLoading } = useNotificationPrefs()
+  const { mutate: update, isPending } = useUpdateNotificationPrefs()
+
+  return (
+    <Card className="border shadow-sm rounded-xl">
+      <CardContent className="p-5 sm:p-6 space-y-4">
+        <SectionTitle icon={Bell}>Préférences de notifications</SectionTitle>
+
+        {isLoading || !prefs ? (
+          <div className="space-y-3">
+            <Skeleton className="h-16 rounded-lg" />
+            <Skeleton className="h-16 rounded-lg" />
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <PrefRow
+              icon={Bell}
+              title="Dans l'application"
+              description="La cloche de notifications, toujours active."
+              checked
+              disabled
+            />
+            <PrefRow
+              icon={Mail}
+              title="Par email"
+              description="Recevez aussi les notifications importantes par email."
+              checked={prefs.email}
+              disabled={isPending}
+              onCheckedChange={(v) => update({ email: v })}
+            />
+            <PrefRow
+              icon={MessageSquare}
+              title="Par SMS"
+              description="Recevez les alertes par SMS (nécessite un téléphone renseigné)."
+              checked={prefs.sms}
+              disabled={isPending}
+              onCheckedChange={(v) => update({ sms: v })}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/shared/profile/ProfilePageClient.tsx
+++ b/components/shared/profile/ProfilePageClient.tsx
@@ -3,13 +3,12 @@
 import { useRef, useState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { Camera, Trash2, Loader2, Bell } from "lucide-react"
+import { Camera, Trash2, Loader2 } from "lucide-react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Card, CardContent } from "@/components/ui/card"
 import { DataError } from "@/components/shared/DataError"
 import { ProfileInfoCard } from "./ProfileInfoCard"
+import { NotificationPrefsCard } from "./NotificationPrefsCard"
 import { useMyProfile, profileKeys } from "@/lib/hooks/useProfile"
 import { profileApi } from "@/lib/api/profile"
 import { getUploadUrl } from "@/lib/utils"
@@ -123,15 +122,7 @@ export function ProfilePageClient() {
 
       <ProfileInfoCard profile={profile} />
 
-      {/* Préférences de notifications — arrive prochainement (PR suivante) */}
-      <Card className="border border-dashed shadow-none rounded-xl">
-        <CardContent className="flex items-center gap-3 p-5 text-muted-foreground">
-          <Bell className="h-5 w-5 shrink-0" />
-          <p className="text-sm">
-            Les préférences de notifications arrivent bientôt : vous pourrez choisir comment être prévenu.
-          </p>
-        </CardContent>
-      </Card>
+      <NotificationPrefsCard />
     </div>
   )
 }

--- a/lib/api/profile.ts
+++ b/lib/api/profile.ts
@@ -1,6 +1,13 @@
 import { getSession } from "next-auth/react"
 import { z } from "zod"
-import { MyProfileSchema, type MyProfile, type MyProfileUpdate } from "@/lib/contracts/profile"
+import {
+  MyProfileSchema,
+  NotificationPrefsSchema,
+  type MyProfile,
+  type MyProfileUpdate,
+  type NotificationPrefs,
+  type NotificationPrefsUpdate,
+} from "@/lib/contracts/profile"
 import { apiFetch, handleExpiredSession, safeValidate } from "./client"
 
 function getBaseUrl(): string {
@@ -54,5 +61,18 @@ export const profileApi = {
 
   deletePhoto: async (): Promise<void> => {
     await apiFetch<void>("/profile/me/photo", { method: "DELETE" })
+  },
+
+  notifications: async (): Promise<NotificationPrefs> => {
+    const json = await apiFetch<unknown>("/profile/me/notifications")
+    return safeValidate(NotificationPrefsSchema, json, "GET /profile/me/notifications")
+  },
+
+  updateNotifications: async (data: NotificationPrefsUpdate): Promise<NotificationPrefs> => {
+    const json = await apiFetch<unknown>("/profile/me/notifications", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(NotificationPrefsSchema, json, "PUT /profile/me/notifications")
   },
 }

--- a/lib/contracts/profile.ts
+++ b/lib/contracts/profile.ts
@@ -21,5 +21,17 @@ export const MyProfileUpdateSchema = z.object({
   phone: z.string().optional(),
 })
 
+export const NotificationPrefsSchema = z.object({
+  email: z.boolean(),
+  sms: z.boolean(),
+})
+
+export const NotificationPrefsUpdateSchema = z.object({
+  email: z.boolean().optional(),
+  sms: z.boolean().optional(),
+})
+
 export type MyProfile = z.infer<typeof MyProfileSchema>
 export type MyProfileUpdate = z.infer<typeof MyProfileUpdateSchema>
+export type NotificationPrefs = z.infer<typeof NotificationPrefsSchema>
+export type NotificationPrefsUpdate = z.infer<typeof NotificationPrefsUpdateSchema>

--- a/lib/hooks/useProfile.ts
+++ b/lib/hooks/useProfile.ts
@@ -7,6 +7,7 @@ import type { MyProfile } from "@/lib/contracts/profile"
 
 export const profileKeys = {
   me: ["profile", "me"] as const,
+  notifications: ["profile", "me", "notifications"] as const,
 }
 
 export function useMyProfile() {
@@ -14,6 +15,26 @@ export function useMyProfile() {
     queryKey: profileKeys.me,
     queryFn: profileApi.me,
     staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useNotificationPrefs() {
+  return useQuery({
+    queryKey: profileKeys.notifications,
+    queryFn: profileApi.notifications,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useUpdateNotificationPrefs() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: profileApi.updateNotifications,
+    onSuccess: (data) => {
+      queryClient.setQueryData(profileKeys.notifications, data)
+      toast.success("Préférences enregistrées")
+    },
+    onError: (err: Error) => toast.error("Erreur", { description: err.message }),
   })
 }
 


### PR DESCRIPTION
Closes #260
Pairs with backend #208.

- Carte « Préférences de notifications » sur la page profil : interrupteurs email / SMS, in-app toujours actif (désactivé, informatif). Enregistrement immédiat au toggle.
- tsc OK.