### PR TITLE
feat(dashboard): staff dashboard + teacher perf score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Tableau de bord dédié au personnel (secrétariat) : indicateurs orientés inscriptions à valider, prospects à inscrire, paiements en attente et élèves inscrits, avec des actions rapides adaptées (inscription, encaissement, présences, classes, congés) *(personnel)*.
+- Tableau de bord enseignant : la carte « Ma performance » affiche désormais directement le score sur 100 et l'appréciation *(enseignant)*.
+
 - Nouvel onglet « MailPulse » dans les Paramètres : activez les notifications parents par email et WhatsApp, réglez l'expéditeur et la clé d'accès (jamais réaffichée), gérez vos destinataires de test avec un interrupteur par adresse ou numéro, envoyez un test (simulation ou réel) et préparez la réponse automatique « INFO » sur WhatsApp *(admin)*.
 - Intérim : sur un congé approuvé, la direction choisit un enseignant remplaçant depuis la page Congés ; le demandeur voit qui assure son remplacement sur sa carte « Mes congés » *(admin, enseignant)*.
 - Demandes de congé : depuis son profil (et son tableau de bord pour l'enseignant), on demande un congé en quelques secondes et on suit son statut ; une page « Congés » côté administration permet d'approuver ou refuser les demandes en attente *(enseignant, personnel, admin)*.

--- a/app/(admin)/admin/dashboard/page.tsx
+++ b/app/(admin)/admin/dashboard/page.tsx
@@ -1,11 +1,21 @@
+import { auth } from "@/auth"
 import { QuickActions } from "@/components/admin/dashboard/QuickActions"
 import { DashboardCharts } from "@/components/admin/dashboard/DashboardChartsWrapper"
 import { DashboardHero } from "@/components/admin/dashboard/DashboardHero"
 import { RecentActivity } from "@/components/admin/dashboard/RecentActivity"
+import { StaffDashboard } from "@/components/admin/dashboard/StaffDashboard"
 
 export const metadata = { title: "Dashboard | KLASSCI" }
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const session = await auth()
+
+  // Le personnel (secrétariat) dispose d'un tableau de bord dédié, orienté
+  // inscriptions / caisse / présences, distinct de la vue administrateur.
+  if (session?.user?.role === "staff") {
+    return <StaffDashboard />
+  }
+
   return (
     <div className="space-y-6">
       <DashboardHero />

--- a/components/admin/dashboard/StaffDashboard.tsx
+++ b/components/admin/dashboard/StaffDashboard.tsx
@@ -1,0 +1,15 @@
+import { RecentActivity } from "./RecentActivity"
+import { StaffHero } from "./StaffHero"
+import { StaffQuickActions } from "./StaffQuickActions"
+
+/** Tableau de bord dédié au personnel (secrétariat) — orienté inscriptions,
+ * caisse et présences, distinct du tableau de bord administrateur. */
+export function StaffDashboard() {
+  return (
+    <div className="space-y-6">
+      <StaffHero />
+      <StaffQuickActions />
+      <RecentActivity />
+    </div>
+  )
+}

--- a/components/admin/dashboard/StaffHero.tsx
+++ b/components/admin/dashboard/StaffHero.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useSession } from "next-auth/react"
+import { ClipboardCheck, GraduationCap, UserPlus, Wallet } from "lucide-react"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
+import { useDashboardStats } from "@/lib/hooks/useDashboard"
+
+/** Hero du tableau de bord du personnel — KPIs orientés secrétariat. */
+export function StaffHero() {
+  const { data: session } = useSession()
+  const { data, isLoading } = useDashboardStats()
+
+  const today = new Date().toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  })
+  const rawName = session?.user?.email?.split("@")[0] ?? "Personnel"
+  const firstName = rawName.split(/[._]/)[0].replace(/^\w/, (c) => c.toUpperCase())
+  const dash = (v: number | undefined) => (isLoading ? "—" : (v ?? 0))
+
+  const kpis: HeroKpi[] = [
+    {
+      label: "Inscriptions à valider",
+      value: dash(data?.enrollment_pending),
+      icon: ClipboardCheck,
+      hint: "Dossiers en attente",
+    },
+    {
+      label: "Prospects à inscrire",
+      value: dash(data?.enrollment_prospect),
+      icon: UserPlus,
+      hint: "À ouvrir",
+    },
+    {
+      label: "Paiements en attente",
+      value: dash(data?.pending_payments),
+      icon: Wallet,
+      hint: "À encaisser",
+    },
+    {
+      label: "Élèves inscrits",
+      value: dash(data?.enrolled_students),
+      icon: GraduationCap,
+      hint: data ? `${data.enrollment_validated ?? 0} validées` : undefined,
+    },
+  ]
+
+  return (
+    <PageHero
+      title={`Bonjour, ${firstName}`}
+      subtitle={
+        <span className="capitalize" suppressHydrationWarning>
+          {today}
+        </span>
+      }
+      kpis={kpis}
+    />
+  )
+}

