### PR TITLE
fix(ui): documents preview/separation + compact notifications tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Onglet Documents de la fiche élève : les pièces jointes ajoutées sont désormais nettement séparées du formulaire d'envoi (section « Documents ajoutés »), avec un bouton Aperçu pour prévisualiser le PDF ou l'image en plus du téléchargement *(admin)*.
+- Onglet Notifications des Paramètres : les options sont plus compactes, la page est moins haute et ne provoque plus de défilement inutile *(admin)*.
 - Fiche parent : les enfants liés ne s'affichaient plus (lignes vides, « on ne voit rien ») ; ils réapparaissent avec leur nom, leur classe et leur situation *(admin)*.
 - La session ne se ferme plus pendant l'utilisation : tant que vous êtes actif, elle reste ouverte et se prolonge automatiquement. Elle n'expire désormais qu'après une période d'inactivité (mode veille), pas après un délai fixe *(tous)*.
 - Mode dictée des notes : le bouton « Mode dictée » de la saisie déléguée admin renvoyait vers le tableau de bord au lieu d'ouvrir la dictée. Il ouvre désormais la saisie vocale et revient à la bonne page en sortie *(admin, enseignant)*.

--- a/components/admin/settings/NotificationSection.tsx
+++ b/components/admin/settings/NotificationSection.tsx
@@ -57,15 +57,15 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
       </CardHeader>
       <CardContent>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             {/* Canaux */}
