### PR TITLE
feat(grades): premium redesign + fix subject cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Page Notes repensée dans la ligne premium KLASSCI : bandeau bleu-orange avec les indicateurs clés (évaluations, terminées, en retard, taux de saisie), filtres et actions PDF regroupés, onglets de statut harmonisés *(admin)*.
 - Onglet MailPulse aux vraies couleurs de la marque : bandeau sombre, logo enveloppe orange et wordmark « Mail·Pulse », avec l'état de la clé API en pastille. La mise en page a été resserrée pour supprimer la barre de défilement superflue *(admin)*.
 - L'onglet Disponibilités d'un enseignant précise désormais qu'il s'agit du planning **annuel** récurrent, base de la génération de l'emploi du temps (et non un réglage semaine par semaine) ; pour une absence ponctuelle, on passe par une demande de congé *(admin)*.
 - Emploi du temps : les flèches « Semaine précédente / suivante » sont retirées au profit d'un repère fixe « Semaine type · Année {en cours} ». L'emploi du temps vaut pour toute l'année scolaire ; l'ancien sélecteur laissait croire, à tort, que chaque semaine avait son propre planning *(admin)*.
@@ -47,6 +48,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Page Notes : à la sélection d'une classe, la liste « Matière » affichait toutes les matières de tous les niveaux (doublons). Elle ne propose désormais que les matières réellement enseignées dans la classe choisie *(admin)*.
 - Après une mise à jour de la plateforme, un onglet resté ouvert pouvait afficher « Une erreur est survenue / Loading chunk failed » à la navigation ; la page se recharge désormais automatiquement pour récupérer la dernière version *(tous)*.
 - Onglet Documents de la fiche élève : les pièces jointes ajoutées sont désormais nettement séparées du formulaire d'envoi (section « Documents ajoutés »), avec un bouton Aperçu pour prévisualiser le PDF ou l'image en plus du téléchargement *(admin)*.
 - Onglet Notifications des Paramètres : les options sont plus compactes, la page est moins haute et ne provoque plus de défilement inutile *(admin)*.

