### PR TITLE
fix(reports): council loads/generates, DREN downloads real files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Conseil de classe : le procès-verbal se charge à nouveau pour une classe et un trimestre ; s'il n'existe pas encore, un bouton « Générer le procès-verbal » le crée à partir des bulletins. Les décisions s'enregistrent, le procès-verbal se valide et se télécharge en PDF *(admin)*.
+- Statistiques DREN : les boutons Excel et PDF téléchargent désormais un vrai fichier (classeur Excel ou document PDF) au lieu d'ouvrir des données brutes *(admin)*.
+
 ### Added
 
 - Tableau de bord dédié au personnel (secrétariat) : indicateurs orientés inscriptions à valider, prospects à inscrire, paiements en attente et élèves inscrits, avec des actions rapides adaptées (inscription, encaissement, présences, classes, congés) *(personnel)*.

--- a/components/admin/reports/council/CouncilDeliberationTable.tsx
+++ b/components/admin/reports/council/CouncilDeliberationTable.tsx
@@ -46,7 +46,11 @@ interface CouncilDeliberationTableProps {
 
 export function CouncilDeliberationTable({ minutes, classId, trimester, onDirtyChange }: CouncilDeliberationTableProps) {
   const isReadOnly = minutes.is_published
-  const { mutate: saveDecisions, isPending: isSaving } = useUpdateDecisions(classId, trimester)
+  const { mutate: saveDecisions, isPending: isSaving } = useUpdateDecisions(
+    classId,
+    trimester,
+    minutes.academic_year_id,
+  )
 
   // État local des décisions modifiées
   const [localDecisions, setLocalDecisions] = useState<
@@ -152,14 +156,18 @@ export function CouncilDeliberationTable({ minutes, classId, trimester, onDirtyC
   const handleDownloadPdf = useCallback(async () => {
     setIsDownloading(true)
     try {
-      const blob = await councilApi.downloadPdf(minutes.id)
+      const blob = await councilApi.downloadPdf(
+        minutes.class_id,
+        minutes.trimester,
+        minutes.academic_year_id,
+      )
       downloadBlob(blob, `pv-conseil-${minutes.id}.pdf`)
     } catch {
       toast.error("Impossible de télécharger le PDF")
     } finally {
       setIsDownloading(false)
     }
-  }, [minutes.id])
+  }, [minutes.id, minutes.class_id, minutes.trimester, minutes.academic_year_id])
 
   const hasChanges = localDecisions.size > 0
 
@@ -267,12 +275,19 @@ export function CouncilDeliberationTable({ minutes, classId, trimester, onDirtyC
             minutesId={minutes.id}
             classId={classId}
             trimester={trimester}
+            academicYearId={minutes.academic_year_id}
             disabled={isReadOnly || stats.pending > 0}
           />
         </div>
         <div className="flex items-center gap-2">
           <PdfPreviewButton
-            fetchBlob={() => councilApi.downloadPdf(minutes.id)}
+            fetchBlob={() =>
+              councilApi.downloadPdf(
+                minutes.class_id,
+                minutes.trimester,
+                minutes.academic_year_id,
+              )
+            }
             label="le PV de conseil"
           />
           <Button variant="outline" onClick={handleDownloadPdf} disabled={isDownloading} aria-label="Télécharger le PV de conseil en PDF">

--- a/components/admin/reports/council/CouncilPageClient.tsx
+++ b/components/admin/reports/council/CouncilPageClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useRef, useState } from "react"
-import { Scale } from "lucide-react"
+import { FileSignature, Loader2, Scale } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -23,13 +23,17 @@ import {
 import { PageHero } from "@/components/shared/PageHero"
 import { CouncilDeliberationTable } from "./CouncilDeliberationTable"
 import { ReportsNav } from "../ReportsNav"
-import { useCouncilMinutes } from "@/lib/hooks/useCouncil"
-import type { CouncilMinutes } from "@/lib/contracts/council"
+import { useCouncilMinutes, useGenerateCouncil } from "@/lib/hooks/useCouncil"
 import { useClasses } from "@/lib/hooks/useClasses"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 
 export function CouncilPageClient() {
   const { data: classesData } = useClasses()
   const classes = classesData?.items ?? []
+  const { data: yearsData } = useAcademicYears()
+  const years = yearsData?.items ?? []
+  const currentYear = years.find((y) => y.is_current) ?? years[0]
+  const ayId = currentYear?.id
   const [classId, setClassId] = useState<number | undefined>(undefined)
   const [trimester, setTrimester] = useState<string | undefined>(undefined)
 
@@ -72,8 +76,18 @@ export function CouncilPageClient() {
     setPendingFilter(null)
   }
 
-  const filtersReady = !!classId && !!trimester
-  const { data: minutes, isLoading, isError } = useCouncilMinutes(classId, trimester)
+  const filtersReady = !!classId && !!trimester && !!ayId
+  const { data: minutes, isLoading } = useCouncilMinutes(classId, trimester, ayId)
+  const { mutate: generate, isPending: isGenerating } = useGenerateCouncil(
+    classId ?? 0,
+    trimester ?? "",
+    ayId ?? 0,
+  )
+
+  function handleGenerate() {
+    if (!classId || !trimester || !ayId) return
+    generate({ class_id: classId, trimester: Number(trimester), academic_year_id: ayId })
+  }
 
   return (
     <div className="space-y-6">
@@ -134,20 +148,32 @@ export function CouncilPageClient() {
         </div>
       ) : isLoading ? (
         <CouncilSkeleton />
-      ) : isError ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          Impossible de charger le procès-verbal. Vérifiez que les bulletins ont été générés.
-        </div>
       ) : minutes ? (
         <CouncilDeliberationTable
           minutes={minutes}
-          classId={classId}
-          trimester={trimester}
+          classId={classId as number}
+          trimester={trimester as string}
           onDirtyChange={handleDirtyChange}
         />
       ) : (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          Aucun procès-verbal trouvé. Générez d&apos;abord les bulletins depuis la page Bulletins.
+        <div className="rounded-xl border border-dashed py-14 text-center">
+          <FileSignature className="mx-auto mb-3 h-8 w-8 text-muted-foreground" aria-hidden="true" />
+          <p className="text-sm font-medium">
+            Aucun procès-verbal pour cette classe et ce trimestre.
+          </p>
+          <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+            Générez le procès-verbal à partir des bulletins du trimestre : la décision de
+            chaque élève (passage, redoublement, exclusion) est pré-calculée, vous pourrez
+            l&apos;ajuster avant de valider.
+          </p>
+          <Button className="mt-4" onClick={handleGenerate} disabled={isGenerating}>
+            {isGenerating ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <FileSignature className="mr-2 h-4 w-4" aria-hidden="true" />
+            )}
+            Générer le procès-verbal
+          </Button>
         </div>
       )}
 

--- a/components/admin/reports/council/CouncilValidateButton.tsx
+++ b/components/admin/reports/council/CouncilValidateButton.tsx
@@ -17,12 +17,19 @@ interface CouncilValidateButtonProps {
   minutesId: number | undefined
   classId: number
   trimester: string
+  academicYearId: number
   disabled?: boolean
 }
 
-export function CouncilValidateButton({ minutesId, classId, trimester, disabled }: CouncilValidateButtonProps) {
+export function CouncilValidateButton({
+  minutesId,
+  classId,
+  trimester,
+  academicYearId,
+  disabled,
+}: CouncilValidateButtonProps) {
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const { mutate, isPending } = useValidateCouncil(classId, trimester)
+  const { mutate, isPending } = useValidateCouncil(classId, trimester, academicYearId)
 
   function handleValidate() {
     if (!minutesId) return

--- a/lib/api/council.ts
+++ b/lib/api/council.ts
@@ -5,41 +5,84 @@ import {
   type CouncilDecisionUpdate,
 } from "@/lib/contracts/council"
 
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object" && "data" in json) {
+    const data = (json as Record<string, unknown>).data
+    if (data !== undefined) return data
+  }
+  return json
+}
+
+export interface CouncilGenerateInput {
+  class_id: number
+  trimester: number
+  academic_year_id: number
+}
+
 export const councilApi = {
-  // Récupérer le PV d'une classe pour un trimestre donné
-  getMinutes: async (classId: number, trimester: string): Promise<CouncilMinutes> => {
-    const json = await apiFetch<{ data?: CouncilMinutes } | CouncilMinutes>(
-      `/reports/council-minutes?class_id=${classId}&trimester=${trimester}`,
+  // Récupérer le PV d'une classe/trimestre/année. Le BE attend les segments de
+  // chemin (class_id, trimester) + academic_year_id en query.
+  getMinutes: async (
+    classId: number,
+    trimester: string,
+    academicYearId: number,
+  ): Promise<CouncilMinutes> => {
+    const json = await apiFetch<unknown>(
+      `/reports/council-minutes/${classId}/${trimester}?academic_year_id=${academicYearId}`,
     )
-    const minutes = (json as { data?: CouncilMinutes }).data ?? (json as CouncilMinutes)
-    return safeValidate(CouncilMinutesSchema, minutes, "GET /reports/council-minutes") as CouncilMinutes
+    return safeValidate(CouncilMinutesSchema, unwrap(json), "GET /reports/council-minutes")
   },
 
-  // Mettre à jour les décisions de délibération
+  // Générer le PV à partir des bulletins (délibération auto par élève).
+  generateMinutes: async (data: CouncilGenerateInput): Promise<CouncilMinutes> => {
+    const json = await apiFetch<unknown>(`/reports/council-minutes/generate`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(
+      CouncilMinutesSchema,
+      unwrap(json),
+      "POST /reports/council-minutes/generate",
+    )
+  },
+
+  // Mettre à jour les décisions de délibération (lot).
   updateDecisions: async (
     minutesId: number,
     decisions: CouncilDecisionUpdate[],
   ): Promise<CouncilMinutes> => {
-    const json = await apiFetch<{ data?: CouncilMinutes } | CouncilMinutes>(
+    const json = await apiFetch<unknown>(
       `/reports/council-minutes/${minutesId}/decisions`,
       { method: "PUT", body: JSON.stringify({ decisions }) },
     )
-    const minutes = (json as { data?: CouncilMinutes }).data ?? (json as CouncilMinutes)
-    return safeValidate(CouncilMinutesSchema, minutes, "PUT /reports/council-minutes/decisions") as CouncilMinutes
+    return safeValidate(
+      CouncilMinutesSchema,
+      unwrap(json),
+      "PUT /reports/council-minutes/decisions",
+    )
   },
 
-  // Valider définitivement le PV
+  // Valider définitivement le PV.
   validate: async (minutesId: number): Promise<CouncilMinutes> => {
-    const json = await apiFetch<{ data?: CouncilMinutes } | CouncilMinutes>(
+    const json = await apiFetch<unknown>(
       `/reports/council-minutes/${minutesId}/validate`,
       { method: "POST" },
     )
-    const minutes = (json as { data?: CouncilMinutes }).data ?? (json as CouncilMinutes)
-    return safeValidate(CouncilMinutesSchema, minutes, "POST /reports/council-minutes/validate") as CouncilMinutes
+    return safeValidate(
+      CouncilMinutesSchema,
+      unwrap(json),
+      "POST /reports/council-minutes/validate",
+    )
   },
 
-  // Télécharger le PDF du PV
-  downloadPdf: async (minutesId: number): Promise<Blob> => {
-    return apiFetchBlob(`/reports/council-minutes/${minutesId}/pdf`)
+  // Télécharger le PDF du PV (segments class_id/trimester + academic_year_id).
+  downloadPdf: async (
+    classId: number,
+    trimester: number,
+    academicYearId: number,
+  ): Promise<Blob> => {
+    return apiFetchBlob(
+      `/reports/council-minutes/${classId}/${trimester}/pdf?academic_year_id=${academicYearId}`,
+    )
   },
 }

--- a/lib/api/dren.ts
+++ b/lib/api/dren.ts
@@ -11,11 +11,11 @@ export const drenApi = {
     return safeValidate(DrenStatsSchema, stats, "GET /reports/dren-stats")
   },
 
-  // Télécharger l'export (authentifié) — le BE retourne un export JSON/blob
+  // Télécharger le classeur Excel (authentifié)
   downloadExcel: (academicYearId: number): Promise<Blob> =>
-    apiFetchBlob(`/reports/dren-stats/${academicYearId}/export`),
+    apiFetchBlob(`/reports/dren-stats/${academicYearId}/export?format=xlsx`),
 
-  // Télécharger l'export PDF (authentifié)
+  // Télécharger le PDF (authentifié)
   downloadPdf: (academicYearId: number): Promise<Blob> =>
-    apiFetchBlob(`/reports/dren-stats/${academicYearId}/export`),
+    apiFetchBlob(`/reports/dren-stats/${academicYearId}/export?format=pdf`),
 }

--- a/lib/contracts/council.ts
+++ b/lib/contracts/council.ts
@@ -20,7 +20,7 @@ export const CouncilDecisionRecordSchema = z.object({
   student_name: z.string(),
   average: z.coerce.number().nullable(),
   rank: z.number().nullable(),
-  absence_count: z.number().default(0),
+  absence_count: z.number(),
   auto_decision: CouncilDecisionSchema.nullable(),
   final_decision: CouncilDecisionSchema.nullable(),
   override_reason: z.string().nullable(),

--- a/lib/hooks/useCouncil.ts
+++ b/lib/hooks/useCouncil.ts
@@ -2,30 +2,62 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { councilApi } from "@/lib/api/council"
+import { councilApi, type CouncilGenerateInput } from "@/lib/api/council"
 import type { CouncilDecisionUpdate } from "@/lib/contracts/council"
 
 export const councilKeys = {
   all: ["council"] as const,
-  minutes: (classId: number, trimester: string) =>
-    ["council", "minutes", classId, trimester] as const,
+  minutes: (classId: number, trimester: string, academicYearId: number) =>
+    ["council", "minutes", classId, trimester, academicYearId] as const,
 }
 
-// Récupérer le PV d'une classe/trimestre
-export function useCouncilMinutes(classId: number | undefined, trimester: string | undefined) {
-  const enabled = !!classId && !!trimester
+// Récupérer le PV d'une classe/trimestre/année.
+export function useCouncilMinutes(
+  classId: number | undefined,
+  trimester: string | undefined,
+  academicYearId: number | undefined,
+) {
+  const enabled = !!classId && !!trimester && !!academicYearId
   return useQuery({
     queryKey: enabled
-      ? councilKeys.minutes(classId as number, trimester as string)
+      ? councilKeys.minutes(classId as number, trimester as string, academicYearId as number)
       : ["council", "minutes", "none"],
-    queryFn: () => councilApi.getMinutes(classId as number, trimester as string),
+    queryFn: () =>
+      councilApi.getMinutes(classId as number, trimester as string, academicYearId as number),
     enabled,
     staleTime: 1000 * 60 * 5,
+    // Le PV peut ne pas exister encore (404) : pas de retry en boucle.
+    retry: false,
   })
 }
 
-// Mettre à jour les décisions — invalidation ciblée sur la classe/trimestre
-export function useUpdateDecisions(classId: number, trimester: string) {
+// Générer le PV à partir des bulletins.
+export function useGenerateCouncil(
+  classId: number,
+  trimester: string,
+  academicYearId: number,
+) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CouncilGenerateInput) => councilApi.generateMinutes(data),
+    onSuccess: () => {
+      toast.success("Procès-verbal généré")
+      queryClient.invalidateQueries({
+        queryKey: councilKeys.minutes(classId, trimester, academicYearId),
+      })
+    },
+    onError: (err) => {
+      toast.error("Génération impossible", { description: err.message })
+    },
+  })
+}
+
+// Mettre à jour les décisions — invalidation ciblée sur la classe/trimestre/année.
+export function useUpdateDecisions(
+  classId: number,
+  trimester: string,
+  academicYearId: number,
+) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: ({
@@ -37,7 +69,9 @@ export function useUpdateDecisions(classId: number, trimester: string) {
     }) => councilApi.updateDecisions(minutesId, decisions),
     onSuccess: () => {
       toast.success("Décisions enregistrées")
-      queryClient.invalidateQueries({ queryKey: councilKeys.minutes(classId, trimester) })
+      queryClient.invalidateQueries({
+        queryKey: councilKeys.minutes(classId, trimester, academicYearId),
+      })
     },
     onError: (err) => {
       toast.error("Erreur", { description: err.message })
@@ -45,14 +79,20 @@ export function useUpdateDecisions(classId: number, trimester: string) {
   })
 }
 
-// Valider le PV — invalidation ciblée sur la classe/trimestre
-export function useValidateCouncil(classId: number, trimester: string) {
+// Valider le PV — invalidation ciblée sur la classe/trimestre/année.
+export function useValidateCouncil(
+  classId: number,
+  trimester: string,
+  academicYearId: number,
+) {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (minutesId: number) => councilApi.validate(minutesId),
     onSuccess: () => {
       toast.success("Procès-verbal validé avec succès")
-      queryClient.invalidateQueries({ queryKey: councilKeys.minutes(classId, trimester) })
+      queryClient.invalidateQueries({
+        queryKey: councilKeys.minutes(classId, trimester, academicYearId),
+      })
     },
     onError: (err) => {
       toast.error("Erreur", { description: err.message })


### PR DESCRIPTION
## Contexte
Le PV du conseil ne se chargeait jamais (routes FE mal alignées, `academic_year_id` manquant) et l'export DREN ouvrait du JSON brut.

## Ce qui change
- **Conseil** : API alignée sur les routes BE (segments `class_id/trimester` + `academic_year_id`) pour le chargement et le PDF. Bouton **« Générer le procès-verbal »** quand il n'existe pas encore. Décisions/validation portent l'année scolaire.
- **DREN** : les téléchargements passent `?format=xlsx|pdf` → vrai fichier.
- Retrait du `.default(0)` sur `absence_count` (divergence input/output `safeValidate`).

## Tests
tsc + eslint OK. Dépend du BE #220.