### PR TITLE
fix(security): allow microphone=(self) for voice dictation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Mode dictée : la saisie vocale des notes fonctionne à nouveau. Le micro était bloqué par une politique de sécurité du site trop stricte, même quand l'enseignant l'avait autorisé dans le navigateur *(enseignant, admin)*.
 - Déconnexion : le bouton « Se déconnecter » renvoie désormais vers la page de connexion du site (college.klassci.com) au lieu d'une adresse locale invalide *(tous)*.
 - Mode dictée : le micro est demandé directement par le navigateur au clic (plus fiable). Quand la reconnaissance vocale est bloquée par le navigateur (fréquent sur Microsoft Edge), le message invite à utiliser Google Chrome ou à saisir au clavier au lieu d'afficher « micro refusé » à tort. Après avoir autorisé le micro dans les réglages, un bouton « Recharger la page » applique le changement. Sur une adresse non sécurisée (http), un message explique que la dictée vocale exige le site sécurisé https *(enseignant, admin)*.
 - Conseil de classe : le procès-verbal se charge à nouveau pour une classe et un trimestre ; s'il n'existe pas encore, un bouton « Générer le procès-verbal » le crée à partir des bulletins. Les décisions s'enregistrent, le procès-verbal se valide et se télécharge en PDF *(admin)*.

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,8 +51,13 @@ const SECURITY_HEADERS = [
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   {
+    // microphone=(self) : la dictée vocale (mode dictée des notes) a besoin du
+    // micro pour NOTRE origine. `microphone=()` le bloquait au niveau document,
+    // AU-DESSUS de la permission utilisateur → `not-allowed` partout. `(self)`
+    // est le défaut navigateur (origine propre seulement, pas les iframes tiers).
+    // camera / geolocation restent bloqués (non utilisés).
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+    value: 'camera=(), microphone=(self), geolocation=(), interest-cohort=()',
   },
 ];
 


### PR DESCRIPTION
## Vraie cause du micro « refusé »

`next.config.ts` servait `Permissions-Policy: … microphone=() …`. Or `microphone=()` **désactive le micro pour toute origine, y compris la nôtre**, au-dessus de la permission utilisateur ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy/microphone) : liste vide = feature désactivée, getUserMedia rejette `NotAllowedError`). D'où le `not-allowed` sur Chrome ET Edge malgré le toggle micro vert. Toutes les tentatives précédentes sur le hook étaient en aval de ce blocage.

## Fix
`microphone=()` → `microphone=(self)` (origine propre uniquement ; c'est le défaut navigateur). camera/geolocation restent bloqués.

Header build-time (next.config) → nécessite rebuild + restart. Vérifié : aucune autre source (Caddy) ne réémet ce header.

Doc: MDN Permissions-Policy/microphone.