### PR TITLE
fix(grades): recover dictee mic + desktop roster layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Mode dictée : le micro se débloque tout seul dès qu'on l'autorise dans le navigateur, sans recharger la page ; quand la reconnaissance vocale est indisponible (réseau ou navigateur), un message clair invite à saisir au clavier au lieu d'afficher « micro refusé » à tort, et un bouton « Réessayer le micro » est proposé *(enseignant, admin)*.
 - Conseil de classe : le procès-verbal se charge à nouveau pour une classe et un trimestre ; s'il n'existe pas encore, un bouton « Générer le procès-verbal » le crée à partir des bulletins. Les décisions s'enregistrent, le procès-verbal se valide et se télécharge en PDF *(admin)*.
 - Statistiques DREN : les boutons Excel et PDF téléchargent désormais un vrai fichier (classeur Excel ou document PDF) au lieu d'ouvrir des données brutes *(admin)*.
 - Page Notes : en choisissant une matière, les évaluations et les compteurs d'onglets (Toutes, À saisir, En retard, Terminées) se mettent bien à jour ; auparavant certaines matières n'affichaient aucune évaluation et les compteurs restaient figés *(admin)*.
@@ -47,6 +48,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Mode dictée sur grand écran : l'espace est désormais utilisé avec un panneau « Classe » à droite listant tous les élèves et leur note, l'élève en cours surligné, cliquable pour y sauter directement. Sur téléphone, l'affichage plein écran séquentiel reste inchangé *(enseignant, admin)*.
 - Page Emploi du temps repensée dans la ligne premium KLASSCI : bandeau bleu-orange rappelant « Semaine type · Année en cours », classe et actions (générer, exporter PDF) regroupées dans une carte de contrôle avec sélection rapide par classe *(admin)*.
 - Page Notes repensée dans la ligne premium KLASSCI : bandeau bleu-orange avec les indicateurs clés (évaluations, terminées, en retard, taux de saisie), filtres et actions PDF regroupés, onglets de statut harmonisés *(admin)*.
 - Onglet MailPulse aux vraies couleurs de la marque : bandeau sombre, logo enveloppe orange et wordmark « Mail·Pulse », avec l'état de la clé API en pastille. La mise en page a été resserrée pour supprimer la barre de défilement superflue *(admin)*.

--- a/components/teacher/grades/DicteeMode.tsx
+++ b/components/teacher/grades/DicteeMode.tsx
@@ -3,19 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import type { Route } from "next"
-import {
-  Mic,
-  MicOff,
-  Check,
-  ChevronLeft,
-  ChevronRight,
-  X,
-  Pencil,
-  AlertTriangle,
-  Loader2,
-} from "lucide-react"
+import { Loader2, X } from "lucide-react"
 import { toast } from "sonner"
-import { cn } from "@/lib/utils"
 import { useGrades, useUpdateGrades, useEvaluations } from "@/lib/hooks/useGrades"
 import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
 import { parseSpokenGrade, detectCommand } from "@/lib/utils/voice-grade-parser"
@@ -30,8 +19,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-
-type EntryValue = number | null | undefined // undefined = pas saisi, null = absent, number = note
+import { DicteeStudentStage } from "./dictee/DicteeStudentStage"
+import { DicteeRoster } from "./dictee/DicteeRoster"
+import { DicteeControls } from "./dictee/DicteeControls"
+import { RecapView } from "./dictee/RecapView"
+import type { EntryValue } from "./dictee/types"
 
 interface DicteeModeProps {
   evaluationId: number
@@ -46,21 +38,12 @@ interface DicteeModeProps {
 }
 
 /**
- * Mode Dictée — saisie vocale plein écran, optimisée pour Mme Diallo (52, Itel S661).
+ * Mode Dictée — saisie vocale, optimisée Mme Diallo (52, Itel S661, plein
+ * soleil). Mobile = plein écran séquentiel dark ; desktop = même flux + panneau
+ * roster de classe à droite (`lg:`) pour remplir l'espace et naviguer d'un clic.
  *
- * Flow :
- *   1) Click "Activer le micro" → permission + listening
- *   2) "douze virgule cinq" → display la note pour l'élève courant
- *   3) "suivant" (ou tap →) → next student
- *   4) Boucle jusqu'au dernier → écran récap
- *   5) Click "Enregistrer" → batch update vers BE
- *
- * Optimisations :
- *   - text-9xl pour le chiffre (visibilité plein soleil sur écran TFT)
- *   - touch targets >= 64px hauteur (h-16) sur mobile
- *   - fond noir → réduit conso batterie OLED, meilleur contraste plein soleil
- *   - beep audio sur succès (feedback non-visuel pour saisie sans regarder)
- *   - fallback total au tap : tout est utilisable sans micro
+ * Flow : activer micro → « douze virgule cinq » → « suivant » → … → récap →
+ * enregistrer (batch BE). Tout reste utilisable au tap sans micro (fallback).
  */
 export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProps) {
   const router = useRouter()
@@ -86,32 +69,23 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
     if (grades) {
       const map = new Map<number, EntryValue>()
       grades.forEach((g) => {
-        // Pré-remplit depuis serveur : value !== null OU status === "absent"
-        // Le contrat actuel renvoie value: null + status: "entered" pour absent.
         if (g.value !== null) {
           map.set(g.student_id, Number(g.value))
         } else if (g.status === "entered") {
           map.set(g.student_id, null) // absent
         }
-        // sinon : laissé undefined (à saisir)
       })
       setEntries(map)
     }
   }, [grades])
 
   // ─── Beep audio (succès) ───────────────────────────────────────────────