-            <div className="space-y-4">
+            <div className="space-y-2">
               <p className="text-sm font-semibold">Canaux de diffusion</p>
               <FormField
                 control={form.control}
                 name="notify_by_email"
                 render={({ field }) => (
-                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2.5">
                     <div className="space-y-0.5">
                       <FormLabel className="text-sm">Email</FormLabel>
                       <FormDescription className="text-xs">
@@ -82,7 +82,7 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
                 control={form.control}
                 name="notify_by_sms"
                 render={({ field }) => (
-                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2.5">
                     <div className="space-y-0.5">
                       <FormLabel className="text-sm">SMS</FormLabel>
                       <FormDescription className="text-xs">
@@ -100,13 +100,13 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
             <Separator />
 
             {/* Types */}
-            <div className="space-y-4">
+            <div className="space-y-2">
               <p className="text-sm font-semibold">Types de notifications</p>
               <FormField
                 control={form.control}
                 name="notify_grades"
                 render={({ field }) => (
-                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2.5">
                     <div className="space-y-0.5">
                       <FormLabel className="text-sm">Notes</FormLabel>
                       <FormDescription className="text-xs">
@@ -123,7 +123,7 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
                 control={form.control}
                 name="notify_absences"
                 render={({ field }) => (
-                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2.5">
                     <div className="space-y-0.5">
                       <FormLabel className="text-sm">Absences</FormLabel>
                       <FormDescription className="text-xs">
@@ -140,7 +140,7 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
                 control={form.control}
                 name="notify_payments"
                 render={({ field }) => (
-                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2.5">
                     <div className="space-y-0.5">
                       <FormLabel className="text-sm">Paiements</FormLabel>
                       <FormDescription className="text-xs">
@@ -157,7 +157,7 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
                 control={form.control}
                 name="notify_enrollment"
                 render={({ field }) => (
-                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2.5">
                     <div className="space-y-0.5">
                       <FormLabel className="text-sm">Inscriptions</FormLabel>
                       <FormDescription className="text-xs">
@@ -174,7 +174,7 @@ export function NotificationSection({ settings }: NotificationSectionProps) {
                 control={form.control}
                 name="notify_reenrollment"
                 render={({ field }) => (
-                  <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border px-4 py-2.5">
                     <div className="space-y-0.5">
                       <FormLabel className="text-sm">Réinscriptions</FormLabel>
                       <FormDescription className="text-xs">

--- a/components/admin/students/attachments/StudentAttachmentsSection.tsx
+++ b/components/admin/students/attachments/StudentAttachmentsSection.tsx
@@ -6,6 +6,7 @@ import {
   FileText,
   Image as ImageIcon,
   Download,
+  Eye,
   Trash2,
   Loader2,
   Upload,
@@ -111,60 +112,74 @@ export function StudentAttachmentsSection({ studentId }: { studentId: number }) 
         </Button>
       </div>
 
-      {/* Liste */}
-      {isLoading ? (
-        <p className="text-sm text-muted-foreground">Chargement…</p>
-      ) : !docs || docs.length === 0 ? (
-        <EmptyState
-          icon={<FilePlus className="h-5 w-5" />}
-          title="Aucune pièce jointe"
-          message="Ajoutez l'extrait de naissance, un certificat médical ou tout autre document via le formulaire ci-dessus."
-        />
-      ) : (
-        <div className="space-y-2">
-          {docs.map((d) => {
-            const isPdf = d.mime_type === "application/pdf"
-            const Icon = isPdf ? FileText : ImageIcon
-            const url = getUploadUrl(d.file_url) ?? d.file_url
-            return (
-              <div
-                key={d.id}
-                className="flex items-center gap-3 rounded-lg border border-border/60 bg-card p-3"
-              >
-                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                  <Icon className="h-4 w-4" />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium">{d.document_type}</p>
-                  <p className="truncate text-xs text-muted-foreground">
-                    {d.file_name ? `${d.file_name} · ` : ""}
-                    {new Date(d.created_at).toLocaleDateString("fr-FR")}
-                  </p>
+      {/* Documents ajoutés — séparés du formulaire d'ajout */}
+      <div className="space-y-2 border-t pt-4">
+        <p className="text-sm font-semibold">
+          Documents ajoutés{docs && docs.length > 0 ? ` (${docs.length})` : ""}
+        </p>
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Chargement…</p>
+        ) : !docs || docs.length === 0 ? (
+          <EmptyState
+            icon={<FilePlus className="h-5 w-5" />}
+            title="Aucune pièce jointe"
+            message="Ajoutez l'extrait de naissance, un certificat médical ou tout autre document via le formulaire ci-dessus."
+          />
+        ) : (
+          <div className="space-y-2">
+            {docs.map((d) => {
+              const isPdf = d.mime_type === "application/pdf"
+              const Icon = isPdf ? FileText : ImageIcon
+              const url = getUploadUrl(d.file_url) ?? d.file_url
+              return (
+                <div
+                  key={d.id}
+                  className="flex items-center gap-3 rounded-lg border border-border/60 bg-card p-3"
+                >
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{d.document_type}</p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {d.file_name ? `${d.file_name} · ` : ""}
+                      {new Date(d.created_at).toLocaleDateString("fr-FR")}
+                    </p>
+                  </div>
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-md text-primary hover:bg-primary/10"
+                    aria-label={`Aperçu de ${d.document_type}`}
+                    title="Aperçu"
+                  >
+                    <Eye className="h-4 w-4" />
+                  </a>
+                  <a
+                    href={url}
+                    download={d.file_name ?? undefined}
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+                    aria-label={`Télécharger ${d.document_type}`}
+                    title="Télécharger"
+                  >
+                    <Download className="h-4 w-4" />
+                  </a>
+                  <button
+                    type="button"
+                    onClick={() => setDeleteTarget(d.id)}
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-md text-destructive hover:bg-destructive/10"
+                    aria-label={`Supprimer ${d.document_type}`}
+                    title="Supprimer"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
                 </div>
-                <a
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-md text-primary hover:bg-primary/10"
-                  aria-label={`Ouvrir ${d.document_type}`}
-                  title="Ouvrir"
-                >
-                  <Download className="h-4 w-4" />
-                </a>
-                <button
-                  type="button"
-                  onClick={() => setDeleteTarget(d.id)}
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-md text-destructive hover:bg-destructive/10"
-                  aria-label={`Supprimer ${d.document_type}`}
-                  title="Supprimer"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
-            )
-          })}
-        </div>
-      )}
+              )
+            })}
+          </div>
+        )}
+      </div>
 
       <AlertDialog open={deleteTarget !== null} onOpenChange={(o) => !o && setDeleteTarget(null)}>
         <AlertDialogContent>


### PR DESCRIPTION
Closes #268

- Pièces jointes élève : section « Documents ajoutés » séparée du formulaire (bordure + titre) ; bouton **Aperçu** (Eye, nouvel onglet) + **Télécharger** (download) au lieu d'un seul.
- Onglet Notifications (Paramètres) : options compactées (padding/espacement réduits) → page moins haute, moins de défilement.
- tsc OK.