### PR TITLE
ci: publish Windows frontend release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     env:
-      NEXT_PUBLIC_API_URL: https://api-staging.klassci.com
-      NEXT_PUBLIC_WS_URL: wss://api-staging.klassci.com
+      NEXT_PUBLIC_API_URL: https://college.klassci.com/api-be
+      NEXT_PUBLIC_EXTRA_ALLOWED_HOSTS: ""
       NEXTAUTH_SECRET: ci-secret-not-real
       NEXTAUTH_URL: http://localhost:3000
+      SKIP_ENV_VALIDATION: "1"
 
     steps:
       - uses: actions/checkout@v4
@@ -58,6 +59,21 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Package Windows production artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        run: |
+          cp -r public .next/standalone/
+          cp -r .next/static .next/standalone/.next/
+          tar czf standalone.tgz -C .next/standalone .
+
+      - name: Upload Windows production artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        uses: actions/upload-artifact@v7
+        with:
+          name: klassci-college-frontend-${{ github.sha }}
+          path: standalone.tgz
+          retention-days: 7
 
   test:
     name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     env:
-      NEXT_PUBLIC_API_URL: https://college.klassci.com/api-be
+      NEXT_PUBLIC_API_URL: https://college.klassci.com/svc
       NEXT_PUBLIC_EXTRA_ALLOWED_HOSTS: ""
       NEXTAUTH_SECRET: ci-secret-not-real
       NEXTAUTH_URL: http://localhost:3000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Publication Windows : le frontend standalone est désormais compilé hors production par la CI puis livré comme artefact versionné.
 - Déploiement : l'ancien workflow EC2 est retiré, la production KLASSCI College reste publiée sur le serveur Windows natif.
 - Fiche inscription et onglet Paiements repensés en premium : en-tête avec bandeau de marque (classe, année, statut), synthèse claire des frais (payé, reste à payer, progression), détail de chaque frais avec sa barre d'avancement et son statut, et historique des versements montrant la répartition sur les frais avec le reçu téléchargeable pour chacun *(admin)*.
 - Onglet Paiements de la fiche élève : même bandeau de synthèse premium des frais (payé, reste à payer) *(admin)*.


### PR DESCRIPTION
## Résumé
- compile le standalone Next.js hors production
- cible l'API de production college.klassci.com
- publie un artefact versionné sur chaque push develop

Closes #307