### PR TITLE
fix(auth): host-agnostic logout redirect + premium login redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Changed
+
+- Page de connexion repensée en version premium : grande photo d'une classe habillée aux couleurs de la marque avec accroche et points forts à gauche, formulaire présenté dans une carte élégante à droite, plus lisible sur mobile comme sur ordinateur *(tous)*.
+
 ### Fixed
 
 - Session : on n'est plus déconnecté pendant qu'on utilise l'application. Un renouvellement de session simultané pouvait éjecter un utilisateur pourtant actif ; seule une vraie inactivité prolongée déconnecte désormais *(tous)*.
 - Mode dictée : la saisie vocale des notes fonctionne à nouveau. Le micro était bloqué par une politique de sécurité du site trop stricte, même quand l'enseignant l'avait autorisé dans le navigateur *(enseignant, admin)*.
-- Déconnexion : le bouton « Se déconnecter » renvoie désormais vers la page de connexion du site (college.klassci.com) au lieu d'une adresse locale invalide *(tous)*.
+- Déconnexion : le bouton « Se déconnecter » ramène toujours vers la page de connexion du site réellement utilisé (college.klassci.com ou autre), et non plus vers une adresse locale invalide *(tous)*.
 - Mode dictée : le micro est demandé directement par le navigateur au clic (plus fiable). Quand la reconnaissance vocale est bloquée par le navigateur (fréquent sur Microsoft Edge), le message invite à utiliser Google Chrome ou à saisir au clavier au lieu d'afficher « micro refusé » à tort. Après avoir autorisé le micro dans les réglages, un bouton « Recharger la page » applique le changement. Sur une adresse non sécurisée (http), un message explique que la dictée vocale exige le site sécurisé https *(enseignant, admin)*.
 - Conseil de classe : le procès-verbal se charge à nouveau pour une classe et un trimestre ; s'il n'existe pas encore, un bouton « Générer le procès-verbal » le crée à partir des bulletins. Les décisions s'enregistrent, le procès-verbal se valide et se télécharge en PDF *(admin)*.
 - Statistiques DREN : les boutons Excel et PDF téléchargent désormais un vrai fichier (classeur Excel ou document PDF) au lieu d'ouvrir des données brutes *(admin)*.

