### PR TITLE
style(settings): MailPulse brand identity + fix tab scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Onglet MailPulse aux vraies couleurs de la marque : bandeau sombre, logo enveloppe orange et wordmark « Mail·Pulse », avec l'état de la clé API en pastille. La mise en page a été resserrée pour supprimer la barre de défilement superflue *(admin)*.
 - L'onglet Disponibilités d'un enseignant précise désormais qu'il s'agit du planning **annuel** récurrent, base de la génération de l'emploi du temps (et non un réglage semaine par semaine) ; pour une absence ponctuelle, on passe par une demande de congé *(admin)*.
 - Emploi du temps : les flèches « Semaine précédente / suivante » sont retirées au profit d'un repère fixe « Semaine type · Année {en cours} ». L'emploi du temps vaut pour toute l'année scolaire ; l'ancien sélecteur laissait croire, à tort, que chaque semaine avait son propre planning *(admin)*.
 - Bandeau de synthèse des Frais (élève, parent) repassé au dégradé bleu-orange de la marque, et indicateurs de la page Années scolaires intégrés au bandeau d'en-tête *(tous)*.

--- a/components/admin/settings/MailPulseSection.tsx
+++ b/components/admin/settings/MailPulseSection.tsx
@@ -2,20 +2,10 @@
 
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import {
-  Activity,
-  KeyRound,
-  Loader2,
-  MessageCircle,
-  Radio,
-  Send,
-  ShieldCheck,
-  Zap,
-} from "lucide-react"
+import { KeyRound, Loader2, MessageCircle, Send, ShieldCheck, Zap } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
-import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -31,15 +21,16 @@ import {
 import { DataError } from "@/components/shared/DataError"
 import { MailPulseConfigFormSchema, type MailPulseConfigForm } from "@/lib/contracts/mailpulse"
 import { useMailPulseConfig, useUpdateMailPulse } from "@/lib/hooks/useMailPulse"
+import { MailPulseBrandCard } from "./mailpulse/MailPulseBrandCard"
 import { MailPulseRecipientList } from "./mailpulse/MailPulseRecipientList"
 import { MailPulseTestPanel } from "./mailpulse/MailPulseTestPanel"
 
 /** Barre d'en-tête d'une sous-section (couche 4). */
 function SectionBar({ icon: Icon, title }: { icon: typeof Zap; title: string }) {
   return (
-    <div className="flex items-center gap-2.5 border-b pb-3">
-      <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
-        <Icon className="h-4 w-4" />
+    <div className="flex items-center gap-2.5 border-b pb-2.5">
+      <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
+        <Icon className="h-3.5 w-3.5" />
       </span>
       <h2 className="text-sm font-semibold">{title}</h2>
     </div>
@@ -50,10 +41,13 @@ export function MailPulseSection() {
   const { data: config, isLoading, isError, refetch } = useMailPulseConfig()
   const { mutate, isPending } = useUpdateMailPulse()
 
-  if (isLoading) return <Skeleton className="h-96 w-full rounded-xl" />
+  if (isLoading) return <Skeleton className="h-80 w-full rounded-xl" />
   if (isError || !config)
     return (
-      <DataError message="Impossible de charger la configuration MailPulse." onRetry={() => refetch()} />
+      <DataError
+        message="Impossible de charger la configuration MailPulse."
+        onRetry={() => refetch()}
+      />
     )
 
   return <MailPulseForm config={config} save={mutate} saving={isPending} />
@@ -87,48 +81,24 @@ function MailPulseForm({
     },
   })
 
-  const enabled = form.watch("enabled")
-
   return (
-    <div className="space-y-6">
-      <Card className="overflow-hidden border-0 shadow-sm ring-1 ring-border">
-        {/* En-tête identitaire MailPulse */}
-        <div className="flex items-center gap-4 border-b bg-gradient-to-r from-[#fff7ed] to-transparent p-5 dark:from-[#f5821f]/10">
-          <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
-            <Radio className="h-6 w-6" />
-          </span>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <h2 className="text-lg font-bold tracking-tight">MailPulse</h2>
-              <Badge
-                className={
-                  enabled
-                    ? "bg-emerald-600 text-white hover:bg-emerald-600"
-                    : "bg-muted text-muted-foreground hover:bg-muted"
-                }
-              >
-                {enabled ? "Actif" : "Inactif"}
-              </Badge>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Notifications aux parents par email et WhatsApp
-            </p>
-          </div>
-        </div>
+    <div className="space-y-4">
+      <MailPulseBrandCard apiKeySet={config.api_key_set} />
 
-        <CardContent className="p-5">
+      <Card className="border-0 shadow-sm ring-1 ring-border">
+        <CardContent className="p-4 sm:p-5">
           <Form {...form}>
-            <form onSubmit={form.handleSubmit((d) => save(d))} className="space-y-6">
+            <form onSubmit={form.handleSubmit((d) => save(d))} className="space-y-5">
               {/* Interrupteur maître */}
               <FormField
                 control={form.control}
                 name="enabled"
                 render={({ field }) => (
-                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 px-4 py-3">
+                  <FormItem className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 px-4 py-2.5">
                     <div className="space-y-0.5">
                       <FormLabel className="text-sm font-semibold">Activer MailPulse</FormLabel>
                       <FormDescription className="text-xs">
-                        Permet les envois de test et, si les workflows réels sont activés, les
+                        Autorise les envois de test et, si les workflows réels sont activés, les
                         notifications automatiques.
                       </FormDescription>
                     </div>
@@ -140,9 +110,9 @@ function MailPulseForm({
               />
 
               {/* Connexion */}
-              <section className="space-y-4">
+              <section className="space-y-3">
                 <SectionBar icon={KeyRound} title="Connexion" />
-                <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-3 sm:grid-cols-2">
                   <FormField
                     control={form.control}
                     name="base_url"
@@ -170,7 +140,7 @@ function MailPulseForm({
                             className="h-11 sm:h-10"
                             placeholder={
                               config.api_key_set
-                                ? "•••••••• enregistrée, laissez vide pour conserver"
+                                ? "•••• enregistrée, laissez vide pour conserver"
                                 : "Coller la clé MailPulse"
                             }
                           />
@@ -186,7 +156,11 @@ function MailPulseForm({
                       <FormItem>
                         <FormLabel className="text-xs">Nom expéditeur</FormLabel>
                         <FormControl>
-                          <Input {...field} className="h-11 sm:h-10" placeholder="Lycée Saint-Augustin" />
+                          <Input
+                            {...field}
+                            className="h-11 sm:h-10"
+                            placeholder="Lycée Saint-Augustin"
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -214,10 +188,10 @@ function MailPulseForm({
               </section>
 
               {/* Destinataires de test */}
-              <section className="space-y-4">
+              <section className="space-y-3">
                 <SectionBar icon={Send} title="Destinataires de test" />
-                <div className="grid gap-5 sm:grid-cols-2">
-                  <div className="space-y-2.5">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
                     <FormField
                       control={form.control}
                       name="test_email_enabled"
@@ -236,7 +210,7 @@ function MailPulseForm({
                       addLabel="Ajouter un email"
                     />
                   </div>
-                  <div className="space-y-2.5">
+                  <div className="space-y-2">
                     <FormField
                       control={form.control}
                       name="test_whatsapp_enabled"
@@ -258,67 +232,65 @@ function MailPulseForm({
                 </div>
               </section>
 
-              {/* Workflows réels */}
-              <section className="space-y-3">
-                <SectionBar icon={Zap} title="Envois réels aux parents" />
-                <FormField
-                  control={form.control}
-                  name="real_workflows_enabled"
-                  render={({ field }) => (
-                    <FormItem className="flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-500/30 dark:bg-amber-500/10">
-                      <div className="space-y-0.5">
-                        <FormLabel className="text-sm font-semibold text-amber-900 dark:text-amber-200">
-                          Notifier les vrais parents
-                        </FormLabel>
-                        <FormDescription className="text-xs text-amber-800 dark:text-amber-300/80">
-                          Une fois activé, un paiement, une absence ou une note déclenche l&apos;envoi
-                          aux parents concernés (selon les canaux de l&apos;établissement).
-                        </FormDescription>
-                      </div>
-                      <FormControl>
-                        <Switch checked={field.value} onCheckedChange={field.onChange} />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </section>
+              {/* Envois réels + réponse INFO côte à côte pour compacter */}
+              <div className="grid gap-4 lg:grid-cols-2">
+                <section className="space-y-3">
+                  <SectionBar icon={Zap} title="Envois réels aux parents" />
+                  <FormField
+                    control={form.control}
+                    name="real_workflows_enabled"
+                    render={({ field }) => (
+                      <FormItem className="flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 dark:border-amber-500/30 dark:bg-amber-500/10">
+                        <div className="space-y-0.5">
+                          <FormLabel className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+                            Notifier les vrais parents
+                          </FormLabel>
+                          <FormDescription className="text-xs text-amber-800 dark:text-amber-300/80">
+                            Un paiement, une absence ou une note déclenche l&apos;envoi aux parents.
+                          </FormDescription>
+                        </div>
+                        <FormControl>
+                          <Switch checked={field.value} onCheckedChange={field.onChange} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </section>
 
-              {/* Réponse INFO WhatsApp */}
-              <section className="space-y-3">
-                <SectionBar icon={MessageCircle} title="Réponse WhatsApp « INFO »" />
-                <p className="text-xs text-muted-foreground">
-                  Un parent écrit <strong>INFO</strong> sur le WhatsApp de l&apos;école et reçoit la
-                  synthèse de ses enfants (classe, moyenne, absences, reste à payer). Renseignez un
-                  secret partagé, à communiquer à MailPulse pour sécuriser le relais.
-                </p>
-                <FormField
-                  control={form.control}
-                  name="inbound_secret"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Secret du webhook entrant</FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          type="password"
-                          autoComplete="off"
-                          className="h-11 sm:h-10"
-                          placeholder={
-                            config.inbound_secret_set
-                              ? "•••••••• enregistré, laissez vide pour conserver"
-                              : "Définir un secret (ex: chaîne aléatoire longue)"
-                          }
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </section>
+                <section className="space-y-3">
+                  <SectionBar icon={MessageCircle} title="Réponse WhatsApp « INFO »" />
+                  <FormField
+                    control={form.control}
+                    name="inbound_secret"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            type="password"
+                            autoComplete="off"
+                            className="h-11 sm:h-10"
+                            placeholder={
+                              config.inbound_secret_set
+                                ? "•••• secret enregistré, laissez vide"
+                                : "Secret partagé (chaîne aléatoire longue)"
+                            }
+                          />
+                        </FormControl>
+                        <FormDescription className="text-xs">
+                          Un parent écrit INFO sur WhatsApp et reçoit la synthèse de ses enfants.
+                          Communiquez ce secret à MailPulse.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </section>
+              </div>
 
               <Separator />
 
-              <div className="flex items-center justify-between gap-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
                   <ShieldCheck className="h-3.5 w-3.5" />
                   Clé et secret ne sont jamais réaffichés.
@@ -335,11 +307,6 @@ function MailPulseForm({
 
       {/* Panneau de test — hors du formulaire de config */}
       <MailPulseTestPanel />
-
-      <p className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground">
-        <Activity className="h-3.5 w-3.5 text-[#f5821f]" />
-        Propulsé par MailPulse, la plateforme de messagerie de KLASSCI.
-      </p>
     </div>
   )
 }

--- a/components/admin/settings/mailpulse/MailPulseBrandCard.tsx
+++ b/components/admin/settings/mailpulse/MailPulseBrandCard.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { KeyRound, Lock } from "lucide-react"
+
+/**
+ * Bloc d'identité MailPulse fidèle à la marque : fond sombre, monogramme
+ * enveloppe orange, wordmark « Mail » clair + « Pulse » orange, tagline et
+ * badge d'état de la clé API. Repris de l'intégration KLASSCIv2.
+ */
+export function MailPulseBrandCard({ apiKeySet }: { apiKeySet: boolean }) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 rounded-2xl border border-[#18181b] bg-[#09090b] p-4 text-[#fafafa] sm:p-5">
+      {/* Monogramme enveloppe */}
+      <div className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-[#27272a] bg-[#09090b]">
+        <div
+          className="pointer-events-none absolute inset-2 rounded-full blur-[12px]"
+          style={{ background: "rgba(249,115,22,0.22)" }}
+        />
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" className="relative z-10 h-7 w-7">
+          <path
+            d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"
+            stroke="#f97316"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M4 6l8 5 8-5"
+            stroke="#f97316"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+
+      {/* Wordmark + tagline */}
+      <div className="min-w-0 flex-1">
+        <p className="text-xl font-extrabold leading-none tracking-tight">
+          Mail<span className="text-[#f97316]">Pulse</span>
+        </p>
+        <p className="mt-1.5 text-[13px] text-[#a1a1aa]">
+          Email, WhatsApp et automatisations transactionnelles
+        </p>
+      </div>
+
+      {/* Badge état clé API */}
+      {apiKeySet ? (
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-300 bg-emerald-50 px-2.5 py-1.5 text-xs font-bold text-emerald-700">
+          <Lock className="h-3.5 w-3.5" />
+          Clé API configurée
+        </span>
+      ) : (
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-orange-200 bg-orange-50 px-2.5 py-1.5 text-xs font-bold text-orange-800">
+          <KeyRound className="h-3.5 w-3.5" />
+          Clé API à configurer
+        </span>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Contexte

Suite au retour de Marcel : appliquer la **vraie identité visuelle MailPulse** (extraite du projet MailPulse) et corriger le **double scrollbar** de l'onglet (même bug que l'onglet Notifications).

## Ce qui change

- Nouveau **bandeau d'identité MailPulse** fidèle à la marque (`MailPulseBrandCard`) : fond sombre `#09090b`, monogramme enveloppe SVG orange `#f97316` (avec halo flouté), wordmark « Mail » clair + « Pulse » orange, tagline « Email, WhatsApp et automatisations transactionnelles », et pastille d'état (« Clé API configurée » verte / « à configurer » ambre).
- **Compaction** de tout l'onglet (espacements resserrés, sections « Envois réels » et « Réponse INFO » mises côte à côte en 2 colonnes) pour supprimer la barre de défilement superflue.

## Test

`/admin/settings` onglet MailPulse : bandeau sombre à la marque, contenu plus court, pas de second scrollbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)