### PR TITLE
feat(students): document attachments UI (combobox type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Pièces jointes sur l'onglet Documents de la fiche élève : téléversez un PDF ou une image (extrait de naissance, certificat médical, etc.), en choisissant le type dans une liste ou en le créant à la volée ; consultez ou supprimez chaque document *(admin)*.
 - Section « Préférences de notifications » sur la page profil : activez ou désactivez l'email et le SMS d'un simple interrupteur ; la cloche dans l'application reste toujours active *(tous)*.
 - Nouvel espace « Mon profil », accessible depuis le menu du compte dans tous les portails : sa photo (l'enseignant et le personnel la mettent eux-mêmes), ses informations et son téléphone modifiable en un clic. L'ajout de photo a été retiré des fiches enseignant et personnel côté admin, la photo étant désormais gérée par la personne elle-même *(tous)*.
 - Le rôle d'accès d'un membre du personnel (Personnel, Comptable, Directeur) se choisit à la création et se modifie ensuite ; il apparaît désormais clairement dans la liste, sur la fiche détail et dans les formulaires, en plus de son poste *(admin)*.

--- a/components/admin/students/attachments/StudentAttachmentsSection.tsx
+++ b/components/admin/students/attachments/StudentAttachmentsSection.tsx
@@ -1,0 +1,194 @@
+"use client"
+
+import { useRef, useState } from "react"
+import {
+  FilePlus,
+  FileText,
+  Image as ImageIcon,
+  Download,
+  Trash2,
+  Loader2,
+  Upload,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { ComboboxCreate } from "@/components/shared/ComboboxCreate"
+import { SectionCard, EmptyState } from "../tabs/_primitives"
+import {
+  useDocumentTypes,
+  useStudentDocuments,
+  useUploadStudentDocument,
+  useDeleteStudentDocument,
+} from "@/lib/hooks/useStudentAttachments"
+import { getUploadUrl } from "@/lib/utils"
+
+export function StudentAttachmentsSection({ studentId }: { studentId: number }) {
+  const { data: types } = useDocumentTypes()
+  const { data: docs, isLoading } = useStudentDocuments(studentId)
+  const { mutate: upload, isPending: uploading } = useUploadStudentDocument(studentId)
+  const { mutate: remove, isPending: removing } = useDeleteStudentDocument(studentId)
+
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [docType, setDocType] = useState("")
+  const [file, setFile] = useState<File | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<number | null>(null)
+
+  const canSubmit = Boolean(docType.trim()) && Boolean(file) && !uploading
+
+  const submit = () => {
+    if (!file || !docType.trim()) return
+    upload(
+      { file, documentType: docType.trim() },
+      {
+        onSuccess: () => {
+          setFile(null)
+          setDocType("")
+          if (fileRef.current) fileRef.current.value = ""
+        },
+      },
+    )
+  }
+
+  return (
+    <SectionCard
+      icon={<FilePlus className="h-4 w-4" />}
+      title="Pièces jointes"
+      description="Acte de naissance, certificat médical, autres documents fournis"
+    >
+      {/* Formulaire d'ajout */}
+      <div className="space-y-3 rounded-lg border border-border/60 bg-muted/40 p-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">Type de document</p>
+            <ComboboxCreate
+              options={(types ?? []).map((t) => t.name)}
+              value={docType}
+              onChange={setDocType}
+              placeholder="Choisir ou créer un type"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">Fichier (PDF ou image)</p>
+            <input
+              ref={fileRef}
+              type="file"
+              accept="application/pdf,image/*"
+              className="hidden"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              className="h-11 w-full justify-start font-normal"
+              onClick={() => fileRef.current?.click()}
+            >
+              <Upload className="mr-2 h-4 w-4 shrink-0" />
+              <span className="truncate">{file ? file.name : "Choisir un fichier"}</span>
+            </Button>
+          </div>
+        </div>
+        <Button className="h-11 w-full sm:w-auto" disabled={!canSubmit} onClick={submit}>
+          {uploading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Envoi…
+            </>
+          ) : (
+            <>
+              <FilePlus className="mr-2 h-4 w-4" />
+              Ajouter le document
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* Liste */}
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Chargement…</p>
+      ) : !docs || docs.length === 0 ? (
+        <EmptyState
+          icon={<FilePlus className="h-5 w-5" />}
+          title="Aucune pièce jointe"
+          message="Ajoutez l'extrait de naissance, un certificat médical ou tout autre document via le formulaire ci-dessus."
+        />
+      ) : (
+        <div className="space-y-2">
+          {docs.map((d) => {
+            const isPdf = d.mime_type === "application/pdf"
+            const Icon = isPdf ? FileText : ImageIcon
+            const url = getUploadUrl(d.file_url) ?? d.file_url
+            return (
+              <div
+                key={d.id}
+                className="flex items-center gap-3 rounded-lg border border-border/60 bg-card p-3"
+              >
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <Icon className="h-4 w-4" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{d.document_type}</p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {d.file_name ? `${d.file_name} · ` : ""}
+                    {new Date(d.created_at).toLocaleDateString("fr-FR")}
+                  </p>
+                </div>
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-md text-primary hover:bg-primary/10"
+                  aria-label={`Ouvrir ${d.document_type}`}
+                  title="Ouvrir"
+                >
+                  <Download className="h-4 w-4" />
+                </a>
+                <button
+                  type="button"
+                  onClick={() => setDeleteTarget(d.id)}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-md text-destructive hover:bg-destructive/10"
+                  aria-label={`Supprimer ${d.document_type}`}
+                  title="Supprimer"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <AlertDialog open={deleteTarget !== null} onOpenChange={(o) => !o && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Supprimer ce document ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Cette action est irréversible. Le document sera définitivement supprimé.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deleteTarget !== null) remove(deleteTarget)
+                setDeleteTarget(null)
+              }}
+              disabled={removing}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Supprimer
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </SectionCard>
+  )
+}

--- a/components/admin/students/tabs/DocumentsTab.tsx
+++ b/components/admin/students/tabs/DocumentsTab.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import { useState } from "react"
-import { Award, FileCheck2, FileText, Loader2, Download, FilePlus } from "lucide-react"
+import { Award, FileCheck2, FileText, Loader2, Download } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { PdfPreviewButton } from "@/components/shared/PdfPreviewButton"
+import { StudentAttachmentsSection } from "../attachments/StudentAttachmentsSection"
 import { studentDocumentsApi } from "@/lib/api/student-documents"
 import { downloadBlob } from "@/lib/utils"
-import { SectionCard, StatusPill, EmptyState } from "./_primitives"
+import { SectionCard, StatusPill } from "./_primitives"
 
 interface DocumentsTabProps {
   studentId: number
@@ -138,17 +139,7 @@ export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) 
         </div>
       </SectionCard>
 
-      <SectionCard
-        icon={<FilePlus className="h-4 w-4" />}
-        title="Pièces jointes"
-        description="Acte de naissance, certificat médical, autres documents fournis"
-      >
-        <EmptyState
-          icon={<FilePlus className="h-5 w-5" />}
-          title="Aucune pièce jointe"
-          message="Cette fonctionnalité arrivera bientôt. En attendant, conservez les pièces dans le dossier papier de l'élève."
-        />
-      </SectionCard>
+      <StudentAttachmentsSection studentId={studentId} />
     </div>
   )
 }

--- a/components/shared/ComboboxCreate.tsx
+++ b/components/shared/ComboboxCreate.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useState } from "react"
+import { Check, ChevronsUpDown, Plus } from "lucide-react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+
+interface ComboboxCreateProps {
+  options: string[]
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  searchPlaceholder?: string
+  className?: string
+}
+
+/** Combobox « sélectionner ou créer » (Popover shadcn + recherche + création inline). */
+export function ComboboxCreate({
+  options,
+  value,
+  onChange,
+  placeholder = "Sélectionner…",
+  searchPlaceholder = "Rechercher ou créer…",
+  className,
+}: ComboboxCreateProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const q = query.trim()
+  const filtered = options.filter((o) => o.toLowerCase().includes(q.toLowerCase()))
+  const exact = options.some((o) => o.toLowerCase() === q.toLowerCase())
+
+  const select = (v: string) => {
+    onChange(v)
+    setOpen(false)
+    setQuery("")
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "h-11 w-full justify-between font-normal",
+            !value && "text-muted-foreground",
+            className,
+          )}
+        >
+          <span className="truncate">{value || placeholder}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <div className="p-2">
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={searchPlaceholder}
+            className="h-9"
+            autoFocus
+          />
+        </div>
+        <div className="max-h-56 overflow-y-auto p-1">
+          {filtered.map((o) => (
+            <button
+              key={o}
+              type="button"
+              onClick={() => select(o)}
+              className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm hover:bg-muted"
+            >
+              <span className="truncate">{o}</span>
+              {value === o && <Check className="h-4 w-4 shrink-0 text-primary" />}
+            </button>
+          ))}
+          {q && !exact && (
+            <button
+              type="button"
+              onClick={() => select(q)}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm text-primary hover:bg-primary/10"
+            >
+              <Plus className="h-4 w-4 shrink-0" />
+              Créer «&nbsp;{q}&nbsp;»
+            </button>
+          )}
+          {filtered.length === 0 && !q && (
+            <p className="px-2 py-2 text-sm text-muted-foreground">Aucun type disponible</p>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/lib/api/student-attachments.ts
+++ b/lib/api/student-attachments.ts
@@ -1,0 +1,68 @@
+import { getSession } from "next-auth/react"
+import { z } from "zod"
+import {
+  DocumentTypeSchema,
+  StudentDocumentSchema,
+  type DocumentType,
+  type StudentDocument,
+} from "@/lib/contracts/student-attachment"
+import { apiFetch, handleExpiredSession, safeValidate } from "./client"
+
+function getBaseUrl(): string {
+  const url = process.env.NEXT_PUBLIC_API_URL
+  if (!url) throw new Error("NEXT_PUBLIC_API_URL is not defined")
+  return url
+}
+
+const TypesArraySchema = z.array(DocumentTypeSchema)
+const DocsArraySchema = z.array(StudentDocumentSchema)
+
+export const studentAttachmentsApi = {
+  listTypes: async (): Promise<DocumentType[]> => {
+    const json = await apiFetch<unknown>("/admin/document-types")
+    return safeValidate(TypesArraySchema, json, "GET /admin/document-types")
+  },
+
+  list: async (studentId: number): Promise<StudentDocument[]> => {
+    const json = await apiFetch<unknown>(`/admin/students/${studentId}/documents`)
+    return safeValidate(DocsArraySchema, json, `GET /admin/students/${studentId}/documents`)
+  },
+
+  upload: async (
+    studentId: number,
+    file: File,
+    documentType: string,
+  ): Promise<StudentDocument> => {
+    const session = await getSession()
+    if (session?.error === "RefreshTokenError") {
+      void handleExpiredSession()
+      throw new Error("Session expirée")
+    }
+    const formData = new FormData()
+    formData.append("file", file)
+    formData.append("document_type", documentType)
+    const headers: Record<string, string> = session?.accessToken
+      ? { Authorization: `Bearer ${session.accessToken}` }
+      : {}
+    const hadToken = "Authorization" in headers
+    const res = await fetch(`${getBaseUrl()}/admin/students/${studentId}/documents`, {
+      method: "POST",
+      headers,
+      body: formData,
+    })
+    if (res.status === 401) {
+      if (hadToken) void handleExpiredSession()
+      throw new Error("Session expirée")
+    }
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: "Échec de l'envoi" }))
+      throw new Error(err.detail || "Échec de l'envoi du document")
+    }
+    const data = await res.json()
+    return safeValidate(StudentDocumentSchema, data, "POST /admin/students/:id/documents")
+  },
+
+  remove: async (studentId: number, docId: number): Promise<void> => {
+    await apiFetch<void>(`/admin/students/${studentId}/documents/${docId}`, { method: "DELETE" })
+  },
+}

