### PR TITLE
feat(leave): leave requests UI (self + admin approval)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Demandes de congé : depuis son profil (et son tableau de bord pour l'enseignant), on demande un congé en quelques secondes et on suit son statut ; une page « Congés » côté administration permet d'approuver ou refuser les demandes en attente *(enseignant, personnel, admin)*.
 - Pièces jointes sur l'onglet Documents de la fiche élève : téléversez un PDF ou une image (extrait de naissance, certificat médical, etc.), en choisissant le type dans une liste ou en le créant à la volée ; consultez ou supprimez chaque document *(admin)*.
 - Section « Préférences de notifications » sur la page profil : activez ou désactivez l'email et le SMS d'un simple interrupteur ; la cloche dans l'application reste toujours active *(tous)*.
 - Nouvel espace « Mon profil », accessible depuis le menu du compte dans tous les portails : sa photo (l'enseignant et le personnel la mettent eux-mêmes), ses informations et son téléphone modifiable en un clic. L'ajout de photo a été retiré des fiches enseignant et personnel côté admin, la photo étant désormais gérée par la personne elle-même *(tous)*.

--- a/app/(admin)/admin/leave/page.tsx
+++ b/app/(admin)/admin/leave/page.tsx
@@ -1,0 +1,7 @@
+import { LeaveManagementClient } from "@/components/admin/leave/LeaveManagementClient"
+
+export const metadata = { title: "Congés | KLASSCI" }
+
+export default function LeavePage() {
+  return <LeaveManagementClient />
+}

--- a/components/admin/leave/LeaveManagementClient.tsx
+++ b/components/admin/leave/LeaveManagementClient.tsx
@@ -1,0 +1,183 @@
+"use client"
+
+import { useState } from "react"
+import { CalendarClock, Check, X, Clock, CalendarCheck2, CalendarX2 } from "lucide-react"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { useLeaveRequests, useReviewLeaveRequest } from "@/lib/hooks/useLeave"
+import { leaveTypeLabel } from "@/lib/contracts/leave"
+import { LeaveStatusBadge, formatDateRange, dayCount } from "@/components/shared/leave/leave-ui"
+import { cn } from "@/lib/utils"
+
+const ROLE_LABELS: Record<string, string> = {
+  teacher: "Enseignant",
+  staff: "Personnel",
+  admin: "Administrateur",
+  director: "Directeur",
+  accountant: "Comptable",
+}
+
+const FILTERS = [
+  { key: "pending", label: "En attente" },
+  { key: "", label: "Toutes" },
+  { key: "approved", label: "Approuvées" },
+  { key: "rejected", label: "Refusées" },
+]
+
+export function LeaveManagementClient() {
+  const [filter, setFilter] = useState("pending")
+  const { data, isLoading } = useLeaveRequests()
+  const { mutate: review, isPending: reviewing } = useReviewLeaveRequest()
+  const [rejectTarget, setRejectTarget] = useState<number | null>(null)
+  const [comment, setComment] = useState("")
+
+  const requests = data ?? []
+  const count = (s: string) => requests.filter((r) => r.status === s).length
+  const filtered = filter ? requests.filter((r) => r.status === filter) : requests
+
+  const kpis: HeroKpi[] = [
+    { label: "En attente", value: count("pending"), icon: Clock },
+    { label: "Approuvées", value: count("approved"), icon: CalendarCheck2 },
+    { label: "Refusées", value: count("rejected"), icon: CalendarX2 },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        icon={CalendarClock}
+        title="Congés"
+        subtitle="Demandes de congé des enseignants et du personnel"
+        kpis={kpis}
+      />
+
+      <div className="flex gap-2 overflow-x-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
+        {FILTERS.map((f) => {
+          const n = f.key ? count(f.key) : requests.length
+          const active = filter === f.key
+          return (
+            <button
+              key={f.key || "all"}
+              type="button"
+              onClick={() => setFilter(f.key)}
+              className={cn(
+                "shrink-0 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                active
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-card text-muted-foreground hover:bg-muted",
+              )}
+            >
+              {f.label} ({n})
+            </button>
+          )
+        })}
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-20 rounded-xl" />
+          <Skeleton className="h-20 rounded-xl" />
+        </div>
+      ) : filtered.length === 0 ? (
+        <Card className="rounded-xl border shadow-sm">
+          <CardContent className="p-10 text-center text-sm text-muted-foreground">
+            Aucune demande dans cette catégorie.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((r) => (
+            <Card key={r.id} className="rounded-xl border shadow-sm">
+              <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-medium">{r.requester_name ?? "—"}</p>
+                    <span className="text-xs text-muted-foreground">
+                      {ROLE_LABELS[r.requester_role ?? ""] ?? r.requester_role ?? ""}
+                    </span>
+                    <LeaveStatusBadge status={r.status} />
+                  </div>
+                  <p className="mt-1 text-sm">
+                    {leaveTypeLabel(r.leave_type)} · {formatDateRange(r.start_date, r.end_date)} ·{" "}
+                    {dayCount(r.start_date, r.end_date)} j
+                  </p>
+                  {r.reason && (
+                    <p className="mt-0.5 text-xs text-muted-foreground">Motif : {r.reason}</p>
+                  )}
+                  {r.review_comment && (
+                    <p className="mt-0.5 text-xs text-muted-foreground">Décision : {r.review_comment}</p>
+                  )}
+                </div>
+
+                {r.status === "pending" && (
+                  <div className="flex shrink-0 gap-2">
+                    <Button
+                      size="sm"
+                      className="h-11 gap-1.5 bg-emerald-600 hover:bg-emerald-600/90 sm:h-10"
+                      onClick={() => review({ id: r.id, approve: true })}
+                      disabled={reviewing}
+                    >
+                      <Check className="h-4 w-4" />
+                      Approuver
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-11 gap-1.5 text-destructive hover:bg-destructive/10 sm:h-10"
+                      onClick={() => {
+                        setRejectTarget(r.id)
+                        setComment("")
+                      }}
+                      disabled={reviewing}
+                    >
+                      <X className="h-4 w-4" />
+                      Refuser
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={rejectTarget !== null} onOpenChange={(o) => !o && setRejectTarget(null)}>
+        <DialogContent aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>Refuser la demande</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Motif du refus (optionnel, communiqué au demandeur)"
+            className="min-h-24"
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRejectTarget(null)}>
+              Annuler
+            </Button>
+            <Button
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => {
+                if (rejectTarget !== null) review({ id: rejectTarget, approve: false, comment })
+                setRejectTarget(null)
+              }}
+              disabled={reviewing}
+            >
+              Confirmer le refus
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Wallet,
   CreditCard,
   CalendarDays,
+  CalendarClock,
   CalendarRange,
   ClipboardList,
   HeartHandshake,
@@ -87,6 +88,7 @@ const navigation: NavSection[] = [
       { label: "Présences", href: "/admin/attendance", icon: UserCheck },
       { label: "Bulletins", href: "/admin/reports", icon: FileText },
       { label: "Performance", href: "/admin/performance" as Route, icon: Gauge },
+      { label: "Congés", href: "/admin/leave" as Route, icon: CalendarClock },
     ],
   },
   {

--- a/components/shared/leave/LeaveRequestModal.tsx
+++ b/components/shared/leave/LeaveRequestModal.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { LeaveCreateSchema, LEAVE_TYPE_OPTIONS, type LeaveCreate } from "@/lib/contracts/leave"
+import { useCreateLeaveRequest } from "@/lib/hooks/useLeave"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+
+interface LeaveRequestModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function LeaveRequestModal({ open, onClose }: LeaveRequestModalProps) {
+  const form = useForm<LeaveCreate>({
+    resolver: zodResolver(LeaveCreateSchema),
+    defaultValues: { leave_type: "annual", start_date: "", end_date: "", reason: "" },
+  })
+  const { mutate, isPending, error } = useCreateLeaveRequest()
+
+  const onSubmit = (data: LeaveCreate) => {
+    mutate(data, {
+      onSuccess: () => {
+        form.reset()
+        onClose()
+      },
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Demander un congé</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="leave_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type de congé *</FormLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <FormControl>
+                      <SelectTrigger className="h-11">
+                        <SelectValue placeholder="Choisir un type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {LEAVE_TYPE_OPTIONS.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="start_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Du *</FormLabel>
+                    <FormControl>
+                      <Input type="date" className="h-11" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="end_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Au *</FormLabel>
+                    <FormControl>
+                      <Input type="date" className="h-11" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="reason"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Motif (optionnel)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Précisez le motif si nécessaire…"
+                      className="min-h-20"
+                      {...field}
+                      value={field.value ?? ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {error && (
+              <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
+                <p className="text-sm text-destructive">{error.message}</p>
+              </div>
+            )}
+
+            <Button type="submit" size="lg" className="h-11 w-full font-semibold" disabled={isPending}>
+              {isPending ? "Envoi…" : "Envoyer la demande"}
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/shared/leave/MyLeaveCard.tsx
+++ b/components/shared/leave/MyLeaveCard.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useState } from "react"
+import { CalendarClock, Plus, X } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { SectionTitle } from "@/components/shared/PageHero"
+import { LeaveRequestModal } from "./LeaveRequestModal"
+import { LeaveStatusBadge, formatDateRange, dayCount } from "./leave-ui"
+import { useMyLeaveRequests, useCancelLeaveRequest } from "@/lib/hooks/useLeave"
+import { leaveTypeLabel } from "@/lib/contracts/leave"
+
+export function MyLeaveCard() {
+  const [open, setOpen] = useState(false)
+  const { data: requests, isLoading } = useMyLeaveRequests()
+  const { mutate: cancel, isPending: cancelling } = useCancelLeaveRequest()
+
+  return (
+    <Card className="rounded-xl border shadow-sm">
+      <CardContent className="space-y-4 p-5 sm:p-6">
+        <div className="flex items-center justify-between gap-3">
+          <SectionTitle icon={CalendarClock}>Mes congés</SectionTitle>
+          <Button size="sm" className="h-9 shrink-0" onClick={() => setOpen(true)}>
+            <Plus className="mr-1.5 h-4 w-4" />
+            Demander
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-16 rounded-lg" />
+            <Skeleton className="h-16 rounded-lg" />
+          </div>
+        ) : !requests || requests.length === 0 ? (
+          <p className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+            Aucune demande de congé pour le moment. Cliquez sur « Demander » pour en créer une.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {requests.map((r) => (
+              <div
+                key={r.id}
+                className="flex items-center gap-3 rounded-lg border border-border/60 bg-muted/40 p-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-medium">{leaveTypeLabel(r.leave_type)}</p>
+                    <LeaveStatusBadge status={r.status} />
+                  </div>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {formatDateRange(r.start_date, r.end_date)} · {dayCount(r.start_date, r.end_date)} j
+                  </p>
+                  {r.review_comment && (
+                    <p className="mt-0.5 text-xs text-muted-foreground">Note : {r.review_comment}</p>
+                  )}
+                </div>
+                {r.status === "pending" && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 shrink-0 text-destructive hover:bg-destructive/10"
+                    onClick={() => cancel(r.id)}
+                    disabled={cancelling}
+                    aria-label="Annuler la demande"
+                    title="Annuler"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <LeaveRequestModal open={open} onClose={() => setOpen(false)} />
+    </Card>
+  )
+}

--- a/components/shared/leave/leave-ui.tsx
+++ b/components/shared/leave/leave-ui.tsx
@@ -1,0 +1,25 @@
+import { Badge } from "@/components/ui/badge"
+
+const STATUS_STYLES: Record<string, { label: string; className: string }> = {
+  pending: { label: "En attente", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400" },
+  approved: { label: "Approuvé", className: "bg-emerald-600 text-white hover:bg-emerald-600/90" },
+  rejected: { label: "Refusé", className: "bg-destructive text-destructive-foreground" },
+  cancelled: { label: "Annulé", className: "bg-muted text-muted-foreground" },
+}
+
+export function LeaveStatusBadge({ status }: { status: string }) {
+  const s = STATUS_STYLES[status] ?? { label: status, className: "bg-muted text-muted-foreground" }
+  return <Badge className={s.className}>{s.label}</Badge>
+}
+
+export function formatDateRange(start: string, end: string): string {
+  const opts: Intl.DateTimeFormatOptions = { day: "numeric", month: "short", year: "numeric" }
+  const s = new Date(start).toLocaleDateString("fr-FR", opts)
+  const e = new Date(end).toLocaleDateString("fr-FR", opts)
+  return s === e ? s : `${s} → ${e}`
+}
+
+export function dayCount(start: string, end: string): number {
+  const ms = new Date(end).getTime() - new Date(start).getTime()
+  return Math.max(1, Math.round(ms / 86_400_000) + 1)
+}

--- a/components/shared/profile/ProfilePageClient.tsx
+++ b/components/shared/profile/ProfilePageClient.tsx
@@ -9,6 +9,9 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { ProfileInfoCard } from "./ProfileInfoCard"
 import { NotificationPrefsCard } from "./NotificationPrefsCard"
+import { MyLeaveCard } from "@/components/shared/leave/MyLeaveCard"
+
+const LEAVE_ROLES = ["admin", "director", "teacher", "staff"]
 import { useMyProfile, profileKeys } from "@/lib/hooks/useProfile"
 import { profileApi } from "@/lib/api/profile"
 import { getUploadUrl } from "@/lib/utils"
@@ -121,6 +124,8 @@ export function ProfilePageClient() {
       <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleUpload} />
 
       <ProfileInfoCard profile={profile} />
+
+      {LEAVE_ROLES.includes(profile.role) && <MyLeaveCard />}
 
       <NotificationPrefsCard />
     </div>

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { PageHero, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
+import { MyLeaveCard } from "@/components/shared/leave/MyLeaveCard"
 import { useTeacherDashboard } from "@/lib/hooks/useTeacherPortal"
 import type { TeacherUpcomingEval } from "@/lib/contracts/teacher-portal"
 import { SelfDeclareAbsenceModal } from "./SelfDeclareAbsenceModal"
@@ -175,6 +176,8 @@ export function TeacherDashboardClient() {
           </div>
         )}
       </section>
+
+      <MyLeaveCard />
 
       <SelfDeclareAbsenceModal
         open={selfDeclareOpen}

--- a/lib/api/leave.ts
+++ b/lib/api/leave.ts
@@ -1,0 +1,47 @@
+import { z } from "zod"
+import { LeaveRequestSchema, type LeaveRequest, type LeaveCreate } from "@/lib/contracts/leave"
+import { apiFetch, safeValidate } from "./client"
+
+const LeaveArraySchema = z.array(LeaveRequestSchema)
+
+export const leaveApi = {
+  myRequests: async (): Promise<LeaveRequest[]> => {
+    const json = await apiFetch<unknown>("/leave/requests/me")
+    return safeValidate(LeaveArraySchema, json, "GET /leave/requests/me")
+  },
+
+  create: async (data: LeaveCreate): Promise<LeaveRequest> => {
+    const json = await apiFetch<unknown>("/leave/requests", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(LeaveRequestSchema, json, "POST /leave/requests")
+  },
+
+  cancel: async (id: number): Promise<LeaveRequest> => {
+    const json = await apiFetch<unknown>(`/leave/requests/${id}/cancel`, { method: "POST" })
+    return safeValidate(LeaveRequestSchema, json, "POST /leave/requests/:id/cancel")
+  },
+
+  all: async (status?: string): Promise<LeaveRequest[]> => {
+    const qs = status ? `?status=${encodeURIComponent(status)}` : ""
+    const json = await apiFetch<unknown>(`/admin/leave/requests${qs}`)
+    return safeValidate(LeaveArraySchema, json, "GET /admin/leave/requests")
+  },
+
+  approve: async (id: number, comment?: string): Promise<LeaveRequest> => {
+    const json = await apiFetch<unknown>(`/admin/leave/requests/${id}/approve`, {
+      method: "POST",
+      body: JSON.stringify({ comment: comment ?? null }),
+    })
+    return safeValidate(LeaveRequestSchema, json, "POST /admin/leave/requests/:id/approve")
+  },
+
+  reject: async (id: number, comment?: string): Promise<LeaveRequest> => {
+    const json = await apiFetch<unknown>(`/admin/leave/requests/${id}/reject`, {
+      method: "POST",
+      body: JSON.stringify({ comment: comment ?? null }),
+    })
+    return safeValidate(LeaveRequestSchema, json, "POST /admin/leave/requests/:id/reject")
+  },
+}

--- a/lib/contracts/leave.ts
+++ b/lib/contracts/leave.ts
@@ -1,0 +1,57 @@
+import { z } from "zod"
+
+export const LEAVE_TYPE_OPTIONS = [
+  { value: "annual", label: "Congé annuel" },
+  { value: "sick", label: "Congé maladie" },
+  { value: "maternity", label: "Congé maternité" },
+  { value: "exceptional", label: "Congé exceptionnel" },
+  { value: "training", label: "Formation" },
+  { value: "other", label: "Autre" },
+] as const
+
+const LEAVE_TYPE_LABELS: Record<string, string> = Object.fromEntries(
+  LEAVE_TYPE_OPTIONS.map((o) => [o.value, o.label]),
+)
+
+export function leaveTypeLabel(v?: string | null): string {
+  if (!v) return "—"
+  return LEAVE_TYPE_LABELS[v] ?? v
+}
+
+export const LEAVE_STATUS_LABELS: Record<string, string> = {
+  pending: "En attente",
+  approved: "Approuvé",
+  rejected: "Refusé",
+  cancelled: "Annulé",
+}
+
+export const LeaveRequestSchema = z.object({
+  id: z.number(),
+  user_id: z.number(),
+  leave_type: z.string(),
+  start_date: z.string(),
+  end_date: z.string(),
+  reason: z.string().nullish(),
+  status: z.string(),
+  reviewed_by: z.number().nullish(),
+  reviewed_at: z.string().nullish(),
+  review_comment: z.string().nullish(),
+  created_at: z.string(),
+  requester_name: z.string().nullish(),
+  requester_role: z.string().nullish(),
+})
+
+export const LeaveCreateSchema = z
+  .object({
+    leave_type: z.string({ required_error: "Type requis" }).min(1, "Type requis"),
+    start_date: z.string({ required_error: "Date de début requise" }).min(1, "Date de début requise"),
+    end_date: z.string({ required_error: "Date de fin requise" }).min(1, "Date de fin requise"),
+    reason: z.string().optional(),
+  })
+  .refine((d) => d.end_date >= d.start_date, {
+    message: "La date de fin doit être postérieure ou égale au début",
+    path: ["end_date"],
+  })
+
+export type LeaveRequest = z.infer<typeof LeaveRequestSchema>
+export type LeaveCreate = z.infer<typeof LeaveCreateSchema>

--- a/lib/hooks/useLeave.ts
+++ b/lib/hooks/useLeave.ts
@@ -1,0 +1,63 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { leaveApi } from "@/lib/api/leave"
+
+export const leaveKeys = {
+  mine: ["leave", "me"] as const,
+  all: (status?: string) => ["leave", "all", status ?? "any"] as const,
+}
+
+export function useMyLeaveRequests() {
+  return useQuery({
+    queryKey: leaveKeys.mine,
+    queryFn: leaveApi.myRequests,
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useCreateLeaveRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: leaveApi.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["leave"] })
+      toast.success("Demande de congé envoyée")
+    },
+    onError: (err: Error) => toast.error("Erreur", { description: err.message }),
+  })
+}
+
+export function useCancelLeaveRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => leaveApi.cancel(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["leave"] })
+      toast.success("Demande annulée")
+    },
+    onError: (err: Error) => toast.error("Erreur", { description: err.message }),
+  })
+}
+
+export function useLeaveRequests(status?: string) {
+  return useQuery({
+    queryKey: leaveKeys.all(status),
+    queryFn: () => leaveApi.all(status),
+    staleTime: 1000 * 30,
+  })
+}
+
+export function useReviewLeaveRequest() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, approve, comment }: { id: number; approve: boolean; comment?: string }) =>
+      approve ? leaveApi.approve(id, comment) : leaveApi.reject(id, comment),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: ["leave"] })
+      toast.success(vars.approve ? "Congé approuvé" : "Congé refusé")
+    },
+    onError: (err: Error) => toast.error("Erreur", { description: err.message }),
+  })
+}


### PR DESCRIPTION
Closes #264
Pairs with backend #212.

- `MyLeaveCard` (demander/annuler + suivi) sur la page profil (rôles pouvant demander) et le dashboard enseignant.
- `LeaveRequestModal` (type, dates, motif).
- Page /admin/leave : KPIs + filtres de statut + approuver/refuser (commentaire).
- Lien sidebar « Congés ». tsc + lint OK.