### PR TITLE
style(ui): Nunito Sans for titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Police des titres remplacée par Nunito Sans, plus sobre et lisible, à la place de l'ancienne police jugée trop fantaisiste *(tous)*.
 - Saisie des notes repensée dans la ligne premium KLASSCI : en-tête au dégradé bleu-orange avec le détail de l'évaluation et les indicateurs clés (saisies, moyenne de la classe, état de sauvegarde), « Mode dictée » mis en avant en orange. Sur grand écran, les élèves s'affichent sur deux colonnes pour moins de défilement ; une seule colonne sur téléphone *(enseignant, admin)*.
 - Mode dictée sur grand écran : l'espace est désormais utilisé avec un panneau « Classe » à droite listant tous les élèves et leur note, l'élève en cours surligné, cliquable pour y sauter directement. Sur téléphone, l'affichage plein écran séquentiel reste inchangé *(enseignant, admin)*.
 - Page Emploi du temps repensée dans la ligne premium KLASSCI : bandeau bleu-orange rappelant « Semaine type · Année en cours », classe et actions (générer, exporter PDF) regroupées dans une carte de contrôle avec sélection rapide par classe *(admin)*.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { DM_Sans, DM_Serif_Display } from 'next/font/google';
+import { DM_Sans, Nunito_Sans } from 'next/font/google';
 import { Providers } from '@/components/shared/Providers';
 import { ChunkErrorReloader } from '@/components/shared/ChunkErrorReloader';
 import './globals.css';
@@ -9,8 +9,11 @@ const dmSans = DM_Sans({
   variable: '--font-sans',
 });
 
-const dmSerif = DM_Serif_Display({
-  weight: '400',
+// Police des titres : Nunito Sans (humaniste, sobre) en remplacement de
+// DM Serif Display, jugé trop fantaisiste. Variable font → tous les poids
+// (les titres utilisent semibold/bold). Le token Tailwind `font-serif`
+// (var --font-serif) pointe désormais sur cette police pour tous les titres.
+const nunitoSans = Nunito_Sans({
   subsets: ['latin'],
   variable: '--font-serif',
 });
@@ -50,7 +53,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="fr" suppressHydrationWarning>
-      <body className={`${dmSans.variable} ${dmSerif.variable} font-sans antialiased`}>
+      <body className={`${dmSans.variable} ${nunitoSans.variable} font-sans antialiased`}>
         <ChunkErrorReloader />
         <Providers>{children}</Providers>
       </body>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,7 +20,9 @@ const config: Config = {
   	extend: {
   		fontFamily: {
   			sans: ['var(--font-sans)', 'system-ui', 'sans-serif'],
-  			serif: ['var(--font-serif)', 'Georgia', 'serif'],
+  			// `serif` = police des titres (Nunito Sans via --font-serif).
+  			// Fallback sur une pile sans-serif (la police n'est plus un serif).
+  			serif: ['var(--font-serif)', 'system-ui', 'sans-serif'],
   		},
   		colors: {
   			border: 'hsl(var(--border))',


### PR DESCRIPTION
Remplace DM Serif Display (jugé trop fantaisiste) par Nunito Sans pour tous les titres. Le token `font-serif` (var --font-serif) pointe désormais sur Nunito Sans ; les ~58 usages de `font-serif` basculent sans autre changement. Fallback Tailwind mis en pile sans-serif.