### PR TITLE
fix(grades): align filters when no class selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Page Notes : les filtres (Classe, Matière, Trimestre) restaient désalignés tant qu'aucune classe n'était choisie ; ils sont désormais alignés dans tous les cas *(admin)*.
 - Page Notes : à la sélection d'une classe, la liste « Matière » affichait toutes les matières de tous les niveaux (doublons). Elle ne propose désormais que les matières réellement enseignées dans la classe choisie *(admin)*.
 - Après une mise à jour de la plateforme, un onglet resté ouvert pouvait afficher « Une erreur est survenue / Loading chunk failed » à la navigation ; la page se recharge désormais automatiquement pour récupérer la dernière version *(tous)*.
 - Onglet Documents de la fiche élève : les pièces jointes ajoutées sont désormais nettement séparées du formulaire d'envoi (section « Documents ajoutés »), avec un bouton Aperçu pour prévisualiser le PDF ou l'image en plus du téléchargement *(admin)*.

--- a/components/admin/grades/GradesFilters.tsx
+++ b/components/admin/grades/GradesFilters.tsx
@@ -85,9 +85,6 @@ export function GradesFilters({
             ))}
           </SelectContent>
         </Select>
-        {noClass && (
-          <p className="mt-1 text-[11px] text-muted-foreground">Choisissez d&apos;abord la classe</p>
-        )}
       </div>
 
       <div className="w-32">

--- a/components/admin/grades/GradesSupervisor.tsx
+++ b/components/admin/grades/GradesSupervisor.tsx
@@ -235,6 +235,13 @@ export function GradesSupervisor() {
             </div>
           </div>
 
+          {noClass && (
+            <p className="text-[11px] text-muted-foreground">
+              Choisissez d&apos;abord une classe pour filtrer les matières et afficher les
+              évaluations.
+            </p>
+          )}
+
           {!noClass && !canCreate && (
             <div className="flex items-start gap-2 rounded-lg border border-blue-100 bg-blue-50/50 px-3 py-2 text-xs text-blue-900 dark:border-blue-500/20 dark:bg-blue-500/10 dark:text-blue-200">
               <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-600" />


### PR DESCRIPTION
## Contexte

Retour Marcel (capture) : sur `/admin/grades`, quand aucune classe n'est sélectionnée, les filtres Classe/Matière/Trimestre étaient désalignés (le texte d'aide « Choisissez d'abord la classe » sous Matière décalait la ligne).

## Ce qui change

Le texte d'aide est sorti de la ligne des sélecteurs et placé **sous** le bloc de filtres. Les trois sélecteurs ont désormais la même hauteur → alignés dans les deux états (classe choisie ou non).

🤖 Generated with [Claude Code](https://claude.com/claude-code)