-  // iOS Safari interdit la création d'AudioContext hors user-gesture chain.
-  // On l'instancie dans `ensureAudio()` (appelée depuis le bouton mic = user
-  // gesture). Si l'AudioContext devient "suspended" entre 2 beeps, on le
-  // resume — toujours dans le bon scope car `beep` est appelé dans la
-  // continuité d'un onResult vocal qui hérite du gesture initial.
   const audioCtxRef = useRef<AudioContext | null>(null)
   const ensureAudio = useCallback(() => {
     if (audioCtxRef.current) return audioCtxRef.current
     const Ctx =
       window.AudioContext ??
-      (window as unknown as { webkitAudioContext?: typeof AudioContext })
-        .webkitAudioContext
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
     if (!Ctx) return null
     try {
       audioCtxRef.current = new Ctx()
@@ -124,10 +98,7 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
     const ctx = audioCtxRef.current
     if (!ctx) return
     try {
-      if (ctx.state === "suspended") {
-        // Fire-and-forget — resume() returns a Promise we don't need to await.
-        void ctx.resume()
-      }
+      if (ctx.state === "suspended") void ctx.resume()
       const osc = ctx.createOscillator()
       const gain = ctx.createGain()
       osc.frequency.setValueAtTime(880, ctx.currentTime)
@@ -145,18 +116,14 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
 
   const totalStudents = grades?.length ?? 0
   const currentStudent = grades?.[currentIdx]
-  const currentValue = currentStudent ? entries.get(currentStudent.student_id) : undefined
 
-  const setEntry = useCallback(
-    (studentId: number, value: EntryValue) => {
-      setEntries((prev) => {
-        const next = new Map(prev)
-        next.set(studentId, value)
-        return next
-      })
-    },
-    [],
-  )
+  const setEntry = useCallback((studentId: number, value: EntryValue) => {
+    setEntries((prev) => {
+      const next = new Map(prev)
+      next.set(studentId, value)
+      return next
+    })
+  }, [])
 
   const goNext = useCallback(() => {
     if (currentIdx < totalStudents - 1) {
@@ -176,30 +143,24 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
     }
   }, [currentIdx])
 
+  const jumpTo = useCallback((idx: number) => {
+    setCurrentIdx(idx)
+    setTranscriptDisplay("")
+    setFeedback(null)
+  }, [])
+
   // ─── Voice handler ─────────────────────────────────────────────────────
   const handleTranscript = useCallback(
     (transcript: string) => {
       setTranscriptDisplay(transcript)
       const cmd = detectCommand(transcript)
-      if (cmd === "next") {
-        goNext()
-        return
-      }
-      if (cmd === "prev") {
-        goPrev()
-        return
-      }
-      if (cmd === "exit") {
-        if (currentIdx >= totalStudents - 1) setMode("recap")
-        else setMode("recap") // sortir = aller au récap pour valider
-        return
-      }
-      if (cmd === "recap") {
+      if (cmd === "next") return goNext()
+      if (cmd === "prev") return goPrev()
+      if (cmd === "exit" || cmd === "recap") {
         setMode("recap")
         return
       }
 
-      // Pas de commande nav → tenter de parser une note
       if (!currentStudent) return
       const result = parseSpokenGrade(transcript)
       if (!result) return
@@ -218,7 +179,7 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
       setFeedback("ok")
       beep()
     },
-    [currentStudent, currentIdx, totalStudents, goNext, goPrev, setEntry, beep],
+    [currentStudent, goNext, goPrev, setEntry, beep],
   )
 
   const speech = useSpeechRecognition({
@@ -227,14 +188,21 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
     onError: (msg) => toast.error("Micro", { description: msg }),
   })
 
-  const toggleMic = useCallback(() => {
+  const onMicToggle = useCallback(() => {
     if (speech.listening) {
       speech.stop()
     } else {
-      // Initialise l'AudioContext dans le user gesture du clic — iOS l'exige.
+      // Init AudioContext dans le geste utilisateur (iOS l'exige), puis pré-vol
+      // permission + démarrage.
       ensureAudio()
-      speech.start()
+      void speech.requestAndStart()
     }
+  }, [speech, ensureAudio])
+
+  const onMicRetry = useCallback(() => {
+    speech.reset()
+    ensureAudio()
+    void speech.requestAndStart()
   }, [speech, ensureAudio])
 
   // ─── Quitter avec garde sur dirty ──────────────────────────────────────
@@ -242,7 +210,8 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
     if (!grades) return false
     for (const g of grades) {
       const local = entries.get(g.student_id)
-      const server = g.value !== null ? Number(g.value) : (g.status === "entered" ? null : undefined)
+      const server =
+        g.value !== null ? Number(g.value) : g.status === "entered" ? null : undefined
       if (local !== server) return true
     }
     return false
@@ -254,11 +223,8 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
   }, [speech, router, backHref])
 
   const requestExit = useCallback(() => {
-    if (hasDirty) {
-      setExitDialogOpen(true)
-    } else {
-      performExit()
-    }
+    if (hasDirty) setExitDialogOpen(true)
+    else performExit()
   }, [hasDirty, performExit])
 
   // ─── Save batch ────────────────────────────────────────────────────────
@@ -300,7 +266,7 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
         entries={entries}
         evaluationTitle={evaluation?.title}
         onModify={(idx) => {
-          setCurrentIdx(idx)
+          jumpTo(idx)
           setMode("entering")
         }}
         onSubmit={submitAll}
@@ -325,10 +291,11 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
 
   const filledCount = grades.filter((g) => entries.get(g.student_id) !== undefined).length
   const progressPct = (filledCount / totalStudents) * 100
+  const currentValue = entries.get(currentStudent.student_id)
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-slate-950 text-white">
-      {/* Top bar — exit + progress */}
+      {/* Top bar — exit + progress + recap */}
       <div className="flex items-center gap-3 px-4 pt-4">
         <Button
           variant="ghost"
@@ -348,7 +315,7 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
           </div>
           <div className="mt-1 h-1 overflow-hidden rounded-full bg-white/10">
             <div
-              className="h-full rounded-full bg-emerald-400 transition-all"
+              className="h-full rounded-full bg-accent transition-all"
               style={{ width: `${progressPct}%` }}
             />
           </div>
@@ -363,145 +330,50 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
         </Button>
       </div>
 
-      {/* Center — student + grade */}
-      <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6 text-center">
-        <div className="space-y-1">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/50">
-            Élève {currentIdx + 1} sur {totalStudents}
-          </p>
-          <h1 className="font-serif text-3xl tracking-tight sm:text-4xl">
-            {currentStudent.student_name}
-          </h1>
-          {evaluation && (
-            <p className="text-sm text-white/60">
-              {evaluation.subject_name} · {evaluation.title}
-            </p>
-          )}
-        </div>
-
-        <div
-          className={cn(
-            "flex flex-col items-center gap-2 rounded-3xl border px-8 py-6 transition-colors",
-            feedback === "ok" && "border-emerald-400/40 bg-emerald-400/5",
-            feedback === "error" && "border-rose-400/40 bg-rose-400/5",
-            !feedback && "border-white/10 bg-white/[0.03]",
-          )}
-        >
-          {currentValue === undefined ? (
-            <span className="text-7xl font-bold text-white/20 sm:text-8xl">—</span>
-          ) : currentValue === null ? (
-            <span className="text-5xl font-bold text-amber-300 sm:text-6xl">ABSENT</span>
-          ) : (
-            <span className="font-bold tabular-nums text-white text-7xl sm:text-9xl">
-              {Number.isInteger(currentValue)
-                ? currentValue
-                : currentValue.toString().replace(".", ",")}
-            </span>
-          )}
-          <span className="text-sm text-white/50">/ 20</span>
-        </div>
-
-        {transcriptDisplay && (
-          <p className="max-w-md text-sm italic text-white/60">
-            « {transcriptDisplay} »
-          </p>
-        )}
-        {speech.interimTranscript && !transcriptDisplay && (
-          <p className="max-w-md text-sm italic text-white/40">
-            … {speech.interimTranscript}
-          </p>
-        )}
-      </div>
-
-      {/* Bottom controls */}
-      <div className="space-y-3 px-4 pb-6">
-        {!speech.supported && (
-          <div className="flex items-center gap-2 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
-            <AlertTriangle className="h-4 w-4 shrink-0" />
-            <span>
-              Reconnaissance vocale indisponible sur ce navigateur. Saisissez avec
-              les boutons ou utilisez Chrome / Safari récent.
-            </span>
+      {/* Body : colonne principale (scène + contrôles) + roster desktop */}
+      <div className="flex min-h-0 flex-1">
+        <div className="flex min-h-0 flex-1 flex-col">
+          <DicteeStudentStage
+            studentName={currentStudent.student_name}
+            position={currentIdx + 1}
+            total={totalStudents}
+            value={currentValue}
+            subjectLabel={
+              evaluation ? `${evaluation.subject_name} · ${evaluation.title}` : undefined
+            }
+            feedback={feedback}
+            transcript={transcriptDisplay}
+            interim={speech.interimTranscript}
+          />
+          <div className="mx-auto w-full max-w-2xl lg:max-w-3xl">
+            <DicteeControls
+              isFirst={currentIdx === 0}
+              isLast={currentIdx === totalStudents - 1}
+              onPrev={goPrev}
+              onAbsent={() => {
+                setEntry(currentStudent.student_id, null)
+                setFeedback("ok")
+                beep()
+              }}
+              onNext={goNext}
+              micSupported={speech.supported}
+              micListening={speech.listening}
+              micPermissionDenied={speech.permissionDenied}
+              micServiceUnavailable={speech.serviceUnavailable}
+              onMicToggle={onMicToggle}
+              onMicRetry={onMicRetry}
+            />
           </div>
-        )}
-
-        {speech.supported && speech.permissionDenied && (
-          <div className="flex items-center gap-2 rounded-lg border border-rose-400/30 bg-rose-400/10 px-3 py-2 text-xs text-rose-200">
-            <AlertTriangle className="h-4 w-4 shrink-0" />
-            <span>
-              Accès au micro refusé. Autorisez-le dans les paramètres du navigateur
-              puis rechargez la page.
-            </span>
-          </div>
-        )}
-
-        <div className="grid grid-cols-3 gap-2">
-          <Button
-            variant="secondary"
-            size="lg"
-            onClick={goPrev}
-            disabled={currentIdx === 0}
-            className="h-16 bg-white/10 text-white hover:bg-white/20 disabled:opacity-30"
-          >
-            <ChevronLeft className="h-6 w-6" />
-            <span className="ml-1 hidden sm:inline">Précédent</span>
-          </Button>
-
-          <Button
-            variant="secondary"
-            size="lg"
-            onClick={() => {
-              if (!currentStudent) return
-              setEntry(currentStudent.student_id, null)
-              setFeedback("ok")
-              beep()
-            }}
-            className="h-16 bg-amber-500/20 text-amber-200 hover:bg-amber-500/30"
-          >
-            Absent
-          </Button>
-
-          <Button
-            size="lg"
-            onClick={goNext}
-            className="h-16 bg-emerald-500 text-white hover:bg-emerald-600"
-          >
-            <span className="hidden sm:inline">
-              {currentIdx === totalStudents - 1 ? "Récap" : "Suivant"}
-            </span>
-            {currentIdx === totalStudents - 1 ? (
-              <Check className="ml-1 h-6 w-6 sm:ml-2" />
-            ) : (
-              <ChevronRight className="ml-1 h-6 w-6 sm:ml-2" />
-            )}
-          </Button>
         </div>
 
-        {speech.supported && !speech.permissionDenied && (
-          <Button
-            variant="ghost"
-            size="lg"
-            onClick={toggleMic}
-            className={cn(
-              "h-14 w-full gap-2 border text-white",
-              speech.listening
-                ? "border-emerald-400/50 bg-emerald-500/10 hover:bg-emerald-500/20"
-                : "border-white/20 bg-white/[0.04] hover:bg-white/10",
-            )}
-          >
-            {speech.listening ? (
-              <>
-                <Mic className={cn("h-5 w-5", speech.listening && "animate-pulse text-emerald-400")} />
-                <span>Micro actif — dites votre note</span>
-              </>
-            ) : (
-              <>
-                <MicOff className="h-5 w-5 opacity-60" />
-                <span>Activer le micro</span>
-              </>
-            )}
-          </Button>
-        )}
+        <DicteeRoster
+          className="hidden lg:flex"
+          students={grades}
+          entries={entries}
+          currentIdx={currentIdx}
+          filledCount={filledCount}
+          onJump={jumpTo}
+        />
       </div>
 
       <AlertDialog open={exitDialogOpen} onOpenChange={setExitDialogOpen}>
@@ -524,164 +396,6 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
-  )
-}
-
-// ─────────────────────────────────────────────────────────────────────────
-// Recap view — final review before save
-// ─────────────────────────────────────────────────────────────────────────
-
-interface RecapViewProps {
-  grades: { student_id: number; student_name: string }[]
-  entries: Map<number, EntryValue>
-  evaluationTitle?: string
-  onModify: (idx: number) => void
-  onSubmit: () => void
-  onCancel: () => void
-  isSubmitting: boolean
-}
-
-function RecapView({
-  grades,
-  entries,
-  evaluationTitle,
-  onModify,
-  onSubmit,
-  onCancel,
-  isSubmitting,
-}: RecapViewProps) {
-  const filled = grades.filter((g) => entries.get(g.student_id) !== undefined).length
-  const absent = grades.filter((g) => entries.get(g.student_id) === null).length
-  const missing = grades.length - filled
-
-  return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950 text-white">
-      <div className="flex items-center gap-3 border-b border-white/10 px-4 py-4">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onCancel}
-          className="h-10 w-10 text-white/80 hover:bg-white/10 hover:text-white"
-          aria-label="Retour à la dictée"
-        >
-          <ChevronLeft className="h-5 w-5" />
-        </Button>
-        <div className="flex-1">
-          <h2 className="font-serif text-xl tracking-tight">Récapitulatif</h2>
-          {evaluationTitle && (
-            <p className="text-xs text-white/60">{evaluationTitle}</p>
-          )}
-        </div>
-      </div>
-
-      <div className="grid grid-cols-3 gap-2 px-4 py-3">
-        <RecapTile label="Saisies" value={filled - absent} tone="ok" />
-        <RecapTile label="Absents" value={absent} tone="warn" />
-        <RecapTile label="Manquants" value={missing} tone={missing > 0 ? "danger" : "neutral"} />
-      </div>
-
-      <div className="flex-1 space-y-1 overflow-y-auto px-2 pb-4">
-        {grades.map((g, idx) => {
-          const v = entries.get(g.student_id)
-          const isMissing = v === undefined
-          return (
-            <button
-              type="button"
-              key={g.student_id}
-              onClick={() => onModify(idx)}
-              className={cn(
-                "flex w-full items-center gap-3 rounded-lg border px-3 py-3 text-left transition-colors",
-                "border-white/10 bg-white/[0.02] hover:bg-white/10",
-                isMissing && "border-rose-400/30 bg-rose-400/5",
-              )}
-            >
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white/10 text-xs tabular-nums">
-                {idx + 1}
-              </span>
-              <span className="flex-1 truncate text-sm">{g.student_name}</span>
-              <span
-                className={cn(
-                  "tabular-nums text-base font-semibold",
-                  v === undefined && "text-rose-300",
-                  v === null && "text-amber-300",
-                  typeof v === "number" && v < 10 && "text-rose-300",
-                  typeof v === "number" && v >= 10 && v < 14 && "text-amber-300",
-                  typeof v === "number" && v >= 14 && "text-emerald-300",
-                )}
-              >
-                {v === undefined
-                  ? "—"
-                  : v === null
-                    ? "Absent"
-                    : Number.isInteger(v)
-                      ? v
-                      : v.toString().replace(".", ",")}
-              </span>
-              <Pencil className="h-4 w-4 text-white/40" />
-            </button>
-          )
-        })}
-      </div>
-
-      <div className="space-y-2 border-t border-white/10 px-4 py-4">
-        {missing > 0 && (
-          <div className="flex items-center gap-2 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
-            <AlertTriangle className="h-4 w-4 shrink-0" />
-            <span>
-              {missing} élève{missing > 1 ? "s" : ""} sans note. Vous pourrez les
-              compléter plus tard.
-            </span>
-          </div>
-        )}
-        <Button
-          size="lg"
-          onClick={onSubmit}
-          disabled={isSubmitting || filled === 0}
-          className="h-14 w-full bg-emerald-500 text-white hover:bg-emerald-600"
-        >
-          {isSubmitting ? (
-            <>
-              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-              Enregistrement...
-            </>
-          ) : (
-            <>
-              <Check className="mr-2 h-5 w-5" />
-              Enregistrer {filled} note{filled > 1 ? "s" : ""}
-            </>
-          )}
-        </Button>
-      </div>
-    </div>
-  )
-}
-
-function RecapTile({
-  label,
-  value,
-  tone,
-}: {
-  label: string
-  value: number
-  tone: "ok" | "warn" | "danger" | "neutral"
-}) {
-  return (
-    <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3 text-center">
-      <p className="text-[10px] font-medium uppercase tracking-wider text-white/50">
-        {label}
-      </p>
-      <p
-        className={cn(
-          "mt-1 text-2xl font-semibold tabular-nums",
-          tone === "ok" && "text-emerald-300",
-          tone === "warn" && "text-amber-300",
-          tone === "danger" && "text-rose-300",
-          tone === "neutral" && "text-white",
-        )}
-      >
-        {value}
-      </p>
     </div>
   )
 }

--- a/components/teacher/grades/dictee/DicteeControls.tsx
+++ b/components/teacher/grades/dictee/DicteeControls.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import {
+  AlertTriangle,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Mic,
+  MicOff,
+  RotateCcw,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+interface DicteeControlsProps {
+  isFirst: boolean
+  isLast: boolean
+  onPrev: () => void
+  onAbsent: () => void
+  onNext: () => void
+  // Micro
+  micSupported: boolean
+  micListening: boolean
+  micPermissionDenied: boolean
+  micServiceUnavailable: boolean
+  onMicToggle: () => void
+  onMicRetry: () => void
+}
+
+/**
+ * Contrôles bas de la dictée : navigation (précédent / absent / suivant) +
+ * gestion micro. Le micro a désormais 4 états clairs et un chemin de
+ * récupération (bug #282) :
+ *   - non supporté     → info clavier
+ *   - service KO       → info clavier + « Réessayer »
+ *   - permission refusée → info + « Réessayer le micro » (auto-débloque aussi
+ *     dès que l'utilisateur autorise via la Permissions API)
+ *   - OK               → bouton activer / micro actif
+ */
+export function DicteeControls({
+  isFirst,
+  isLast,
+  onPrev,
+  onAbsent,
+  onNext,
+  micSupported,
+  micListening,
+  micPermissionDenied,
+  micServiceUnavailable,
+  onMicToggle,
+  onMicRetry,
+}: DicteeControlsProps) {
+  return (
+    <div className="space-y-3 px-4 pb-6">
+      {!micSupported && (
+        <MicBanner tone="info">
+          Reconnaissance vocale indisponible sur ce navigateur. Saisissez avec les
+          boutons, ou utilisez Chrome / Edge / Safari récent.
+        </MicBanner>
+      )}
+
+      {micSupported && micServiceUnavailable && (
+        <MicBanner
+          tone="info"
+          action={
+            <RetryButton onClick={onMicRetry}>Réessayer</RetryButton>
+          }
+        >
+          Reconnaissance vocale indisponible sur ce navigateur ou ce réseau. Le
+          micro fonctionne, saisissez au clavier ou réessayez.
+        </MicBanner>
+      )}
+
+      {micSupported && !micServiceUnavailable && micPermissionDenied && (
+        <MicBanner
+          tone="danger"
+          action={
+            <RetryButton onClick={onMicRetry}>Réessayer le micro</RetryButton>
+          }
+        >
+          Accès au micro refusé. Autorisez-le dans le navigateur, l&apos;activation
+          se fait ensuite toute seule (ou appuyez sur « Réessayer »).
+        </MicBanner>
+      )}
+
+      <div className="grid grid-cols-3 gap-2">
+        <Button
+          variant="secondary"
+          size="lg"
+          onClick={onPrev}
+          disabled={isFirst}
+          className="h-16 bg-white/10 text-white hover:bg-white/20 disabled:opacity-30"
+        >
+          <ChevronLeft className="h-6 w-6" />
+          <span className="ml-1 hidden sm:inline">Précédent</span>
+        </Button>
+
+        <Button
+          variant="secondary"
+          size="lg"
+          onClick={onAbsent}
+          className="h-16 bg-amber-500/20 text-amber-200 hover:bg-amber-500/30"
+        >
+          Absent
+        </Button>
+
+        <Button
+          size="lg"
+          onClick={onNext}
+          className="h-16 bg-emerald-500 text-white hover:bg-emerald-600"
+        >
+          <span className="hidden sm:inline">{isLast ? "Récap" : "Suivant"}</span>
+          {isLast ? (
+            <Check className="ml-1 h-6 w-6 sm:ml-2" />
+          ) : (
+            <ChevronRight className="ml-1 h-6 w-6 sm:ml-2" />
+          )}
+        </Button>
+      </div>
+
+      {micSupported && !micPermissionDenied && !micServiceUnavailable && (
+        <Button
+          variant="ghost"
+          size="lg"
+          onClick={onMicToggle}
+          className={cn(
+            "h-14 w-full gap-2 border text-white",
+            micListening
+              ? "border-accent/60 bg-accent/15 hover:bg-accent/25"
+              : "border-white/20 bg-white/[0.04] hover:bg-white/10",
+          )}
+        >
+          {micListening ? (
+            <>
+              <Mic className="h-5 w-5 animate-pulse text-accent" />
+              <span>Micro actif — dites votre note</span>
+            </>
+          ) : (
+            <>
+              <MicOff className="h-5 w-5 opacity-60" />
+              <span>Activer le micro</span>
+            </>
+          )}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+function MicBanner({
+  tone,
+  action,
+  children,
+}: {
+  tone: "info" | "danger"
+  action?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-lg border px-3 py-2 text-xs",
+        tone === "info" && "border-amber-400/30 bg-amber-400/10 text-amber-200",
+        tone === "danger" && "border-rose-400/30 bg-rose-400/10 text-rose-200",
+      )}
+    >
+      <AlertTriangle className="h-4 w-4 shrink-0" />
+      <span className="flex-1">{children}</span>
+      {action}
+    </div>
+  )
+}
+
+function RetryButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex shrink-0 items-center gap-1 rounded-md border border-white/25 bg-white/10 px-2.5 py-1 text-xs font-semibold text-white hover:bg-white/20"
+    >
+      <RotateCcw className="h-3.5 w-3.5" />
+      {children}
+    </button>
+  )
+}

--- a/components/teacher/grades/dictee/DicteeRoster.tsx
+++ b/components/teacher/grades/dictee/DicteeRoster.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { entryToneClass, formatEntry, type EntryValue } from "./types"
+
+interface RosterStudent {
+  student_id: number
+  student_name: string
+}
+
+interface DicteeRosterProps {
+  students: RosterStudent[]
+  entries: Map<number, EntryValue>
+  currentIdx: number
+  filledCount: number
+  onJump: (idx: number) => void
+  className?: string
+}
+
+/**
+ * Panneau roster — vue live de toute la classe à droite en desktop. Remplit
+ * l'espace horizontal (avant vide sur grand écran), permet de sauter
+ * directement à un élève, et montre l'avancement d'un coup d'œil. Masqué en
+ * mobile (le récap plein écran joue ce rôle sur petit écran).
+ */
+export function DicteeRoster({
+  students,
+  entries,
+  currentIdx,
+  filledCount,
+  onJump,
+  className,
+}: DicteeRosterProps) {
+  return (
+    <aside
+      className={cn(
+        "flex w-[340px] shrink-0 flex-col border-l border-white/10 bg-white/[0.02]",
+        className,
+      )}
+    >
+      <div className="border-b border-white/10 px-4 py-3">
+        <p className="text-xs font-semibold uppercase tracking-wider text-white/60">
+          Classe
+        </p>
+        <p className="mt-0.5 text-sm text-white/80">
+          {filledCount} / {students.length} saisis
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-1 overflow-y-auto p-2">
+        {students.map((s, idx) => {
+          const v = entries.get(s.student_id)
+          const isCurrent = idx === currentIdx
+          return (
+            <button
+              type="button"
+              key={s.student_id}
+              onClick={() => onJump(idx)}
+              className={cn(
+                "flex w-full items-center gap-2.5 rounded-lg border px-2.5 py-2 text-left transition-colors",
+                isCurrent
+                  ? "border-accent/60 bg-accent/15"
+                  : "border-transparent hover:bg-white/[0.06]",
+              )}
+              aria-current={isCurrent ? "true" : undefined}
+            >
+              <span
+                className={cn(
+                  "flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] tabular-nums",
+                  isCurrent ? "bg-accent text-accent-foreground" : "bg-white/10 text-white/70",
+                )}
+              >
+                {idx + 1}
+              </span>
+              <span className="flex-1 truncate text-sm text-white/85">
+                {s.student_name}
+              </span>
+              <span
+                className={cn(
+                  "shrink-0 text-sm font-semibold tabular-nums",
+                  entryToneClass(v),
+                )}
+              >
+                {formatEntry(v)}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}

--- a/components/teacher/grades/dictee/DicteeStudentStage.tsx
+++ b/components/teacher/grades/dictee/DicteeStudentStage.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { EntryValue } from "./types"
+
+interface DicteeStudentStageProps {
+  studentName: string
+  position: number
+  total: number
+  value: EntryValue
+  subjectLabel?: string
+  feedback: "ok" | "error" | null
+  transcript: string
+  interim: string
+}
+
+/**
+ * Scène centrale de la dictée : élève courant + grande note lisible plein
+ * soleil (text-8xl/9xl). Occupe tout l'espace vertical disponible. Responsive :
+ * la note grossit encore sur desktop pour remplir la colonne principale.
+ */
+export function DicteeStudentStage({
+  studentName,
+  position,
+  total,
+  value,
+  subjectLabel,
+  feedback,
+  transcript,
+  interim,
+}: DicteeStudentStageProps) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6 text-center">
+      <div className="space-y-1">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-white/50">
+          Élève {position} sur {total}
+        </p>
+        <h1 className="font-serif text-3xl tracking-tight sm:text-4xl lg:text-5xl">
+          {studentName}
+        </h1>
+        {subjectLabel && <p className="text-sm text-white/60">{subjectLabel}</p>}
+      </div>
+
+      <div
+        className={cn(
+          "flex flex-col items-center gap-2 rounded-3xl border px-10 py-8 transition-colors",
+          feedback === "ok" && "border-emerald-400/40 bg-emerald-400/5",
+          feedback === "error" && "border-rose-400/40 bg-rose-400/5",
+          !feedback && "border-white/10 bg-white/[0.03]",
+        )}
+      >
+        {value === undefined ? (
+          <span className="text-7xl font-bold text-white/20 sm:text-8xl lg:text-9xl">—</span>
+        ) : value === null ? (
+          <span className="text-5xl font-bold text-amber-300 sm:text-6xl lg:text-7xl">
+            ABSENT
+          </span>
+        ) : (
+          <span className="text-7xl font-bold tabular-nums text-white sm:text-8xl lg:text-9xl">
+            {Number.isInteger(value) ? value : value.toString().replace(".", ",")}
+          </span>
+        )}
+        <span className="text-sm text-white/50">/ 20</span>
+      </div>
+
+      {transcript ? (
+        <p className="max-w-md text-sm italic text-white/60">« {transcript} »</p>
+      ) : interim ? (
+        <p className="max-w-md text-sm italic text-white/40">… {interim}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/components/teacher/grades/dictee/RecapView.tsx
+++ b/components/teacher/grades/dictee/RecapView.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { AlertTriangle, Check, ChevronLeft, Loader2, Pencil } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { entryToneClass, formatEntry, type EntryValue } from "./types"
+
+interface RecapStudent {
+  student_id: number
+  student_name: string
+}
+
+interface RecapViewProps {
+  grades: RecapStudent[]
+  entries: Map<number, EntryValue>
+  evaluationTitle?: string
+  onModify: (idx: number) => void
+  onSubmit: () => void
+  onCancel: () => void
+  isSubmitting: boolean
+}
+
+/** Écran récap — revue finale avant enregistrement batch. */
+export function RecapView({
+  grades,
+  entries,
+  evaluationTitle,
+  onModify,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: RecapViewProps) {
+  const filled = grades.filter((g) => entries.get(g.student_id) !== undefined).length
+  const absent = grades.filter((g) => entries.get(g.student_id) === null).length
+  const missing = grades.length - filled
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-slate-950 text-white">
+      <div className="flex items-center gap-3 border-b border-white/10 px-4 py-4">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onCancel}
+          className="h-10 w-10 text-white/80 hover:bg-white/10 hover:text-white"
+          aria-label="Retour à la dictée"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
+        <div className="flex-1">
+          <h2 className="font-serif text-xl tracking-tight">Récapitulatif</h2>
+          {evaluationTitle && <p className="text-xs text-white/60">{evaluationTitle}</p>}
+        </div>
+      </div>
+
+      <div className="mx-auto grid w-full max-w-2xl grid-cols-3 gap-2 px-4 py-3">
+        <RecapTile label="Saisies" value={filled - absent} tone="ok" />
+        <RecapTile label="Absents" value={absent} tone="warn" />
+        <RecapTile label="Manquants" value={missing} tone={missing > 0 ? "danger" : "neutral"} />
+      </div>
+
+      <div className="mx-auto min-h-0 w-full max-w-2xl flex-1 space-y-1 overflow-y-auto px-2 pb-4">
+        {grades.map((g, idx) => {
+          const v = entries.get(g.student_id)
+          const isMissing = v === undefined
+          return (
+            <button
+              type="button"
+              key={g.student_id}
+              onClick={() => onModify(idx)}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-lg border px-3 py-3 text-left transition-colors",
+                "border-white/10 bg-white/[0.02] hover:bg-white/10",
+                isMissing && "border-rose-400/30 bg-rose-400/5",
+              )}
+            >
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white/10 text-xs tabular-nums">
+                {idx + 1}
+              </span>
+              <span className="flex-1 truncate text-sm">{g.student_name}</span>
+              <span className={cn("text-base font-semibold tabular-nums", entryToneClass(v))}>
+                {formatEntry(v)}
+              </span>
+              <Pencil className="h-4 w-4 text-white/40" />
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="mx-auto w-full max-w-2xl space-y-2 border-t border-white/10 px-4 py-4">
+        {missing > 0 && (
+          <div className="flex items-center gap-2 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>
+              {missing} élève{missing > 1 ? "s" : ""} sans note. Vous pourrez les
+              compléter plus tard.
+            </span>
+          </div>
+        )}
+        <Button
+          size="lg"
+          onClick={onSubmit}
+          disabled={isSubmitting || filled === 0}
+          className="h-14 w-full bg-emerald-500 text-white hover:bg-emerald-600"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              Enregistrement...
+            </>
+          ) : (
+            <>
+              <Check className="mr-2 h-5 w-5" />
+              Enregistrer {filled} note{filled > 1 ? "s" : ""}
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function RecapTile({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: number
+  tone: "ok" | "warn" | "danger" | "neutral"
+}) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3 text-center">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-white/50">{label}</p>
+      <p
+        className={cn(
+          "mt-1 text-2xl font-semibold tabular-nums",
+          tone === "ok" && "text-emerald-300",
+          tone === "warn" && "text-amber-300",
+          tone === "danger" && "text-rose-300",
+          tone === "neutral" && "text-white",
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  )
+}

--- a/components/teacher/grades/dictee/types.ts
+++ b/components/teacher/grades/dictee/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Types + helpers partagés du mode dictée. `undefined` = pas saisi,
+ * `null` = absent, `number` = note /20.
+ */
+export type EntryValue = number | null | undefined
+
+/** Affichage FR d'une valeur : "—" (non saisi), "Absent", ou la note. */
+export function formatEntry(v: EntryValue): string {
+  if (v === undefined) return "—"
+  if (v === null) return "Absent"
+  return Number.isInteger(v) ? String(v) : v.toString().replace(".", ",")
+}
+
+/** Classe de couleur (texte, thème dark) selon la valeur — sémantique. */
+export function entryToneClass(v: EntryValue): string {
+  if (v === undefined) return "text-white/40"
+  if (v === null) return "text-amber-300"
+  if (v < 10) return "text-rose-300"
+  if (v < 14) return "text-amber-300"
+  return "text-emerald-300"
+}

--- a/lib/hooks/useSpeechRecognition.ts
+++ b/lib/hooks/useSpeechRecognition.ts
@@ -8,17 +8,28 @@ import { useCallback, useEffect, useRef, useState } from "react"
  * Compatibilité validée 2026-04-26 :
  * - Chrome Android (Itel S661, Samsung A14) — `webkitSpeechRecognition`
  * - iOS Safari 16+ (iPhone 12) — `SpeechRecognition` natif
- * - Desktop Chrome — `webkitSpeechRecognition`
+ * - Desktop Chrome / Edge — `webkitSpeechRecognition`
  *
  * Comportement :
  * - lang `fr-FR`
  * - continuous + interimResults : on capture chaque pause respiratoire
  * - auto-restart sur `onend` quand l'user n'a pas explicitement arrêté
- * - le 1er `start()` doit suivre une user gesture (click) pour iOS — la chaîne
- *   d'événements en cascade côté React est OK car appelée depuis un onClick.
  *
- * Le consommateur reçoit chaque transcript final via onResult(text).
- * `interimTranscript` affiché en live pour feedback visuel.
+ * Deux modes d'échec DISTINCTS (avant, confondus → bandeau « micro refusé »
+ * menteur sur desktop, cf. bug #282) :
+ *
+ * - `permissionDenied` : vrai refus du micro (getUserMedia NotAllowedError, ou
+ *   `not-allowed` de l'ASR). Récupérable en autorisant le micro. On relit la
+ *   Permissions API et on écoute son `onchange` → dès que l'utilisateur
+ *   autorise, le flag se lève tout seul (aucun reload nécessaire).
+ * - `serviceUnavailable` : le SERVICE de reconnaissance (serveur distant utilisé
+ *   par `webkitSpeechRecognition` sur desktop) est indisponible (`network`,
+ *   `service-not-allowed`, `audio-capture`). Le micro n'est PAS en cause. On
+ *   invite alors à saisir au clavier, sans message alarmant.
+ *
+ * Le pré-vol `requestAndStart()` appelle `getUserMedia({audio:true})` dans le
+ * geste utilisateur (clic) : prompt de permission propre + distinction nette
+ * refus-micro / souci-service. `reset()` permet un « Réessayer » sans reload.
  */
 
 interface SpeechRecognitionEventLike {
@@ -66,12 +77,23 @@ interface UseSpeechRecognitionOptions {
 interface UseSpeechRecognitionReturn {
   listening: boolean
   interimTranscript: string
+  /** Démarre la reconnaissance sans pré-vol (usage interne / retry). */
   start: () => void
+  /** Arrête la reconnaissance (geste volontaire). */
   stop: () => void
+  /**
+   * Demande la permission micro (getUserMedia) DANS le geste utilisateur, puis
+   * démarre. À câbler sur le clic du bouton — c'est le chemin fiable desktop +
+   * mobile. Résout après le start (ou après avoir positionné un flag d'échec).
+   */
+  requestAndStart: () => Promise<void>
+  /** Réinitialise les flags d'échec pour permettre un « Réessayer ». */
+  reset: () => void
   supported: boolean
-  /** True if the browser/user has denied microphone access. The button should
-   *  then be disabled — `start()` will keep failing silently otherwise. */
+  /** Vrai refus du micro — récupérable en autorisant. */
   permissionDenied: boolean
+  /** Service de reconnaissance indisponible — micro OK, saisir au clavier. */
+  serviceUnavailable: boolean
   error: string | null
 }
 
@@ -85,6 +107,7 @@ export function useSpeechRecognition({
   const [error, setError] = useState<string | null>(null)
   const [supported, setSupported] = useState(false)
   const [permissionDenied, setPermissionDenied] = useState(false)
+  const [serviceUnavailable, setServiceUnavailable] = useState(false)
 
   const recognitionRef = useRef<SpeechRecognitionInstance | null>(null)
   const userStoppedRef = useRef(false)
@@ -134,15 +157,35 @@ export function useSpeechRecognition({
     recognition.onerror = (event) => {
       // "no-speech" et "aborted" sont normaux (silence ou stop volontaire).
       if (event.error === "no-speech" || event.error === "aborted") return
-      // "not-allowed" / "service-not-allowed" : permission refusée — sticky, ne plus retry.
-      if (event.error === "not-allowed" || event.error === "service-not-allowed") {
-        setPermissionDenied(true)
+
+      // Souci du SERVICE de reconnaissance (pas le micro). Fréquent sur desktop
+      // où `webkitSpeechRecognition` s'appuie sur un service distant. Le micro
+      // reste utilisable — on bascule sur la saisie clavier sans alarmer.
+      if (
+        event.error === "network" ||
+        event.error === "service-not-allowed" ||
+        event.error === "audio-capture"
+      ) {
+        setServiceUnavailable(true)
         userStoppedRef.current = true
-        const msg = "Accès au micro refusé. Autorisez-le dans les paramètres du navigateur."
+        const msg =
+          "Reconnaissance vocale indisponible sur ce navigateur ou ce réseau. Saisissez les notes au clavier."
         setError(msg)
         onErrorRef.current?.(msg)
         return
       }
+
+      // Vrai refus du micro — récupérable, ne plus auto-restart.
+      if (event.error === "not-allowed") {
+        setPermissionDenied(true)
+        userStoppedRef.current = true
+        const msg =
+          "Accès au micro refusé. Autorisez-le puis appuyez sur « Réessayer le micro »."
+        setError(msg)
+        onErrorRef.current?.(msg)
+        return
+      }
+
       const msg = `Reconnaissance vocale : ${event.error}`
       setError(msg)
       onErrorRef.current?.(msg)
@@ -151,7 +194,7 @@ export function useSpeechRecognition({
     recognition.onend = () => {
       setListening(false)
       setInterimTranscript("")
-      // Auto-restart sauf si l'user a stop explicitement (pause/exit).
+      // Auto-restart sauf si l'user a stop explicitement (pause/exit/échec).
       if (!userStoppedRef.current) {
         try {
           recognition.start()
@@ -173,6 +216,36 @@ export function useSpeechRecognition({
     }
   }, [lang])
 
+  // ─── Permissions API : auto-déblocage quand l'utilisateur autorise ────────
+  // Sur les navigateurs qui exposent `permissions.query({name:'microphone'})`
+  // (Chrome/Edge), on écoute le changement d'état : passer à "granted" lève le
+  // flag permissionDenied tout seul — plus besoin de recharger la page.
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.permissions?.query) return
+    let status: PermissionStatus | null = null
+    let cancelled = false
+    const onChange = () => {
+      if (status && status.state === "granted") {
+        setPermissionDenied(false)
+        setError(null)
+      }
+    }
+    navigator.permissions
+      .query({ name: "microphone" as PermissionName })
+      .then((s) => {
+        if (cancelled) return
+        status = s
+        status.addEventListener("change", onChange)
+      })
+      .catch(() => {
+        // 'microphone' non supporté par cette Permissions API — pas grave.
+      })
+    return () => {
+      cancelled = true
+      status?.removeEventListener("change", onChange)
+    }
+  }, [])
+
   const start = useCallback(() => {
     const recognition = recognitionRef.current
     if (!recognition) return
@@ -183,6 +256,39 @@ export function useSpeechRecognition({
       // Probably already started — ignore.
     }
   }, [])
+
+  const requestAndStart = useCallback(async () => {
+    // Pré-vol permission dans le geste utilisateur : distingue refus-micro net
+    // d'un souci de service, et pose un prompt de permission propre.
+    if (typeof navigator !== "undefined" && navigator.mediaDevices?.getUserMedia) {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+        // On n'a pas besoin du flux — l'ASR ouvre le sien. Libérer aussitôt.
+        stream.getTracks().forEach((t) => t.stop())
+        setPermissionDenied(false)
+      } catch (err) {
+        const name = (err as { name?: string })?.name
+        if (name === "NotAllowedError" || name === "SecurityError") {
+          setPermissionDenied(true)
+          const msg =
+            "Accès au micro refusé. Autorisez-le puis appuyez sur « Réessayer le micro »."
+          setError(msg)
+          onErrorRef.current?.(msg)
+          return
+        }
+        if (name === "NotFoundError" || name === "NotReadableError") {
+          setServiceUnavailable(true)
+          const msg =
+            "Aucun micro disponible. Saisissez les notes au clavier."
+          setError(msg)
+          onErrorRef.current?.(msg)
+          return
+        }
+        // Autre erreur getUserMedia — on tente quand même l'ASR.
+      }
+    }
+    start()
+  }, [start])
 
   const stop = useCallback(() => {
     const recognition = recognitionRef.current
@@ -197,5 +303,22 @@ export function useSpeechRecognition({
     setInterimTranscript("")
   }, [])
 
-  return { listening, interimTranscript, start, stop, supported, permissionDenied, error }
+  const reset = useCallback(() => {
+    setPermissionDenied(false)
+    setServiceUnavailable(false)
+    setError(null)
+  }, [])
+
+  return {
+    listening,
+    interimTranscript,
+    start,
+    stop,
+    requestAndStart,
+    reset,
+    supported,
+    permissionDenied,
+    serviceUnavailable,
+    error,
+  }
 }


### PR DESCRIPTION
Closes #282

## Bug micro
- `useSpeechRecognition` distingue enfin le **vrai refus micro** (`not-allowed`, getUserMedia `NotAllowedError`) du **service vocal indisponible** (`network`/`service-not-allowed`, fréquent en desktop). Messages adaptés au lieu du « micro refusé » menteur.
- Pré-vol `getUserMedia` dans le geste utilisateur (`requestAndStart`) + écoute Permissions API `onchange` → auto-déblocage dès autorisation, sans reload. `reset()` pour le bouton « Réessayer le micro ».

## Desktop responsive
- `DicteeMode` (688 LOC) splitté en `dictee/` (< 260 LOC/fichier) : `DicteeStudentStage`, `DicteeRoster`, `DicteeControls`, `RecapView`, `types`.
- Mobile inchangé (plein écran séquentiel dark, persona plein soleil). Desktop (`lg:`) ajoute un panneau roster de classe à droite : liste live des élèves + note, courant surligné, clic pour sauter.

## Vérifs
- tsc --noEmit clean, ESLint clean.
- API publique de `DicteeMode` inchangée (imports pages admin/teacher intacts).
- Fallback tactile + batch save conservés.