### PR TITLE
feat(payments): premium enrollment detail + fee breakdown/history, account to bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Fiche inscription et onglet Paiements repensés en premium : en-tête avec bandeau de marque (classe, année, statut), synthèse claire des frais (payé, reste à payer, progression), détail de chaque frais avec sa barre d'avancement et son statut, et historique des versements montrant la répartition sur les frais avec le reçu téléchargeable pour chacun *(admin)*.
+- Onglet Paiements de la fiche élève : même bandeau de synthèse premium des frais (payé, reste à payer) *(admin)*.
+- Fiches élève, enseignant et personnel : la carte « Compte de connexion » passe en bas de page, ce n'est pas l'information principale à l'ouverture de la fiche *(admin)*.
 - Page de connexion repensée en version premium : grande photo d'une classe habillée aux couleurs de la marque avec accroche et points forts à gauche, formulaire présenté dans une carte élégante à droite, plus lisible sur mobile comme sur ordinateur *(tous)*.
 - Page Frais repensée : la grille des frais obligatoires s'affiche désormais en arbre par niveau (on voit d'un coup ce qu'un élève d'un niveau paie et le total), et les frais optionnels avec leurs options (montant par option) sont visibles et modifiables directement, au lieu d'être cachés derrière un bouton *(admin)*.
 

--- a/components/admin/enrollments/EnrollmentDetailClient.tsx
+++ b/components/admin/enrollments/EnrollmentDetailClient.tsx
@@ -4,18 +4,24 @@ import { useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import {
-  ArrowLeft,
   ExternalLink,
   Pencil,
   Trash2,
   BookOpen,
   Wallet,
+  MoreVertical,
+  GraduationCap,
+  CalendarDays,
 } from "lucide-react"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -27,17 +33,19 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
+import { DetailHero } from "@/components/shared/DetailHero"
+import type { HeroKpi } from "@/components/shared/PageHero"
 import { EnrollmentEditModal } from "./EnrollmentEditModal"
 import { EnrollmentOverviewTab } from "./tabs/EnrollmentOverviewTab"
 import { EnrollmentPaymentsTab } from "./tabs/EnrollmentPaymentsTab"
 import { useEnrollment, useDeleteEnrollment } from "@/lib/hooks/useEnrollments"
 
-const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  prospect: { label: "Prospect", variant: "outline" },
-  en_validation: { label: "En validation", variant: "secondary" },
-  valide: { label: "Validé", variant: "default" },
-  rejete: { label: "Rejeté", variant: "destructive" },
-  annule: { label: "Annulé", variant: "destructive" },
+const statusConfig: Record<string, string> = {
+  prospect: "Prospect",
+  en_validation: "En validation",
+  valide: "Validé",
+  rejete: "Rejeté",
+  annule: "Annulé",
 }
 
 interface EnrollmentDetailClientProps {
@@ -70,57 +78,58 @@ export function EnrollmentDetailClient({ enrollmentId }: EnrollmentDetailClientP
     .join(" ") || `Élève #${enrollment.student_id}`
   const className = enrollment.class_name ?? `Classe #${enrollment.class_id}`
   const academicYear = enrollment.academic_year_name ?? ""
-  const subtitle = [className, academicYear].filter(Boolean).join(" — ")
-  const status = statusConfig[enrollment.status] ?? { label: enrollment.status, variant: "outline" as const }
+  const statusLabel = statusConfig[enrollment.status] ?? enrollment.status
 
   const initials = `${enrollment.student_first_name?.[0] ?? ""}${enrollment.student_last_name?.[0] ?? ""}`.toUpperCase()
 
+  const kpis: HeroKpi[] = [
+    { label: "Classe", value: className, icon: GraduationCap },
+    { label: "Année scolaire", value: academicYear || "—", icon: CalendarDays },
+  ]
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex items-start gap-4">
-          <Link
-            href="/admin/enrollments"
-            aria-label="Retour à la liste des inscriptions"
-            className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border transition-colors hover:bg-muted sm:h-9 sm:w-9"
-          >
-            <ArrowLeft aria-hidden="true" className="h-4 w-4" />
-          </Link>
-
-          <Avatar className="h-20 w-20 text-2xl shrink-0">
-            <AvatarFallback className="bg-primary/10 text-primary text-xl font-semibold">
-              {initials}
-            </AvatarFallback>
-          </Avatar>
-
-          <div className="min-w-0">
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-0.5">Fiche inscription</p>
-            <h1 className="font-serif text-2xl tracking-tight">{studentName}</h1>
-            <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              <span>{subtitle}</span>
-              <Badge variant={status.variant}>{status.label}</Badge>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex gap-2 shrink-0">
-          <Button variant="outline" size="sm" asChild>
-            <Link href={`/admin/students/${enrollment.student_id}`}>
-              <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
-              Fiche élève
-            </Link>
-          </Button>
-          <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
-            <Pencil className="mr-1.5 h-3.5 w-3.5" />
-            Modifier
-          </Button>
-          <Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)}>
-            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-            Supprimer
-          </Button>
-        </div>
-      </div>
+      <DetailHero
+        onBack={() => router.push("/admin/enrollments")}
+        backLabel="Retour à la liste des inscriptions"
+        initials={initials}
+        name={studentName}
+        subtitle="Fiche inscription"
+        badge={
+          <span className="rounded-full border border-white/25 bg-white/15 px-2.5 py-0.5 text-xs font-semibold text-white">
+            {statusLabel}
+          </span>
+        }
+        kpis={kpis}
+        actions={
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex h-9 w-9 items-center justify-center rounded-lg border border-white/25 bg-white/10 text-white transition-colors hover:bg-white/20">
+              <MoreVertical className="h-4 w-4" />
+              <span className="sr-only">Actions sur l&apos;inscription</span>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-52">
+              <DropdownMenuItem asChild>
+                <Link href={`/admin/students/${enrollment.student_id}`}>
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  Voir la fiche élève
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setEditOpen(true)}>
+                <Pencil className="mr-2 h-4 w-4" />
+                Modifier l&apos;inscription
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={() => setDeleteOpen(true)}
+                className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Supprimer l&apos;inscription
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        }
+      />
 
       {/* Tabs */}
       <Tabs defaultValue="overview" className="space-y-4">

