### PR TITLE
fix(auth): staff/director/accountant login + student dashboard links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 - Tableau de bord dédié au personnel (secrétariat) : indicateurs orientés inscriptions à valider, prospects à inscrire, paiements en attente et élèves inscrits, avec des actions rapides adaptées (inscription, encaissement, présences, classes, congés) *(personnel)*.
 - Tableau de bord enseignant : la carte « Ma performance » affiche désormais directement le score sur 100 et l'appréciation *(enseignant)*.
+- Tableau de bord élève enrichi de deux accès rapides : « Mes notes » et « Mes bulletins » *(élève)*.
 
 - Nouvel onglet « MailPulse » dans les Paramètres : activez les notifications parents par email et WhatsApp, réglez l'expéditeur et la clé d'accès (jamais réaffichée), gérez vos destinataires de test avec un interrupteur par adresse ou numéro, envoyez un test (simulation ou réel) et préparez la réponse automatique « INFO » sur WhatsApp *(admin)*.
 - Intérim : sur un congé approuvé, la direction choisit un enseignant remplaçant depuis la page Congés ; le demandeur voit qui assure son remplacement sur sa carte « Mes congés » *(admin, enseignant)*.
@@ -52,6 +53,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Connexion : les comptes Personnel, Comptable et Directeur étaient refusés à tort (« email ou mot de passe incorrect ») ; ils peuvent désormais se connecter *(personnel, comptable, directeur)*.
 - Page Notes : les filtres (Classe, Matière, Trimestre) restaient désalignés tant qu'aucune classe n'était choisie ; ils sont désormais alignés dans tous les cas *(admin)*.
 - Page Notes : à la sélection d'une classe, la liste « Matière » affichait toutes les matières de tous les niveaux (doublons). Elle ne propose désormais que les matières réellement enseignées dans la classe choisie *(admin)*.
 - Après une mise à jour de la plateforme, un onglet resté ouvert pouvait afficher « Une erreur est survenue / Loading chunk failed » à la navigation ; la page se recharge désormais automatiquement pour récupérer la dernière version *(tous)*.

--- a/components/student/StudentDashboardClient.tsx
+++ b/components/student/StudentDashboardClient.tsx
@@ -1,6 +1,15 @@
 "use client"
 
-import { CalendarDays, ClipboardList, Wallet, AlertCircle } from "lucide-react"
+import type { Route } from "next"
+import Link from "next/link"
+import {
+  CalendarDays,
+  ClipboardList,
+  Wallet,
+  AlertCircle,
+  FileText,
+  ChevronRight,
+} from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
@@ -94,6 +103,44 @@ export function StudentDashboardClient() {
           </div>
         </CardContent>
       </Card>
+
+      {isEnrolled && (
+        <Link href={"/student/grades" as Route} className="group block">
+          <Card className="shadow-sm transition-colors group-hover:border-primary/40">
+            <CardContent className="flex items-center gap-3 p-4">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <ClipboardList className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold">Mes notes</p>
+                <p className="text-xs text-muted-foreground">
+                  Voir le détail de mes notes par matière et trimestre
+                </p>
+              </div>
+              <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            </CardContent>
+          </Card>
+        </Link>
+      )}
+
+      {isEnrolled && (
+        <Link href={"/student/bulletins" as Route} className="group block">
+          <Card className="shadow-sm transition-colors group-hover:border-primary/40">
+            <CardContent className="flex items-center gap-3 p-4">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                <FileText className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold">Mes bulletins</p>
+                <p className="text-xs text-muted-foreground">
+                  Consulter mes bulletins publiés par trimestre
+                </p>
+              </div>
+              <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            </CardContent>
+          </Card>
+        </Link>
+      )}
     </div>
   )
 }

--- a/lib/contracts/auth.ts
+++ b/lib/contracts/auth.ts
@@ -2,7 +2,16 @@ import { z } from "zod"
 
 // Miroir de app/schemas/auth.py (backend)
 
-export const UserRoleSchema = z.enum(["admin", "teacher", "student", "parent", "super_admin"])
+export const UserRoleSchema = z.enum([
+  "admin",
+  "director",
+  "staff",
+  "accountant",
+  "teacher",
+  "student",
+  "parent",
+  "super_admin",
+])
 
 export const LoginRequestSchema = z.object({
   email: z


### PR DESCRIPTION
Corrige un bug pré-existant : le schéma de validation du rôle côté connexion (Zod) n'incluait pas staff/director/accountant, donc ces comptes étaient refusés (« email ou mot de passe incorrect ») alors que le backend les acceptait. Enrichit aussi le tableau de bord élève de deux accès rapides (Mes notes, Mes bulletins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)