### PR TITLE
fix(grades): honest dictee message on insecure (http) origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
-- Mode dictée : le micro se débloque tout seul dès qu'on l'autorise dans le navigateur, sans recharger la page ; quand la reconnaissance vocale est indisponible (réseau ou navigateur), un message clair invite à saisir au clavier au lieu d'afficher « micro refusé » à tort, et un bouton « Réessayer le micro » est proposé *(enseignant, admin)*.
+- Mode dictée : le micro se débloque tout seul dès qu'on l'autorise dans le navigateur, sans recharger la page ; quand la reconnaissance vocale est indisponible (réseau ou navigateur), un message clair invite à saisir au clavier au lieu d'afficher « micro refusé » à tort, et un bouton « Réessayer le micro » est proposé. Sur une adresse non sécurisée (http), un message explique que la dictée vocale exige le site sécurisé https, au lieu de laisser croire à un refus de permission *(enseignant, admin)*.
 - Conseil de classe : le procès-verbal se charge à nouveau pour une classe et un trimestre ; s'il n'existe pas encore, un bouton « Générer le procès-verbal » le crée à partir des bulletins. Les décisions s'enregistrent, le procès-verbal se valide et se télécharge en PDF *(admin)*.
 - Statistiques DREN : les boutons Excel et PDF téléchargent désormais un vrai fichier (classeur Excel ou document PDF) au lieu d'ouvrir des données brutes *(admin)*.
 - Page Notes : en choisissant une matière, les évaluations et les compteurs d'onglets (Toutes, À saisir, En retard, Terminées) se mettent bien à jour ; auparavant certaines matières n'affichaient aucune évaluation et les compteurs restaient figés *(admin)*.

--- a/components/teacher/grades/DicteeMode.tsx
+++ b/components/teacher/grades/DicteeMode.tsx
@@ -357,6 +357,7 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
               }}
               onNext={goNext}
               micSupported={speech.supported}
+              micSecureContext={speech.secureContext}
               micListening={speech.listening}
               micPermissionDenied={speech.permissionDenied}
               micServiceUnavailable={speech.serviceUnavailable}

--- a/components/teacher/grades/dictee/DicteeControls.tsx
+++ b/components/teacher/grades/dictee/DicteeControls.tsx
@@ -20,6 +20,7 @@ interface DicteeControlsProps {
   onNext: () => void
   // Micro
   micSupported: boolean
+  micSecureContext: boolean
   micListening: boolean
   micPermissionDenied: boolean
   micServiceUnavailable: boolean
@@ -44,6 +45,7 @@ export function DicteeControls({
   onAbsent,
   onNext,
   micSupported,
+  micSecureContext,
   micListening,
   micPermissionDenied,
   micServiceUnavailable,
@@ -59,7 +61,15 @@ export function DicteeControls({
         </MicBanner>
       )}
 
-      {micSupported && micServiceUnavailable && (
+      {micSupported && !micSecureContext && (
+        <MicBanner tone="info">
+          La dictée vocale nécessite une connexion sécurisée (https). Ouvrez le
+          site via https://college.klassci.com pour dicter, ou saisissez les notes
+          au clavier.
+        </MicBanner>
+      )}
+
+      {micSupported && micSecureContext && micServiceUnavailable && (
         <MicBanner
           tone="info"
           action={
@@ -71,7 +81,7 @@ export function DicteeControls({
         </MicBanner>
       )}
 
-      {micSupported && !micServiceUnavailable && micPermissionDenied && (
+      {micSupported && micSecureContext && !micServiceUnavailable && micPermissionDenied && (
         <MicBanner
           tone="danger"
           action={
@@ -118,7 +128,7 @@ export function DicteeControls({
         </Button>
       </div>
 
-      {micSupported && !micPermissionDenied && !micServiceUnavailable && (
+      {micSupported && micSecureContext && !micPermissionDenied && !micServiceUnavailable && (
         <Button
           variant="ghost"
           size="lg"

--- a/lib/hooks/useSpeechRecognition.ts
+++ b/lib/hooks/useSpeechRecognition.ts
@@ -90,6 +90,12 @@ interface UseSpeechRecognitionReturn {
   /** Réinitialise les flags d'échec pour permettre un « Réessayer ». */
   reset: () => void
   supported: boolean
+  /**
+   * Contexte sécurisé (https ou localhost). Le micro et la reconnaissance
+   * vocale sont BLOQUÉS par le navigateur sur origine non sécurisée (http hors
+   * localhost, ex. une IP brute) : rien à autoriser côté utilisateur.
+   */
+  secureContext: boolean
   /** Vrai refus du micro — récupérable en autorisant. */
   permissionDenied: boolean
   /** Service de reconnaissance indisponible — micro OK, saisir au clavier. */
@@ -108,6 +114,9 @@ export function useSpeechRecognition({
   const [supported, setSupported] = useState(false)
   const [permissionDenied, setPermissionDenied] = useState(false)
   const [serviceUnavailable, setServiceUnavailable] = useState(false)
+  // Optimiste au SSR ; corrigé au mount. `isSecureContext` peut être undefined
+  // sur de vieux navigateurs → on ne bloque que si explicitement false.
+  const [secureContext, setSecureContext] = useState(true)
 
   const recognitionRef = useRef<SpeechRecognitionInstance | null>(null)
   const userStoppedRef = useRef(false)
@@ -122,6 +131,7 @@ export function useSpeechRecognition({
 
   useEffect(() => {
     if (typeof window === "undefined") return
+    setSecureContext(window.isSecureContext !== false)
     const Ctor = window.SpeechRecognition ?? window.webkitSpeechRecognition
     if (!Ctor) {
       setSupported(false)
@@ -317,6 +327,7 @@ export function useSpeechRecognition({
     requestAndStart,
     reset,
     supported,
+    secureContext,
     permissionDenied,
     serviceUnavailable,
     error,


### PR DESCRIPTION
Suite de #282. Confirmé par la doc MDN : `getUserMedia` est réservé aux **contextes sécurisés** (`navigator.mediaDevices` est `undefined` en http hors localhost, et `NotAllowedError` est explicitement levé quand l'origine est insecure), et `webkitSpeechRecognition` renvoie `not-allowed` sur origine non sécurisée.

Donc sur `http://94.72.96.119` le micro est bloqué par le navigateur, pas par une permission refusée. Le message « autorisez-le » était trompeur.

- Le hook expose `secureContext` (`window.isSecureContext`).
- Sur origine non sécurisée : bannière dédiée « la dictée vocale nécessite https, ouvrez college.klassci.com ou saisissez au clavier », le bouton micro et le bandeau rouge « refusé » sont masqués.
- Sur https : comportement inchangé (le micro fonctionne).