### PR TITLE
feat(settings): MailPulse notifications configuration tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Nouvel onglet « MailPulse » dans les Paramètres : activez les notifications parents par email et WhatsApp, réglez l'expéditeur et la clé d'accès (jamais réaffichée), gérez vos destinataires de test avec un interrupteur par adresse ou numéro, envoyez un test (simulation ou réel) et préparez la réponse automatique « INFO » sur WhatsApp *(admin)*.
 - Intérim : sur un congé approuvé, la direction choisit un enseignant remplaçant depuis la page Congés ; le demandeur voit qui assure son remplacement sur sa carte « Mes congés » *(admin, enseignant)*.
 - Demandes de congé : depuis son profil (et son tableau de bord pour l'enseignant), on demande un congé en quelques secondes et on suit son statut ; une page « Congés » côté administration permet d'approuver ou refuser les demandes en attente *(enseignant, personnel, admin)*.
 - Pièces jointes sur l'onglet Documents de la fiche élève : téléversez un PDF ou une image (extrait de naissance, certificat médical, etc.), en choisissant le type dans une liste ou en le créant à la volée ; consultez ou supprimez chaque document *(admin)*.

--- a/components/admin/settings/MailPulseSection.tsx
+++ b/components/admin/settings/MailPulseSection.tsx
@@ -1,0 +1,345 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import {
+  Activity,
+  KeyRound,
+  Loader2,
+  MessageCircle,
+  Radio,
+  Send,
+  ShieldCheck,
+  Zap,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { DataError } from "@/components/shared/DataError"
+import { MailPulseConfigFormSchema, type MailPulseConfigForm } from "@/lib/contracts/mailpulse"
+import { useMailPulseConfig, useUpdateMailPulse } from "@/lib/hooks/useMailPulse"
+import { MailPulseRecipientList } from "./mailpulse/MailPulseRecipientList"
+import { MailPulseTestPanel } from "./mailpulse/MailPulseTestPanel"
+
+/** Barre d'en-tête d'une sous-section (couche 4). */
+function SectionBar({ icon: Icon, title }: { icon: typeof Zap; title: string }) {
+  return (
+    <div className="flex items-center gap-2.5 border-b pb-3">
+      <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
+        <Icon className="h-4 w-4" />
+      </span>
+      <h2 className="text-sm font-semibold">{title}</h2>
+    </div>
+  )
+}
+
+export function MailPulseSection() {
+  const { data: config, isLoading, isError, refetch } = useMailPulseConfig()
+  const { mutate, isPending } = useUpdateMailPulse()
+
+  if (isLoading) return <Skeleton className="h-96 w-full rounded-xl" />
+  if (isError || !config)
+    return (
+      <DataError message="Impossible de charger la configuration MailPulse." onRetry={() => refetch()} />
+    )
+
+  return <MailPulseForm config={config} save={mutate} saving={isPending} />
+}
+
+function MailPulseForm({
+  config,
+  save,
+  saving,
+}: {
+  config: NonNullable<ReturnType<typeof useMailPulseConfig>["data"]>
+  save: (data: MailPulseConfigForm) => void
+  saving: boolean
+}) {
+  const form = useForm<MailPulseConfigForm>({
+    resolver: zodResolver(MailPulseConfigFormSchema),
+    defaultValues: {
+      enabled: config.enabled,
+      base_url: config.base_url,
+      api_key: "",
+      sender_email: config.sender_email ?? "",
+      sender_name: config.sender_name ?? "",
+      default_language: config.default_language,
+      timeout: config.timeout,
+      real_workflows_enabled: config.real_workflows_enabled,
+      test_email_enabled: config.test_email_enabled,
+      test_whatsapp_enabled: config.test_whatsapp_enabled,
+      test_email_recipients: config.test_email_recipients,
+      test_phone_recipients: config.test_phone_recipients,
+      inbound_secret: "",
+    },
+  })
+
+  const enabled = form.watch("enabled")
+
+  return (
+    <div className="space-y-6">
+      <Card className="overflow-hidden border-0 shadow-sm ring-1 ring-border">
+        {/* En-tête identitaire MailPulse */}
+        <div className="flex items-center gap-4 border-b bg-gradient-to-r from-[#fff7ed] to-transparent p-5 dark:from-[#f5821f]/10">
+          <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
+            <Radio className="h-6 w-6" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-bold tracking-tight">MailPulse</h2>
+              <Badge
+                className={
+                  enabled
+                    ? "bg-emerald-600 text-white hover:bg-emerald-600"
+                    : "bg-muted text-muted-foreground hover:bg-muted"
+                }
+              >
+                {enabled ? "Actif" : "Inactif"}
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Notifications aux parents par email et WhatsApp
+            </p>
+          </div>
+        </div>
+
+        <CardContent className="p-5">
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit((d) => save(d))} className="space-y-6">
+              {/* Interrupteur maître */}
+              <FormField
+                control={form.control}
+                name="enabled"
+                render={({ field }) => (
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 px-4 py-3">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-sm font-semibold">Activer MailPulse</FormLabel>
+                      <FormDescription className="text-xs">
+                        Permet les envois de test et, si les workflows réels sont activés, les
+                        notifications automatiques.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              {/* Connexion */}
+              <section className="space-y-4">
+                <SectionBar icon={KeyRound} title="Connexion" />
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="base_url"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-xs">URL MailPulse</FormLabel>
+                        <FormControl>
+                          <Input {...field} className="h-11 sm:h-10" placeholder="https://..." />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="api_key"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-xs">Clé d&apos;accès</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            type="password"
+                            autoComplete="off"
+                            className="h-11 sm:h-10"
+                            placeholder={
+                              config.api_key_set
+                                ? "•••••••• enregistrée, laissez vide pour conserver"
+                                : "Coller la clé MailPulse"
+                            }
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="sender_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-xs">Nom expéditeur</FormLabel>
+                        <FormControl>
+                          <Input {...field} className="h-11 sm:h-10" placeholder="Lycée Saint-Augustin" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="sender_email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-xs">Email expéditeur</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            type="email"
+                            className="h-11 sm:h-10"
+                            placeholder="noreply@ecole.ci"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </section>
+
+              {/* Destinataires de test */}
+              <section className="space-y-4">
+                <SectionBar icon={Send} title="Destinataires de test" />
+                <div className="grid gap-5 sm:grid-cols-2">
+                  <div className="space-y-2.5">
+                    <FormField
+                      control={form.control}
+                      name="test_email_enabled"
+                      render={({ field }) => (
+                        <div className="flex items-center justify-between">
+                          <p className="text-sm font-medium">Emails de test</p>
+                          <Switch checked={field.value} onCheckedChange={field.onChange} />
+                        </div>
+                      )}
+                    />
+                    <MailPulseRecipientList
+                      control={form.control}
+                      name="test_email_recipients"
+                      placeholder="test@ecole.ci"
+                      inputType="email"
+                      addLabel="Ajouter un email"
+                    />
+                  </div>
+                  <div className="space-y-2.5">
+                    <FormField
+                      control={form.control}
+                      name="test_whatsapp_enabled"
+                      render={({ field }) => (
+                        <div className="flex items-center justify-between">
+                          <p className="text-sm font-medium">Numéros WhatsApp de test</p>
+                          <Switch checked={field.value} onCheckedChange={field.onChange} />
+                        </div>
+                      )}
+                    />
+                    <MailPulseRecipientList
+                      control={form.control}
+                      name="test_phone_recipients"
+                      placeholder="+225 07 00 00 00 00"
+                      inputType="tel"
+                      addLabel="Ajouter un numéro"
+                    />
+                  </div>
+                </div>
+              </section>
+
+              {/* Workflows réels */}
+              <section className="space-y-3">
+                <SectionBar icon={Zap} title="Envois réels aux parents" />
+                <FormField
+                  control={form.control}
+                  name="real_workflows_enabled"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-500/30 dark:bg-amber-500/10">
+                      <div className="space-y-0.5">
+                        <FormLabel className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+                          Notifier les vrais parents
+                        </FormLabel>
+                        <FormDescription className="text-xs text-amber-800 dark:text-amber-300/80">
+                          Une fois activé, un paiement, une absence ou une note déclenche l&apos;envoi
+                          aux parents concernés (selon les canaux de l&apos;établissement).
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch checked={field.value} onCheckedChange={field.onChange} />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </section>
+
+              {/* Réponse INFO WhatsApp */}
+              <section className="space-y-3">
+                <SectionBar icon={MessageCircle} title="Réponse WhatsApp « INFO »" />
+                <p className="text-xs text-muted-foreground">
+                  Un parent écrit <strong>INFO</strong> sur le WhatsApp de l&apos;école et reçoit la
+                  synthèse de ses enfants (classe, moyenne, absences, reste à payer). Renseignez un
+                  secret partagé, à communiquer à MailPulse pour sécuriser le relais.
+                </p>
+                <FormField
+                  control={form.control}
+                  name="inbound_secret"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs">Secret du webhook entrant</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="password"
+                          autoComplete="off"
+                          className="h-11 sm:h-10"
+                          placeholder={
+                            config.inbound_secret_set
+                              ? "•••••••• enregistré, laissez vide pour conserver"
+                              : "Définir un secret (ex: chaîne aléatoire longue)"
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </section>
+
+              <Separator />
+
+              <div className="flex items-center justify-between gap-3">
+                <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <ShieldCheck className="h-3.5 w-3.5" />
+                  Clé et secret ne sont jamais réaffichés.
+                </p>
+                <Button type="submit" disabled={saving} className="h-11 sm:h-10">
+                  {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Enregistrer
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      {/* Panneau de test — hors du formulaire de config */}
+      <MailPulseTestPanel />
+
+      <p className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground">
+        <Activity className="h-3.5 w-3.5 text-[#f5821f]" />
+        Propulsé par MailPulse, la plateforme de messagerie de KLASSCI.
+      </p>
+    </div>
+  )
+}

--- a/components/admin/settings/SettingsPageClient.tsx
+++ b/components/admin/settings/SettingsPageClient.tsx
@@ -12,6 +12,7 @@ import { TrimesterSection } from "./TrimesterSection"
 import { HolidaySection } from "./HolidaySection"
 import { NotificationSection } from "./NotificationSection"
 import { PdfIdentitySection } from "./PdfIdentitySection"
+import { MailPulseSection } from "./MailPulseSection"
 
 export function SettingsPageClient() {
   const { data: settings, isLoading, isError, refetch } = useSettings()
@@ -37,6 +38,7 @@ export function SettingsPageClient() {
             <TabsTrigger value="identity">Identité visuelle</TabsTrigger>
             <TabsTrigger value="trimesters">Calendrier</TabsTrigger>
             <TabsTrigger value="notifications">Notifications</TabsTrigger>
+            <TabsTrigger value="mailpulse">MailPulse</TabsTrigger>
           </TabsList>
 
           <TabsContent value="school">
@@ -54,6 +56,10 @@ export function SettingsPageClient() {
 
           <TabsContent value="notifications">
             <NotificationSection settings={settings} />
+          </TabsContent>
+
+          <TabsContent value="mailpulse">
+            <MailPulseSection />
           </TabsContent>
         </Tabs>
       ) : null}

--- a/components/admin/settings/mailpulse/MailPulseRecipientList.tsx
+++ b/components/admin/settings/mailpulse/MailPulseRecipientList.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useFieldArray, type Control } from "react-hook-form"
+import { Plus, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
+import { FormField } from "@/components/ui/form"
+import type { MailPulseConfigForm } from "@/lib/contracts/mailpulse"
+
+interface MailPulseRecipientListProps {
+  control: Control<MailPulseConfigForm>
+  name: "test_email_recipients" | "test_phone_recipients"
+  placeholder: string
+  inputType?: "email" | "tel" | "text"
+  addLabel: string
+}
+
+/** Liste de destinataires de test avec interrupteur actif/inactif par entrée. */
+export function MailPulseRecipientList({
+  control,
+  name,
+  placeholder,
+  inputType = "text",
+  addLabel,
+}: MailPulseRecipientListProps) {
+  const { fields, append, remove } = useFieldArray({ control, name })
+
+  return (
+    <div className="space-y-2">
+      {fields.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border/60 bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
+          Aucun destinataire. Ajoutez-en un pour tester les envois.
+        </p>
+      ) : (
+        fields.map((field, index) => (
+          <div
+            key={field.id}
+            className="flex items-center gap-2 rounded-md border border-border/60 bg-background px-3 py-2"
+          >
+            <FormField
+              control={control}
+              name={`${name}.${index}.value`}
+              render={({ field: f }) => (
+                <Input
+                  {...f}
+                  type={inputType}
+                  placeholder={placeholder}
+                  className="h-9 flex-1 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0"
+                />
+              )}
+            />
+            <FormField
+              control={control}
+              name={`${name}.${index}.enabled`}
+              render={({ field: f }) => (
+                <Switch checked={f.value} onCheckedChange={f.onChange} aria-label="Actif" />
+              )}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+              onClick={() => remove(index)}
+              aria-label="Retirer"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        ))
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-9"
+        onClick={() => append({ value: "", enabled: true })}
+      >
+        <Plus className="mr-1.5 h-4 w-4" />
+        {addLabel}
+      </Button>
+    </div>
+  )
+}

--- a/components/admin/settings/mailpulse/MailPulseTestPanel.tsx
+++ b/components/admin/settings/mailpulse/MailPulseTestPanel.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import { useState } from "react"
+import { CheckCircle2, Loader2, Send, XCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useTestMailPulse } from "@/lib/hooks/useMailPulse"
+import {
+  MAILPULSE_CHANNELS,
+  MAILPULSE_EVENTS,
+  type MailPulseEvent,
+  type MailPulseTestChannel,
+  type MailPulseTestResponse,
+} from "@/lib/contracts/mailpulse"
+
+/** Panneau d'envoi de test — vers les destinataires de test uniquement. */
+export function MailPulseTestPanel() {
+  const [event, setEvent] = useState<MailPulseEvent>("payment_received")
+  const [channel, setChannel] = useState<MailPulseTestChannel>("both")
+  const [dryRun, setDryRun] = useState(true)
+  const [result, setResult] = useState<MailPulseTestResponse | null>(null)
+  const { mutate, isPending } = useTestMailPulse()
+
+  const run = () => {
+    mutate({ event, channel, dry_run: dryRun }, { onSuccess: setResult })
+  }
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/40 p-4 space-y-4">
+      <div className="flex items-center gap-2.5">
+        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
+          <Send className="h-4 w-4" />
+        </span>
+        <div>
+          <h3 className="text-sm font-semibold">Envoyer un test</h3>
+          <p className="text-xs text-muted-foreground">
+            Uniquement vers vos destinataires de test, jamais un vrai parent.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label className="text-xs">Évènement</Label>
+          <Select value={event} onValueChange={(v) => setEvent(v as MailPulseEvent)}>
+            <SelectTrigger className="h-11 sm:h-10">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MAILPULSE_EVENTS.map((e) => (
+                <SelectItem key={e.value} value={e.value}>
+                  {e.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs">Canal</Label>
+          <Select value={channel} onValueChange={(v) => setChannel(v as MailPulseTestChannel)}>
+            <SelectTrigger className="h-11 sm:h-10">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MAILPULSE_CHANNELS.map((c) => (
+                <SelectItem key={c.value} value={c.value}>
+                  {c.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <label className="flex items-center gap-2.5 text-sm">
+          <Switch checked={dryRun} onCheckedChange={setDryRun} />
+          <span>
+            Mode simulation
+            <span className="block text-xs text-muted-foreground">
+              {dryRun ? "Aucun message réel envoyé" : "Envoi réel via MailPulse"}
+            </span>
+          </span>
+        </label>
+        <Button type="button" onClick={run} disabled={isPending} className="h-11 sm:h-10">
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Envoi…
+            </>
+          ) : (
+            <>
+              <Send className="mr-2 h-4 w-4" />
+              Lancer le test
+            </>
+          )}
+        </Button>
+      </div>
+
+      {result && (
+        <div className="space-y-2 rounded-md border bg-background p-3">
+          <p className="text-sm font-medium">{result.message}</p>
+          {result.results.length > 0 && (
+            <ul className="space-y-1.5">
+              {result.results.map((r, i) => (
+                <li key={i} className="flex items-center gap-2 text-xs">
+                  {r.ok ? (
+                    <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600" />
+                  ) : (
+                    <XCircle className="h-4 w-4 shrink-0 text-destructive" />
+                  )}
+                  <span className="font-medium capitalize">{r.channel}</span>
+                  <span className="text-muted-foreground">{r.recipient}</span>
+                  <span className="ml-auto text-muted-foreground">
+                    {r.error_message ?? r.status}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/api/mailpulse.ts
+++ b/lib/api/mailpulse.ts
@@ -1,0 +1,44 @@
+import { apiFetch, safeValidate } from "./client"
+import {
+  MailPulseConfigSchema,
+  MailPulseTestResponseSchema,
+  type MailPulseConfig,
+  type MailPulseConfigForm,
+  type MailPulseTestRequest,
+  type MailPulseTestResponse,
+} from "@/lib/contracts/mailpulse"
+
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object" && "data" in json) {
+    const data = (json as { data?: unknown }).data
+    if (data !== undefined) return data
+  }
+  return json
+}
+
+export const mailpulseApi = {
+  get: async (): Promise<MailPulseConfig> => {
+    const json = await apiFetch<unknown>("/admin/settings/mailpulse")
+    return safeValidate(MailPulseConfigSchema, unwrap(json), "GET /admin/settings/mailpulse")
+  },
+
+  update: async (data: MailPulseConfigForm): Promise<MailPulseConfig> => {
+    const json = await apiFetch<unknown>("/admin/settings/mailpulse", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(MailPulseConfigSchema, unwrap(json), "PUT /admin/settings/mailpulse")
+  },
+
+  test: async (data: MailPulseTestRequest): Promise<MailPulseTestResponse> => {
+    const json = await apiFetch<unknown>("/admin/settings/mailpulse/test", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(
+      MailPulseTestResponseSchema,
+      unwrap(json),
+      "POST /admin/settings/mailpulse/test",
+    )
+  },
+}

--- a/lib/contracts/mailpulse.ts
+++ b/lib/contracts/mailpulse.ts
@@ -1,0 +1,98 @@
+import { z } from "zod"
+
+/** Destinataire de test avec interrupteur actif/inactif. */
+export const MailPulseRecipientSchema = z.object({
+  value: z.string(),
+  enabled: z.boolean(),
+})
+export type MailPulseRecipient = z.infer<typeof MailPulseRecipientSchema>
+
+/** Réponse GET /admin/settings/mailpulse — la clé API n'est jamais renvoyée. */
+export const MailPulseConfigSchema = z.object({
+  enabled: z.boolean(),
+  base_url: z.string(),
+  api_key_set: z.boolean(),
+  sender_email: z.string().nullable(),
+  sender_name: z.string().nullable(),
+  default_language: z.string(),
+  timeout: z.number(),
+  real_workflows_enabled: z.boolean(),
+  test_email_enabled: z.boolean(),
+  test_whatsapp_enabled: z.boolean(),
+  test_email_recipients: z.array(MailPulseRecipientSchema),
+  test_phone_recipients: z.array(MailPulseRecipientSchema),
+  inbound_secret_set: z.boolean(),
+})
+export type MailPulseConfig = z.infer<typeof MailPulseConfigSchema>
+
+/** Corps du formulaire de configuration (PUT). Secrets write-only, vides = conservés. */
+export const MailPulseConfigFormSchema = z.object({
+  enabled: z.boolean(),
+  base_url: z
+    .string()
+    .min(1, "L'URL est requise")
+    .refine((v) => /^https?:\/\//.test(v), "L'URL doit commencer par http:// ou https://"),
+  api_key: z.string().optional(),
+  sender_email: z
+    .string()
+    .email("Email invalide")
+    .or(z.literal(""))
+    .optional(),
+  sender_name: z.string().optional(),
+  default_language: z.string(),
+  timeout: z.coerce.number().int().min(5).max(120),
+  real_workflows_enabled: z.boolean(),
+  test_email_enabled: z.boolean(),
+  test_whatsapp_enabled: z.boolean(),
+  test_email_recipients: z.array(MailPulseRecipientSchema),
+  test_phone_recipients: z.array(MailPulseRecipientSchema),
+  inbound_secret: z.string().optional(),
+})
+export type MailPulseConfigForm = z.infer<typeof MailPulseConfigFormSchema>
+
+/** Résultat d'un envoi de test individuel. */
+export const MailPulseTestResultSchema = z.object({
+  channel: z.enum(["email", "whatsapp"]),
+  recipient: z.string(),
+  ok: z.boolean(),
+  status: z.string(),
+  error_code: z.string().nullable(),
+  error_message: z.string().nullable(),
+})
+export type MailPulseTestResult = z.infer<typeof MailPulseTestResultSchema>
+
+/** Réponse POST /admin/settings/mailpulse/test. */
+export const MailPulseTestResponseSchema = z.object({
+  dry_run: z.boolean(),
+  event: z.string(),
+  sent: z.number(),
+  results: z.array(MailPulseTestResultSchema),
+  message: z.string(),
+})
+export type MailPulseTestResponse = z.infer<typeof MailPulseTestResponseSchema>
+
+export type MailPulseEvent =
+  | "payment_received"
+  | "absence_reported"
+  | "grade_published"
+  | "fee_reminder"
+export type MailPulseTestChannel = "email" | "whatsapp" | "both"
+
+export interface MailPulseTestRequest {
+  event: MailPulseEvent
+  channel: MailPulseTestChannel
+  dry_run: boolean
+}
+
+export const MAILPULSE_EVENTS: { value: MailPulseEvent; label: string }[] = [
+  { value: "payment_received", label: "Paiement reçu" },
+  { value: "absence_reported", label: "Absence signalée" },
+  { value: "grade_published", label: "Note publiée" },
+  { value: "fee_reminder", label: "Rappel de frais" },
+]
+
+export const MAILPULSE_CHANNELS: { value: MailPulseTestChannel; label: string }[] = [
+  { value: "both", label: "Email + WhatsApp" },
+  { value: "email", label: "Email seulement" },
+  { value: "whatsapp", label: "WhatsApp seulement" },
+]

--- a/lib/hooks/useMailPulse.ts
+++ b/lib/hooks/useMailPulse.ts
@@ -1,0 +1,41 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { mailpulseApi } from "@/lib/api/mailpulse"
+import type { MailPulseConfigForm, MailPulseTestRequest } from "@/lib/contracts/mailpulse"
+
+export const mailpulseKeys = {
+  all: ["mailpulse"] as const,
+}
+
+export function useMailPulseConfig() {
+  return useQuery({
+    queryKey: mailpulseKeys.all,
+    queryFn: mailpulseApi.get,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useUpdateMailPulse() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: MailPulseConfigForm) => mailpulseApi.update(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mailpulseKeys.all })
+      toast.success("Configuration MailPulse enregistrée")
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Erreur lors de l'enregistrement")
+    },
+  })
+}
+
+export function useTestMailPulse() {
+  return useMutation({
+    mutationFn: (data: MailPulseTestRequest) => mailpulseApi.test(data),
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Erreur lors de l'envoi du test")
+    },
+  })
+}


### PR DESCRIPTION
## Contexte

Onglet **MailPulse** dans `/admin/settings`, front de l'intégration MailPulse (BE #215/#216/#217). Identité visuelle MailPulse (orange, en cohérence avec l'accent KLASSCI) + design premium (système 10 couches, shadcn).

## Ce qui change

- **Onglet MailPulse** avec en-tête identitaire (pastille orange + wordmark + badge Actif/Inactif réactif).
- **Connexion** : URL, clé d'accès **masquée** (placeholder « laissez vide pour conserver » quand déjà enregistrée), expéditeur (nom + email).
- **Destinataires de test** : listes email + WhatsApp, un **interrupteur par destinataire** + interrupteur de canal, ajout/suppression (`useFieldArray`).
- **Envois réels aux parents** : interrupteur gardé (bandeau ambre d'avertissement).
- **Réponse WhatsApp « INFO »** : secret du webhook entrant (masqué, même règle que la clé).
- **Panneau de test** : évènement + canal + mode simulation → résultats par destinataire (ok/échec).

## Détails techniques

- Vertical slice : `lib/contracts/mailpulse.ts` (Zod), `lib/api/mailpulse.ts` (`apiFetch<unknown>` + `safeValidate`, jamais de cast), `lib/hooks/useMailPulse.ts` (TanStack Query + toasts).
- Composants découpés (no-god-code) : `MailPulseSection` (orchestrateur) + `MailPulseRecipientList` + `MailPulseTestPanel`.
- `tsc --noEmit` et `eslint` clean. Touch targets `h-11` mobile, tokens (dark/light).

## Test

1. `/admin/settings` onglet MailPulse : GET affiche la config (clé jamais visible).
2. Activer + saisir clé + destinataires → Enregistrer → persiste, clé conservée si laissée vide.
3. Panneau de test en simulation → liste des envois préparés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)