--- a/app/(auth)/change-password/page.tsx
+++ b/app/(auth)/change-password/page.tsx
@@ -9,12 +9,12 @@ export const metadata = { title: "Changer le mot de passe" }
  */
 export default function ChangePasswordPage() {
   return (
-    <div className="space-y-8">
-      <div className="space-y-3">
-        <h1 className="font-serif text-3xl text-foreground">
+    <div className="space-y-7">
+      <div className="space-y-2">
+        <h1 className="font-serif text-[1.7rem] font-bold leading-tight text-foreground">
           Choisissez un mot de passe
         </h1>
-        <p className="text-[15px] font-light text-muted-foreground">
+        <p className="text-[14px] font-light text-muted-foreground">
           Pour votre sécurité, remplacez le mot de passe temporaire avant
           d&apos;accéder à votre espace.
         </p>

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,23 +1,25 @@
 import Image from "next/image"
-import { BookOpen, Users, Shield } from "lucide-react"
+import { BookOpen, Users, ShieldCheck } from "lucide-react"
 
 const features = [
   {
     icon: BookOpen,
     title: "Gestion académique",
-    description: "Notes, bulletins, emplois du temps centralisés",
+    description: "Notes, bulletins et emplois du temps centralisés",
   },
   {
     icon: Users,
-    title: "Suivi personnalisé",
-    description: "Portails dédiés pour enseignants, élèves et parents",
+    title: "Portails dédiés",
+    description: "Un espace pour chaque enseignant, parent et élève",
   },
   {
-    icon: Shield,
-    title: "Sécurisé & fiable",
-    description: "Données protégées, accès contrôlé par rôle",
+    icon: ShieldCheck,
+    title: "Sécurisé et fiable",
+    description: "Vos données protégées, accès contrôlé par rôle",
   },
 ]
+
+const year = new Date().getFullYear()
 
 export default function AuthLayout({
   children,
@@ -26,87 +28,90 @@ export default function AuthLayout({
 }) {
   return (
     <div className="flex min-h-screen">
-      {/* Left panel — branding sur photo d'une classe ivoirienne */}
-      <div className="hidden lg:flex lg:w-[55%] relative overflow-hidden bg-[#08264f]">
-        {/* Photo de fond (enseignante + élèves) — object-right pour garder le
-            visage visible côté clair du voile. */}
+      {/* ── Panneau gauche — récit de marque sur photo d'une classe ivoirienne ── */}
+      <div className="relative hidden overflow-hidden bg-[#08264f] lg:flex lg:w-[56%]">
+        {/* Photo de fond (enseignante + élèves). object-right garde le visage
+            visible côté clair du voile. */}
         <Image
           src="/images/login-bg.png"
           alt=""
           fill
           priority
-          sizes="55vw"
+          sizes="56vw"
           className="object-cover object-right"
         />
-        {/* Voile de marque : bleu foncé à gauche (là où est le texte) →
-            translucide à droite (la photo respire), pour la lisibilité. */}
-        <div className="absolute inset-0 bg-gradient-to-r from-[#08264f]/[0.97] via-[#0f3f8c]/[0.86] to-[#0f3f8c]/[0.32]" />
-        {/* Vignette verticale : renforce logo (haut) et pied (bas). */}
-        <div className="absolute inset-0 bg-gradient-to-t from-[#08264f]/85 via-transparent to-[#08264f]/45" />
-        {/* Halo orange de marque, discret, en bas à droite. */}
-        <div className="absolute -bottom-24 -right-20 h-80 w-80 rounded-full bg-[#f58220]/25 blur-3xl" />
+        {/* Voile de marque : bleu profond à gauche (le texte) qui s'ouvre vers la
+            droite pour laisser respirer la photo. */}
+        <div className="absolute inset-0 bg-gradient-to-r from-[#07203f] via-[#0d3574]/[0.9] to-[#0f3f8c]/30" />
+        {/* Assise verticale : renforce le logo (haut) et le pied (bas). */}
+        <div className="absolute inset-0 bg-gradient-to-t from-[#07203f]/90 via-transparent to-[#07203f]/40" />
 
-        {/* Content */}
-        <div className="relative z-10 flex flex-col justify-between p-12 xl:p-16 text-white">
-          {/* Logo + College */}
-          <div className="flex flex-col items-center w-fit">
+        <div className="relative z-10 flex w-full flex-col justify-between p-12 text-white xl:p-16">
+          {/* Logo */}
+          <div className="flex w-fit flex-col items-center">
             <Image
               src="/images/logo_klassci.png"
               alt="KLASSCI"
-              width={180}
-              height={48}
+              width={168}
+              height={44}
               className="brightness-0 invert"
               priority
             />
-            <span className="font-serif text-[17px] -mt-4 text-white/60">
+            <span className="-mt-4 font-serif text-[16px] text-white/55">
               College
             </span>
           </div>
 
-          {/* Center — tagline */}
-          <div className="space-y-10">
-            <div className="space-y-5">
-              <h1 className="font-serif text-4xl leading-tight xl:text-[3.2rem] xl:leading-[1.15] text-white">
-                Votre plateforme
-                <br />
-                <span className="text-[#F58220]">de gestion scolaire</span>
-              </h1>
-              <p className="max-w-lg text-[15px] leading-relaxed text-white/65 font-light">
-                Une solution moderne et complète pour piloter votre établissement
-                avec efficacité et transparence.
-              </p>
-            </div>
+          {/* Récit central */}
+          <div className="max-w-xl space-y-9 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:duration-700">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-3.5 py-1.5 text-[11px] font-medium uppercase tracking-[0.14em] text-white/75 backdrop-blur-sm">
+              <span className="h-1.5 w-1.5 rounded-full bg-[#F58220]" />
+              Plateforme de gestion scolaire
+            </span>
 
-            {/* Divider */}
-            <div className="h-px w-16 bg-white/20" />
+            <h1 className="border-l-2 border-[#F58220] pl-6 font-serif text-[2.6rem] font-bold leading-[1.1] text-white xl:text-[3.1rem]">
+              Toute votre école,
+              <br />
+              <span className="text-[#F58220]">au même endroit.</span>
+            </h1>
 
-            {/* Features */}
-            <div className="space-y-6">
+            <p className="max-w-md text-[15px] font-light leading-relaxed text-white/70">
+              Notes, bulletins, présences et paiements réunis dans un seul espace
+              pour piloter votre établissement au quotidien, en toute sérénité.
+            </p>
+
+            {/* Points forts, séparés par de fins filets */}
+            <div className="divide-y divide-white/10 border-y border-white/10">
               {features.map((feature) => (
-                <div key={feature.title} className="flex items-start gap-4">
-                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white/[0.08] border border-white/[0.06]">
-                    <feature.icon className="h-[18px] w-[18px] text-white/80" />
-                  </div>
-                  <div>
-                    <h3 className="text-[15px] font-medium tracking-wide">{feature.title}</h3>
-                    <p className="text-[13px] text-white/50 font-light">{feature.description}</p>
+                <div key={feature.title} className="flex items-start gap-4 py-4">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.08]">
+                    <feature.icon className="h-[18px] w-[18px] text-[#F58220]" />
+                  </span>
+                  <div className="pt-0.5">
+                    <h3 className="text-[15px] font-medium tracking-wide text-white">
+                      {feature.title}
+                    </h3>
+                    <p className="text-[13px] font-light text-white/50">
+                      {feature.description}
+                    </p>
                   </div>
                 </div>
               ))}
             </div>
           </div>
 
-          {/* Footer */}
-          <p className="text-[13px] text-white/30 font-light">
-            &copy; {new Date().getFullYear()} KLASSCI College. Tous droits réservés.
-          </p>
+          {/* Pied */}
+          <div className="flex items-center justify-between text-[12px] font-light text-white/35">
+            <span>&copy; {year} KLASSCI College</span>
+            <span>Conçu pour les écoles de Côte d&apos;Ivoire</span>
+          </div>
         </div>
       </div>
 
-      {/* Right panel — form */}
-      <div className="flex w-full flex-col items-center justify-center bg-background px-6 py-12 lg:w-[45%]">
-        {/* Mobile logo */}
-        <div className="mb-10 flex flex-col items-center w-fit lg:hidden">
+      {/* ── Panneau droit — formulaire ── */}
+      <div className="relative flex w-full flex-col items-center justify-center bg-muted/30 px-6 py-12 lg:w-[44%]">
+        {/* Logo mobile */}
+        <div className="mb-8 flex w-fit flex-col items-center lg:hidden">
           <Image
             src="/images/logo_klassci.png"
             alt="KLASSCI"
@@ -114,19 +119,23 @@ export default function AuthLayout({
             height={40}
             priority
           />
-          <span className="font-serif text-[14px] -mt-3 text-muted-foreground">
+          <span className="-mt-3 font-serif text-[14px] text-muted-foreground">
             College
           </span>
         </div>
 
-        <div className="w-full max-w-[400px]">
-          {children}
-        </div>
+        {/* Carte formulaire élevée, filet orange focal en tête */}
+        <div className="w-full max-w-[420px] motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-2 motion-safe:duration-500">
+          <div className="relative overflow-hidden rounded-2xl border bg-card p-6 shadow-[0_24px_70px_-34px_rgba(4,83,203,0.4)] sm:p-8">
+            <span className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#F58220] to-[#f9a826]" />
+            {children}
+          </div>
 
-        {/* Mobile footer */}
-        <p className="mt-12 text-[11px] text-muted-foreground/60 font-light lg:hidden">
-          &copy; {new Date().getFullYear()} KLASSCI College
-        </p>
+          {/* Pied mobile */}
+          <p className="mt-8 text-center text-[11px] font-light text-muted-foreground/60 lg:hidden">
+            &copy; {year} KLASSCI College &middot; Côte d&apos;Ivoire
+          </p>
+        </div>
       </div>
     </div>
   )

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -12,19 +12,19 @@ export default async function LoginPage() {
   }
 
   return (
-    <div className="space-y-8">
-      <div className="space-y-3">
-        <h1 className="font-serif text-3xl text-foreground">
+    <div className="space-y-7">
+      <div className="space-y-2">
+        <h1 className="font-serif text-[1.7rem] font-bold leading-tight text-foreground">
           Bienvenue
         </h1>
-        <p className="text-[15px] text-muted-foreground font-light">
-          Connectez-vous pour accéder à votre espace
+        <p className="text-[14px] font-light text-muted-foreground">
+          Connectez-vous pour accéder à votre espace de travail.
         </p>
       </div>
 
       <LoginForm />
 
-      <p className="text-center text-[11px] text-muted-foreground/60 font-light">
+      <p className="text-center text-[11px] font-light leading-relaxed text-muted-foreground/60">
         En vous connectant, vous acceptez les conditions d&apos;utilisation
         de la plateforme KLASSCI.
       </p>

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import type { Route } from "next"
-import { signOut, useSession } from "next-auth/react"
+import { useSession } from "next-auth/react"
 import { useTheme } from "next-themes"
 import { Menu, LogOut, User, ChevronDown, Sun, Moon } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { NotificationBell } from "@/components/shared/NotificationBell"
 import { AcademicYearBadge } from "@/components/shared/AcademicYearBadge"
+import { logout } from "@/lib/utils/logout"
 
 interface NavbarProps {
   onMenuClick: () => void
@@ -99,7 +100,7 @@ export function Navbar({ onMenuClick }: NavbarProps) {
             <DropdownMenuSeparator />
             <DropdownMenuItem
               className="text-destructive focus:text-destructive"
-              onClick={() => signOut({ callbackUrl: `${window.location.origin}/login` })}
+              onClick={() => void logout()}
             >
               <LogOut className="mr-2 h-4 w-4" />
               Deconnexion

--- a/components/shared/ParentNav.tsx
+++ b/components/shared/ParentNav.tsx
@@ -2,9 +2,9 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { signOut } from "next-auth/react"
 import { LayoutDashboard, Users, LogOut, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { logout } from "@/lib/utils/logout"
 import type { Route } from "next"
 
 const navItems: { label: string; href: Route; icon: LucideIcon }[] = [
@@ -37,7 +37,7 @@ export function ParentNav() {
           )
         })}
         <button
-          onClick={() => signOut({ callbackUrl: `${window.location.origin}/login` })}
+          onClick={() => void logout()}
           className="flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium text-muted-foreground transition-colors min-w-[56px] hover:text-destructive"
         >
           <LogOut className="h-5 w-5" />

--- a/components/shared/StudentNav.tsx
+++ b/components/shared/StudentNav.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useRef } from "react"
 import type { Route } from "next"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { signOut } from "next-auth/react"
 import {
   LayoutDashboard,
   CalendarDays,
@@ -17,6 +16,7 @@ import {
   type LucideIcon,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { logout } from "@/lib/utils/logout"
 
 const mainNavItems: { label: string; href: Route; icon: LucideIcon }[] = [
   { label: "Accueil", href: "/student/dashboard", icon: LayoutDashboard },
@@ -84,7 +84,7 @@ export function StudentNav() {
               role="menuitem"
               onClick={() => {
                 setMoreOpen(false)
-                signOut({ callbackUrl: `${window.location.origin}/login` })
+                void logout()
               }}
               className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-sm text-destructive hover:bg-destructive/10 transition-colors"
             >

--- a/components/shared/TeacherNav.tsx
+++ b/components/shared/TeacherNav.tsx
@@ -4,9 +4,9 @@ import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { signOut } from "next-auth/react"
 import { LayoutDashboard, CalendarDays, ClipboardList, UserCheck, Gauge, LogOut, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { logout } from "@/lib/utils/logout"
 
 const navItems: { label: string; href: Route; icon: LucideIcon }[] = [
   { label: "Accueil", href: "/teacher/dashboard", icon: LayoutDashboard },
@@ -41,7 +41,7 @@ export function TeacherNav() {
           )
         })}
         <button
-          onClick={() => signOut({ callbackUrl: `${window.location.origin}/login` })}
+          onClick={() => void logout()}
           className="flex flex-col items-center gap-0.5 rounded-lg px-3 py-2 text-[10px] font-medium text-muted-foreground transition-colors min-w-[56px] hover:text-destructive"
         >
           <LogOut className="h-5 w-5" />
@@ -97,7 +97,7 @@ export function TeacherSidebar() {
       </nav>
       <div className="border-t p-3">
         <button
-          onClick={() => signOut({ callbackUrl: `${window.location.origin}/login` })}
+          onClick={() => void logout()}
           className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
         >
           <LogOut className="h-4 w-4" />

--- a/lib/utils/logout.ts
+++ b/lib/utils/logout.ts
@@ -1,0 +1,21 @@
+import { signOut } from "next-auth/react"
+
+/**
+ * Déconnexion host-agnostique.
+ *
+ * `signOut({ callbackUrl })` fait résoudre l'URL de retour par NextAuth côté
+ * serveur, contre `NEXTAUTH_URL` (ou l'origine dérivée du build). En prod
+ * derrière le reverse proxy, cette valeur peut rester `http://localhost:3000`,
+ * si bien que la déconnexion renvoie l'utilisateur sur `localhost` au lieu du
+ * domaine réellement utilisé.
+ *
+ * On coupe court : `signOut({ redirect: false })` se contente d'invalider le
+ * cookie de session, puis on redirige nous-mêmes vers un chemin relatif. Le
+ * navigateur résout `/login` contre l'origine courante (le domaine ou l'IP que
+ * l'utilisateur a réellement ouvert), quel que soit l'hôte. Même contrat que
+ * `ChangePasswordForm` après un changement de mot de passe.
+ */
+export async function logout(): Promise<void> {
+  await signOut({ redirect: false }).catch(() => {})
+  window.location.href = "/login"
+}


### PR DESCRIPTION
Closes #294

## Problème
1. La déconnexion renvoyait vers `localhost:3000/login` : `signOut({ callbackUrl })` fait résoudre l'URL par NextAuth côté serveur contre `NEXTAUTH_URL` (localhost derrière le proxy).
2. Page login à moderniser.

## Solution
- **`lib/utils/logout.ts`** (partagé) : `signOut({ redirect: false })` + `window.location.href = '/login'` — chemin relatif résolu par le navigateur contre l'origine réelle, quel que soit l'hôte. Branché sur les 5 boutons de déconnexion (Navbar, TeacherNav ×2, ParentNav, StudentNav). `signOut` inutilisé retiré des imports.
- **Refonte login premium** : panneau gauche (eyebrow, titre avec filet orange, points forts en filets), carte formulaire élevée + filet orange focal, responsive, clair/sombre. `/change-password` (même layout) harmonisée.

## Vérifs
- `tsc --noEmit` ✅
- `next lint` ✅
- Déploiement Contabo + /visual-check à suivre.