--- a/components/admin/enrollments/tabs/EnrollmentPaymentsTab.tsx
+++ b/components/admin/enrollments/tabs/EnrollmentPaymentsTab.tsx
@@ -3,40 +3,17 @@
 import { useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { getSession } from "next-auth/react"
-import { Wallet, CheckCircle, Plus } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
+import { Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
 import { Skeleton } from "@/components/ui/skeleton"
+import { FeeSummaryHero } from "@/components/shared/fees/FeeSummaryHero"
+import { EnrollmentFeesBreakdown, type EnrollmentFeeItem } from "@/components/admin/payments/EnrollmentFeesBreakdown"
+import { PaymentHistoryList } from "@/components/admin/payments/PaymentHistoryList"
 import { StudentPaymentModal } from "@/components/admin/students/tabs/StudentPaymentModal"
 
 interface EnrollmentPaymentsTabProps {
   enrollmentId: number
   enrollment?: { student_id?: number }
-}
-
-interface EnrollmentFeeItem {
-  id: number
-  enrollment_id: number
-  category_name: string
-  amount: number
-  paid: number
-  remaining: number
-  status: string
-  is_optional?: boolean
-  option_name?: string | null
-}
-
-function formatFCFA(amount: number): string {
-  return `${amount.toLocaleString("fr-FR")} FCFA`
-}
-
-const STATUS_LABEL: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  pending: { label: "En attente", variant: "secondary" },
-  partial: { label: "Partiel", variant: "outline" },
-  paid: { label: "Payé", variant: "default" },
-  waived: { label: "Exonéré", variant: "secondary" },
 }
 
 export function EnrollmentPaymentsTab({ enrollmentId, enrollment }: EnrollmentPaymentsTabProps) {
@@ -46,7 +23,7 @@ export function EnrollmentPaymentsTab({ enrollmentId, enrollment }: EnrollmentPa
 
   const { data: fees, isLoading } = useQuery({
     queryKey: ["enrollment-fees", enrollmentId],
-    queryFn: async () => {
+    queryFn: async (): Promise<EnrollmentFeeItem[]> => {
       if (!studentId) return []
       const session = await getSession()
       const baseUrl = process.env.NEXT_PUBLIC_API_URL
@@ -58,102 +35,44 @@ export function EnrollmentPaymentsTab({ enrollmentId, enrollment }: EnrollmentPa
       })
       if (!res.ok) return []
       const data = await res.json()
-      const items: EnrollmentFeeItem[] = Array.isArray(data) ? data : data.items ?? []
-      // Filter to only this enrollment's fees
+      const items: (EnrollmentFeeItem & { enrollment_id: number })[] = Array.isArray(data) ? data : data.items ?? []
       return items.filter((f) => f.enrollment_id === enrollmentId)
     },
     enabled: !!studentId,
     staleTime: 1000 * 60 * 2,
   })
 
-  const totalExpected = (fees ?? []).reduce((s, f) => s + f.amount, 0)
-  const totalPaid = (fees ?? []).reduce((s, f) => s + f.paid, 0)
-  const feesRemaining = Math.max(0, totalExpected - totalPaid)
-  const feesRate = totalExpected > 0 ? Math.round((totalPaid / totalExpected) * 100) : 0
+  const feeList = fees ?? []
+  const totalExpected = feeList.reduce((s, f) => s + f.amount, 0)
+  const totalPaid = feeList.reduce((s, f) => s + f.paid, 0)
+  const totalRemaining = Math.max(0, totalExpected - totalPaid)
 
   if (isLoading) {
     return (
       <div className="space-y-4">
-        <Skeleton className="h-36 rounded-lg" />
-        <Skeleton className="h-16 rounded-lg" />
+        <Skeleton className="h-40 rounded-2xl" />
+        <Skeleton className="h-32 rounded-lg" />
       </div>
     )
   }
 
   return (
     <div className="space-y-4">
-      {/* Hero section */}
-      <Card className="border-0 shadow-sm ring-1 ring-border bg-primary text-primary-foreground">
-        <CardContent className="p-6">
-          <div className="flex items-start justify-between mb-4">
-            <div className="grid gap-4 sm:grid-cols-2 flex-1">
-              <div>
-                <p className="text-xs text-primary-foreground/70">Total attendu</p>
-                <p className="text-2xl font-bold">{formatFCFA(totalExpected)}</p>
-              </div>
-              <div className="sm:text-right">
-                <p className="text-xs text-primary-foreground/70">Total payé</p>
-                <p className="text-2xl font-bold">{formatFCFA(totalPaid)}</p>
-              </div>
-            </div>
-            {studentId && feesRemaining > 0 && (
-              <Button
-                size="sm"
-                variant="secondary"
-                className="shrink-0 ml-4"
-                onClick={() => setPaymentOpen(true)}
-              >
-                <Plus className="mr-1.5 h-3.5 w-3.5" />
-                Enregistrer paiement
-              </Button>
-            )}
-          </div>
-          <Progress
-            value={feesRate}
-            className="h-3 bg-primary-foreground/20 [&>div]:bg-primary-foreground"
-          />
-          <p className="mt-2 text-sm text-primary-foreground/80">
-            Reste à payer : <span className="font-semibold">{formatFCFA(feesRemaining)}</span>
-          </p>
-        </CardContent>
-      </Card>
+      <FeeSummaryHero totalExpected={totalExpected} totalPaid={totalPaid} totalRemaining={totalRemaining} />
 
-      {/* Fee details */}
-      {(fees ?? []).length > 0 ? (
-        <div className="grid gap-3 sm:grid-cols-2">
-          {(fees ?? []).map((fee) => {
-            const st = STATUS_LABEL[fee.status] ?? { label: fee.status, variant: "outline" as const }
-            return (
-              <Card key={fee.id} className="border-0 shadow-sm ring-1 ring-border">
-                <CardContent className="p-4">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="space-y-1 min-w-0">
-                      <p className="text-sm font-semibold truncate">
-                        {fee.option_name ?? fee.category_name}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {formatFCFA(fee.paid)} / {formatFCFA(fee.amount)}
-                      </p>
-                    </div>
-                    <Badge variant={st.variant} className="text-[10px] shrink-0">
-                      {st.label}
-                    </Badge>
-                  </div>
-                </CardContent>
-              </Card>
-            )
-          })}
-        </div>
-      ) : (
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-muted mb-3">
-            <Wallet className="h-6 w-6 text-muted-foreground" />
-          </div>
-          <p className="text-sm text-muted-foreground">Aucun frais associé à cette inscription.</p>
+      {studentId && totalRemaining > 0 && (
+        <div className="flex justify-end">
+          <Button onClick={() => setPaymentOpen(true)} className="h-11 sm:h-10">
+            <Plus className="mr-1.5 h-4 w-4" />
+            Enregistrer un paiement
+          </Button>
         </div>
       )}
 
-      {/* Payment modal */}
+      <EnrollmentFeesBreakdown fees={feeList} />
+
+      <PaymentHistoryList enrollmentId={enrollmentId} />
+
       {studentId && (
         <StudentPaymentModal
           studentId={studentId}
@@ -161,6 +80,7 @@ export function EnrollmentPaymentsTab({ enrollmentId, enrollment }: EnrollmentPa
           onClose={() => {
             setPaymentOpen(false)
             queryClient.invalidateQueries({ queryKey: ["enrollment-fees", enrollmentId] })
+            queryClient.invalidateQueries({ queryKey: ["payments", "enrollment", enrollmentId] })
           }}
         />
       )}

--- a/components/admin/payments/EnrollmentFeesBreakdown.tsx
+++ b/components/admin/payments/EnrollmentFeesBreakdown.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { CheckCircle2, CircleDot, Circle, MinusCircle, ListChecks } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { SectionTitle } from "@/components/shared/PageHero"
+import { cn } from "@/lib/utils"
+
+export interface EnrollmentFeeItem {
+  id: number
+  category_name: string
+  amount: number
+  paid: number
+  remaining: number
+  status: string
+  is_optional?: boolean
+  option_name?: string | null
+}
+
+const fmt = (n: number) => `${n.toLocaleString("fr-FR")} FCFA`
+
+const STATUS: Record<
+  string,
+  { label: string; icon: typeof CheckCircle2; dot: string; text: string }
+> = {
+  paid: { label: "Payé", icon: CheckCircle2, dot: "bg-emerald-500", text: "text-emerald-600 dark:text-emerald-400" },
+  partial: { label: "Partiel", icon: CircleDot, dot: "bg-amber-500", text: "text-amber-600 dark:text-amber-400" },
+  pending: { label: "En attente", icon: Circle, dot: "bg-muted-foreground/40", text: "text-muted-foreground" },
+  waived: { label: "Exonéré", icon: MinusCircle, dot: "bg-muted-foreground/40", text: "text-muted-foreground" },
+}
+
+/**
+ * Détail des frais d'une inscription : une ligne par frais avec sa progression
+ * (payé / dû), le reste et le statut. Reprend la logique de lecture de
+ * l'allocation d'un versement, appliquée à l'état courant des frais.
+ */
+export function EnrollmentFeesBreakdown({ fees }: { fees: EnrollmentFeeItem[] }) {
+  if (fees.length === 0) {
+    return (
+      <Card className="border-0 shadow-sm ring-1 ring-border">
+        <CardContent className="flex flex-col items-center justify-center py-10 text-center text-muted-foreground">
+          <ListChecks className="mb-2 h-8 w-8 opacity-40" />
+          <p className="text-sm">Aucun frais associé à cette inscription.</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardContent className="space-y-3 p-4 sm:p-5">
+        <SectionTitle icon={ListChecks}>Détail des frais</SectionTitle>
+        <div className="divide-y divide-border/60">
+          {fees.map((fee) => {
+            const st = STATUS[fee.status] ?? STATUS.pending
+            const StIcon = st.icon
+            const pct = fee.amount > 0 ? Math.min(100, Math.round((fee.paid / fee.amount) * 100)) : 0
+            const name = fee.option_name ?? fee.category_name
+            return (
+              <div key={fee.id} className="py-3 first:pt-1 last:pb-1">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <StIcon className={cn("h-4 w-4 shrink-0", st.text)} />
+                    <span className="truncate text-sm font-medium">{name}</span>
+                    {fee.is_optional && (
+                      <span className="shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                        Optionnel
+                      </span>
+                    )}
+                  </div>
+                  <span className={cn("shrink-0 text-[11px] font-semibold uppercase tracking-wide", st.text)}>
+                    {st.label}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center gap-3">
+                  <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+                    <div className={cn("h-full rounded-full transition-all", st.dot)} style={{ width: `${pct}%` }} />
+                  </div>
+                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    <span className="font-semibold text-foreground">{fmt(fee.paid)}</span> / {fmt(fee.amount)}
+                  </span>
+                </div>
+                {fee.remaining > 0 && fee.status !== "waived" && (
+                  <p className="mt-1 text-right text-[11px] text-muted-foreground">
+                    Reste : <span className="font-medium text-foreground">{fmt(fee.remaining)}</span>
+                  </p>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/payments/PaymentHistoryList.tsx
+++ b/components/admin/payments/PaymentHistoryList.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useState } from "react"
+import { Receipt, Banknote, Smartphone, Building2, FileText, Loader2, ArrowRight } from "lucide-react"
+import { toast } from "sonner"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { SectionTitle } from "@/components/shared/PageHero"
+import { useEnrollmentPayments } from "@/lib/hooks/usePayments"
+import { paymentsApi } from "@/lib/api/payments"
+import type { Payment, PaymentMethod } from "@/lib/contracts/payment"
+
+const fmt = (n: number) => `${Number(n).toLocaleString("fr-FR")} FCFA`
+
+const METHOD: Record<PaymentMethod, { label: string; icon: typeof Banknote }> = {
+  cash: { label: "Espèces", icon: Banknote },
+  mobile_money: { label: "Mobile Money", icon: Smartphone },
+  bank_transfer: { label: "Virement", icon: Building2 },
+  cheque: { label: "Chèque", icon: FileText },
+}
+
+const STATUS_LABEL: Record<string, { label: string; cls: string }> = {
+  completed: { label: "Validé", cls: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300" },
+  pending: { label: "En attente", cls: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300" },
+  cancelled: { label: "Annulé", cls: "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300" },
+  refunded: { label: "Remboursé", cls: "border-border bg-muted text-muted-foreground" },
+  failed: { label: "Échoué", cls: "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-300" },
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString("fr-FR", { day: "numeric", month: "long", year: "numeric" })
+}
+
+/**
+ * Historique des versements d'une inscription, avec la répartition (allocation)
+ * de chaque versement sur les frais. Comble le vide : l'API renvoyait déjà les
+ * allocations mais aucune vue ne les montrait. Chaque versement propose son reçu.
+ */
+export function PaymentHistoryList({ enrollmentId }: { enrollmentId: number }) {
+  const { data: payments, isLoading } = useEnrollmentPayments(enrollmentId)
+  const [downloading, setDownloading] = useState<number | null>(null)
+
+  async function openReceipt(payment: Payment) {
+    setDownloading(payment.id)
+    try {
+      const blob = await paymentsApi.downloadReceipt(payment.id)
+      window.open(URL.createObjectURL(blob), "_blank", "noopener,noreferrer")
+    } catch {
+      toast.error("Impossible d'ouvrir le reçu")
+    } finally {
+      setDownloading(null)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <Card className="border-0 shadow-sm ring-1 ring-border">
+        <CardContent className="space-y-2 p-4 sm:p-5">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const list = payments ?? []
+
+  return (
+    <Card className="border-0 shadow-sm ring-1 ring-border">
+      <CardContent className="space-y-3 p-4 sm:p-5">
+        <SectionTitle icon={Receipt}>Historique des versements</SectionTitle>
+
+        {list.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center text-muted-foreground">
+            <Receipt className="mb-2 h-8 w-8 opacity-40" />
+            <p className="text-sm">Aucun versement enregistré pour l&apos;instant.</p>
+          </div>
+        ) : (
+          <div className="space-y-2.5">
+            {list.map((p) => {
+              const method = METHOD[p.method]
+              const MethodIcon = method.icon
+              const st = STATUS_LABEL[p.status] ?? { label: p.status, cls: "border-border bg-muted text-muted-foreground" }
+              const allocations = p.allocations ?? []
+              return (
+                <div key={p.id} className="rounded-xl border border-border/70 bg-muted/30 p-3.5">
+                  {/* Ligne principale */}
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-base font-bold tabular-nums">{fmt(p.amount)}</p>
+                      <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                        <span>{formatDate(p.created_at)}</span>
+                        <span className="inline-flex items-center gap-1">
+                          <MethodIcon className="h-3 w-3" />
+                          {method.label}
+                        </span>
+                        {p.reference && <span className="font-mono">{p.reference}</span>}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 flex-col items-end gap-1.5">
+                      <span className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${st.cls}`}>
+                        {st.label}
+                      </span>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 px-2 text-xs text-primary"
+                        onClick={() => openReceipt(p)}
+                        disabled={downloading === p.id}
+                      >
+                        {downloading === p.id ? (
+                          <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Receipt className="mr-1 h-3.5 w-3.5" />
+                        )}
+                        Reçu
+                      </Button>
+                    </div>
+                  </div>
+
+                  {/* Répartition sur les frais */}
+                  {allocations.length > 0 && (
+                    <div className="mt-2.5 space-y-1 border-t border-border/50 pt-2.5">
+                      <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                        Réparti sur
+                      </p>
+                      {allocations.map((a) => (
+                        <div key={a.id} className="flex items-center gap-2 text-xs">
+                          <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+                          <span className="min-w-0 flex-1 truncate">{a.fee_category_name ?? "Frais"}</span>
+                          {a.enrollment_fee_status_after && (
+                            <Badge variant="outline" className="h-4 px-1.5 text-[9px]">
+                              {a.enrollment_fee_status_after === "paid"
+                                ? "Payé"
+                                : a.enrollment_fee_status_after === "partial"
+                                  ? "Partiel"
+                                  : a.enrollment_fee_status_after}
+                            </Badge>
+                          )}
+                          <span className="shrink-0 font-semibold tabular-nums text-primary">+ {fmt(a.amount)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/staff/StaffDetailClient.tsx
+++ b/components/admin/staff/StaffDetailClient.tsx
@@ -12,7 +12,6 @@ import {
   UserPlus,
   Clock,
 } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
 import {
   DropdownMenu,
@@ -146,8 +145,6 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
         </Dialog>
       )}
 
-      <AccountSection entityType="staff" entityId={staffId} />
-
       {/* Tabs */}
       <Tabs defaultValue="profil" className="space-y-4">
         <TabsList>
@@ -168,6 +165,9 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
           <StaffActivityTab fullData={fullData} />
         </TabsContent>
       </Tabs>
+
+      {/* Compte de connexion — information secondaire, placée en bas de fiche */}
+      <AccountSection entityType="staff" entityId={staffId} />
 
       <StaffEditModal staffId={staffId} open={editOpen} onClose={() => setEditOpen(false)} />
 

--- a/components/admin/students/StudentDetailClient.tsx
+++ b/components/admin/students/StudentDetailClient.tsx
@@ -243,8 +243,6 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
         </Dialog>
       )}
 
-      <AccountSection entityType="student" entityId={studentId} />
-
       {/* Tabs — reordered by usage frequency, scroll-x on mobile, controlled for cross-tab links */}
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <div className="-mx-1 overflow-x-auto px-1 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
@@ -317,6 +315,9 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
           <DocumentsTab studentId={studentId} studentLastName={student.last_name} />
         </TabsContent>
       </Tabs>
+
+      {/* Compte de connexion — information secondaire, placée en bas de fiche */}
+      <AccountSection entityType="student" entityId={studentId} />
 
       {/* Edit modal */}
       <StudentEditModal studentId={studentId} open={editOpen} onClose={() => setEditOpen(false)} />

--- a/components/admin/students/tabs/PaymentsTab.tsx
+++ b/components/admin/students/tabs/PaymentsTab.tsx
@@ -9,9 +9,9 @@ import { toast } from "sonner"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
+import { FeeSummaryHero } from "@/components/shared/fees/FeeSummaryHero"
 import { useEnrollments, enrollmentKeys } from "@/lib/hooks/useEnrollments"
 import { studentKeys, useStudentFees } from "@/lib/hooks/useStudents"
 import { StudentPaymentModal } from "./StudentPaymentModal"
@@ -19,10 +19,6 @@ import { StudentPaymentModal } from "./StudentPaymentModal"
 interface PaymentsTabProps {
   studentId: number
   fullData?: Record<string, unknown>
-}
-
-function formatFCFA(amount: number): string {
-  return `${amount.toLocaleString("fr-FR")} FCFA`
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -45,7 +41,6 @@ export function PaymentsTab({ studentId }: PaymentsTabProps) {
   const totalExpected = (fees ?? []).reduce((sum, f) => sum + f.amount, 0)
   const totalPaid = (fees ?? []).reduce((sum, f) => sum + f.paid, 0)
   const feesRemaining = Math.max(0, totalExpected - totalPaid)
-  const feesRate = totalExpected > 0 ? Math.round((totalPaid / totalExpected) * 100) : 0
 
   async function handleRegenerateFees() {
     if (enrollments.length === 0) return
@@ -104,56 +99,28 @@ export function PaymentsTab({ studentId }: PaymentsTabProps) {
 
   return (
     <div className="space-y-4">
-      {/* Hero section */}
-      <Card className="border-0 shadow-sm ring-1 ring-border bg-primary text-primary-foreground">
-        <CardContent className="p-6">
-          <div className="flex items-start justify-between mb-4">
-            <div className="grid gap-4 sm:grid-cols-2 flex-1">
-              <div>
-                <p className="text-xs text-primary-foreground/70">Total attendu</p>
-                <p className="text-2xl font-bold">{formatFCFA(totalExpected as number)}</p>
-              </div>
-              <div className="sm:text-right">
-                <p className="text-xs text-primary-foreground/70">Total payé</p>
-                <p className="text-2xl font-bold">{formatFCFA(totalPaid as number)}</p>
-              </div>
-            </div>
-          </div>
-          <Progress
-            value={feesRate}
-            className="h-3 bg-primary-foreground/20 [&>div]:bg-primary-foreground"
-          />
-          <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-primary-foreground/80">
-              Reste à payer : <span className="font-semibold">{formatFCFA(feesRemaining as number)}</span>
-            </p>
-            <div className="flex flex-wrap items-center gap-2">
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-10 text-xs text-primary-foreground/90 hover:text-primary-foreground hover:bg-primary-foreground/10 border border-primary-foreground/30 sm:h-9"
-                onClick={handleRegenerateFees}
-                disabled={regenerating}
-              >
-                <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${regenerating ? "animate-spin" : ""}`} />
-                {regenerating ? "Régénération..." : "Régénérer les frais"}
-              </Button>
-              <Button
-                size="sm"
-                variant="secondary"
-                className="h-10 text-xs sm:h-9"
-                onClick={() => setPaymentOpen(true)}
-              >
-                <Plus className="mr-1.5 h-3.5 w-3.5" />
-                Enregistrer un paiement
-              </Button>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <FeeSummaryHero totalExpected={totalExpected} totalPaid={totalPaid} totalRemaining={feesRemaining} />
 
-      {/* Enrollments payment list */}
-      <div className="grid gap-4 sm:grid-cols-2">
+      {/* Actions */}
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-11 sm:h-10"
+          onClick={handleRegenerateFees}
+          disabled={regenerating}
+        >
+          <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${regenerating ? "animate-spin" : ""}`} />
+          {regenerating ? "Régénération..." : "Régénérer les frais"}
+        </Button>
+        <Button size="sm" className="h-11 sm:h-10" onClick={() => setPaymentOpen(true)}>
+          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          Enregistrer un paiement
+        </Button>
+      </div>
+
+      {/* Détail par inscription — lien vers la fiche paiement complète */}
+      <div className="grid gap-3 sm:grid-cols-2">
         {enrollments.map((enrollment) => {
           const e = enrollment as Record<string, unknown>
           const status = String(e.status ?? "")

--- a/components/admin/teachers/TeacherDetailClient.tsx
+++ b/components/admin/teachers/TeacherDetailClient.tsx
@@ -140,8 +140,6 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
         </Dialog>
       )}
 
-      <AccountSection entityType="teacher" entityId={teacherId} />
-
       {/* Tabs — controlled + scroll-x mobile (pattern principe 13/14) */}
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <div className="-mx-1 overflow-x-auto px-1 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
@@ -210,6 +208,9 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
           <TeacherAttendanceTab teacherId={teacherId} />
         </TabsContent>
       </Tabs>
+
+      {/* Compte de connexion — information secondaire, placée en bas de fiche */}
+      <AccountSection entityType="teacher" entityId={teacherId} />
 
       {/* Edit modal */}
       <TeacherEditModal teacherId={teacherId} open={editOpen} onClose={() => setEditOpen(false)} />


### PR DESCRIPTION
Closes #298

## /admin/enrollments/[id]
- En-tête **DetailHero** premium (bandeau bleu→orange, avatar, badge statut, KPIs Classe/Année, menu actions).
- Onglet **Paiements** : `FeeSummaryHero` + **détail des frais** (progression + statut par frais) + **historique des versements avec répartition** (allocations) + reçu par versement.

## Fiche élève
- Onglet **Paiements** : `FeeSummaryHero` premium.
- **Compte de connexion** déplacé en bas (élève, enseignant, personnel).

Nouveaux composants : `EnrollmentFeesBreakdown`, `PaymentHistoryList`. tsc + lint verts.