### PR TITLE
feat(accounts): account section + forced password change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Section « Compte de connexion » sur la fiche d'un élève, parent, enseignant ou membre du personnel : voir l'état du compte (email, dernière connexion), créer le compte s'il n'existe pas (élève/parent) avec un email pré-rempli et éditable, et réinitialiser le mot de passe. Le mot de passe temporaire est affiché pour être communiqué *(admin, personnel)*.
+- Changement de mot de passe obligatoire à la première connexion après création ou réinitialisation par un administrateur : l'utilisateur choisit son propre mot de passe avant d'accéder à son espace *(tous)*.
 - Partage du lien de l'application soigné : sur Slack, WhatsApp, Twitter/X, LinkedIn ou par message, le lien college.klassci.com affiche désormais une carte aux couleurs de KLASSCI College (logo, accroche) au lieu d'un lien nu *(tous)*.
 - Page Notes : bouton unique « Relevé de notes » qui regroupe l'aperçu et le téléchargement du relevé rempli, plus le téléchargement d'une feuille de notes vierge à remplir à la main (élèves de la classe, matière et trimestre pré-renseignés si choisis) *(admin, enseignant)*.
 - Tableau de bord élève : la dernière note obtenue est mise en avant (matière, note sur 20 et intitulé de l'évaluation) *(élève)*.

--- a/app/(auth)/change-password/page.tsx
+++ b/app/(auth)/change-password/page.tsx
@@ -1,0 +1,26 @@
+import { ChangePasswordForm } from "@/components/forms/ChangePasswordForm"
+
+export const metadata = { title: "Changer le mot de passe" }
+
+/**
+ * Écran de changement de mot de passe forcé (1re connexion après création ou
+ * réinitialisation par un admin). Le middleware y redirige tant que le compte
+ * porte `mustChangePassword`. Réutilise la mise en page (auth) avec la photo.
+ */
+export default function ChangePasswordPage() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3">
+        <h1 className="font-serif text-3xl text-foreground">
+          Choisissez un mot de passe
+        </h1>
+        <p className="text-[15px] font-light text-muted-foreground">
+          Pour votre sécurité, remplacez le mot de passe temporaire avant
+          d&apos;accéder à votre espace.
+        </p>
+      </div>
+
+      <ChangePasswordForm />
+    </div>
+  )
+}

--- a/auth.ts
+++ b/auth.ts
@@ -52,6 +52,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             role: data.user.role,
             accessToken: data.access_token,
             refreshToken: data.refreshToken ?? undefined,
+            mustChangePassword: data.user.must_change_password,
           }
         } catch {
           return null
@@ -68,6 +69,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         token.role = user.role
         token.accessToken = user.accessToken
         token.refreshToken = user.refreshToken
+        token.mustChangePassword = user.mustChangePassword
         token.error = undefined
         return token
       }
@@ -138,6 +140,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       session.user.id = token.id
       session.user.email = token.email
       session.user.role = token.role
+      session.user.mustChangePassword = token.mustChangePassword
       return session
     },
   },

--- a/components/admin/parents/ParentDetailClient.tsx
+++ b/components/admin/parents/ParentDetailClient.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
+import { AccountSection } from "@/components/shared/account/AccountSection"
 import { ContactActions } from "@/components/shared/ContactActions"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { useParent, useParentFull, useDeleteParent, useUnlinkParent } from "@/lib/hooks/useParents"
@@ -199,6 +200,8 @@ export function ParentDetailClient({ parentId }: { parentId: number }) {
           </div>
         </CardContent>
       </Card>
+
+      <AccountSection entityType="parent" entityId={parentId} />
 
       <ParentEditModal parentId={parentId} open={editOpen} onClose={() => setEditOpen(false)} />
       <ParentLinkChildModal

--- a/components/admin/staff/StaffDetailClient.tsx
+++ b/components/admin/staff/StaffDetailClient.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
+import { AccountSection } from "@/components/shared/account/AccountSection"
 import { ContactActions } from "@/components/shared/ContactActions"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { StaffEditModal } from "./StaffEditModal"
@@ -144,6 +145,8 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
           </DialogContent>
         </Dialog>
       )}
+
+      <AccountSection entityType="staff" entityId={staffId} />
 
       {/* Tabs */}
       <Tabs defaultValue="profil" className="space-y-4">

