### PR TITLE
feat(leave): interim UI + clarify annual availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Intérim : sur un congé approuvé, la direction choisit un enseignant remplaçant depuis la page Congés ; le demandeur voit qui assure son remplacement sur sa carte « Mes congés » *(admin, enseignant)*.
 - Demandes de congé : depuis son profil (et son tableau de bord pour l'enseignant), on demande un congé en quelques secondes et on suit son statut ; une page « Congés » côté administration permet d'approuver ou refuser les demandes en attente *(enseignant, personnel, admin)*.
 - Pièces jointes sur l'onglet Documents de la fiche élève : téléversez un PDF ou une image (extrait de naissance, certificat médical, etc.), en choisissant le type dans une liste ou en le créant à la volée ; consultez ou supprimez chaque document *(admin)*.
 - Section « Préférences de notifications » sur la page profil : activez ou désactivez l'email et le SMS d'un simple interrupteur ; la cloche dans l'application reste toujours active *(tous)*.
@@ -33,6 +34,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- L'onglet Disponibilités d'un enseignant précise désormais qu'il s'agit du planning **annuel** récurrent, base de la génération de l'emploi du temps (et non un réglage semaine par semaine) ; pour une absence ponctuelle, on passe par une demande de congé *(admin)*.
 - Emploi du temps : les flèches « Semaine précédente / suivante » sont retirées au profit d'un repère fixe « Semaine type · Année {en cours} ». L'emploi du temps vaut pour toute l'année scolaire ; l'ancien sélecteur laissait croire, à tort, que chaque semaine avait son propre planning *(admin)*.
 - Bandeau de synthèse des Frais (élève, parent) repassé au dégradé bleu-orange de la marque, et indicateurs de la page Années scolaires intégrés au bandeau d'en-tête *(tous)*.
 - Tableaux de bord enseignant, élève et parent désormais en tête de page sur le bandeau bleu-orange KLASSCI, indicateurs clés intégrés. Pages Promotions, Paramètres, Conseil de classe et Statistiques DREN harmonisées sur le même bandeau *(tous)*.

--- a/components/admin/leave/LeaveManagementClient.tsx
+++ b/components/admin/leave/LeaveManagementClient.tsx
@@ -8,13 +8,21 @@ import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { useLeaveRequests, useReviewLeaveRequest } from "@/lib/hooks/useLeave"
+import { useLeaveRequests, useReviewLeaveRequest, useSetInterim } from "@/lib/hooks/useLeave"
+import { useTeachers } from "@/lib/hooks/useTeachers"
 import { leaveTypeLabel } from "@/lib/contracts/leave"
 import { LeaveStatusBadge, formatDateRange, dayCount } from "@/components/shared/leave/leave-ui"
 import { cn } from "@/lib/utils"
@@ -38,6 +46,9 @@ export function LeaveManagementClient() {
   const [filter, setFilter] = useState("pending")
   const { data, isLoading } = useLeaveRequests()
   const { mutate: review, isPending: reviewing } = useReviewLeaveRequest()
+  const { mutate: setInterim } = useSetInterim()
+  const { data: teacherData } = useTeachers({ size: 100 })
+  const teachers = teacherData?.items ?? []
   const [rejectTarget, setRejectTarget] = useState<number | null>(null)
   const [comment, setComment] = useState("")
 
@@ -97,51 +108,77 @@ export function LeaveManagementClient() {
         <div className="space-y-3">
           {filtered.map((r) => (
             <Card key={r.id} className="rounded-xl border shadow-sm">
-              <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="font-medium">{r.requester_name ?? "—"}</p>
-                    <span className="text-xs text-muted-foreground">
-                      {ROLE_LABELS[r.requester_role ?? ""] ?? r.requester_role ?? ""}
-                    </span>
-                    <LeaveStatusBadge status={r.status} />
+              <CardContent className="space-y-3 p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium">{r.requester_name ?? "—"}</p>
+                      <span className="text-xs text-muted-foreground">
+                        {ROLE_LABELS[r.requester_role ?? ""] ?? r.requester_role ?? ""}
+                      </span>
+                      <LeaveStatusBadge status={r.status} />
+                    </div>
+                    <p className="mt-1 text-sm">
+                      {leaveTypeLabel(r.leave_type)} · {formatDateRange(r.start_date, r.end_date)} ·{" "}
+                      {dayCount(r.start_date, r.end_date)} j
+                    </p>
+                    {r.reason && (
+                      <p className="mt-0.5 text-xs text-muted-foreground">Motif : {r.reason}</p>
+                    )}
+                    {r.review_comment && (
+                      <p className="mt-0.5 text-xs text-muted-foreground">Décision : {r.review_comment}</p>
+                    )}
                   </div>
-                  <p className="mt-1 text-sm">
-                    {leaveTypeLabel(r.leave_type)} · {formatDateRange(r.start_date, r.end_date)} ·{" "}
-                    {dayCount(r.start_date, r.end_date)} j
-                  </p>
-                  {r.reason && (
-                    <p className="mt-0.5 text-xs text-muted-foreground">Motif : {r.reason}</p>
-                  )}
-                  {r.review_comment && (
-                    <p className="mt-0.5 text-xs text-muted-foreground">Décision : {r.review_comment}</p>
+
+                  {r.status === "pending" && (
+                    <div className="flex shrink-0 gap-2">
+                      <Button
+                        size="sm"
+                        className="h-11 gap-1.5 bg-emerald-600 hover:bg-emerald-600/90 sm:h-10"
+                        onClick={() => review({ id: r.id, approve: true })}
+                        disabled={reviewing}
+                      >
+                        <Check className="h-4 w-4" />
+                        Approuver
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-11 gap-1.5 text-destructive hover:bg-destructive/10 sm:h-10"
+                        onClick={() => {
+                          setRejectTarget(r.id)
+                          setComment("")
+                        }}
+                        disabled={reviewing}
+                      >
+                        <X className="h-4 w-4" />
+                        Refuser
+                      </Button>
+                    </div>
                   )}
                 </div>
 
-                {r.status === "pending" && (
-                  <div className="flex shrink-0 gap-2">
-                    <Button
-                      size="sm"
-                      className="h-11 gap-1.5 bg-emerald-600 hover:bg-emerald-600/90 sm:h-10"
-                      onClick={() => review({ id: r.id, approve: true })}
-                      disabled={reviewing}
+                {r.status === "approved" && (
+                  <div className="flex flex-wrap items-center gap-2 border-t pt-3">
+                    <span className="text-xs font-medium text-muted-foreground">Remplaçant :</span>
+                    <Select
+                      value={r.interim_teacher_id ? String(r.interim_teacher_id) : "none"}
+                      onValueChange={(v) =>
+                        setInterim({ id: r.id, teacherId: v === "none" ? null : Number(v) })
+                      }
                     >
-                      <Check className="h-4 w-4" />
-                      Approuver
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-11 gap-1.5 text-destructive hover:bg-destructive/10 sm:h-10"
-                      onClick={() => {
-                        setRejectTarget(r.id)
-                        setComment("")
-                      }}
-                      disabled={reviewing}
-                    >
-                      <X className="h-4 w-4" />
-                      Refuser
-                    </Button>
+                      <SelectTrigger className="h-9 w-56">
+                        <SelectValue placeholder="Aucun remplaçant" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">Aucun remplaçant</SelectItem>
+                        {teachers.map((t) => (
+                          <SelectItem key={t.id} value={String(t.id)}>
+                            {t.last_name} {t.first_name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
                 )}
               </CardContent>

--- a/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
+++ b/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useState } from "react"
 import { toast } from "sonner"
 import { useQueryClient } from "@tanstack/react-query"
+import { Info } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 import { timetableApi } from "@/lib/api/timetable"
 import { timetableKeys, useTeacherAvailabilities } from "@/lib/hooks/useTimetable"
@@ -179,6 +180,16 @@ export function TeacherAvailabilityTab({ teacherId }: TeacherAvailabilityTabProp
 
   return (
     <div className="space-y-4">
+      <div className="flex items-start gap-2.5 rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm">
+        <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+        <p className="text-muted-foreground">
+          Disponibilités <span className="font-medium text-foreground">annuelles</span> : ce planning
+          récurrent (par jour de la semaine) sert de base à la génération de l&apos;emploi du temps, il
+          ne se règle pas semaine par semaine. Pour une absence ponctuelle, utilisez plutôt une{" "}
+          <span className="font-medium text-foreground">demande de congé</span>.
+        </p>
+      </div>
+
       <AvailabilityToolbar
         editMode={editMode}
         saving={saving}

--- a/components/shared/leave/MyLeaveCard.tsx
+++ b/components/shared/leave/MyLeaveCard.tsx
@@ -54,6 +54,11 @@ export function MyLeaveCard() {
                   {r.review_comment && (
                     <p className="mt-0.5 text-xs text-muted-foreground">Note : {r.review_comment}</p>
                   )}
+                  {r.interim_teacher_name && (
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      Remplacé par : {r.interim_teacher_name}
+                    </p>
+                  )}
                 </div>
                 {r.status === "pending" && (
                   <Button

--- a/lib/api/leave.ts
+++ b/lib/api/leave.ts
@@ -44,4 +44,12 @@ export const leaveApi = {
     })
     return safeValidate(LeaveRequestSchema, json, "POST /admin/leave/requests/:id/reject")
   },
+
+  setInterim: async (id: number, teacherId: number | null): Promise<LeaveRequest> => {
+    const json = await apiFetch<unknown>(`/admin/leave/requests/${id}/interim`, {
+      method: "PATCH",
+      body: JSON.stringify({ teacher_id: teacherId }),
+    })
+    return safeValidate(LeaveRequestSchema, json, "PATCH /admin/leave/requests/:id/interim")
+  },
 }

--- a/lib/contracts/leave.ts
+++ b/lib/contracts/leave.ts
@@ -36,6 +36,8 @@ export const LeaveRequestSchema = z.object({
   reviewed_by: z.number().nullish(),
   reviewed_at: z.string().nullish(),
   review_comment: z.string().nullish(),
+  interim_teacher_id: z.number().nullish(),
+  interim_teacher_name: z.string().nullish(),
   created_at: z.string(),
   requester_name: z.string().nullish(),
   requester_role: z.string().nullish(),

--- a/lib/hooks/useLeave.ts
+++ b/lib/hooks/useLeave.ts
@@ -61,3 +61,16 @@ export function useReviewLeaveRequest() {
     onError: (err: Error) => toast.error("Erreur", { description: err.message }),
   })
 }
+
+export function useSetInterim() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, teacherId }: { id: number; teacherId: number | null }) =>
+      leaveApi.setInterim(id, teacherId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["leave"] })
+      toast.success("Remplaçant mis à jour")
+    },
+    onError: (err: Error) => toast.error("Erreur", { description: err.message }),
+  })
+}


### PR DESCRIPTION
Closes #266
Pairs with backend #214.

- Sélecteur de remplaçant (liste enseignants) sur chaque congé approuvé dans /admin/leave ; « Remplacé par X » affiché sur la carte « Mes congés » du demandeur.
- Bandeau explicatif sur l'onglet Disponibilités enseignant : planning annuel récurrent (base EDT), pas semaine par semaine ; absence ponctuelle → demande de congé.
- tsc OK.