### PR TITLE
feat(verification): secure public document checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Vérification publique enrichie du Sceau numérique institutionnel KLASSCI : état actif, révoqué, remplacé ou expiré, aucune identité d'élève exposée et comparaison du PDF avec l'empreinte signée conservée par KLASSCI *(public)*.
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed

--- a/app/verifier/[tenant]/[token]/page.tsx
+++ b/app/verifier/[tenant]/[token]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next"
 import { verifyDocument } from "@/lib/api/verify"
-import { AuthenticView, NotRecognizedView } from "../../_components/result-views"
+import {
+  NotRecognizedView,
+  RecognizedDocumentView,
+  VerificationUnavailableView,
+} from "../../_components/result-views"
 
 // Jamais indexé : un document de vérification nominatif ne doit pas remonter
 // dans les moteurs de recherche.
@@ -16,8 +20,12 @@ export default async function VerifierPage({
   const { tenant, token } = await params
   const result = await verifyDocument(tenant, token)
 
-  if (result.status === "valid") {
-    return <AuthenticView doc={result.document} />
+  if (result.status === "recognized") {
+    return <RecognizedDocumentView doc={result.document} tenant={tenant} token={token} />
+  }
+
+  if (result.status === "unavailable") {
+    return <VerificationUnavailableView />
   }
 
   return <NotRecognizedView />

--- a/app/verifier/_components/file-integrity-check.tsx
+++ b/app/verifier/_components/file-integrity-check.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { AlertTriangle, CheckCircle2, FileCheck2, Loader2, ShieldX } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { verifyDocumentFile, type FileVerificationResult } from "@/lib/api/verify"
+
+type Props = {
+  tenant: string
+  token?: string
+  sealCode?: string
+}
+
+export function FileIntegrityCheck({ tenant, token, sealCode }: Props) {
+  const [file, setFile] = useState<File | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<FileVerificationResult | null>(null)
+  const [failed, setFailed] = useState(false)
+  const requestId = useRef(0)
+
+  async function verifyFile() {
+    if (!file || (!token && !sealCode)) return
+    const currentRequest = ++requestId.current
+    setLoading(true)
+    setResult(null)
+    setFailed(false)
+    const verification = await verifyDocumentFile(
+      tenant,
+      file,
+      token ? { token } : { sealCode: sealCode! },
+    )
+    if (currentRequest === requestId.current) {
+      setResult(verification)
+      setFailed(verification === null)
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="space-y-3 border-t pt-5" aria-labelledby="file-integrity-title">
+      <div className="space-y-1">
+        <h2 id="file-integrity-title" className="flex items-center gap-2 text-sm font-semibold">
+          <FileCheck2 className="h-4 w-4 text-primary" aria-hidden="true" />
+          Vérifier le fichier PDF
+        </h2>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Sélectionnez le PDF original pour comparer son empreinte au document scellé.
+        </p>
+      </div>
+      <Input
+        type="file"
+        accept="application/pdf,.pdf"
+        disabled={loading}
+        className="h-11 cursor-pointer"
+        onChange={(event) => {
+          requestId.current += 1
+          setFile(event.target.files?.[0] ?? null)
+          setResult(null)
+          setFailed(false)
+          setLoading(false)
+        }}
+      />
+      <Button type="button" className="h-11 w-full" disabled={!file || loading} onClick={verifyFile}>
+        {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+        Comparer l&apos;empreinte
+      </Button>
+      <div aria-live="polite">
+        {result?.status === "unavailable" ? (
+          <p className="flex items-start gap-2 text-sm font-medium text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            La comparaison du fichier n&apos;est pas disponible pour cet ancien sceau.
+          </p>
+        ) : null}
+        {result?.status === "matching" && result.document_status === "active" ? (
+          <p className="flex items-center gap-2 text-sm font-medium text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+            Empreinte identique, ce fichier n&apos;a pas été modifié.
+          </p>
+        ) : null}
+        {result?.status === "matching" && result.document_status !== "active" ? (
+          <p className="flex items-start gap-2 text-sm font-medium text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            L&apos;empreinte est identique, mais ce sceau est {statusLabel(result.document_status)}.
+          </p>
+        ) : null}
+        {result?.status === "modified" ? (
+          <p className="flex items-center gap-2 text-sm font-medium text-destructive">
+            <ShieldX className="h-4 w-4" aria-hidden="true" />
+            Empreinte différente, ce fichier est modifié ou ne correspond pas au sceau.
+          </p>
+        ) : null}
+        {failed ? (
+          <p className="text-sm text-destructive">La vérification est momentanément indisponible.</p>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+function statusLabel(status: FileVerificationResult["document_status"]): string {
+  if (status === "revoked") return "révoqué"
+  if (status === "superseded") return "remplacé par une version plus récente"
+  if (status === "expired") return "expiré"
+  return "actif"
+}

--- a/app/verifier/_components/manual-verifier.tsx
+++ b/app/verifier/_components/manual-verifier.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { useState, type FormEvent } from "react"
+import { Loader2, ScanLine, ShieldQuestion } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { verifyDocumentByCode, type VerifyResult } from "@/lib/api/verify"
+import type { TenantSlugResolution } from "@/lib/utils/tenant-slug"
+import {
+  NotRecognizedView,
+  RecognizedDocumentView,
+  VerificationUnavailableView,
+} from "./result-views"
+
+type Props = {
+  tenantResolution: TenantSlugResolution
+}
+
+export function ManualVerifier({ tenantResolution }: Props) {
+  if (tenantResolution.status !== "valid") {
+    return <TenantResolutionError status={tenantResolution.status} />
+  }
+
+  return <ManualVerifierForm tenant={tenantResolution.tenant} />
+}
+
+function TenantResolutionError({ status }: { status: "missing" | "invalid" }) {
+  const isMissing = status === "missing"
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-6 text-center">
+        <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+          <ShieldQuestion className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h1 className="text-lg font-semibold">
+          {isMissing ? "Établissement requis" : "Établissement invalide"}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {isMissing
+            ? "Ce lien de vérification ne précise pas l'établissement concerné."
+            : "Ce lien de vérification contient un identifiant d'établissement invalide."}
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function ManualVerifierForm({ tenant }: { tenant: string }) {
+  const [code, setCode] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<VerifyResult | null>(null)
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const normalized = code.trim().toUpperCase()
+    if (!normalized) return
+
+    setLoading(true)
+    setResult(null)
+    try {
+      const res = await verifyDocumentByCode(tenant, normalized)
+      setResult(res)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card className="overflow-hidden">
+        <div className="flex flex-col items-center gap-3 bg-primary px-6 py-7 text-center text-primary-foreground">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/30">
+            <ShieldQuestion className="h-8 w-8" aria-hidden="true" />
+          </div>
+          <div className="space-y-1">
+            <h1 className="text-lg font-semibold tracking-tight">Vérifier un document</h1>
+            <p className="text-sm text-primary-foreground/85">
+              Saisissez le code de vérification figurant sur le document
+            </p>
+          </div>
+        </div>
+
+        <CardContent className="space-y-4 p-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+              <label htmlFor="seal-code" className="text-sm font-medium text-foreground">
+                Code de vérification
+              </label>
+              <Input
+                id="seal-code"
+                name="code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="SNI-XXXX-XXXX-XXXX-XXXX"
+                autoComplete="off"
+                autoCapitalize="characters"
+                spellCheck={false}
+                disabled={loading}
+                className="h-11 font-mono tracking-wide"
+                aria-describedby="seal-help"
+              />
+              <p id="seal-help" className="text-xs text-muted-foreground">
+                Le code se trouve sous le Sceau numérique institutionnel KLASSCI.
+              </p>
+            </div>
+
+            <Button
+              type="submit"
+              disabled={loading || code.trim().length === 0}
+              className="h-11 w-full"
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  Vérification...
+                </>
+              ) : (
+                <>
+                  <ScanLine className="h-4 w-4" aria-hidden="true" />
+                  Vérifier
+                </>
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {result?.status === "recognized" ? (
+        <RecognizedDocumentView doc={result.document} tenant={tenant} sealCode={code.trim()} />
+      ) : null}
+      {result?.status === "not_found" ? <NotRecognizedView /> : null}
+      {result?.status === "unavailable" ? <VerificationUnavailableView /> : null}
+    </div>
+  )
+}

--- a/app/verifier/_components/result-views.tsx
+++ b/app/verifier/_components/result-views.tsx
@@ -1,6 +1,18 @@
-import { AlertTriangle, BadgeCheck, CalendarDays, GraduationCap, Hash, School, ShieldAlert, User } from "lucide-react"
+import {
+  AlertTriangle,
+  BadgeCheck,
+  CalendarDays,
+  Clock3,
+  GraduationCap,
+  KeyRound,
+  RefreshCcw,
+  School,
+  ShieldAlert,
+  ShieldX,
+} from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import type { VerifiedDocument } from "@/lib/api/verify"
+import { FileIntegrityCheck } from "./file-integrity-check"
 
 // Vues de résultat partagées entre la page scannée (/verifier/[tenant]/[token])
 // et le formulaire de saisie manuelle (/verifier). Composants purement
@@ -23,7 +35,7 @@ function DetailRow({
   value,
   mono,
 }: {
-  icon: typeof User
+  icon: typeof School
   label: string
   value: string
   mono?: boolean
@@ -47,19 +59,58 @@ function DetailRow({
   )
 }
 
-export function AuthenticView({ doc }: { doc: VerifiedDocument }) {
+const statusPresentation = {
+  active: {
+    title: "Sceau actif dans le registre",
+    subtitle: "Comparez le PDF pour confirmer l'intégrité du fichier",
+    className: "bg-emerald-600",
+    Icon: BadgeCheck,
+  },
+  revoked: {
+    title: "Document révoqué",
+    subtitle: "L'établissement a retiré la validité de ce document",
+    className: "bg-red-600",
+    Icon: ShieldX,
+  },
+  superseded: {
+    title: "Document remplacé",
+    subtitle: "Une version plus récente a été émise",
+    className: "bg-amber-600",
+    Icon: RefreshCcw,
+  },
+  expired: {
+    title: "Document expiré",
+    subtitle: "La période de validité du sceau est terminée",
+    className: "bg-amber-600",
+    Icon: Clock3,
+  },
+} as const
+
+export function RecognizedDocumentView({
+  doc,
+  tenant,
+  token,
+  sealCode,
+}: {
+  doc: VerifiedDocument
+  tenant: string
+  token?: string
+  sealCode?: string
+}) {
+  const presentation = statusPresentation[doc.status]
+  const StatusIcon = presentation.Icon
+
   return (
     <Card className="overflow-hidden">
-      {/* Sceau de validité — vert réservé à l'authenticité, l'identité reste bleue. */}
-      <div className="flex flex-col items-center gap-3 bg-emerald-600 px-6 py-7 text-center text-white">
+      <div
+        className={`flex flex-col items-center gap-3 px-6 py-7 text-center text-white ${presentation.className}`}
+      >
         <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/30">
-          <BadgeCheck className="h-8 w-8" aria-hidden="true" />
+          <StatusIcon className="h-8 w-8" aria-hidden="true" />
         </div>
         <div className="space-y-1">
-          <p className="text-lg font-semibold tracking-tight">Document authentique</p>
-          <p className="text-sm text-white/85">
-            Vérifié dans les registres de l&apos;établissement
-          </p>
+          <p className="text-lg font-semibold tracking-tight">{presentation.title}</p>
+          <p className="text-sm text-white/90">{presentation.subtitle}</p>
         </div>
       </div>
 
@@ -82,26 +133,27 @@ export function AuthenticView({ doc }: { doc: VerifiedDocument }) {
         {/* Récapitulatif du document. */}
         <div className="rounded-xl border bg-muted/30 px-4">
           <DetailRow icon={GraduationCap} label="Type de document" value={doc.document_type} />
-          <DetailRow icon={User} label="Élève" value={doc.student_name} />
-          <DetailRow icon={School} label="Classe" value={doc.class_name ?? "Non précisée"} />
-          <DetailRow
-            icon={CalendarDays}
-            label="Année scolaire"
-            value={doc.academic_year ?? "Non précisée"}
-          />
           <DetailRow
             icon={CalendarDays}
             label="Date d'émission"
             value={formatIssuedAt(doc.issued_at)}
           />
-          <DetailRow icon={Hash} label="Référence" value={doc.reference} mono />
+          <DetailRow
+            icon={KeyRound}
+            label="Protection"
+            value={doc.signature_algorithm ? `${doc.signature_algorithm} · ${doc.scheme}` : doc.scheme}
+            mono
+          />
         </div>
 
-        {/* Mention légale. */}
         <p className="text-[12px] leading-relaxed text-muted-foreground">
-          Ce document a été émis par {doc.school_name} via KLASSCI. Toute falsification est
-          passible de poursuites.
+          Sceau numérique institutionnel émis par {doc.school_name} via KLASSCI. Il ne constitue
+          pas un cachet électronique qualifié délivré par un prestataire de confiance agréé.
         </p>
+
+        {doc.file_verification_available ? (
+          <FileIntegrityCheck tenant={tenant} token={token} sealCode={sealCode} />
+        ) : null}
       </CardContent>
     </Card>
   )
@@ -137,6 +189,30 @@ export function NotRecognizedView() {
         <p className="text-sm leading-relaxed text-muted-foreground">
           Si vous pensez qu&apos;il s&apos;agit d&apos;une erreur, contactez directement
           l&apos;établissement qui a délivré le document pour confirmer son authenticité.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function VerificationUnavailableView() {
+  return (
+    <Card className="overflow-hidden border-border">
+      <div className="flex flex-col items-center gap-3 bg-muted px-6 py-7 text-center text-foreground">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-background ring-1 ring-border">
+          <ShieldAlert className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
+        </div>
+        <div className="space-y-1">
+          <p className="text-lg font-semibold tracking-tight">Vérification indisponible</p>
+          <p className="text-sm text-muted-foreground">
+            Le service ne peut pas répondre pour le moment
+          </p>
+        </div>
+      </div>
+      <CardContent className="p-6">
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          Aucun verdict n&apos;a été établi sur ce document. Réessayez plus tard ou contactez
+          directement l&apos;établissement émetteur.
         </p>
       </CardContent>
     </Card>

--- a/app/verifier/page.tsx
+++ b/app/verifier/page.tsx
@@ -1,106 +1,12 @@
-"use client"
+import { ManualVerifier } from "./_components/manual-verifier"
+import { resolveTenantSlug } from "@/lib/utils/tenant-slug"
 
-import { useState, type FormEvent } from "react"
-import { Loader2, ScanLine, ShieldQuestion } from "lucide-react"
-import { Card, CardContent } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Button } from "@/components/ui/button"
-import { verifyDocumentByCode, type VerifyResult } from "@/lib/api/verify"
-import { AuthenticView, NotRecognizedView } from "./_components/result-views"
+export default async function VerifierByCodePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tenant?: string | string[] }>
+}) {
+  const { tenant } = await searchParams
 
-// Démo mono-tenant : le tenant est fixé à "local". En multi-tenant, il viendrait
-// du sous-domaine / du host (ex: lycee-saint-augustin.klassci.com → "lycee-saint-augustin").
-const TENANT = "local"
-
-// Le noindex est porté par le layout (app/verifier/layout.tsx), ce qui couvre
-// cette page cliente sans casser le SSR.
-
-export default function VerifierByCodePage() {
-  const [code, setCode] = useState("")
-  const [loading, setLoading] = useState(false)
-  const [result, setResult] = useState<VerifyResult | null>(null)
-
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    // Normalise le code saisi (espaces + casse). Le BE gère déjà la
-    // normalisation des tirets et du préfixe, donc on envoie tel quel.
-    const normalized = code.trim().toUpperCase()
-    if (!normalized) return
-
-    setLoading(true)
-    setResult(null)
-    try {
-      const res = await verifyDocumentByCode(TENANT, normalized)
-      setResult(res)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  return (
-    <div className="space-y-6">
-      <Card className="overflow-hidden">
-        {/* En-tête bleu KLASSCI : on vérifie une identité, pas un statut. */}
-        <div className="flex flex-col items-center gap-3 bg-primary px-6 py-7 text-center text-primary-foreground">
-          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/30">
-            <ShieldQuestion className="h-8 w-8" aria-hidden="true" />
-          </div>
-          <div className="space-y-1">
-            <h1 className="text-lg font-semibold tracking-tight">Vérifier un document</h1>
-            <p className="text-sm text-primary-foreground/85">
-              Saisissez le code de vérification figurant sur le document
-            </p>
-          </div>
-        </div>
-
-        <CardContent className="space-y-4 p-6">
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-1.5">
-              <label htmlFor="cev-code" className="text-sm font-medium text-foreground">
-                Code de vérification
-              </label>
-              <Input
-                id="cev-code"
-                name="code"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                placeholder="CEV-XXXX-XXXX-XXXX"
-                autoComplete="off"
-                autoCapitalize="characters"
-                spellCheck={false}
-                disabled={loading}
-                className="h-11 font-mono tracking-wide"
-                aria-describedby="cev-help"
-              />
-              <p id="cev-help" className="text-xs text-muted-foreground">
-                Le code se trouve au dos du document, sous le cachet de l&apos;établissement.
-              </p>
-            </div>
-
-            <Button
-              type="submit"
-              disabled={loading || code.trim().length === 0}
-              className="h-11 w-full"
-            >
-              {loading ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                  Vérification...
-                </>
-              ) : (
-                <>
-                  <ScanLine className="h-4 w-4" aria-hidden="true" />
-                  Vérifier
-                </>
-              )}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
-
-      {/* Résultat affiché sous le formulaire. */}
-      {result?.status === "valid" ? <AuthenticView doc={result.document} /> : null}
-      {result?.status === "not_found" ? <NotRecognizedView /> : null}
-    </div>
-  )
+  return <ManualVerifier tenantResolution={resolveTenantSlug(tenant)} />
 }

--- a/lib/api/verify.test.ts
+++ b/lib/api/verify.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { verifyDocument, verifyDocumentFile } from "./verify"
+
+const validPayload = {
+  valid: true,
+  status: "active",
+  scheme: "KSI2",
+  document_type: "Bulletin de notes",
+  issued_at: "2026-07-21T12:00:00",
+  expires_at: null,
+  school_name: "Collège Test",
+  signature_algorithm: "Ed25519",
+  key_id: "key-2026",
+  file_verification_available: true,
+}
+
+describe("verifyDocument", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("returns recognized only for a valid API contract", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(validPayload))))
+    await expect(verifyDocument("local", "token")).resolves.toEqual({
+      status: "recognized",
+      document: validPayload,
+    })
+  })
+
+  it("reserves not_found for an explicit 404", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 404 })))
+    await expect(verifyDocument("local", "missing")).resolves.toEqual({ status: "not_found" })
+  })
+
+  it.each([
+    new Response(null, { status: 503 }),
+    new Response(JSON.stringify({ valid: true }), { status: 200 }),
+  ])("returns unavailable for outages and malformed contracts", async (response) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response))
+    await expect(verifyDocument("local", "token")).resolves.toEqual({ status: "unavailable" })
+  })
+
+  it("returns unavailable for network failures", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")))
+    await expect(verifyDocument("local", "token")).resolves.toEqual({ status: "unavailable" })
+  })
+})
+
+describe("verifyDocumentFile", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("keeps exact file integrity distinct from a revoked seal", async () => {
+    const payload = {
+      valid: false,
+      matches: true,
+      status: "matching",
+      signature_valid: true,
+      document_status: "revoked",
+    }
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(payload))))
+
+    await expect(
+      verifyDocumentFile("local", new File(["%PDF-1.7"], "doc.pdf"), { token: "token" }),
+    ).resolves.toEqual(payload)
+  })
+
+  it("rejects error responses before parsing their body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 500 })),
+    )
+
+    await expect(
+      verifyDocumentFile("local", new File(["%PDF-1.7"], "doc.pdf"), { token: "token" }),
+    ).resolves.toBeNull()
+  })
+
+  it("accepts the typed 409 unavailable contract", async () => {
+    const payload = {
+      valid: false,
+      matches: false,
+      status: "unavailable",
+      code: "FILE_VERIFICATION_UNAVAILABLE",
+      signature_valid: true,
+      document_status: "active",
+    }
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    )
+
+    await expect(
+      verifyDocumentFile("local", new File(["%PDF-1.7"], "doc.pdf"), { token: "legacy" }),
+    ).resolves.toEqual(payload)
+  })
+})