--- a/components/admin/students/StudentDetailClient.tsx
+++ b/components/admin/students/StudentDetailClient.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
+import { AccountSection } from "@/components/shared/account/AccountSection"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { StudentEditModal } from "./StudentEditModal"
 import { StudentJourneyTimeline } from "./StudentJourneyTimeline"
@@ -241,6 +242,8 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
           </DialogContent>
         </Dialog>
       )}
+
+      <AccountSection entityType="student" entityId={studentId} />
 
       {/* Tabs — reordered by usage frequency, scroll-x on mobile, controlled for cross-tab links */}
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">

--- a/components/admin/teachers/TeacherDetailClient.tsx
+++ b/components/admin/teachers/TeacherDetailClient.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
+import { AccountSection } from "@/components/shared/account/AccountSection"
 import { ContactActions } from "@/components/shared/ContactActions"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { TeacherEditModal } from "./TeacherEditModal"
@@ -138,6 +139,8 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
           </DialogContent>
         </Dialog>
       )}
+
+      <AccountSection entityType="teacher" entityId={teacherId} />
 
       {/* Tabs — controlled + scroll-x mobile (pattern principe 13/14) */}
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">

--- a/components/forms/ChangePasswordForm.tsx
+++ b/components/forms/ChangePasswordForm.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { signOut } from "next-auth/react"
+import { Loader2, Lock, ShieldCheck } from "lucide-react"
+import { toast } from "sonner"
+import { accountsApi } from "@/lib/api/accounts"
+import { ChangePasswordSchema, type ChangePasswordInput } from "@/lib/contracts/account"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+/**
+ * Changement de mot de passe forcé à la 1re connexion (compte créé ou
+ * réinitialisé par un admin). Après succès on déconnecte pour forcer une
+ * reconnexion propre : le nouveau login renvoie `must_change_password=false`,
+ * ce qui débloque l'accès (le flag du JWT courant, lui, reste à true).
+ */
+export function ChangePasswordForm() {
+  const [submitting, setSubmitting] = useState(false)
+  const form = useForm<ChangePasswordInput>({
+    resolver: zodResolver(ChangePasswordSchema),
+    defaultValues: { current_password: "", new_password: "", confirm_password: "" },
+  })
+
+  async function onSubmit(values: ChangePasswordInput) {
+    setSubmitting(true)
+    try {
+      await accountsApi.changePassword(values.current_password, values.new_password)
+      toast.success("Mot de passe mis à jour", {
+        description: "Reconnectez-vous avec votre nouveau mot de passe.",
+      })
+      await signOut({ redirect: false }).catch(() => {})
+      window.location.href = "/login?changed=1"
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Échec du changement"
+      form.setError("current_password", { message })
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <FormField
+          control={form.control}
+          name="current_password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Mot de passe actuel</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <Lock className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    type="password"
+                    autoComplete="current-password"
+                    placeholder="Ex : Bonjour@2026"
+                    className="h-11 pl-9"
+                    {...field}
+                  />
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="new_password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nouveau mot de passe</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <ShieldCheck className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="8 caractères minimum"
+                    className="h-11 pl-9"
+                    {...field}
+                  />
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="confirm_password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Confirmer le nouveau mot de passe</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <ShieldCheck className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="Répétez le mot de passe"
+                    className="h-11 pl-9"
+                    {...field}
+                  />
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="h-11 w-full" disabled={submitting}>
+          {submitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Mise à jour...
+            </>
+          ) : (
+            "Changer mon mot de passe"
+          )}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/components/shared/account/AccountSection.tsx
+++ b/components/shared/account/AccountSection.tsx
@@ -1,0 +1,274 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  Check,
+  Copy,
+  KeyRound,
+  Loader2,
+  Mail,
+  ShieldAlert,
+  UserPlus,
+} from "lucide-react"
+import { toast } from "sonner"
+import { accountsApi } from "@/lib/api/accounts"
+import type { AccountAction, AccountEntityType } from "@/lib/contracts/account"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+} from "@/components/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { SectionTitle } from "@/components/shared/PageHero"
+
+interface AccountSectionProps {
+  entityType: AccountEntityType
+  entityId: number
+}
+
+const accountKey = (t: AccountEntityType, id: number) => ["account", t, id] as const
+
+export function AccountSection({ entityType, entityId }: AccountSectionProps) {
+  const qc = useQueryClient()
+  const { data, isLoading } = useQuery({
+    queryKey: accountKey(entityType, entityId),
+    queryFn: () => accountsApi.get(entityType, entityId),
+  })
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [resetOpen, setResetOpen] = useState(false)
+  const [email, setEmail] = useState("")
+  const [result, setResult] = useState<AccountAction | null>(null)
+
+  useEffect(() => {
+    if (data?.suggested_email) setEmail(data.suggested_email)
+  }, [data?.suggested_email])
+
+  const createMut = useMutation({
+    mutationFn: () => accountsApi.create(entityType, entityId, email),
+    onSuccess: (res) => {
+      setResult(res)
+      setCreateOpen(false)
+      qc.invalidateQueries({ queryKey: accountKey(entityType, entityId) })
+      toast.success("Compte créé")
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Échec de la création"),
+  })
+
+  const resetMut = useMutation({
+    mutationFn: () => accountsApi.resetPassword(entityType, entityId),
+    onSuccess: (res) => {
+      setResult(res)
+      setResetOpen(false)
+      qc.invalidateQueries({ queryKey: accountKey(entityType, entityId) })
+      toast.success("Mot de passe réinitialisé")
+    },
+    onError: (e) => toast.error(e instanceof Error ? e.message : "Échec de la réinitialisation"),
+  })
+
+  return (
+    <div className="rounded-xl border bg-card p-5 shadow-sm">
+      <div className="flex items-center justify-between gap-3 border-b pb-3">
+        <SectionTitle icon={KeyRound}>Compte de connexion</SectionTitle>
+      </div>
+
+      {isLoading || !data ? (
+        <div className="mt-4 space-y-3">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-9 w-40" />
+        </div>
+      ) : (
+        <div className="mt-4 space-y-4">
+          {data.has_account ? (
+            <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+                <span className="inline-flex items-center gap-2">
+                  <Mail className="h-4 w-4 text-muted-foreground" />
+                  <span className="font-medium">{data.email}</span>
+                </span>
+                <StatusPill
+                  active={data.is_active}
+                  neverLogged={!data.last_login}
+                  mustChange={data.must_change_password}
+                />
+                <span className="text-xs text-muted-foreground">
+                  {data.last_login
+                    ? `Dernière connexion : ${new Date(data.last_login).toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })}`
+                    : "Jamais connecté"}
+                </span>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4 h-11 gap-2 sm:h-10"
+                onClick={() => setResetOpen(true)}
+              >
+                <KeyRound className="h-4 w-4" />
+                Réinitialiser le mot de passe
+              </Button>
+            </div>
+          ) : data.can_create ? (
+            <div className="rounded-lg border border-amber-200 bg-amber-50/60 p-4 dark:border-amber-900 dark:bg-amber-950/40">
+              <p className="text-sm text-amber-900 dark:text-amber-200">
+                {data.full_name} n&apos;a pas encore de compte pour se connecter.
+              </p>
+              <Button
+                size="sm"
+                className="mt-3 h-11 gap-2 bg-accent text-accent-foreground hover:bg-accent/90 sm:h-10"
+                onClick={() => {
+                  setEmail(data.suggested_email ?? "")
+                  setCreateOpen(true)
+                }}
+              >
+                <UserPlus className="h-4 w-4" />
+                Créer le compte
+              </Button>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Ce compte est géré à la création de la fiche.
+            </p>
+          )}
+
+          {result && <TempPasswordCard result={result} />}
+        </div>
+      )}
+
+      {/* Créer le compte — email pré-rempli éditable, confirmé */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Créer le compte de {data?.full_name}</DialogTitle>
+            <DialogDescription>
+              Vérifiez l&apos;email de connexion. Le mot de passe temporaire sera
+              <strong> Bonjour@{new Date().getFullYear()}</strong>, à changer à la
+              première connexion.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="account-email">Email de connexion</Label>
+            <Input
+              id="account-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="h-11"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setCreateOpen(false)}>
+              Annuler
+            </Button>
+            <Button
+              onClick={() => createMut.mutate()}
+              disabled={createMut.isPending || !email}
+              className="gap-2"
+            >
+              {createMut.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+              Créer le compte
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Réinitialiser le mot de passe */}
+      <AlertDialog open={resetOpen} onOpenChange={setResetOpen}>
+        <AlertDialogContent>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-base font-semibold">
+              <ShieldAlert className="h-5 w-5 text-amber-600" />
+              Réinitialiser le mot de passe ?
+            </div>
+            <AlertDialogDescription>
+              Le mot de passe de {data?.full_name} deviendra{" "}
+              <strong>Bonjour@{new Date().getFullYear()}</strong>. L&apos;utilisateur
+              devra le changer à sa prochaine connexion.
+            </AlertDialogDescription>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction onClick={() => resetMut.mutate()} disabled={resetMut.isPending}>
+              {resetMut.isPending ? "Réinitialisation..." : "Réinitialiser"}
+            </AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
+
+function StatusPill({
+  active,
+  neverLogged,
+  mustChange,
+}: {
+  active: boolean
+  neverLogged: boolean
+  mustChange: boolean
+}) {
+  let label = "Actif"
+  let cls = "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
+  if (mustChange) {
+    label = "Mot de passe à changer"
+    cls = "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+  } else if (!active) {
+    label = "Désactivé"
+    cls = "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300"
+  } else if (neverLogged) {
+    label = "En attente"
+    cls = "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+  }
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>{label}</span>
+  )
+}
+
+function TempPasswordCard({ result }: { result: AccountAction }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="rounded-lg border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900 dark:bg-emerald-950/30">
+      <p className="text-sm font-medium text-emerald-900 dark:text-emerald-200">
+        Mot de passe temporaire à communiquer
+      </p>
+      <div className="mt-2 flex items-center gap-2">
+        <code className="rounded-md border bg-background px-3 py-1.5 font-mono text-sm">
+          {result.temporary_password}
+        </code>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-9 gap-1.5"
+          onClick={() => {
+            void navigator.clipboard?.writeText(result.temporary_password)
+            setCopied(true)
+            setTimeout(() => setCopied(false), 1500)
+          }}
+        >
+          {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          {copied ? "Copié" : "Copier"}
+        </Button>
+      </div>
+      <p className="mt-2 text-xs text-emerald-800/80 dark:text-emerald-300/80">
+        {result.email} — à changer obligatoirement à la première connexion.
+      </p>
+    </div>
+  )
+}

--- a/lib/api/accounts.ts
+++ b/lib/api/accounts.ts
@@ -1,0 +1,74 @@
+import { apiFetch, safeValidate } from "./client"
+import {
+  AccountActionSchema,
+  AccountStatusSchema,
+  type AccountAction,
+  type AccountEntityType,
+  type AccountStatus,
+} from "@/lib/contracts/account"
+
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object") {
+    const obj = json as Record<string, unknown>
+    if (obj.data !== undefined) return obj.data
+  }
+  return json
+}
+
+export const accountsApi = {
+  get: async (
+    entityType: AccountEntityType,
+    entityId: number,
+  ): Promise<AccountStatus> => {
+    const json = await apiFetch<unknown>(`/admin/accounts/${entityType}/${entityId}`)
+    return safeValidate(
+      AccountStatusSchema,
+      unwrap(json),
+      `GET /admin/accounts/${entityType}/${entityId}`,
+    )
+  },
+
+  create: async (
+    entityType: AccountEntityType,
+    entityId: number,
+    email: string,
+  ): Promise<AccountAction> => {
+    const json = await apiFetch<unknown>(`/admin/accounts/${entityType}/${entityId}`, {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    })
+    return safeValidate(
+      AccountActionSchema,
+      unwrap(json),
+      `POST /admin/accounts/${entityType}/${entityId}`,
+    )
+  },
+
+  resetPassword: async (
+    entityType: AccountEntityType,
+    entityId: number,
+  ): Promise<AccountAction> => {
+    const json = await apiFetch<unknown>(
+      `/admin/accounts/${entityType}/${entityId}/reset-password`,
+      { method: "POST" },
+    )
+    return safeValidate(
+      AccountActionSchema,
+      unwrap(json),
+      `POST /admin/accounts/${entityType}/${entityId}/reset-password`,
+    )
+  },
+
+  changePassword: async (
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<void> => {
+    await apiFetch<unknown>("/auth/change-password", {
+      method: "POST",
+      body: JSON.stringify({
+        current_password: currentPassword,
+        new_password: newPassword,
+      }),
+    })
+  },
+}

--- a/lib/contracts/account.ts
+++ b/lib/contracts/account.ts
@@ -1,0 +1,45 @@
+import { z } from "zod"
+
+/** Type d'acteur dont on gère le compte de connexion. */
+export const AccountEntityTypeSchema = z.enum(["student", "parent", "teacher", "staff"])
+export type AccountEntityType = z.infer<typeof AccountEntityTypeSchema>
+
+export const AccountStatusSchema = z.object({
+  entity_type: AccountEntityTypeSchema,
+  entity_id: z.number(),
+  full_name: z.string(),
+  has_account: z.boolean(),
+  can_create: z.boolean(),
+  user_id: z.number().nullish(),
+  email: z.string().nullish(),
+  is_active: z.boolean(),
+  last_login: z.string().nullish(),
+  must_change_password: z.boolean(),
+  suggested_email: z.string().nullish(),
+})
+export type AccountStatus = z.infer<typeof AccountStatusSchema>
+
+export const AccountActionSchema = z.object({
+  user_id: z.number(),
+  email: z.string(),
+  temporary_password: z.string(),
+  must_change_password: z.boolean(),
+})
+export type AccountAction = z.infer<typeof AccountActionSchema>
+
+export const AccountCreateSchema = z.object({
+  email: z.string().email("Email invalide"),
+})
+export type AccountCreateInput = z.infer<typeof AccountCreateSchema>
+
+export const ChangePasswordSchema = z
+  .object({
+    current_password: z.string().min(1, "Mot de passe actuel requis"),
+    new_password: z.string().min(8, "8 caractères minimum"),
+    confirm_password: z.string().min(1, "Confirmation requise"),
+  })
+  .refine((d) => d.new_password === d.confirm_password, {
+    message: "Les mots de passe ne correspondent pas",
+    path: ["confirm_password"],
+  })
+export type ChangePasswordInput = z.infer<typeof ChangePasswordSchema>

--- a/lib/contracts/auth.ts
+++ b/lib/contracts/auth.ts
@@ -28,6 +28,7 @@ export const UserSchema = z.object({
   role: UserRoleSchema,
   first_name: z.string(),
   last_name: z.string(),
+  must_change_password: z.boolean().optional(),
 })
 
 export const LoginResponseSchema = z.object({

--- a/middleware.ts
+++ b/middleware.ts
@@ -73,6 +73,16 @@ const authMiddleware = auth((req) => {
     return hostRedirect(req, "/login")
   }
 
+  // Mot de passe temporaire (compte créé ou réinitialisé par un admin) :
+  // forcer l'écran de changement avant tout autre accès.
+  if (
+    isLoggedIn &&
+    session.user.mustChangePassword &&
+    pathname !== "/change-password"
+  ) {
+    return hostRedirect(req, "/change-password")
+  }
+
   const portalFromPath = getPortalFromPath(pathname)
   const isProtectedRoute = portalFromPath !== null
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -17,6 +17,8 @@ declare module "next-auth" {
     email: string
     role: UserRole
     accessToken: string
+    /** Mot de passe temporaire à changer à la 1re connexion. */
+    mustChangePassword?: boolean
     /**
      * Refresh token BE, capté côté serveur depuis le cookie httpOnly posé par
      * /auth/login. Stocké uniquement dans le JWT NextAuth chiffré (jamais
@@ -31,6 +33,7 @@ declare module "next-auth" {
       id: string
       email: string
       role: UserRole
+      mustChangePassword?: boolean
     }
     accessToken: string
     error?: string
@@ -43,6 +46,7 @@ declare module "next-auth/jwt" {
     email: string
     role: UserRole
     accessToken: string
+    mustChangePassword?: boolean
     /** Refresh token BE — server-side only, jamais propagé à la session client. */
     refreshToken?: string
     error?: string


### PR DESCRIPTION
FE de la gestion des comptes (voir BE #222).

- `AccountSection` (partagé) sur les fiches élève/parent/enseignant/personnel : état du compte, créer (élève/parent, email pré-rempli éditable), réinitialiser le mot de passe, mot de passe temporaire affiché + copiable.
- Changement forcé à la 1re connexion : `must_change_password` propagé login → session ; middleware redirige vers /change-password ; page + formulaire ; après succès, signOut + relogin propre.
- Contracts Zod sans `.default()` (piège safeValidate).