### PR TITLE
fix(ui): auto-recover from chunk load errors after deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Après une mise à jour de la plateforme, un onglet resté ouvert pouvait afficher « Une erreur est survenue / Loading chunk failed » à la navigation ; la page se recharge désormais automatiquement pour récupérer la dernière version *(tous)*.
 - Onglet Documents de la fiche élève : les pièces jointes ajoutées sont désormais nettement séparées du formulaire d'envoi (section « Documents ajoutés »), avec un bouton Aperçu pour prévisualiser le PDF ou l'image en plus du téléchargement *(admin)*.
 - Onglet Notifications des Paramètres : les options sont plus compactes, la page est moins haute et ne provoque plus de défilement inutile *(admin)*.
 - Fiche parent : les enfants liés ne s'affichaient plus (lignes vides, « on ne voit rien ») ; ils réapparaissent avec leur nom, leur classe et leur situation *(admin)*.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { DM_Sans, DM_Serif_Display } from 'next/font/google';
 import { Providers } from '@/components/shared/Providers';
+import { ChunkErrorReloader } from '@/components/shared/ChunkErrorReloader';
 import './globals.css';
 
 const dmSans = DM_Sans({
@@ -27,6 +28,7 @@ export default function RootLayout({
   return (
     <html lang="fr" suppressHydrationWarning>
       <body className={`${dmSans.variable} ${dmSerif.variable} font-sans antialiased`}>
+        <ChunkErrorReloader />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/components/shared/ChunkErrorReloader.tsx
+++ b/components/shared/ChunkErrorReloader.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect } from "react"
+
+/**
+ * Après un déploiement, les chunks JS changent de hash : un onglet ouvert avec
+ * l'ancien build échoue en « Loading chunk … failed ». On recharge alors la page
+ * une seule fois (garde en sessionStorage) pour récupérer le build courant.
+ */
+const GUARD_KEY = "chunk-reload-once"
+
+function isChunkError(message: string): boolean {
+  return (
+    /Loading chunk [\w-]+ failed/i.test(message) ||
+    /ChunkLoadError/i.test(message) ||
+    /Loading CSS chunk/i.test(message) ||
+    /Failed to fetch dynamically imported module/i.test(message)
+  )
+}
+
+export function ChunkErrorReloader() {
+  useEffect(() => {
+    // Recharge au plus une fois par fenêtre de 15 s : évite une boucle si le
+    // build courant échoue vraiment, tout en récupérant sur un futur déploiement.
+    function reloadOnce() {
+      const last = Number(sessionStorage.getItem(GUARD_KEY) || "0")
+      if (Date.now() - last < 15000) return
+      sessionStorage.setItem(GUARD_KEY, String(Date.now()))
+      window.location.reload()
+    }
+
+    function onError(event: ErrorEvent) {
+      if (isChunkError(event.message || String(event.error ?? ""))) reloadOnce()
+    }
+    function onRejection(event: PromiseRejectionEvent) {
+      const reason = event.reason
+      const message = reason instanceof Error ? reason.message : String(reason ?? "")
+      if (isChunkError(message)) reloadOnce()
+    }
+
+    window.addEventListener("error", onError)
+    window.addEventListener("unhandledrejection", onRejection)
+    return () => {
+      window.removeEventListener("error", onError)
+      window.removeEventListener("unhandledrejection", onRejection)
+    }
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
Un onglet ouvert pendant un redéploiement échoue en « Loading chunk failed » (hash des chunks changés, cache immutable). Ajout d'un listener global qui recharge une fois (garde 15 s anti-boucle) pour récupérer le build courant. Corrige le « gros bug » signalé.