--- a/lib/contracts/student-attachment.ts
+++ b/lib/contracts/student-attachment.ts
@@ -1,0 +1,20 @@
+import { z } from "zod"
+
+export const DocumentTypeSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+
+export const StudentDocumentSchema = z.object({
+  id: z.number(),
+  student_id: z.number(),
+  document_type: z.string(),
+  file_url: z.string(),
+  file_name: z.string().nullish(),
+  mime_type: z.string().nullish(),
+  uploaded_by: z.number().nullish(),
+  created_at: z.string(),
+})
+
+export type DocumentType = z.infer<typeof DocumentTypeSchema>
+export type StudentDocument = z.infer<typeof StudentDocumentSchema>

--- a/lib/hooks/useStudentAttachments.ts
+++ b/lib/hooks/useStudentAttachments.ts
@@ -1,0 +1,52 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { studentAttachmentsApi } from "@/lib/api/student-attachments"
+
+export const attachmentKeys = {
+  types: ["document-types"] as const,
+  list: (studentId: number) => ["student-documents", studentId] as const,
+}
+
+export function useDocumentTypes() {
+  return useQuery({
+    queryKey: attachmentKeys.types,
+    queryFn: studentAttachmentsApi.listTypes,
+    staleTime: 1000 * 60 * 10,
+  })
+}
+
+export function useStudentDocuments(studentId: number | undefined) {
+  return useQuery({
+    queryKey: attachmentKeys.list(studentId as number),
+    queryFn: () => studentAttachmentsApi.list(studentId as number),
+    enabled: !!studentId,
+  })
+}
+
+export function useUploadStudentDocument(studentId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ file, documentType }: { file: File; documentType: string }) =>
+      studentAttachmentsApi.upload(studentId, file, documentType),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: attachmentKeys.list(studentId) })
+      queryClient.invalidateQueries({ queryKey: attachmentKeys.types })
+      toast.success("Document ajouté")
+    },
+    onError: (err: Error) => toast.error("Erreur", { description: err.message }),
+  })
+}
+
+export function useDeleteStudentDocument(studentId: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (docId: number) => studentAttachmentsApi.remove(studentId, docId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: attachmentKeys.list(studentId) })
+      toast.success("Document supprimé")
+    },
+    onError: (err: Error) => toast.error("Erreur", { description: err.message }),
+  })
+}


### PR DESCRIPTION
Closes #262
Pairs with backend #210.

- Section pièces jointes dans l'onglet Documents : upload (fichier + type via `ComboboxCreate` select-or-create), liste, consultation (nouvel onglet), suppression (confirm).
- `ComboboxCreate` réutilisable basé sur shadcn Popover (aucune dépendance ajoutée).
- tsc + lint OK.