### PR TITLE
fix(auth): keep active session alive on refresh rotation race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Fixed
 
+- Session : on n'est plus déconnecté pendant qu'on utilise l'application. Un renouvellement de session simultané pouvait éjecter un utilisateur pourtant actif ; seule une vraie inactivité prolongée déconnecte désormais *(tous)*.
 - Mode dictée : la saisie vocale des notes fonctionne à nouveau. Le micro était bloqué par une politique de sécurité du site trop stricte, même quand l'enseignant l'avait autorisé dans le navigateur *(enseignant, admin)*.
 - Déconnexion : le bouton « Se déconnecter » renvoie désormais vers la page de connexion du site (college.klassci.com) au lieu d'une adresse locale invalide *(tous)*.
 - Mode dictée : le micro est demandé directement par le navigateur au clic (plus fiable). Quand la reconnaissance vocale est bloquée par le navigateur (fréquent sur Microsoft Edge), le message invite à utiliser Google Chrome ou à saisir au clavier au lieu d'afficher « micro refusé » à tort. Après avoir autorisé le micro dans les réglages, un bouton « Recharger la page » applique le changement. Sur une adresse non sécurisée (http), un message explique que la dictée vocale exige le site sécurisé https *(enseignant, admin)*.

--- a/auth.ts
+++ b/auth.ts
@@ -95,7 +95,20 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           token.error = undefined
           return token
         } catch {
-          // Refresh token révoqué/expiré (inactivité prolongée) → re-login.
+          // Le refresh a échoué. Cause la plus fréquente : COURSE DE ROTATION.
+          // Le refresh token BE est à usage unique (rotation) ; un autre appel
+          // jwt concurrent (navigation via middleware, SessionKeepAlive,
+          // useSession) l'a déjà consommé et rotaté, invalidant notre copie.
+          // Tant que l'access token courant n'est PAS réellement expiré, on
+          // GARDE la session : le prochain appel jwt lira le cookie rafraîchi
+          // par l'appel gagnant et repartira propre. On ne déconnecte QUE si
+          // l'access token est vraiment périmé (vraie fin de session côté
+          // inactivité, ou refresh durablement cassé). Sans ça, un utilisateur
+          // ACTIF était éjecté au moindre refresh concurrent.
+          if (token.accessToken && !isTokenExpired(token.accessToken, 0)) {
+            token.error = undefined
+            return token
+          }
           token.error = "RefreshTokenError"
           return token
         }


### PR DESCRIPTION
## Bug
Un utilisateur ACTIF était déconnecté en pleine utilisation.

## Cause (testée en prod)
Le refresh token BE est à usage unique (rotation) : réutiliser l'ancien → 401 (vérifié). Chez un utilisateur actif, deux appels jwt concurrents (middleware sur navigation + `update()` de SessionKeepAlive) lisent le même refresh token ; l'un le consomme et le rotate, l'autre échoue → `RefreshTokenError` → déconnexion. Plus on est actif, plus ça arrive.

## Fix
Dans le callback `jwt`, si le refresh échoue MAIS que l'access token courant n'est pas réellement expiré, on GARDE la session (le prochain appel jwt lira le cookie rafraîchi par l'appel gagnant). On ne déconnecte que si l'access token est vraiment périmé.

Couplé à la PR BE qui porte l'access token à 60 min (refresh rares).