--- a/components/admin/grades/GradesFilters.tsx
+++ b/components/admin/grades/GradesFilters.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+interface ClassOption {
+  id: number
+  name: string
+  level_name?: string | null
+  series_name?: string | null
+}
+
+interface SubjectOption {
+  id: number
+  name: string
+}
+
+interface GradesFiltersProps {
+  classes: ClassOption[]
+  subjects: SubjectOption[]
+  classId: number | null
+  subjectId: number | null
+  trimester: number | null
+  onClassChange: (id: number | null) => void
+  onSubjectChange: (id: number | null) => void
+  onTrimesterChange: (t: number | null) => void
+}
+
+export function GradesFilters({
+  classes,
+  subjects,
+  classId,
+  subjectId,
+  trimester,
+  onClassChange,
+  onSubjectChange,
+  onTrimesterChange,
+}: GradesFiltersProps) {
+  const noClass = classId === null
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+      <div className="min-w-[180px] flex-1">
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">Classe</label>
+        <Select
+          value={classId ? String(classId) : ""}
+          onValueChange={(v) => onClassChange(v ? Number(v) : null)}
+        >
+          <SelectTrigger className="h-11 sm:h-10">
+            <SelectValue placeholder="Choisir une classe" />
+          </SelectTrigger>
+          <SelectContent>
+            {classes.map((c) => (
+              <SelectItem key={c.id} value={String(c.id)}>
+                {c.name}
+                {c.level_name ? ` · ${c.level_name}` : ""}
+                {c.series_name ? ` · ${c.series_name}` : ""}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="min-w-[160px] flex-1">
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">Matière</label>
+        <Select
+          value={subjectId ? String(subjectId) : "all"}
+          onValueChange={(v) => onSubjectChange(v === "all" ? null : Number(v))}
+          disabled={noClass}
+        >
+          <SelectTrigger className="h-11 sm:h-10">
+            <SelectValue placeholder="Toutes" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Toutes les matières</SelectItem>
+            {subjects.map((s) => (
+              <SelectItem key={s.id} value={String(s.id)}>
+                {s.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {noClass && (
+          <p className="mt-1 text-[11px] text-muted-foreground">Choisissez d&apos;abord la classe</p>
+        )}
+      </div>
+
+      <div className="w-32">
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">Trimestre</label>
+        <Select
+          value={trimester ? String(trimester) : "all"}
+          onValueChange={(v) => onTrimesterChange(v === "all" ? null : Number(v))}
+          disabled={noClass}
+        >
+          <SelectTrigger className="h-11 sm:h-10">
+            <SelectValue placeholder="Tous" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Tous</SelectItem>
+            <SelectItem value="1">T1</SelectItem>
+            <SelectItem value="2">T2</SelectItem>
+            <SelectItem value="3">T3</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/grades/GradesSupervisor.tsx
+++ b/components/admin/grades/GradesSupervisor.tsx
@@ -1,31 +1,21 @@
 "use client"
 
-import { useState, useMemo } from "react"
-import Link from "next/link"
-import type { Route } from "next"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 import {
   AlertTriangle,
   CheckCircle2,
   ClipboardList,
-  Edit3,
   FileText,
-  Hourglass,
   Info,
   Loader2,
   Plus,
   TrendingUp,
 } from "lucide-react"
-import { cn } from "@/lib/utils"
-import { useEvaluations } from "@/lib/hooks/useGrades"
-import { useClasses } from "@/lib/hooks/useClasses"
-import { useSubjects } from "@/lib/hooks/useSubjects"
-import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
-import { usePermissions } from "@/lib/hooks/usePermissions"
-import type { Evaluation } from "@/lib/contracts/grade"
-import { Badge } from "@/components/ui/badge"
+import { PageHero, heroAccentBtn } from "@/components/shared/PageHero"
+import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ExportMenu } from "@/components/export/ExportMenu"
 import { PdfPreviewButton } from "@/components/shared/PdfPreviewButton"
 import { apiFetchBlob } from "@/lib/api/client"
@@ -33,49 +23,40 @@ import {
   fileSafeName,
   triggerBlobDownload,
 } from "@/components/admin/classes/detail/class-downloads"
+import { useEvaluations } from "@/lib/hooks/useGrades"
+import { useClasses } from "@/lib/hooks/useClasses"
+import { useSubjects } from "@/lib/hooks/useSubjects"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { usePermissions } from "@/lib/hooks/usePermissions"
 import { useSettings } from "@/lib/hooks/useSettings"
 import { EvaluationCreateModal } from "./EvaluationCreateModal"
 import { buildGradesExportPayload } from "./grades-export"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-
-const TYPE_LABELS: Record<string, string> = {
-  controle: "Contrôle",
-  devoir: "Devoir",
-  examen: "Examen",
-  oral: "Oral",
-}
-
-type FilterTab = "all" | "todo" | "overdue" | "done"
-
-function isOverdue(evaluation: Evaluation): boolean {
-  const daysAgo = (Date.now() - new Date(evaluation.date).getTime()) / (1000 * 60 * 60 * 24)
-  return daysAgo > 3 && evaluation.graded_students < evaluation.total_students
-}
-
-function isDone(evaluation: Evaluation): boolean {
-  return evaluation.total_students > 0 && evaluation.graded_students === evaluation.total_students
-}
+import { GradesFilters } from "./GradesFilters"
+import { GradesTable } from "./GradesTable"
+import { TAB_LABELS, isDone, isOverdue, type FilterTab } from "./grades-helpers"
 
 export function GradesSupervisor() {
   const { data: classesData } = useClasses({ size: 100 })
   const classes = classesData?.items ?? []
 
-  const { data: subjectsData } = useSubjects({ size: 100 })
-  const subjects = subjectsData?.items ?? []
+  const [classId, setClassId] = useState<number | null>(null)
+  const [subjectId, setSubjectId] = useState<number | null>(null)
+  const [trimester, setTrimester] = useState<number | null>(null)
+  const [tab, setTab] = useState<FilterTab>("all")
+  const [createOpen, setCreateOpen] = useState(false)
+  const [downloadingReport, setDownloadingReport] = useState(false)
+
+  // Cascade : les matières sont filtrées par la classe (niveau + série). On
+  // n'affiche que les INSTANCES (level_id défini), pas l'entrée catalogue, pour
+  // ne montrer que les matières réellement enseignées dans cette classe.
+  const { data: subjectsData } = useSubjects(
+    classId ? { class_id: classId, size: 100 } : { size: 100 },
+  )
+  const subjects = useMemo(() => {
+    const raw = subjectsData?.items ?? []
+    const instances = raw.filter((s) => s.level_id !== null)
+    return instances.length > 0 ? instances : raw
+  }, [subjectsData])
 
   const { data: yearsData } = useAcademicYears()
   const years = yearsData?.items ?? []
@@ -86,14 +67,9 @@ export function GradesSupervisor() {
   const canCreate = has("grades:write")
   const { data: settings } = useSettings()
 
-  const [classId, setClassId] = useState<number | null>(null)
-  const [subjectId, setSubjectId] = useState<number | null>(null)
-  const [trimester, setTrimester] = useState<number | null>(null)
-  const [tab, setTab] = useState<FilterTab>("all")
-  const [createOpen, setCreateOpen] = useState(false)
-  const [downloadingReport, setDownloadingReport] = useState(false)
-
   const { data: evaluations, isLoading, error } = useEvaluations(classId ?? 0)
+
+  const noClass = classId === null
 
   const filtered = useMemo(() => {
     if (!evaluations) return []
@@ -119,47 +95,30 @@ export function GradesSupervisor() {
     return { total, done, overdue, todo, completionRate }
   }, [evaluations])
 
-  if (error) {
-    return (
-      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-6 text-center">
-        <p className="text-sm text-destructive">{error.message}</p>
-      </div>
-    )
-  }
-
-  const noClassSelected = classId === null
-
-  // Résumé lisible du contexte pour l'entête du document exporté.
-  const TAB_LABELS: Record<FilterTab, string> = {
-    all: "Toutes",
-    todo: "À saisir",
-    overdue: "En retard",
-    done: "Terminées",
-  }
-  const exportFilters = (() => {
-    const parts: string[] = []
-    const className = classes.find((c) => c.id === classId)?.name
-    if (className) parts.push(`Classe ${className}`)
-    const subjectName = subjects.find((s) => s.id === subjectId)?.name
-    if (subjectName) parts.push(subjectName)
-    if (trimester) parts.push(`T${trimester}`)
-    if (tab !== "all") parts.push(TAB_LABELS[tab])
-    return parts.length > 0 ? parts.join(" · ") : undefined
-  })()
+  const dash = "—"
+  const kpis = [
+    { label: "Évaluations", value: noClass ? dash : String(stats.total), icon: ClipboardList },
+    { label: "Terminées", value: noClass ? dash : String(stats.done), icon: CheckCircle2 },
+    { label: "En retard", value: noClass ? dash : String(stats.overdue), icon: AlertTriangle },
+    {
+      label: "Taux saisi",
+      value: noClass ? dash : `${stats.completionRate}%`,
+      icon: TrendingUp,
+    },
+  ]
 
   // Relevé de notes rempli : n'a de sens que par matière ET trimestre précis.
-  const reportReady =
-    classId != null && subjectId != null && trimester != null && ayId != null
+  const reportReady = classId != null && subjectId != null && trimester != null && ayId != null
   const reportClassName = classes.find((c) => c.id === classId)?.name
   const reportSubjectName = subjects.find((s) => s.id === subjectId)?.name
   const reportLabel = `le relevé de notes${
     reportClassName ? ` de la classe ${reportClassName}` : ""
-  }${reportSubjectName ? ` en ${reportSubjectName}` : ""}${
-    trimester ? ` (T${trimester})` : ""
-  }`
+  }${reportSubjectName ? ` en ${reportSubjectName}` : ""}${trimester ? ` (T${trimester})` : ""}`
   const reportFilename = `releve-notes-${fileSafeName(
     reportClassName ?? "classe",
   )}-${fileSafeName(reportSubjectName ?? "matiere")}-T${trimester}.pdf`
+  const reportHint = "Choisir une classe, une matière et un trimestre"
+
   const fetchGradeReport = () =>
     apiFetchBlob(
       `/reports/classes/${classId}/grade-report?subject_id=${subjectId}&trimester=${trimester}&academic_year_id=${ayId}`,
@@ -172,40 +131,73 @@ export function GradesSupervisor() {
       triggerBlobDownload(await fetchGradeReport(), reportFilename)
     } catch (err) {
       toast.error("Téléchargement impossible", {
-        description:
-          err instanceof Error ? err.message : "Erreur lors de la génération du PDF",
+        description: err instanceof Error ? err.message : "Erreur lors de la génération du PDF",
       })
     } finally {
       setDownloadingReport(false)
     }
   }
 
-  const reportHint = "Choisir une classe, une matière et un trimestre"
+  const exportFilters = (() => {
+    const parts: string[] = []
+    if (reportClassName) parts.push(`Classe ${reportClassName}`)
+    if (reportSubjectName) parts.push(reportSubjectName)
+    if (trimester) parts.push(`T${trimester}`)
+    if (tab !== "all") parts.push(TAB_LABELS[tab])
+    return parts.length > 0 ? parts.join(" · ") : undefined
+  })()
 
-  const tabsOrder: { key: FilterTab; label: string; count: number }[] = [
-    { key: "all", label: "Toutes", count: stats.total },
-    { key: "todo", label: "À saisir", count: stats.todo },
-    { key: "overdue", label: "En retard", count: stats.overdue },
-    { key: "done", label: "Terminées", count: stats.done },
+  const tabsOrder: { key: FilterTab; count: number }[] = [
+    { key: "all", count: stats.total },
+    { key: "todo", count: stats.todo },
+    { key: "overdue", count: stats.overdue },
+    { key: "done", count: stats.done },
   ]
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-6 text-center">
+        <p className="text-sm text-destructive">{error.message}</p>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-5">
-      {/* ─── Hero KPI card ─────────────────────────────────────────── */}
-      <div className="rounded-2xl border bg-gradient-to-br from-primary/5 via-card to-card p-5">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-primary">
-              Supervision des notes
-            </span>
-            <h1 className="mt-1 font-serif text-2xl tracking-tight">Évaluations &amp; saisies</h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Suivez la progression des évaluations et saisissez au nom des enseignants si besoin.
-            </p>
-          </div>
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+      <PageHero
+        icon={ClipboardList}
+        title="Évaluations & saisies"
+        subtitle="Suivez la progression des évaluations et saisissez au nom des enseignants si besoin."
+        kpis={kpis}
+        actions={
+          canCreate ? (
+            <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Nouvelle évaluation
+            </button>
+          ) : undefined
+        }
+      />
+
+      {/* Filtres + actions documentaires */}
+      <Card className="border-0 shadow-sm ring-1 ring-border">
+        <CardContent className="space-y-3 p-4 sm:p-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <GradesFilters
+              classes={classes}
+              subjects={subjects}
+              classId={classId}
+              subjectId={subjectId}
+              trimester={trimester}
+              onClassChange={(id) => {
+                setClassId(id)
+                setSubjectId(null)
+              }}
+              onSubjectChange={setSubjectId}
+              onTrimesterChange={setTrimester}
+            />
             <div
-              className="flex items-center gap-2"
+              className="flex flex-wrap items-center gap-2"
               title={reportReady ? undefined : reportHint}
             >
               <PdfPreviewButton
@@ -227,293 +219,57 @@ export function GradesSupervisor() {
                 ) : (
                   <FileText className="mr-2 h-4 w-4" aria-hidden="true" />
                 )}
-                Relevé de notes (PDF)
+                Relevé (PDF)
               </Button>
+              <ExportMenu
+                filename="notes"
+                disabled={noClass || filtered.length === 0}
+                getPayload={() =>
+                  buildGradesExportPayload({
+                    evaluations: filtered,
+                    settings,
+                    filters: exportFilters,
+                  })
+                }
+              />
             </div>
-            <ExportMenu
-              filename="notes"
-              disabled={noClassSelected || filtered.length === 0}
-              getPayload={() =>
-                buildGradesExportPayload({ evaluations: filtered, settings, filters: exportFilters })
-              }
-            />
-            {canCreate && (
-              <Button onClick={() => setCreateOpen(true)}>
-                <Plus className="mr-2 h-4 w-4" />
-                Nouvelle évaluation
-              </Button>
-            )}
           </div>
-        </div>
 
-        {!noClassSelected && (
-          <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <KpiTile
-              label="Évaluations"
-              value={String(stats.total)}
-              icon={ClipboardList}
-              tone="neutral"
-            />
-            <KpiTile
-              label="Terminées"
-              value={String(stats.done)}
-              icon={CheckCircle2}
-              tone="success"
-            />
-            <KpiTile
-              label="En retard"
-              value={String(stats.overdue)}
-              icon={AlertTriangle}
-              tone={stats.overdue > 0 ? "danger" : "neutral"}
-            />
-            <KpiTile
-              label="Taux saisi"
-              value={`${stats.completionRate}%`}
-              icon={TrendingUp}
-              tone={stats.completionRate >= 80 ? "success" : "warning"}
-            />
-          </div>
-        )}
-      </div>
+          {!noClass && !canCreate && (
+            <div className="flex items-start gap-2 rounded-lg border border-blue-100 bg-blue-50/50 px-3 py-2 text-xs text-blue-900 dark:border-blue-500/20 dark:bg-blue-500/10 dark:text-blue-200">
+              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-600" />
+              <p>
+                Les évaluations sont créées par les enseignants depuis leur portail. Vous pouvez
+                saisir les notes au nom d&apos;un enseignant via{" "}
+                <span className="font-medium">«&nbsp;Saisir&nbsp;»</span>.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
-      {/* ─── Filters ────────────────────────────────────────────────── */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
-        <div className="flex-1 min-w-[180px]">
-          <label className="mb-1 block text-xs font-medium text-muted-foreground">Classe</label>
-          <Select
-            value={classId ? String(classId) : ""}
-            onValueChange={(v) => setClassId(v ? Number(v) : null)}
-          >
-            <SelectTrigger className="h-10">
-              <SelectValue placeholder="Choisir une classe" />
-            </SelectTrigger>
-            <SelectContent>
-              {classes.map((c) => (
-                <SelectItem key={c.id} value={String(c.id)}>
-                  {c.name}
-                  {c.level_name ? ` · ${c.level_name}` : ""}
-                  {c.series_name ? ` · ${c.series_name}` : ""}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="flex-1 min-w-[160px]">
-          <label className="mb-1 block text-xs font-medium text-muted-foreground">Matière</label>
-          <Select
-            value={subjectId ? String(subjectId) : "all"}
-            onValueChange={(v) => setSubjectId(v === "all" ? null : Number(v))}
-            disabled={noClassSelected}
-          >
-            <SelectTrigger className="h-10">
-              <SelectValue placeholder="Toutes" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Toutes les matières</SelectItem>
-              {subjects.map((s) => (
-                <SelectItem key={s.id} value={String(s.id)}>
-                  {s.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="w-32">
-          <label className="mb-1 block text-xs font-medium text-muted-foreground">Trimestre</label>
-          <Select
-            value={trimester ? String(trimester) : "all"}
-            onValueChange={(v) => setTrimester(v === "all" ? null : Number(v))}
-            disabled={noClassSelected}
-          >
-            <SelectTrigger className="h-10">
-              <SelectValue placeholder="Tous" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Tous</SelectItem>
-              <SelectItem value="1">T1</SelectItem>
-              <SelectItem value="2">T2</SelectItem>
-              <SelectItem value="3">T3</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-
-      {/* ─── Info contextuelle (uniquement si l'user ne peut pas créer) ── */}
-      {!noClassSelected && !canCreate && (
-        <div className="flex items-start gap-2 rounded-lg border border-blue-100 bg-blue-50/50 px-3 py-2 text-xs text-blue-900">
-          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-600" />
-          <p>
-            Les évaluations sont créées par les enseignants depuis leur portail. Vous
-            pouvez saisir les notes au nom d&apos;un enseignant en cliquant{" "}
-            <span className="font-medium">«&nbsp;Saisir&nbsp;»</span> sur une évaluation
-            existante.
-          </p>
-        </div>
-      )}
-
-      {/* ─── Tabs ──────────────────────────────────────────────────── */}
-      {!noClassSelected && (
-        <div className="flex flex-wrap gap-1 border-b">
-          {tabsOrder.map((t) => (
-            <button
-              key={t.key}
-              type="button"
-              onClick={() => setTab(t.key)}
-              className={cn(
-                "relative px-4 py-2 text-sm font-medium transition-colors",
-                tab === t.key
-                  ? "text-primary"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <span className="flex items-center gap-2">
-                {t.label}
-                <span
-                  className={cn(
-                    "rounded-full px-1.5 py-0.5 text-[10px] font-semibold tabular-nums",
-                    tab === t.key
-                      ? "bg-primary/10 text-primary"
-                      : "bg-muted text-muted-foreground",
-                  )}
-                >
+      {/* Onglets de filtrage */}
+      {!noClass && (
+        <Tabs value={tab} onValueChange={(v) => setTab(v as FilterTab)}>
+          <TabsList>
+            {tabsOrder.map((t) => (
+              <TabsTrigger key={t.key} value={t.key} className="gap-1.5">
+                {TAB_LABELS[t.key]}
+                <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-muted-foreground">
                   {t.count}
                 </span>
-              </span>
-              {tab === t.key && (
-                <span className="absolute -bottom-px left-0 right-0 h-0.5 bg-primary" />
-              )}
-            </button>
-          ))}
-        </div>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
       )}
 
-      {/* ─── Table ─────────────────────────────────────────────────── */}
-      <div className="overflow-hidden rounded-xl border bg-card">
-        <Table>
-          <TableHeader>
-            <TableRow className="hover:bg-transparent">
-              <TableHead>Évaluation</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead>Matière</TableHead>
-              <TableHead className="hidden md:table-cell">Date</TableHead>
-              <TableHead className="hidden lg:table-cell text-center">Coeff.</TableHead>
-              <TableHead>Progression</TableHead>
-              <TableHead>Statut</TableHead>
-              <TableHead className="text-right">Action</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {noClassSelected ? (
-              <TableRow>
-                <TableCell colSpan={8} className="h-32 text-center">
-                  <div className="flex flex-col items-center gap-2 text-muted-foreground">
-                    <ClipboardList className="h-8 w-8 opacity-40" />
-                    <p className="text-sm">Choisissez une classe pour afficher ses évaluations</p>
-                  </div>
-                </TableCell>
-              </TableRow>
-            ) : isLoading ? (
-              Array.from({ length: 5 }).map((_, i) => (
-                <TableRow key={i}>
-                  {Array.from({ length: 8 }).map((_, j) => (
-                    <TableCell key={j}>
-                      <Skeleton className="h-4 w-full" />
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : filtered.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={8} className="h-24 text-center text-sm text-muted-foreground">
-                  Aucune évaluation ne correspond aux filtres.
-                </TableCell>
-              </TableRow>
-            ) : (
-              filtered.map((evaluation) => {
-                const overdue = isOverdue(evaluation)
-                const complete = isDone(evaluation)
-                const progressPct =
-                  evaluation.total_students > 0
-                    ? (evaluation.graded_students / evaluation.total_students) * 100
-                    : 0
-                return (
-                  <TableRow key={evaluation.id} className={cn(overdue && "bg-destructive/5")}>
-                    <TableCell className="font-medium">{evaluation.title}</TableCell>
-                    <TableCell>
-                      <Badge variant="secondary" className="text-[10px] uppercase">
-                        {TYPE_LABELS[evaluation.type] ?? evaluation.type}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-sm">{evaluation.subject_name}</TableCell>
-                    <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
-                      {new Date(evaluation.date).toLocaleDateString("fr-FR", {
-                        day: "numeric",
-                        month: "short",
-                      })}
-                    </TableCell>
-                    <TableCell className="hidden lg:table-cell text-center text-sm tabular-nums">
-                      {evaluation.coefficient}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-2">
-                        <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
-                          <div
-                            className={cn(
-                              "h-full rounded-full transition-all",
-                              complete ? "bg-emerald-500" : overdue ? "bg-destructive" : "bg-primary",
-                            )}
-                            style={{ width: `${progressPct}%` }}
-                          />
-                        </div>
-                        <span className="text-xs tabular-nums text-muted-foreground">
-                          {evaluation.graded_students}/{evaluation.total_students}
-                        </span>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      {overdue ? (
-                        <Badge variant="destructive" className="gap-1 text-[10px]">
-                          <AlertTriangle className="h-3 w-3" />
-                          En retard
-                        </Badge>
-                      ) : complete ? (
-                        <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100 text-[10px] gap-1">
-                          <CheckCircle2 className="h-3 w-3" />
-                          Complète
-                        </Badge>
-                      ) : (
-                        <Badge variant="outline" className="gap-1 text-[10px]">
-                          <Hourglass className="h-3 w-3" />
-                          En cours
-                        </Badge>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <Button
-                        asChild
-                        size="sm"
-                        variant={complete ? "outline" : "default"}
-                        className="h-8"
-                      >
-                        <Link
-                          href={
-                            `/admin/grades/${evaluation.id}?classId=${classId}` as Route
-                          }
-                        >
-                          <Edit3 className="mr-1 h-3 w-3" />
-                          {complete ? "Réviser" : "Saisir"}
-                        </Link>
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                )
-              })
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <GradesTable
+        evaluations={filtered}
+        isLoading={isLoading}
+        noClassSelected={noClass}
+        classId={classId}
+      />
 
       {canCreate && (
         <EvaluationCreateModal
@@ -522,39 +278,6 @@ export function GradesSupervisor() {
           defaultClassId={classId}
         />
       )}
-    </div>
-  )
-}
-
-// ─────────────────────────────────────────────────────────────────────────
-// KpiTile sub-component
-// ─────────────────────────────────────────────────────────────────────────
-
-interface KpiTileProps {
-  label: string
-  value: string
-  icon: React.ComponentType<{ className?: string }>
-  tone: "success" | "warning" | "danger" | "neutral"
-}
-
-function KpiTile({ label, value, icon: Icon, tone }: KpiTileProps) {
-  return (
-    <div className="rounded-lg border bg-card/50 p-3">
-      <div className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-        <Icon className="h-3 w-3" />
-        {label}
-      </div>
-      <div
-        className={cn(
-          "mt-1 text-xl font-semibold tabular-nums",
-          tone === "success" && "text-emerald-600",
-          tone === "warning" && "text-amber-600",
-          tone === "danger" && "text-destructive",
-          tone === "neutral" && "text-foreground",
-        )}
-      >
-        {value}
-      </div>
     </div>
   )
 }

--- a/components/admin/grades/GradesTable.tsx
+++ b/components/admin/grades/GradesTable.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import Link from "next/link"
+import type { Route } from "next"
+import { AlertTriangle, CheckCircle2, ClipboardList, Edit3, Hourglass } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { Evaluation } from "@/lib/contracts/grade"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { TYPE_LABELS, isDone, isOverdue } from "./grades-helpers"
+
+interface GradesTableProps {
+  evaluations: Evaluation[]
+  isLoading: boolean
+  noClassSelected: boolean
+  classId: number | null
+}
+
+export function GradesTable({
+  evaluations,
+  isLoading,
+  noClassSelected,
+  classId,
+}: GradesTableProps) {
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead>Évaluation</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Matière</TableHead>
+            <TableHead className="hidden md:table-cell">Date</TableHead>
+            <TableHead className="hidden text-center lg:table-cell">Coeff.</TableHead>
+            <TableHead>Progression</TableHead>
+            <TableHead>Statut</TableHead>
+            <TableHead className="text-right">Action</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {noClassSelected ? (
+            <TableRow>
+              <TableCell colSpan={8} className="h-32 text-center">
+                <div className="flex flex-col items-center gap-2 text-muted-foreground">
+                  <ClipboardList className="h-8 w-8 opacity-40" />
+                  <p className="text-sm">Choisissez une classe pour afficher ses évaluations</p>
+                </div>
+              </TableCell>
+            </TableRow>
+          ) : isLoading ? (
+            Array.from({ length: 5 }).map((_, i) => (
+              <TableRow key={i}>
+                {Array.from({ length: 8 }).map((_, j) => (
+                  <TableCell key={j}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : evaluations.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={8} className="h-24 text-center text-sm text-muted-foreground">
+                Aucune évaluation ne correspond aux filtres.
+              </TableCell>
+            </TableRow>
+          ) : (
+            evaluations.map((evaluation) => {
+              const overdue = isOverdue(evaluation)
+              const complete = isDone(evaluation)
+              const progressPct =
+                evaluation.total_students > 0
+                  ? (evaluation.graded_students / evaluation.total_students) * 100
+                  : 0
+              return (
+                <TableRow key={evaluation.id} className={cn(overdue && "bg-destructive/5")}>
+                  <TableCell className="font-medium">{evaluation.title}</TableCell>
+                  <TableCell>
+                    <Badge variant="secondary" className="text-[10px] uppercase">
+                      {TYPE_LABELS[evaluation.type] ?? evaluation.type}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm">{evaluation.subject_name}</TableCell>
+                  <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
+                    {new Date(evaluation.date).toLocaleDateString("fr-FR", {
+                      day: "numeric",
+                      month: "short",
+                    })}
+                  </TableCell>
+                  <TableCell className="hidden text-center text-sm tabular-nums lg:table-cell">
+                    {evaluation.coefficient}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
+                        <div
+                          className={cn(
+                            "h-full rounded-full transition-all",
+                            complete
+                              ? "bg-emerald-500"
+                              : overdue
+                                ? "bg-destructive"
+                                : "bg-primary",
+                          )}
+                          style={{ width: `${progressPct}%` }}
+                        />
+                      </div>
+                      <span className="text-xs tabular-nums text-muted-foreground">
+                        {evaluation.graded_students}/{evaluation.total_students}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    {overdue ? (
+                      <Badge variant="destructive" className="gap-1 text-[10px]">
+                        <AlertTriangle className="h-3 w-3" />
+                        En retard
+                      </Badge>
+                    ) : complete ? (
+                      <Badge className="gap-1 bg-emerald-100 text-[10px] text-emerald-800 hover:bg-emerald-100">
+                        <CheckCircle2 className="h-3 w-3" />
+                        Complète
+                      </Badge>
+                    ) : (
+                      <Badge variant="outline" className="gap-1 text-[10px]">
+                        <Hourglass className="h-3 w-3" />
+                        En cours
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      asChild
+                      size="sm"
+                      variant={complete ? "outline" : "default"}
+                      className="h-8"
+                    >
+                      <Link href={`/admin/grades/${evaluation.id}?classId=${classId}` as Route}>
+                        <Edit3 className="mr-1 h-3 w-3" />
+                        {complete ? "Réviser" : "Saisir"}
+                      </Link>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              )
+            })
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/components/admin/grades/grades-helpers.ts
+++ b/components/admin/grades/grades-helpers.ts
@@ -1,0 +1,26 @@
+import type { Evaluation } from "@/lib/contracts/grade"
+
+export const TYPE_LABELS: Record<string, string> = {
+  controle: "Contrôle",
+  devoir: "Devoir",
+  examen: "Examen",
+  oral: "Oral",
+}
+
+export type FilterTab = "all" | "todo" | "overdue" | "done"
+
+export const TAB_LABELS: Record<FilterTab, string> = {
+  all: "Toutes",
+  todo: "À saisir",
+  overdue: "En retard",
+  done: "Terminées",
+}
+
+export function isOverdue(evaluation: Evaluation): boolean {
+  const daysAgo = (Date.now() - new Date(evaluation.date).getTime()) / (1000 * 60 * 60 * 24)
+  return daysAgo > 3 && evaluation.graded_students < evaluation.total_students
+}
+
+export function isDone(evaluation: Evaluation): boolean {
+  return evaluation.total_students > 0 && evaluation.graded_students === evaluation.total_students
+}


### PR DESCRIPTION
## Contexte

Redesign premium de `/admin/grades` (« Évaluations & saisies ») + correction du bug : la liste **Matière** montrait toutes les instances de tous les niveaux (Anglais ×5, EPS ×5…) au lieu des matières de la classe sélectionnée.

## Ce qui change

**Bug matières (correctness)** : la liste Matière passe désormais `class_id` à l'API (comme le fait déjà la modale de création) et n'affiche que les **instances** de matières de la classe choisie (niveau + série), plus l'entrée catalogue. À la sélection d'une nouvelle classe, la matière est réinitialisée.

**Redesign premium** (design system KLASSCI) :
- `<PageHero>` bleu→orange avec les 4 indicateurs (Évaluations / Terminées / En retard / Taux saisi), affichés « — » tant qu'aucune classe n'est choisie, action focale orange « Nouvelle évaluation ».
- Filtres + actions PDF/Export regroupés dans une carte, onglets de statut en **shadcn Tabs** (au lieu de boutons custom).
- **No-god-code** : `GradesSupervisor` (561 LOC) découpé en orchestrateur + `GradesTable` + `GradesFilters` + `grades-helpers`. API publique inchangée (`<GradesSupervisor />`).

## Test

1. `/admin/grades` : choisir « 6ème A » → Matière ne liste que les matières de la 6ème (plus de doublons).
2. Le relevé de notes PDF, l'export et la création d'évaluation fonctionnent comme avant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)