--- a/lib/api/verify.ts
+++ b/lib/api/verify.ts
@@ -21,22 +21,60 @@ function getBaseUrl(): string {
   return url
 }
 
+const DocumentStatusSchema = z.enum(["active", "revoked", "superseded", "expired"])
+
 export const VerifiedDocumentSchema = z.object({
-  valid: z.literal(true),
+  valid: z.boolean(),
+  status: DocumentStatusSchema,
+  scheme: z.string(),
   document_type: z.string(),
-  reference: z.string(),
-  student_name: z.string(),
-  class_name: z.string().nullable().default(null),
-  academic_year: z.string().nullable().default(null),
   issued_at: z.string(),
+  expires_at: z.string().nullable().default(null),
   school_name: z.string(),
-})
+  signature_algorithm: z.string().nullable().default(null),
+  key_id: z.string().nullable().default(null),
+  file_verification_available: z.boolean().default(false),
+}).strict()
 
 export type VerifiedDocument = z.infer<typeof VerifiedDocumentSchema>
 
 export type VerifyResult =
-  | { status: "valid"; document: VerifiedDocument }
+  | { status: "recognized"; document: VerifiedDocument }
   | { status: "not_found" }
+  | { status: "unavailable" }
+
+const FileVerificationSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      valid: z.boolean(),
+      matches: z.boolean(),
+      status: z.literal("matching"),
+      signature_valid: z.boolean(),
+      document_status: DocumentStatusSchema,
+    })
+    .strict(),
+  z
+    .object({
+      valid: z.boolean(),
+      matches: z.boolean(),
+      status: z.literal("modified"),
+      signature_valid: z.boolean(),
+      document_status: DocumentStatusSchema,
+    })
+    .strict(),
+  z
+    .object({
+      valid: z.literal(false),
+      matches: z.literal(false),
+      status: z.literal("unavailable"),
+      code: z.literal("FILE_VERIFICATION_UNAVAILABLE"),
+      signature_valid: z.boolean(),
+      document_status: DocumentStatusSchema,
+    })
+    .strict(),
+])
+
+export type FileVerificationResult = z.infer<typeof FileVerificationSchema>
 
 /**
  * Interroge GET {BASE}/public/verify/{tenant}/{token} sans authentification.
@@ -57,28 +95,29 @@ export async function verifyDocument(tenant: string, token: string): Promise<Ver
       },
     )
   } catch {
-    return { status: "not_found" }
+    return { status: "unavailable" }
   }
 
+  if (res.status === 404) return { status: "not_found" }
   if (!res.ok) {
-    return { status: "not_found" }
+    return { status: "unavailable" }
   }
 
   const json = (await res.json().catch(() => null)) as unknown
   const parsed = VerifiedDocumentSchema.safeParse(json)
   if (!parsed.success) {
     console.error("[verify] réponse inattendue du serveur:", parsed.error.issues)
-    return { status: "not_found" }
+    return { status: "unavailable" }
   }
 
-  return { status: "valid", document: parsed.data }
+  return { status: "recognized", document: parsed.data }
 }
 
 /**
  * Interroge GET {BASE}/public/verify-code/{tenant}/{code} sans authentification.
  *
  * Pendant que verifyDocument() vérifie via le token scanné (Datamatrix), cette
- * variante vérifie via le code CEV saisi manuellement (au dos du document). Le
+ * variante vérifie via le code du sceau saisi manuellement. Le
  * contrat de réponse est IDENTIQUE : même validation Zod, même politique
  * d'échec. Tout statut non-200, tout shape inattendu, toute erreur réseau →
  * "not_found".
@@ -95,19 +134,47 @@ export async function verifyDocumentByCode(tenant: string, code: string): Promis
       },
     )
   } catch {
-    return { status: "not_found" }
+    return { status: "unavailable" }
   }
 
+  if (res.status === 404) return { status: "not_found" }
   if (!res.ok) {
-    return { status: "not_found" }
+    return { status: "unavailable" }
   }
 
   const json = (await res.json().catch(() => null)) as unknown
   const parsed = VerifiedDocumentSchema.safeParse(json)
   if (!parsed.success) {
     console.error("[verify] réponse inattendue du serveur:", parsed.error.issues)
-    return { status: "not_found" }
+    return { status: "unavailable" }
   }
 
-  return { status: "valid", document: parsed.data }
+  return { status: "recognized", document: parsed.data }
+}
+
+export async function verifyDocumentFile(
+  tenant: string,
+  file: File,
+  identifier: { token: string } | { sealCode: string },
+): Promise<FileVerificationResult | null> {
+  const endpoint =
+    "token" in identifier
+      ? `/public/verify-file/${encodeURIComponent(tenant)}/${encodeURIComponent(identifier.token)}`
+      : `/public/verify-file-code/${encodeURIComponent(tenant)}/${encodeURIComponent(identifier.sealCode)}`
+  const formData = new FormData()
+  formData.append("document", file)
+
+  try {
+    const response = await fetch(`${getBaseUrl()}${endpoint}`, {
+      method: "POST",
+      body: formData,
+      cache: "no-store",
+    })
+    if (!response.ok && response.status !== 409) return null
+    const json = (await response.json().catch(() => null)) as unknown
+    const parsed = FileVerificationSchema.safeParse(json)
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
 }

--- a/lib/utils/tenant-slug.test.ts
+++ b/lib/utils/tenant-slug.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { resolveTenantSlug } from "./tenant-slug"
+
+describe("resolveTenantSlug", () => {
+  it("accepts a lowercase tenant slug", () => {
+    expect(resolveTenantSlug("college-saint-michel")).toEqual({
+      status: "valid",
+      tenant: "college-saint-michel",
+    })
+  })
+
+  it.each([
+    [undefined, "missing"],
+    ["", "invalid"],
+    ["College-Saint-Michel", "invalid"],
+    ["-college", "invalid"],
+    ["college-", "invalid"],
+    ["college_saint_michel", "invalid"],
+    [["college-a", "college-b"], "invalid"],
+  ] as const)("rejects %j as %s", (value, status) => {
+    expect(resolveTenantSlug(value)).toEqual({ status })
+  })
+})

--- a/lib/utils/tenant-slug.ts
+++ b/lib/utils/tenant-slug.ts
@@ -1,0 +1,16 @@
+export const TENANT_SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$/
+
+export type TenantSlugResolution =
+  | { status: "valid"; tenant: string }
+  | { status: "missing" | "invalid" }
+
+/**
+ * Resolves the public verifier tenant from a query-string value.
+ * Repeated values are rejected to keep the request tenant unambiguous.
+ */
+export function resolveTenantSlug(value: string | readonly string[] | undefined): TenantSlugResolution {
+  if (value === undefined) return { status: "missing" }
+  if (typeof value !== "string" || !TENANT_SLUG_REGEX.test(value)) return { status: "invalid" }
+
+  return { status: "valid", tenant: value }
+}


### PR DESCRIPTION
## Résumé
- distingue document reconnu, introuvable et service indisponible
- compare l'empreinte exacte du PDF indépendamment du statut du sceau
- impose un tenant explicite au vérificateur manuel
- ajoute les états révoqué, remplacé et expiré avec une UX accessible

## Validation
- 16 tests Vitest passés
- TypeScript et lint validés
- revue UX/sécurité: APPROVE