--- a/components/admin/dashboard/StaffQuickActions.tsx
+++ b/components/admin/dashboard/StaffQuickActions.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import type { Route } from "next"
+import Link from "next/link"
+import {
+  CalendarClock,
+  CreditCard,
+  School,
+  UserCheck,
+  UserPlus,
+  Users,
+  type LucideIcon,
+} from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+const actions: { label: string; href: Route; icon: LucideIcon }[] = [
+  { label: "Nouvelle inscription", href: "/admin/enrollments?action=create" as Route, icon: UserPlus },
+  { label: "Encaisser un paiement", href: "/admin/payments", icon: CreditCard },
+  { label: "Présences", href: "/admin/attendance", icon: UserCheck },
+  { label: "Élèves", href: "/admin/students", icon: Users },
+  { label: "Classes", href: "/admin/classes", icon: School },
+  { label: "Mes congés", href: "/admin/profile" as Route, icon: CalendarClock },
+]
+
+/** Actions rapides du personnel (secrétariat) — inscriptions, caisse, présences. */
+export function StaffQuickActions() {
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">Actions rapides</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+          {actions.map((action) => (
+            <Link
+              key={action.href}
+              href={action.href}
+              className="group flex flex-col items-center gap-2 rounded-lg border border-transparent p-4 text-center transition-colors hover:border-border hover:bg-muted"
+            >
+              <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
+                <action.icon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <span className="text-xs font-medium text-muted-foreground group-hover:text-foreground">
+                {action.label}
+              </span>
+            </Link>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/teacher/TeacherDashboardClient.tsx
+++ b/components/teacher/TeacherDashboardClient.tsx
@@ -21,11 +21,14 @@ import { PageHero, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHe
 import { AcademicYearBanner } from "@/components/shared/AcademicYearBanner"
 import { MyLeaveCard } from "@/components/shared/leave/MyLeaveCard"
 import { useTeacherDashboard } from "@/lib/hooks/useTeacherPortal"
+import { useMyPerformance } from "@/lib/hooks/usePerformance"
+import { formatScore } from "@/lib/utils/performance"
 import type { TeacherUpcomingEval } from "@/lib/contracts/teacher-portal"
 import { SelfDeclareAbsenceModal } from "./SelfDeclareAbsenceModal"
 
 export function TeacherDashboardClient() {
   const { data, isLoading, isError, refetch } = useTeacherDashboard()
+  const { data: perf } = useMyPerformance()
   const [selfDeclareOpen, setSelfDeclareOpen] = useState(false)
 
   if (isLoading) return <DashboardSkeleton />
@@ -130,8 +133,16 @@ export function TeacherDashboardClient() {
             </span>
             <div className="min-w-0 flex-1">
               <p className="text-sm font-semibold">Ma performance</p>
-              <p className="text-xs text-muted-foreground">Mon score et son détail</p>
+              <p className="text-xs text-muted-foreground">
+                {perf ? `${perf.performance.rating} · voir le détail` : "Mon score et son détail"}
+              </p>
             </div>
+            {perf && perf.performance.global_score !== null && (
+              <span className="shrink-0 text-lg font-bold tabular-nums text-primary">
+                {formatScore(perf.performance.global_score)}
+                <span className="text-xs font-medium text-muted-foreground"> / 100</span>
+              </span>
+            )}
             <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           </CardContent>
         </Card>

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,7 +1,15 @@
 import "next-auth"
 import "next-auth/jwt"
 
-export type UserRole = "admin" | "teacher" | "student" | "parent" | "super_admin"
+export type UserRole =
+  | "admin"
+  | "director"
+  | "staff"
+  | "accountant"
+  | "teacher"
+  | "student"
+  | "parent"
+  | "super_admin"
 
 declare module "next-auth" {
   interface User {


### PR DESCRIPTION
## Contexte

Tâche #26 : tableau de bord dédié au personnel + enrichissement des dashboards.

## Ce qui change

- **Tableau de bord personnel** : le rôle `staff` (secrétariat) voit désormais un tableau de bord dédié (au lieu de la vue admin), branché par rôle sur `/admin/dashboard`. KPIs orientés secrétariat (inscriptions à valider, prospects à inscrire, paiements en attente, élèves inscrits) + actions rapides adaptées (inscription, encaissement, présences, élèves, classes, congés) + flux d'activité récente. Réutilise les endpoints existants (`/dashboard/stats`, `/dashboard/activity`), aucune modification backend.
- **Dashboard enseignant** : la carte « Ma performance » affiche le score sur 100 + l'appréciation (au lieu d'un simple lien).
- Type `UserRole` complété (`staff`, `director`, `accountant` manquaient).

## Note

Les détail (fiches élève/enseignant/parent/personnel) sont déjà premium (DetailHero + ContactActions, PR #254). Enrichissements plus profonds côté élève (dernière note, statut bulletin) nécessitent des champs backend et pourront suivre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)