### PR TITLE
feat(inscriptions): photo eleve, wizard scinde, matieres refactorisees et image Docker prod

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -1,4 +1,4 @@
----
+﻿---
 paths:
   - "scripts/**"
   - ".github/workflows/**"
@@ -10,128 +10,70 @@ paths:
   - "**/Dockerfile*"
 ---
 
-# Règle Déploiement — Jamais de build sur EC2 prod
+# Regle Deploiement · Demo Windows, prod Contabo
 
-## La règle
+## La regle
 
-**Aucun `pnpm build` / `next build` ne doit s'exécuter sur EC2 16.58.132.68** tant que c'est l'unique serveur de prod KLASSCI College (t3.small, 2 vCPU, 2 GB RAM).
+Deux cibles KLASSCI College :
 
-Build = ailleurs (CI GitHub Actions, dev local Linux/WSL).
-Artefact = `.next/standalone/` + `.next/static/` + `public/` + `.env.local`.
-Ship via rsync/scp/CI.
-Sur EC2 = uniquement `sudo systemctl restart klassci-frontend`.
+- **Demo** : Windows Server 2022 `94.72.96.119` (HTTP sur l'IP). Build frontend autorise uniquement via `C:\klassci-deploy\frontend-build.ps1`.
+- **Production** : VPS Contabo Linux `169.58.156.206`, jusqu'a 24 Go RAM, Dokploy compose `klassci-college-prod`. Domaine public `https://college.klassci.com`. **Build autorise sur cet hote** (`docker build` puis recreate du service `frontend`). SSH : `ssh -F deploy/ssh_config klassci-prod`.
+
+L'ancienne **EC2 Linux `16.58.132.68` (2 Go RAM) n'existe plus**. L'interdiction de build venait de cette machine, pas du Contabo.
 
 ## Pourquoi
 
-Sur t3.small, `next build` sature les 2 vCPU à 99 %. Pendant ces 6-10 min :
+Sur 2 Go, un `next build` saturait le login (incident EC2 2026-04-26). Le Contabo a 24 Go : Wourri + College + un `docker build` tiennent ensemble. Ne pas relancer `pnpm build` / `next build` **dans** le conteneur frontend live : builder une image, puis recreate.
 
-- nginx ne sert plus les requêtes en temps acceptable
-- SSH banner timeout
-- Real users (ex: `102.209.220.136`, observé 2026-04-26) prennent 30 s+ de timeout sur `https://college.klassci.com`
-- Récupération nécessite souvent `aws ec2 stop-instances --force` → 2-3 min de downtime supplémentaires
-
-`nice -n 19 ionice -c 3 + max-old-space-size=1536` ne suffit pas. La preuve : 2 force-stop AWS CLI nécessaires dans la session 2026-04-26 malgré ces palliatifs.
-
-## Pattern acceptable — GitHub Actions (objectif S2)
-
-```yaml
-# .github/workflows/deploy-fe.yml
-name: Deploy FE
-on:
-  push:
-    branches: [main]
-  workflow_dispatch:
-
-jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-        with: { version: 10 }
-      - uses: actions/setup-node@v6
-        with: { node-version: 22, cache: pnpm }
-      - run: pnpm install --frozen-lockfile
-
-      - name: Build standalone
-        env:
-          NEXT_PUBLIC_API_URL: https://college.klassci.com
-        run: pnpm build
-
-      - name: Pack artifact
-        run: |
-          cp -r public .next/standalone/
-          cp -r .next/static .next/standalone/.next/
-          tar czf standalone.tgz -C .next/standalone .
-
-      - name: Ship + restart
-        env:
-          SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
-          HOST:    ${{ secrets.EC2_HOST }}
-        run: |
-          echo "$SSH_KEY" > /tmp/k && chmod 600 /tmp/k
-          scp -i /tmp/k -o StrictHostKeyChecking=no standalone.tgz ubuntu@$HOST:/tmp/
-          ssh -i /tmp/k -o StrictHostKeyChecking=no ubuntu@$HOST '
-            set -e
-            STAGE=/tmp/standalone-new-$(date +%s)
-            mkdir -p $STAGE && tar xzf /tmp/standalone.tgz -C $STAGE
-            cp /home/ubuntu/klassci/klassci-frontend/.next/standalone/.env.local $STAGE/
-            sudo mv /home/ubuntu/klassci/klassci-frontend/.next/standalone /home/ubuntu/klassci/klassci-frontend/.next/standalone.old
-            sudo mv $STAGE /home/ubuntu/klassci/klassci-frontend/.next/standalone
-            sudo systemctl restart klassci-frontend
-            sleep 3
-            curl -fsS http://localhost:3000/login > /dev/null || (sudo mv /home/ubuntu/klassci/klassci-frontend/.next/standalone /home/ubuntu/klassci/klassci-frontend/.next/standalone.broken && sudo mv /home/ubuntu/klassci/klassci-frontend/.next/standalone.old /home/ubuntu/klassci/klassci-frontend/.next/standalone && sudo systemctl restart klassci-frontend && exit 1)
-            sudo rm -rf /home/ubuntu/klassci/klassci-frontend/.next/standalone.old'
-```
-
-Downtime perçu : <1 s.
-Auto-rollback si `/login` ne répond pas après restart.
-
-## Pattern de secours — Build local Linux/WSL
-
-Pas Windows shell direct (la syntaxe inline `NODE_OPTIONS='--max-old-space-size=1536'` du `build` script casse sur Windows).
+## Pattern demo Windows
 
 ```bash
-# Sur sa machine dev (WSL ou Mac/Linux)
-pnpm install --frozen-lockfile
-pnpm build
-cp -r public .next/standalone/
-cp -r .next/static .next/standalone/.next/
-tar czf /tmp/fe-build.tgz -C .next/standalone .
-
-# Ship + restart
-rsync -avz /tmp/fe-build.tgz ubuntu@16.58.132.68:/tmp/
-ssh ubuntu@16.58.132.68 '
-  cd /home/ubuntu/klassci/klassci-frontend &&
-  cp .next/standalone/.env.local /tmp/env.local &&
-  rm -rf .next/standalone &&
-  mkdir .next/standalone &&
-  tar xzf /tmp/fe-build.tgz -C .next/standalone &&
-  cp /tmp/env.local .next/standalone/.env.local &&
-  sudo systemctl restart klassci-frontend'
+cd ~/Downloads/dev/klassci-college
+ssh -F deploy/ssh_config klassci
+# extraire le tar, puis :
+powershell -File C:\klassci-deploy\frontend-build.ps1
+nssm restart klassci-frontend
 ```
 
-## Anti-patterns à bloquer
+Conditions : sauvegarder `.env.local`, un seul deploiement a la fois, verifier `/login` et `/svc/health`, restaurer si echec.
+
+## Pattern production Contabo
+
+Hote : `169.58.156.206` (`ssh -F deploy/ssh_config klassci-prod`).
+Stack live : `/etc/dokploy/compose/klassci-college-prod/code/` (compose + Caddyfile + `.env`).
+UI Dokploy : `https://dokploy.africandigitconsulting.com` (projet `klassci-college`, env `production`, app `klassci-college-prod`).
+MySQL/Redis sont dans le compose, pas dans les cartes Database Dokploy. Volumes : `linux_klassci_mysql`, `linux_klassci_redis`. Jamais `docker compose down -v`.
+Wourri tourne sur le meme VPS : ne pas y toucher.
+
+Build **sur Contabo** (prefere si Docker Desktop local est down) :
+
+```bash
+ssh -4 -F deploy/ssh_config klassci-prod
+docker build -t klassci-college-frontend:prod /chemin/vers/klassci-frontend
+docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /etc/dokploy/compose/klassci-college-prod/code:/etc/dokploy/compose/klassci-college-prod/code \
+  -w /etc/dokploy/compose/klassci-college-prod/code \
+  docker:27-cli compose -p klassci-college-prod up -d --no-deps --force-recreate frontend
+```
+
+Build hors serveur (CI / Docker Desktop + `docker save | ssh ... docker load`) reste valide.
+
+Login ecoles : `https://college.klassci.com/login` + code `ROSTAN` (alias de `rostan-bouake`). `?c=rostan-bouake` reste un raccourci.
+Login plateforme (pas pour l'ecole) : tenant `local`, `superadmin@klassci.com`.
+
+## Anti-patterns
 
 | Pattern | Pourquoi NON |
 |---|---|
-| `ssh ubuntu@16.58.132.68 "pnpm build"` | sature CPU prod |
-| `screen -dmS fe-build pnpm build` côté EC2 | screen retarde juste le constat de panne |
-| `nice -n 19 ionice -c 3 pnpm build` côté EC2 | palliatif insuffisant — 2 force-stop le 2026-04-26 le prouvent |
-| README de deploy qui documente le build sur EC2 comme commande standard | dette technique à supprimer une fois le pipeline CI/CD live |
-| « Rapide rebuild juste pour cette feature » | × 5 = 30 min de downtime cumulé/jour |
-
-## Smell qui doit me sauter aux yeux
-
-Si je vois dans une mémoire ou doc :
-- un workaround (`nice`, `ionice`, swap)
-- ET un dernier recours après échec (`force-stop`, `kill -9`, reboot)
-
-→ ne pas appliquer le workaround. **Fix l'architecture**. Build off-prod, point.
+| `pnpm build` / `next build` dans le conteneur frontend live | image + recreate seulement |
+| Recreer MySQL/Redis ou `down -v` | perd le tenant Rostan |
+| Toucher le stack Wourri | autre produit live sur le meme VPS |
+| Commandes vers `16.58.132.68` / `ubuntu@` / `EC2_HOST` | infra morte |
+| Build Windows hors `frontend-build.ps1` | script versionne obligatoire |
 
 ## Voir aussi
 
-- Mémoire incident fondateur : `feedback_never_build_on_prod.md`
 - Rule globale : `~/.claude/rules/never-build-on-prod-server.md`
-- Rule sœur : `ssh-remote-commands.md` (commandes courtes, pas de sleep dans SSH)
+- Doc : `deploy/README.md`
+- Skill E2E : `klassci-e2e-test` (demo Windows par defaut)

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+.next
+.git
+.env
+.env.local
+.env.development.local
+*.png
+_build_prod.bat
+_reinstall.bat
+_start_prod.bat
+.claude
+.github
+e2e
+tests

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ playwright/.cache/
 
 # Sentry
 .sentryclirc
+
+# Agent scratch (worktrees éphémères, scripts et captures E2E locales)
+.claude/worktrees/
+/_*.bat
+/_e2e_*.js
+/test[0-9]*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Wizard Nouvelle inscription : le modal ne se ferme plus si on appuie hors du cadre (la saisie n'est plus perdue). L'étape élève et la sélection de classe sont lisibles sur téléphone, avec des boutons assez grands. La liste des classes montre les places encore disponibles, pas seulement le maximum *(admin)*.
 - Publication Windows : le frontend standalone est désormais compilé hors production par la CI puis livré comme artefact versionné.
-- Déploiement : l'ancien workflow EC2 est retiré, la production KLASSCI College reste publiée sur le serveur Windows natif.
+- Déploiement : l'ancien workflow EC2 est retiré. La démo reste sur le serveur Windows, la production vise le VPS Contabo (artefact + restart, aucun build sur le serveur).
 - Fiche inscription et onglet Paiements repensés en premium : en-tête avec bandeau de marque (classe, année, statut), synthèse claire des frais (payé, reste à payer, progression), détail de chaque frais avec sa barre d'avancement et son statut, et historique des versements montrant la répartition sur les frais avec le reçu téléchargeable pour chacun *(admin)*.
 - Onglet Paiements de la fiche élève : même bandeau de synthèse premium des frais (payé, reste à payer) *(admin)*.
 - Fiches élève, enseignant et personnel : la carte « Compte de connexion » passe en bas de page, ce n'est pas l'information principale à l'ouverture de la fiche *(admin)*.
@@ -20,6 +21,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Inscription élève : prise de photo directe (caméra, aperçu, reprise) avec import de fichier en repli. La photo est enregistrée sur le profil après création. Sur HTTP, la caméra live n'est pas disponible : utiliser HTTPS (`college.klassci.com`) ou l'import. États permission refusée, chargement, erreur et succès couverts *(admin)*.
 - Vérification publique enrichie du Sceau numérique institutionnel KLASSCI : état actif, révoqué, remplacé ou expiré, aucune identité d'élève exposée et comparaison du PDF avec l'empreinte signée conservée par KLASSCI *(public)*.
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+﻿FROM node:20-bookworm-slim AS deps
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM node:20-bookworm-slim AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NODE_OPTIONS=--max-old-space-size=4096 \
+    SKIP_ENV_VALIDATION=1 \
+    NEXT_PUBLIC_API_URL=/svc \
+    NEXTAUTH_URL=https://college.klassci.com \
+    AUTH_TRUST_HOST=true \
+    NEXTAUTH_SECRET=build-placeholder-not-used-at-runtime
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm exec next build \
+    && mkdir -p .next/standalone/.next \
+    && cp -r .next/static .next/standalone/.next/static \
+    && if [ -d public ]; then cp -r public .next/standalone/public; fi
+
+FROM node:20-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+COPY --from=builder /app/.next/standalone ./
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/components/admin/enrollments/EnrollmentCreateModal.tsx
+++ b/components/admin/enrollments/EnrollmentCreateModal.tsx
@@ -12,7 +12,13 @@ interface EnrollmentCreateModalProps {
 
 export function EnrollmentCreateModal({ open, onClose, preselectedStudentId }: EnrollmentCreateModalProps) {
   return (
-    <CreateModal open={open} onClose={onClose} title="Nouvelle inscription" className="max-w-2xl">
+    <CreateModal
+      open={open}
+      onClose={onClose}
+      title="Nouvelle inscription"
+      persistOnOutsideClick
+      className="flex max-h-[92dvh] w-[calc(100vw-1.5rem)] max-w-2xl flex-col gap-4 overflow-y-auto p-4 sm:p-6"
+    >
       <EnrollmentForm onSuccess={onClose} preselectedStudentId={preselectedStudentId} />
     </CreateModal>
   )

--- a/components/admin/students/photo/StudentPhotoCaptureDialog.tsx
+++ b/components/admin/students/photo/StudentPhotoCaptureDialog.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { useEffect } from "react"
+import { Camera, Loader2, RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { useLiveCamera } from "@/lib/hooks/useLiveCamera"
+
+interface StudentPhotoCaptureDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCaptured: (file: File) => void
+}
+
+export function StudentPhotoCaptureDialog({
+  open,
+  onOpenChange,
+  onCaptured,
+}: StudentPhotoCaptureDialogProps) {
+  const { videoRef, status, error, start, stop, capture } = useLiveCamera()
+  const busy = status === "requesting"
+
+  useEffect(() => {
+    if (!open) {
+      stop()
+      return
+    }
+    void start()
+    return () => stop()
+  }, [open, start, stop])
+
+  function handleOpenChange(next: boolean) {
+    if (!next) stop()
+    onOpenChange(next)
+  }
+
+  async function handleCapture() {
+    const file = await capture()
+    if (!file) return
+    onCaptured(file)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Prendre une photo</DialogTitle>
+          <DialogDescription>
+            Placez le visage de l&apos;élève dans le cadre, puis validez. Vous pourrez reprendre avant d&apos;enregistrer.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="overflow-hidden rounded-lg bg-zinc-950">
+          <video
+            ref={videoRef}
+            autoPlay
+            muted
+            playsInline
+            className="aspect-square h-auto w-full object-cover"
+          />
+        </div>
+
+        {status === "requesting" && (
+          <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Ouverture de la caméra...
+          </p>
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
+            <p className="text-sm text-destructive">{error.message}</p>
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button type="button" variant="outline" className="h-11" onClick={() => handleOpenChange(false)}>
+            Annuler
+          </Button>
+          <div className="flex w-full gap-2 sm:w-auto">
+            <Button
+              type="button"
+              variant="outline"
+              className="h-11 flex-1 sm:flex-none"
+              onClick={() => void start()}
+              disabled={busy}
+            >
+              <RotateCcw className="h-4 w-4" />
+              Relancer
+            </Button>
+            <Button
+              type="button"
+              className="h-11 flex-1 sm:flex-none"
+              onClick={() => void handleCapture()}
+              disabled={status !== "live"}
+            >
+              <Camera className="h-4 w-4" />
+              Capturer
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/students/photo/StudentPhotoField.tsx
+++ b/components/admin/students/photo/StudentPhotoField.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { Camera, ImagePlus, RotateCcw, X } from "lucide-react"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { StudentPhotoCaptureDialog } from "./StudentPhotoCaptureDialog"
+import { canUseLiveCamera, validatePhotoFile } from "@/lib/photo/camera"
+
+interface StudentPhotoFieldProps {
+  value: File | null
+  onChange: (file: File | null) => void
+  disabled?: boolean
+}
+
+export function StudentPhotoField({ value, onChange, disabled = false }: StudentPhotoFieldProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const captureInputRef = useRef<HTMLInputElement>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [cameraOpen, setCameraOpen] = useState(false)
+  const [liveCamera, setLiveCamera] = useState(false)
+
+  useEffect(() => {
+    setLiveCamera(canUseLiveCamera())
+  }, [])
+
+  useEffect(() => {
+    if (!value) {
+      setPreviewUrl(null)
+      return
+    }
+    const url = URL.createObjectURL(value)
+    setPreviewUrl(url)
+    return () => URL.revokeObjectURL(url)
+  }, [value])
+
+  function applyFile(file: File | null) {
+    if (!file) {
+      setError(null)
+      onChange(null)
+      return
+    }
+    const validationError = validatePhotoFile(file)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    setError(null)
+    onChange(file)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-4">
+        <Avatar className="h-24 w-24 ring-1 ring-border">
+          {previewUrl ? <AvatarImage src={previewUrl} alt="Aperçu de la photo élève" className="object-cover" /> : null}
+          <AvatarFallback className="bg-primary/10 text-sm font-semibold text-primary">Photo</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1 space-y-2">
+          <p className="text-sm font-medium">Photo de l&apos;élève</p>
+          <p className="text-xs text-muted-foreground">
+            {liveCamera
+              ? "Ouvrez la caméra, vérifiez l'aperçu, puis enregistrez. L'import reste disponible."
+              : "La caméra n'est pas disponible ici. Importez une photo JPEG, PNG ou WebP."}
+          </p>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button
+              type="button"
+              className="h-11"
+              disabled={disabled || !liveCamera}
+              onClick={() => setCameraOpen(true)}
+            >
+              <Camera className="h-4 w-4" />
+              Prendre une photo
+            </Button>
+            {!liveCamera && (
+              <Button
+                type="button"
+                className="h-11"
+                disabled={disabled}
+                onClick={() => captureInputRef.current?.click()}
+              >
+                <Camera className="h-4 w-4" />
+                Ouvrir l&apos;appareil
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              className="h-11"
+              disabled={disabled}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <ImagePlus className="h-4 w-4" />
+              Importer une photo
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {value && (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="button" variant="outline" className="h-11" disabled={disabled} onClick={() => applyFile(null)}>
+            <X className="h-4 w-4" />
+            Retirer
+          </Button>
+          {liveCamera && (
+            <Button type="button" variant="outline" className="h-11" disabled={disabled} onClick={() => setCameraOpen(true)}>
+              <RotateCcw className="h-4 w-4" />
+              Reprendre
+            </Button>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      {!liveCamera && (
+        <p className="text-xs text-muted-foreground">
+          Sur HTTP ou sans permission caméra, utilisez l&apos;import de fichier. La prise directe fonctionne en HTTPS.
+        </p>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp"
+        className="hidden"
+        onChange={(event) => {
+          applyFile(event.target.files?.[0] ?? null)
+          event.target.value = ""
+        }}
+      />
+      <input
+        ref={captureInputRef}
+        type="file"
+        accept="image/*"
+        capture="user"
+        className="hidden"
+        onChange={(event) => {
+          applyFile(event.target.files?.[0] ?? null)
+          event.target.value = ""
+        }}
+      />
+
+      <StudentPhotoCaptureDialog
+        open={cameraOpen}
+        onOpenChange={setCameraOpen}
+        onCaptured={applyFile}
+      />
+    </div>
+  )
+}
+

--- a/components/admin/subjects/SubjectAssignDetailsForm.tsx
+++ b/components/admin/subjects/SubjectAssignDetailsForm.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import { isSeriesSlotTaken, type AssignableInstance } from "@/lib/utils/subject-assignment"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { AssignSeriesOption } from "./subject-assign-types"
+
+interface TeacherOption {
+  id: number
+  first_name: string
+  last_name: string
+  speciality: string | null
+}
+
+interface DetailsValue {
+  seriesId: number | null
+  coef: number
+  hours: number
+  teacherId: number | null
+}
+
+interface DetailsHandlers {
+  onSeriesChange: (value: number | null) => void
+  onCoefChange: (value: number) => void
+  onHoursChange: (value: number) => void
+  onTeacherChange: (value: number | null) => void
+}
+
+interface Props {
+  series: AssignSeriesOption[]
+  levelInstances: AssignableInstance[]
+  value: DetailsValue
+  teachers: TeacherOption[]
+  error: string | null
+  handlers: DetailsHandlers
+}
+
+export function SubjectAssignDetailsForm({
+  series,
+  levelInstances,
+  value,
+  teachers,
+  error,
+  handlers,
+}: Props) {
+  return (
+    <div className="space-y-4 py-2">
+      {series.length > 0 && (
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium">Série (optionnel)</label>
+          <Select
+            value={value.seriesId?.toString() ?? "none"}
+            onValueChange={(v) => handlers.onSeriesChange(v === "none" ? null : Number(v))}
+          >
+            <SelectTrigger className="h-11">
+              <SelectValue placeholder="Toutes séries" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none" disabled={isSeriesSlotTaken(levelInstances, null)}>
+                Toutes séries
+              </SelectItem>
+              {series.map((item) => (
+                <SelectItem
+                  key={item.id}
+                  value={item.id.toString()}
+                  disabled={isSeriesSlotTaken(levelInstances, item.id)}
+                >
+                  Série {item.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <label className="text-sm font-medium">Enseignant</label>
+        <Select
+          value={value.teacherId?.toString() ?? "none"}
+          onValueChange={(v) => handlers.onTeacherChange(v === "none" ? null : Number(v))}
+        >
+          <SelectTrigger className="h-11">
+            <SelectValue placeholder="Sélectionner un enseignant" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">Aucun (à assigner plus tard)</SelectItem>
+            {teachers.map((teacher) => (
+              <SelectItem key={teacher.id} value={teacher.id.toString()}>
+                {teacher.first_name} {teacher.last_name}
+                {teacher.speciality ? ` (${teacher.speciality})` : ""}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium">Coefficient</label>
+          <Input
+            type="number"
+            min={1}
+            value={value.coef}
+            onChange={(e) => handlers.onCoefChange(Number(e.target.value) || 1)}
+            className="h-11"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium">Heures / semaine</label>
+          <Input
+            type="number"
+            min={1}
+            value={value.hours}
+            onChange={(e) => handlers.onHoursChange(Number(e.target.value) || 1)}
+            className="h-11"
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/admin/subjects/SubjectAssignLevelPicker.tsx
+++ b/components/admin/subjects/SubjectAssignLevelPicker.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import type { Level } from "@/lib/contracts/level"
+import {
+  instancesForLevel,
+  isLevelAssignable,
+  type AssignableInstance,
+} from "@/lib/utils/subject-assignment"
+import type { AssignSeriesOption } from "./subject-assign-types"
+
+interface Props {
+  levels: Level[]
+  series: AssignSeriesOption[]
+  instances: AssignableInstance[]
+  onChoose: (levelId: number) => void
+}
+
+export function SubjectAssignLevelPicker({ levels, series, instances, onChoose }: Props) {
+  if (levels.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        Aucun niveau n'est disponible.
+      </p>
+    )
+  }
+
+  return (
+    <div className="max-h-72 space-y-1 overflow-y-auto py-1">
+      {levels.map((level) => {
+        const levelSeries = series.filter((item) => item.level_id === level.id)
+        const levelInstances = instancesForLevel(instances, level.id)
+        const available = isLevelAssignable(levelInstances, levelSeries)
+        return (
+          <button
+            key={level.id}
+            type="button"
+            disabled={!available}
+            onClick={() => onChoose(level.id)}
+            className="flex h-11 w-full items-center justify-between rounded-md px-3 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <span className="font-medium">{level.name}</span>
+            {!available && (
+              <span className="text-xs text-muted-foreground">Déjà assignée</span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/admin/subjects/SubjectAssignModal.tsx
+++ b/components/admin/subjects/SubjectAssignModal.tsx
@@ -1,0 +1,182 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+import { useQueryClient } from "@tanstack/react-query"
+import { duplicateSubject } from "@/lib/api/subjects"
+import { useTeachers } from "@/lib/hooks/useTeachers"
+import type { Level } from "@/lib/contracts/level"
+import {
+  firstFreeSeriesSlot,
+  instancesForLevel,
+  isLevelAssignable,
+  isSeriesSlotTaken,
+  type AssignableInstance,
+} from "@/lib/utils/subject-assignment"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { SubjectAssignDetailsForm } from "./SubjectAssignDetailsForm"
+import { SubjectAssignLevelPicker } from "./SubjectAssignLevelPicker"
+import type { AssignSeriesOption, AssignTarget } from "./subject-assign-types"
+
+export type { AssignSeriesOption, AssignTarget }
+
+interface Props {
+  target: AssignTarget | null
+  levels: Level[]
+  series: AssignSeriesOption[]
+  instances: AssignableInstance[]
+  open: boolean
+  onClose: () => void
+  onAssigned?: (subjectName: string) => void
+}
+
+export function SubjectAssignModal({
+  target,
+  levels,
+  series,
+  instances,
+  open,
+  onClose,
+  onAssigned,
+}: Props) {
+  const skipLevelStep = target?.levelId != null
+  const [step, setStep] = useState<"level" | "details">(skipLevelStep ? "details" : "level")
+  const [levelId, setLevelId] = useState<number | null>(target?.levelId ?? null)
+  const [seriesId, setSeriesId] = useState<number | null>(target?.seriesId ?? null)
+  const [coef, setCoef] = useState(target?.defaultCoef ?? 1)
+  const [hours, setHours] = useState(target?.defaultHours ?? 2)
+  const [teacherId, setTeacherId] = useState<number | null>(null)
+  const [isPending, setIsPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const queryClient = useQueryClient()
+  const { data: teachersData } = useTeachers({ size: 100 })
+  const teachers = teachersData?.items ?? []
+
+  useEffect(() => {
+    if (!open || !target) return
+    setStep(target.levelId != null ? "details" : "level")
+    setLevelId(target.levelId ?? null)
+    setSeriesId(target.seriesId ?? null)
+    setCoef(target.defaultCoef)
+    setHours(target.defaultHours)
+    setTeacherId(null)
+    setError(null)
+    setIsPending(false)
+  }, [open, target])
+
+  const selectedLevel = levels.find((level) => level.id === levelId) ?? null
+  const levelSeries = useMemo(
+    () => series.filter((item) => item.level_id === levelId),
+    [series, levelId],
+  )
+  const levelInstances = useMemo(
+    () => (levelId == null ? [] : instancesForLevel(instances, levelId)),
+    [instances, levelId],
+  )
+
+  function chooseLevel(nextLevelId: number) {
+    const nextSeries = series.filter((item) => item.level_id === nextLevelId)
+    const nextInstances = instancesForLevel(instances, nextLevelId)
+    if (!isLevelAssignable(nextInstances, nextSeries)) return
+    const free = firstFreeSeriesSlot(nextInstances, nextSeries)
+    setLevelId(nextLevelId)
+    setSeriesId(free === undefined ? null : free)
+    setStep("details")
+    setError(null)
+  }
+
+  function handleSubmit() {
+    if (!target || levelId == null) return
+    if (isSeriesSlotTaken(levelInstances, seriesId)) {
+      setError("Cette matière existe déjà dans ce niveau / cette série")
+      return
+    }
+    setIsPending(true)
+    setError(null)
+    const payload: Parameters<typeof duplicateSubject>[0] = {
+      subject_id: target.subjectId,
+      level_id: levelId,
+      coefficient: coef,
+      hours_per_week: hours,
+    }
+    if (seriesId !== null) payload.series_id = seriesId
+    if (teacherId !== null) payload.teacher_id = teacherId
+
+    duplicateSubject(payload)
+      .then(() => {
+        const levelName = selectedLevel?.name ?? target.levelName ?? "ce niveau"
+        toast.success(`${target.subjectName} assignée à ${levelName}`)
+        queryClient.invalidateQueries({ queryKey: ["subjects"] })
+        onAssigned?.(target.subjectName)
+        onClose()
+      })
+      .catch((err: Error) => {
+        setError(err.message)
+      })
+      .finally(() => setIsPending(false))
+  }
+
+  const title = skipLevelStep || step === "details"
+    ? `Assigner à ${selectedLevel?.name ?? target?.levelName ?? "un niveau"}`
+    : `Assigner ${target?.subjectName ?? "la matière"}`
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose() }}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {step === "level"
+              ? "Choisir le niveau où créer l'instance"
+              : `Configurer ${target?.subjectName} pour ce niveau`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === "level" ? (
+          <SubjectAssignLevelPicker
+            levels={levels}
+            series={series}
+            instances={instances}
+            onChoose={chooseLevel}
+          />
+        ) : (
+          <SubjectAssignDetailsForm
+            series={levelSeries}
+            levelInstances={levelInstances}
+            value={{ seriesId, coef, hours, teacherId }}
+            teachers={teachers}
+            error={error}
+            handlers={{
+              onSeriesChange: setSeriesId,
+              onCoefChange: setCoef,
+              onHoursChange: setHours,
+              onTeacherChange: setTeacherId,
+            }}
+          />
+        )}
+
+        <DialogFooter>
+          {step === "details" && !skipLevelStep ? (
+            <Button variant="outline" onClick={() => setStep("level")}>Retour</Button>
+          ) : (
+            <Button variant="outline" onClick={onClose}>Annuler</Button>
+          )}
+          {step === "details" && (
+            <Button onClick={handleSubmit} disabled={isPending || levelId == null}>
+              {isPending ? "Assignation..." : "Assigner"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/subjects/SubjectCatalogueColumn.tsx
+++ b/components/admin/subjects/SubjectCatalogueColumn.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import type { DragEvent } from "react"
+import { BookMarked } from "lucide-react"
+import type { Subject } from "@/lib/contracts/subject"
+import { Badge } from "@/components/ui/badge"
+import { SubjectKanbanCard } from "./SubjectKanbanCard"
+
+interface CatalogueActions {
+  onEdit: (id: number) => void
+  onDelete: (id: number, name: string) => void
+  onDragStart: (event: DragEvent) => void
+  onDragEnd: () => void
+}
+
+interface Props {
+  catalogue: Subject[]
+  emptyLabel: string
+  actions: CatalogueActions
+}
+
+export function SubjectCatalogueColumn({ catalogue, emptyLabel, actions }: Props) {
+  return (
+    <div className="w-72 shrink-0 rounded-lg border bg-card shadow-sm">
+      <div className="flex items-center justify-between border-b bg-primary/5 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <BookMarked className="h-4 w-4 text-primary" />
+          <span className="text-sm font-semibold">Catalogue</span>
+          <Badge variant="secondary" className="text-xs">{catalogue.length}</Badge>
+        </div>
+      </div>
+      <div data-kanban-scroll className="max-h-[calc(100vh-300px)] space-y-2 overflow-y-auto p-2">
+        {catalogue.length === 0 ? (
+          <div className="py-8 text-center text-xs italic text-muted-foreground">{emptyLabel}</div>
+        ) : (
+          catalogue.map((subject) => (
+            <SubjectKanbanCard
+              key={subject.id}
+              subject={subject}
+              isDraggable
+              isCatalogue
+              actions={{
+                onEdit: () => actions.onEdit(subject.id),
+                onDelete: () => actions.onDelete(subject.id, subject.name),
+                onDragStart: actions.onDragStart,
+                onDragEnd: actions.onDragEnd,
+              }}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/admin/subjects/SubjectGroupRow.tsx
+++ b/components/admin/subjects/SubjectGroupRow.tsx
@@ -1,37 +1,30 @@
 "use client"
 
-import { ChevronRight, GraduationCap, Pencil, Trash2, UserX } from "lucide-react"
+import { ChevronRight, GraduationCap, UserX } from "lucide-react"
 import type { Subject } from "@/lib/contracts/subject"
+import type { SubjectGroup } from "@/lib/contracts/subject-group"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { getSubjectColor, teacherInitials } from "@/lib/utils/subject-colors"
-
-export interface SubjectGroup {
-  name: string
-  catalogue: Subject | null
-  instances: Subject[]
-  totalHours: number
-}
+import { SubjectRowActions } from "./SubjectRowActions"
 
 interface Props {
   group: SubjectGroup
   expanded: boolean
   onToggle: () => void
   onEdit: (id: number) => void
+  onAssign: (catalogue: Subject) => void
   onDelete: (subject: Subject) => void
 }
 
-// Layout grid réutilisé entre header et instance rows pour alignement parfait.
 const GRID_COLS = "grid-cols-[36px_minmax(0,2fr)_72px_96px_minmax(0,1.6fr)_104px]"
 
-export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onDelete }: Props) {
+export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onAssign, onDelete }: Props) {
   const color = getSubjectColor(group.catalogue?.color)
   const hasInstances = group.instances.length > 0
   const catalogue = group.catalogue
 
   return (
     <li className="border-b last:border-b-0">
-      {/* Catalogue header row */}
       <div
         role={hasInstances ? "button" : undefined}
         tabIndex={hasInstances ? 0 : undefined}
@@ -56,11 +49,11 @@ export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onDelete }:
               className={`h-4 w-4 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""}`}
             />
           ) : (
-            <span className="text-muted-foreground/30">—</span>
+            <span className="text-muted-foreground/30">-</span>
           )}
         </div>
 
-        <div className="flex items-center gap-3 min-w-0">
+        <div className="flex min-w-0 items-center gap-3">
           <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${color.badge}`} aria-hidden />
           <div className="min-w-0">
             <div className="truncate text-sm font-semibold">{group.name}</div>
@@ -85,7 +78,7 @@ export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onDelete }:
           )}
         </div>
 
-        <div className="text-center tabular-nums text-sm">
+        <div className="text-center text-sm tabular-nums">
           {catalogue ? (
             <>
               <span className="font-medium">{catalogue.hours_per_week}h</span>
@@ -94,7 +87,7 @@ export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onDelete }:
               )}
             </>
           ) : (
-            <span className="text-muted-foreground">—</span>
+            <span className="text-muted-foreground">-</span>
           )}
         </div>
 
@@ -110,45 +103,30 @@ export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onDelete }:
           onKeyDown={(e) => e.stopPropagation()}
         >
           {catalogue && (
-            <>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                aria-label={`Modifier ${group.name}`}
-                onClick={() => onEdit(catalogue.id)}
-              >
-                <Pencil className="h-3.5 w-3.5" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                aria-label={`Supprimer ${group.name}`}
-                onClick={() => onDelete(catalogue)}
-              >
-                <Trash2 className="h-3.5 w-3.5 text-destructive" />
-              </Button>
-            </>
+            <SubjectRowActions
+              name={group.name}
+              onEdit={() => onEdit(catalogue.id)}
+              onAssign={() => onAssign(catalogue)}
+              onDelete={() => onDelete(catalogue)}
+            />
           )}
         </div>
       </div>
 
-      {/* Instance rows */}
       {expanded && hasInstances && (
         <ul className="border-t bg-muted/15">
           {group.instances.map((inst) => (
             <li
               key={inst.id}
-              className={`grid ${GRID_COLS} items-center gap-3 px-4 py-2.5 border-t border-border/40 first:border-t-0`}
+              className={`grid ${GRID_COLS} items-center gap-3 border-t border-border/40 px-4 py-2.5 first:border-t-0`}
             >
-              <div className="flex items-center justify-center text-muted-foreground/50 text-base leading-none">
-                └
+              <div className="flex items-center justify-center text-base leading-none text-muted-foreground/50">
+                -
               </div>
 
-              <div className="flex items-center gap-2 pl-3 min-w-0">
+              <div className="flex min-w-0 items-center gap-2 pl-3">
                 <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <span className="truncate text-sm font-medium">{inst.level_name ?? "—"}</span>
+                <span className="truncate text-sm font-medium">{inst.level_name ?? "-"}</span>
                 {inst.series_name && (
                   <Badge variant="outline" className="text-[10px]">
                     Série {inst.series_name}
@@ -162,13 +140,13 @@ export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onDelete }:
                 </Badge>
               </div>
 
-              <div className="text-center tabular-nums text-sm font-medium">
+              <div className="text-center text-sm font-medium tabular-nums">
                 {inst.hours_per_week}h
               </div>
 
               <div className="min-w-0">
                 {inst.teacher_name ? (
-                  <div className="flex items-center gap-2 min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
                     <div
                       className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white ${color.badge}`}
                       aria-hidden
@@ -186,24 +164,11 @@ export function SubjectGroupRow({ group, expanded, onToggle, onEdit, onDelete }:
               </div>
 
               <div className="flex justify-end gap-1">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8"
-                  aria-label={`Modifier ${group.name} ${inst.level_name ?? ""}`}
-                  onClick={() => onEdit(inst.id)}
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8"
-                  aria-label={`Supprimer ${group.name} ${inst.level_name ?? ""}`}
-                  onClick={() => onDelete(inst)}
-                >
-                  <Trash2 className="h-3.5 w-3.5 text-destructive" />
-                </Button>
+                <SubjectRowActions
+                  name={`${group.name} ${inst.level_name ?? ""}`}
+                  onEdit={() => onEdit(inst.id)}
+                  onDelete={() => onDelete(inst)}
+                />
               </div>
             </li>
           ))}

--- a/components/admin/subjects/SubjectKanbanCard.tsx
+++ b/components/admin/subjects/SubjectKanbanCard.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import type { DragEvent } from "react"
+import { Award, Clock, GripVertical, Pencil, Trash2 } from "lucide-react"
+import type { Subject } from "@/lib/contracts/subject"
+import { getSubjectColor } from "@/lib/utils/subject-colors"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+
+interface CardActions {
+  onEdit: () => void
+  onDelete: () => void
+  onDragStart?: (event: DragEvent) => void
+  onDragEnd?: () => void
+}
+
+interface Props {
+  subject: Subject
+  isDraggable?: boolean
+  isCatalogue?: boolean
+  actions: CardActions
+}
+
+export function SubjectKanbanCard({ subject, isDraggable, isCatalogue, actions }: Props) {
+  const color = getSubjectColor(subject.color)
+
+  return (
+    <div
+      className={`group rounded-lg border p-3 transition-all hover:shadow-md ${color.bg} ${color.border} ${
+        isDraggable ? "cursor-grab active:cursor-grabbing" : ""
+      }`}
+      draggable={isDraggable}
+      onDragStart={isDraggable ? (e) => {
+        e.dataTransfer.setData("subjectId", String(subject.id))
+        e.dataTransfer.effectAllowed = "copy"
+        actions.onDragStart?.(e)
+      } : undefined}
+      onDragEnd={isDraggable ? actions.onDragEnd : undefined}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-1.5">
+          {isDraggable && <GripVertical className="h-3.5 w-3.5 shrink-0 text-muted-foreground/40" />}
+          <h4 className={`text-sm font-semibold leading-tight ${color.text}`}>
+            {subject.name}
+          </h4>
+        </div>
+        {!isCatalogue && (
+          <div className={`ml-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white ${color.badge}`}>
+            {subject.coefficient}
+          </div>
+        )}
+        {isCatalogue && (
+          <div className={`ml-2 h-3 w-3 shrink-0 rounded-full ${color.badge}`} />
+        )}
+      </div>
+
+      {!isCatalogue && (
+        <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            <span>{subject.hours_per_week}h/sem</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Award className="h-3 w-3" />
+            <span>Coef. {subject.coefficient}</span>
+          </div>
+        </div>
+      )}
+      {!isCatalogue && subject.teacher_name && (
+        <p className="mt-1 truncate text-[10px] text-muted-foreground">
+          Prof. {subject.teacher_name}
+        </p>
+      )}
+
+      <div className="mt-2 flex items-center justify-between">
+        {subject.series_name ? (
+          <Badge variant="outline" className="text-[10px]">Série {subject.series_name}</Badge>
+        ) : <span />}
+        <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={actions.onEdit}>
+            <Pencil className="h-3 w-3" />
+          </Button>
+          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={actions.onDelete}>
+            <Trash2 className="h-3 w-3 text-destructive" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/subjects/SubjectLevelColumn.tsx
+++ b/components/admin/subjects/SubjectLevelColumn.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { GraduationCap } from "lucide-react"
+import type { Subject } from "@/lib/contracts/subject"
+import type { Level } from "@/lib/contracts/level"
+import { Badge } from "@/components/ui/badge"
+import { SubjectKanbanCard } from "./SubjectKanbanCard"
+
+interface SeriesOption {
+  id: number
+  name: string
+}
+
+interface ColumnActions {
+  onDrop: (subjectId: number, levelId: number, levelName: string, seriesId: number | null) => void
+  onEdit: (id: number) => void
+  onDelete: (id: number, name: string) => void
+  setDragOverTarget: (target: string | null) => void
+}
+
+interface Props {
+  level: Level
+  subjects: Subject[]
+  series: SeriesOption[]
+  dragOverTarget: string | null
+  actions: ColumnActions
+}
+
+export function SubjectLevelColumn({ level, subjects, series, dragOverTarget, actions }: Props) {
+  const totalHours = subjects.reduce((sum, subject) => sum + subject.hours_per_week, 0)
+  const key = `level-${level.id}`
+  const isDragOver = dragOverTarget === key
+  const hasSeries = series.length > 0
+  const directSubjects = subjects.filter((subject) => !subject.series_id)
+
+  return (
+    <div
+      className={`w-72 shrink-0 rounded-lg border transition-colors ${
+        isDragOver ? "bg-primary/5 ring-2 ring-primary/40" : "bg-muted/30"
+      }`}
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.dataTransfer.dropEffect = "copy"
+        actions.setDragOverTarget(key)
+      }}
+      onDragLeave={() => actions.setDragOverTarget(null)}
+      onDrop={(e) => {
+        e.preventDefault()
+        actions.setDragOverTarget(null)
+        const subjectId = Number(e.dataTransfer.getData("subjectId"))
+        if (subjectId) actions.onDrop(subjectId, level.id, level.name, null)
+      }}
+    >
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <div className="flex items-center gap-2">
+          <GraduationCap className="h-4 w-4 text-primary" />
+          <span className="text-sm font-semibold">{level.name}</span>
+          <Badge variant="secondary" className="text-xs">{subjects.length}</Badge>
+        </div>
+        <span className="text-xs text-muted-foreground">{totalHours}h</span>
+      </div>
+
+      <div data-kanban-scroll className="max-h-[calc(100vh-300px)] space-y-1 overflow-y-auto p-2">
+        {directSubjects.map((subject) => (
+          <SubjectKanbanCard
+            key={subject.id}
+            subject={subject}
+            actions={{
+              onEdit: () => actions.onEdit(subject.id),
+              onDelete: () => actions.onDelete(subject.id, subject.name),
+            }}
+          />
+        ))}
+
+        {hasSeries && series.map((ser) => {
+          const seriesSubjects = subjects.filter((subject) => subject.series_id === ser.id)
+          const seriesKey = `series-${ser.id}`
+          const isSeriesDragOver = dragOverTarget === seriesKey
+          return (
+            <div
+              key={ser.id}
+              className={`mt-1 rounded-md border border-dashed p-1.5 transition-colors ${
+                isSeriesDragOver ? "border-accent bg-accent/5" : "border-border/50"
+              }`}
+              onDragOver={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                e.dataTransfer.dropEffect = "copy"
+                actions.setDragOverTarget(seriesKey)
+              }}
+              onDragLeave={(e) => {
+                e.stopPropagation()
+                actions.setDragOverTarget(null)
+              }}
+              onDrop={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                actions.setDragOverTarget(null)
+                const subjectId = Number(e.dataTransfer.getData("subjectId"))
+                if (subjectId) actions.onDrop(subjectId, level.id, level.name, ser.id)
+              }}
+            >
+              <p className="mb-1 px-1 text-[10px] font-medium text-muted-foreground">
+                Série {ser.name}
+              </p>
+              {seriesSubjects.length === 0 ? (
+                <p className="px-1 py-2 text-[10px] italic text-muted-foreground/60">Déposer ici</p>
+              ) : (
+                seriesSubjects.map((subject) => (
+                  <SubjectKanbanCard
+                    key={subject.id}
+                    subject={subject}
+                    actions={{
+                      onEdit: () => actions.onEdit(subject.id),
+                      onDelete: () => actions.onDelete(subject.id, subject.name),
+                    }}
+                  />
+                ))
+              )}
+            </div>
+          )
+        })}
+
+        {subjects.length === 0 && !hasSeries && (
+          <div className="py-8 text-center text-xs italic text-muted-foreground">
+            Déposer une matière ici
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/admin/subjects/SubjectMobileCard.tsx
+++ b/components/admin/subjects/SubjectMobileCard.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { ChevronRight, GraduationCap, UserX } from "lucide-react"
+import type { Subject } from "@/lib/contracts/subject"
+import { Badge } from "@/components/ui/badge"
+import { getSubjectColor, teacherInitials } from "@/lib/utils/subject-colors"
+import { SubjectRowActions } from "./SubjectRowActions"
+import type { SubjectGroup } from "@/lib/contracts/subject-group"
+
+interface Props {
+  group: SubjectGroup
+  expanded: boolean
+  onToggle: () => void
+  onEdit: (id: number) => void
+  onAssign: (catalogue: Subject) => void
+  onDelete: (subject: Subject) => void
+}
+
+export function SubjectMobileCard({ group, expanded, onToggle, onEdit, onAssign, onDelete }: Props) {
+  const color = getSubjectColor(group.catalogue?.color)
+  const catalogue = group.catalogue
+  const hasInstances = group.instances.length > 0
+
+  return (
+    <article className="rounded-lg border bg-card">
+      <div className="flex items-start gap-3 p-3">
+        {hasInstances ? (
+          <button
+            type="button"
+            className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-md hover:bg-muted"
+            aria-expanded={expanded}
+            aria-label={expanded ? `Replier ${group.name}` : `Déplier ${group.name}`}
+            onClick={onToggle}
+          >
+            <ChevronRight className={`h-4 w-4 text-muted-foreground transition-transform ${expanded ? "rotate-90" : ""}`} />
+          </button>
+        ) : (
+          <span className={`mt-3 h-2.5 w-2.5 shrink-0 rounded-full ${color.badge}`} aria-hidden />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold">{group.name}</p>
+              <p className="text-xs text-muted-foreground">
+                {hasInstances
+                  ? `Catalogue · ${group.instances.length} ${group.instances.length === 1 ? "instance" : "instances"}`
+                  : "Catalogue seul"}
+              </p>
+            </div>
+            <Badge variant="outline" className="shrink-0 text-[10px] uppercase">Catalogue</Badge>
+          </div>
+          {catalogue && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Coef. {catalogue.coefficient} · {catalogue.hours_per_week}h/sem
+              {hasInstances ? ` · ${group.totalHours}h total` : ""}
+            </p>
+          )}
+          {catalogue && (
+            <div className="mt-2">
+              <SubjectRowActions
+                name={group.name}
+                size="mobile"
+                onEdit={() => onEdit(catalogue.id)}
+                onAssign={() => onAssign(catalogue)}
+                onDelete={() => onDelete(catalogue)}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {expanded && hasInstances && (
+        <ul className="space-y-2 border-t bg-muted/15 p-3">
+          {group.instances.map((inst) => (
+            <li key={inst.id} className="rounded-md border bg-card p-3">
+              <div className="flex items-center gap-2">
+                <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate text-sm font-medium">{inst.level_name ?? "-"}</span>
+                {inst.series_name && (
+                  <Badge variant="outline" className="text-[10px]">Série {inst.series_name}</Badge>
+                )}
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Coef. {inst.coefficient} · {inst.hours_per_week}h/sem
+              </p>
+              <div className="mt-2">
+                {inst.teacher_name ? (
+                  <div className="flex items-center gap-2">
+                    <div className={`flex h-7 w-7 items-center justify-center rounded-full text-[10px] font-semibold text-white ${color.badge}`}>
+                      {teacherInitials(inst.teacher_name)}
+                    </div>
+                    <span className="truncate text-sm">{inst.teacher_name}</span>
+                  </div>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800">
+                    <UserX className="h-3 w-3" />
+                    Non assigné
+                  </span>
+                )}
+              </div>
+              <div className="mt-2">
+                <SubjectRowActions
+                  name={`${group.name} ${inst.level_name ?? ""}`}
+                  size="mobile"
+                  onEdit={() => onEdit(inst.id)}
+                  onDelete={() => onDelete(inst)}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </article>
+  )
+}

--- a/components/admin/subjects/SubjectRowActions.tsx
+++ b/components/admin/subjects/SubjectRowActions.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { Pencil, Plus, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface Props {
+  name: string
+  size?: "desktop" | "mobile"
+  onEdit?: () => void
+  onAssign?: () => void
+  onDelete?: () => void
+}
+
+export function SubjectRowActions({ name, size = "desktop", onEdit, onAssign, onDelete }: Props) {
+  const compact = size === "desktop"
+  const buttonClass = compact ? "h-8 w-8" : "h-11 w-11"
+  return (
+    <div className={cn("flex items-center justify-end gap-1", !compact && "w-full")}>
+      {onEdit && (
+        <Button variant="ghost" size="icon" className={buttonClass} aria-label={`Modifier ${name}`} onClick={onEdit}>
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+      )}
+      {onAssign && (
+        <Button variant="ghost" size="icon" className={buttonClass} aria-label={`Assigner ${name}`} onClick={onAssign}>
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+      )}
+      {onDelete && (
+        <Button variant="ghost" size="icon" className={buttonClass} aria-label={`Supprimer ${name}`} onClick={onDelete}>
+          <Trash2 className="h-3.5 w-3.5 text-destructive" />
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/components/admin/subjects/SubjectsKanbanView.tsx
+++ b/components/admin/subjects/SubjectsKanbanView.tsx
@@ -1,30 +1,16 @@
 "use client"
 
 import { useMemo, useState } from "react"
-import {
-  BookOpen,
-  Clock,
-  Award,
-  Pencil,
-  Trash2,
-  GraduationCap,
-  Search,
-  GripVertical,
-  BookMarked,
-} from "lucide-react"
-import { useForm } from "react-hook-form"
-import { toast } from "sonner"
-import { useQueryClient } from "@tanstack/react-query"
+import { Search } from "lucide-react"
+
 import { useSubjects, useDeleteSubject } from "@/lib/hooks/useSubjects"
 import { useLevels } from "@/lib/hooks/useLevels"
 import { useSeriesList } from "@/lib/hooks/useSeries"
-import { useTeachers } from "@/lib/hooks/useTeachers"
-import { duplicateSubject } from "@/lib/api/subjects"
-import type { Subject } from "@/lib/contracts/subject"
-import type { Level } from "@/lib/contracts/level"
+import { useKanbanAutoScroll } from "@/lib/hooks/useKanbanAutoScroll"
+import { useDebounce } from "@/lib/hooks/useDebounce"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
+
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Dialog,
@@ -34,205 +20,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { SubjectEditModal } from "./SubjectEditModal"
-import { useDebounce } from "@/lib/hooks/useDebounce"
-
-// ---------------------------------------------------------------------------
-// Color mapping
-// ---------------------------------------------------------------------------
-
-const COLOR_MAP: Record<string, { bg: string; text: string; border: string; badge: string }> = {
-  blue: { bg: "bg-blue-500/10", text: "text-blue-700", border: "border-blue-200", badge: "bg-blue-600" },
-  emerald: { bg: "bg-emerald-500/10", text: "text-emerald-700", border: "border-emerald-200", badge: "bg-emerald-600" },
-  amber: { bg: "bg-amber-500/10", text: "text-amber-700", border: "border-amber-200", badge: "bg-amber-600" },
-  violet: { bg: "bg-violet-500/10", text: "text-violet-700", border: "border-violet-200", badge: "bg-violet-600" },
-  rose: { bg: "bg-rose-500/10", text: "text-rose-700", border: "border-rose-200", badge: "bg-rose-500" },
-  cyan: { bg: "bg-cyan-500/10", text: "text-cyan-700", border: "border-cyan-200", badge: "bg-cyan-600" },
-  orange: { bg: "bg-orange-500/10", text: "text-orange-700", border: "border-orange-200", badge: "bg-orange-500" },
-  indigo: { bg: "bg-indigo-500/10", text: "text-indigo-700", border: "border-indigo-200", badge: "bg-indigo-600" },
-  teal: { bg: "bg-teal-500/10", text: "text-teal-700", border: "border-teal-200", badge: "bg-teal-600" },
-  red: { bg: "bg-red-500/10", text: "text-red-700", border: "border-red-200", badge: "bg-red-500" },
-  green: { bg: "bg-green-500/10", text: "text-green-700", border: "border-green-200", badge: "bg-green-600" },
-  pink: { bg: "bg-pink-500/10", text: "text-pink-700", border: "border-pink-200", badge: "bg-pink-500" },
-}
-
-const DEFAULT_COLOR = { bg: "bg-slate-500/10", text: "text-slate-700", border: "border-slate-200", badge: "bg-slate-500" }
-
-function getColor(color: string | null | undefined) {
-  if (!color) return DEFAULT_COLOR
-  return COLOR_MAP[color] ?? DEFAULT_COLOR
-}
-
-// ---------------------------------------------------------------------------
-// Assign modal form
-// ---------------------------------------------------------------------------
-
-interface AssignTarget {
-  subjectId: number
-  subjectName: string
-  levelId: number
-  levelName: string
-  seriesId: number | null
-  defaultCoef: number
-  defaultHours: number
-}
-
-function AssignModal({
-  target,
-  series,
-  open,
-  onClose,
-}: {
-  target: AssignTarget | null
-  series: { id: number; name: string }[]
-  open: boolean
-  onClose: () => void
-}) {
-  const queryClient = useQueryClient()
-  const { data: teachersData } = useTeachers({ size: 100 })
-  const teachers = teachersData?.items ?? []
-  const [coef, setCoef] = useState(target?.defaultCoef ?? 1)
-  const [hours, setHours] = useState(target?.defaultHours ?? 2)
-  const [seriesId, setSeriesId] = useState<number | null>(target?.seriesId ?? null)
-  const [teacherId, setTeacherId] = useState<number | null>(null)
-  const [isPending, setIsPending] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  function handleSubmit() {
-    if (!target) return
-    setIsPending(true)
-    setError(null)
-    duplicateSubject({
-      subject_id: target.subjectId,
-      level_id: target.levelId,
-      series_id: seriesId,
-      coefficient: coef,
-      hours_per_week: hours,
-      teacher_id: teacherId,
-    })
-      .then(() => {
-        toast.success(`${target.subjectName} assignée à ${target.levelName}`)
-        queryClient.invalidateQueries({ queryKey: ["subjects"] })
-        onClose()
-      })
-      .catch((err: Error) => {
-        setError(err.message)
-      })
-      .finally(() => setIsPending(false))
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Assigner à {target?.levelName}</DialogTitle>
-          <DialogDescription>
-            Configurer {target?.subjectName} pour ce niveau
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4 py-2">
-          {series.length > 0 && (
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium">Série (optionnel)</label>
-              <Select
-                value={seriesId?.toString() ?? "none"}
-                onValueChange={(v) => setSeriesId(v === "none" ? null : Number(v))}
-              >
-                <SelectTrigger className="h-10">
-                  <SelectValue placeholder="Toutes séries" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">Toutes séries</SelectItem>
-                  {series.map((s) => (
-                    <SelectItem key={s.id} value={s.id.toString()}>
-                      Série {s.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          {/* Teacher select */}
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium">Enseignant</label>
-            <Select
-              value={teacherId?.toString() ?? "none"}
-              onValueChange={(v) => setTeacherId(v === "none" ? null : Number(v))}
-            >
-              <SelectTrigger className="h-10">
-                <SelectValue placeholder="Sélectionner un enseignant" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">Aucun (à assigner plus tard)</SelectItem>
-                {teachers.map((t) => (
-                  <SelectItem key={t.id} value={t.id.toString()}>
-                    {t.first_name} {t.last_name} {t.speciality ? `(${t.speciality})` : ""}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium">Coefficient</label>
-              <Input
-                type="number"
-                min={1}
-                value={coef}
-                onChange={(e) => setCoef(Number(e.target.value) || 1)}
-                className="h-10"
-              />
-            </div>
-            <div className="space-y-1.5">
-              <label className="text-sm font-medium">Heures / semaine</label>
-              <Input
-                type="number"
-                min={1}
-                value={hours}
-                onChange={(e) => setHours(Number(e.target.value) || 1)}
-                className="h-10"
-              />
-            </div>
-          </div>
-
-          {error && (
-            <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
-              <p className="text-sm text-destructive">{error}</p>
-            </div>
-          )}
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={onClose}>Annuler</Button>
-          <Button onClick={handleSubmit} disabled={isPending}>
-            {isPending ? "Assignation..." : "Assigner"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
+import { SubjectAssignModal, type AssignTarget } from "./SubjectAssignModal"
+import { SubjectCatalogueColumn } from "./SubjectCatalogueColumn"
+import { SubjectLevelColumn } from "./SubjectLevelColumn"
+import { firstFreeSeriesSlot, isSeriesSlotTaken } from "@/lib/utils/subject-assignment"
+import { cn } from "@/lib/utils"
 
 export function SubjectsKanbanView() {
-  const queryClient = useQueryClient()
   const { data: subjectsData, isLoading: subjectsLoading } = useSubjects({ size: 100 })
   const { data: levelsData, isLoading: levelsLoading } = useLevels({ size: 100 })
   const { data: seriesData } = useSeriesList({ size: 100 })
   const deleteMutation = useDeleteSubject()
+  const scroll = useKanbanAutoScroll()
 
   const [editId, setEditId] = useState<number | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null)
@@ -243,7 +43,7 @@ export function SubjectsKanbanView() {
 
   const isLoading = subjectsLoading || levelsLoading
   const subjects = subjectsData?.items ?? []
-  const levels = levelsData?.items?.sort((a, b) => a.order - b.order) ?? []
+  const levels = levelsData?.items?.slice().sort((a, b) => a.order - b.order) ?? []
   const allSeries = seriesData?.items ?? []
 
   const filteredSubjects = useMemo(() => {
@@ -251,11 +51,10 @@ export function SubjectsKanbanView() {
     const q = debouncedSearch.toLowerCase()
     return subjects.filter((s) =>
       s.name.toLowerCase().includes(q) ||
-      s.level_name?.toLowerCase().includes(q)
+      s.level_name?.toLowerCase().includes(q),
     )
   }, [subjects, debouncedSearch])
 
-  // Catalogue = subjects without level_id
   const catalogue = useMemo(
     () => filteredSubjects.filter((s) => s.level_id === null),
     [filteredSubjects],
@@ -264,16 +63,18 @@ export function SubjectsKanbanView() {
   function handleDrop(subjectId: number, levelId: number, levelName: string, seriesId: number | null) {
     const source = subjects.find((s) => s.id === subjectId)
     if (!source) return
-
-    // Get series for this level
-    const levelSeries = allSeries.filter((s) => s.level_id === levelId)
-
+    const levelSeries = allSeries.filter((item) => item.level_id === levelId)
+    const levelInstances = subjects.filter((item) => item.level_id === levelId && item.name === source.name)
+    const free = firstFreeSeriesSlot(levelInstances, levelSeries)
+    scroll.stop()
     setAssignTarget({
       subjectId,
       subjectName: source.name,
       levelId,
       levelName,
-      seriesId,
+      seriesId: seriesId != null && !isSeriesSlotTaken(levelInstances, seriesId)
+        ? seriesId
+        : (free === undefined ? null : free),
       defaultCoef: source.coefficient,
       defaultHours: source.hours_per_week,
     })
@@ -306,71 +107,58 @@ export function SubjectsKanbanView() {
           <span className="text-xs italic">Glisser du catalogue vers un niveau pour assigner</span>
         </div>
         <div className="relative max-w-xs">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Rechercher une matière..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="pl-9 h-9 text-sm"
+            className="h-9 pl-9 text-sm"
           />
         </div>
       </div>
 
-      <div className="flex gap-4 overflow-x-auto pb-4 -mx-2 px-2">
-        {/* Catalogue */}
-        <div className="w-72 shrink-0 rounded-lg border bg-card shadow-sm">
-          <div className="flex items-center justify-between px-4 py-3 border-b bg-primary/5">
-            <div className="flex items-center gap-2">
-              <BookMarked className="h-4 w-4 text-primary" />
-              <span className="font-semibold text-sm">Catalogue</span>
-              <Badge variant="secondary" className="text-xs">{catalogue.length}</Badge>
-            </div>
-          </div>
-          <div className="p-2 space-y-2 max-h-[calc(100vh-300px)] overflow-y-auto">
-            {catalogue.length === 0 ? (
-              <div className="py-8 text-center text-xs text-muted-foreground italic">
-                {debouncedSearch ? "Aucun résultat" : "Créez des matières avec le bouton +"}
-              </div>
-            ) : (
-              catalogue.map((s) => (
-                <SubjectCard
-                  key={s.id}
-                  subject={s}
-                  isDraggable
-                  isCatalogue
-                  onEdit={() => setEditId(s.id)}
-                  onDelete={() => setDeleteTarget({ id: s.id, name: s.name })}
-                />
-              ))
-            )}
-          </div>
+      <div
+        ref={scroll.boardRef}
+        className="-mx-2 flex gap-4 overflow-x-auto px-2 pb-4"
+      >
+        <div
+          ref={scroll.catalogueRef}
+          className={cn(scroll.isDragging && "sticky left-0 z-10 bg-background pr-4")}
+        >
+          <SubjectCatalogueColumn
+            catalogue={catalogue}
+            emptyLabel={debouncedSearch ? "Aucun résultat" : "Créez des matières avec le bouton +"}
+            actions={{
+              onEdit: setEditId,
+              onDelete: (id, name) => setDeleteTarget({ id, name }),
+              onDragStart: scroll.start,
+              onDragEnd: scroll.stop,
+            }}
+          />
         </div>
 
-        {/* Level columns */}
-        {levels.map((level) => {
-          const levelSubjects = filteredSubjects.filter((s) => s.level_id === level.id)
-          const levelSeries = allSeries.filter((s) => s.level_id === level.id)
-
-          return (
-            <LevelColumn
-              key={level.id}
-              level={level}
-              subjects={levelSubjects}
-              series={levelSeries}
-              dragOverTarget={dragOverTarget}
-              setDragOverTarget={setDragOverTarget}
-              onDrop={handleDrop}
-              onEdit={setEditId}
-              onDelete={(id, name) => setDeleteTarget({ id, name })}
-            />
-          )
-        })}
+        {levels.map((level) => (
+          <SubjectLevelColumn
+            key={level.id}
+            level={level}
+            subjects={filteredSubjects.filter((s) => s.level_id === level.id)}
+            series={allSeries.filter((s) => s.level_id === level.id)}
+            dragOverTarget={dragOverTarget}
+            actions={{
+              onDrop: handleDrop,
+              onEdit: setEditId,
+              onDelete: (id, name) => setDeleteTarget({ id, name }),
+              setDragOverTarget,
+            }}
+          />
+        ))}
       </div>
 
-      {/* Assign modal */}
-      <AssignModal
+      <SubjectAssignModal
         target={assignTarget}
-        series={assignTarget ? allSeries.filter((s) => s.level_id === assignTarget.levelId) : []}
+        levels={levels}
+        series={allSeries}
+        instances={subjects}
         open={assignTarget !== null}
         onClose={() => setAssignTarget(null)}
       />
@@ -401,193 +189,6 @@ export function SubjectsKanbanView() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Level column with series sub-groups
-// ---------------------------------------------------------------------------
-
-function LevelColumn({
-  level,
-  subjects,
-  series,
-  dragOverTarget,
-  setDragOverTarget,
-  onDrop,
-  onEdit,
-  onDelete,
-}: {
-  level: Level
-  subjects: Subject[]
-  series: { id: number; name: string }[]
-  dragOverTarget: string | null
-  setDragOverTarget: (t: string | null) => void
-  onDrop: (subjectId: number, levelId: number, levelName: string, seriesId: number | null) => void
-  onEdit: (id: number) => void
-  onDelete: (id: number, name: string) => void
-}) {
-  const totalHours = subjects.reduce((sum, s) => sum + s.hours_per_week, 0)
-  const key = `level-${level.id}`
-  const isDragOver = dragOverTarget === key
-  const hasSeries = series.length > 0
-  const directSubjects = subjects.filter((s) => !s.series_id)
-
-  return (
-    <div
-      className={`w-72 shrink-0 rounded-lg border transition-colors ${
-        isDragOver ? "ring-2 ring-primary/40 bg-primary/5" : "bg-muted/30"
-      }`}
-      onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = "copy"; setDragOverTarget(key) }}
-      onDragLeave={() => setDragOverTarget(null)}
-      onDrop={(e) => {
-        e.preventDefault()
-        setDragOverTarget(null)
-        const subjectId = Number(e.dataTransfer.getData("subjectId"))
-        if (subjectId) onDrop(subjectId, level.id, level.name, null)
-      }}
-    >
-      <div className="flex items-center justify-between px-4 py-3 border-b">
-        <div className="flex items-center gap-2">
-          <GraduationCap className="h-4 w-4 text-primary" />
-          <span className="font-semibold text-sm">{level.name}</span>
-          <Badge variant="secondary" className="text-xs">{subjects.length}</Badge>
-        </div>
-        <span className="text-xs text-muted-foreground">{totalHours}h</span>
-      </div>
-
-      <div className="p-2 space-y-1 max-h-[calc(100vh-300px)] overflow-y-auto">
-        {/* Direct subjects (no series) */}
-        {directSubjects.map((s) => (
-          <SubjectCard key={s.id} subject={s} onEdit={() => onEdit(s.id)} onDelete={() => onDelete(s.id, s.name)} />
-        ))}
-
-        {/* Series sub-groups */}
-        {hasSeries && series.map((ser) => {
-          const seriesSubjects = subjects.filter((s) => s.series_id === ser.id)
-          const seriesKey = `series-${ser.id}`
-          const isSeriesDragOver = dragOverTarget === seriesKey
-
-          return (
-            <div
-              key={ser.id}
-              className={`rounded-md border border-dashed p-1.5 mt-1 transition-colors ${
-                isSeriesDragOver ? "border-accent bg-accent/5" : "border-border/50"
-              }`}
-              onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); e.dataTransfer.dropEffect = "copy"; setDragOverTarget(seriesKey) }}
-              onDragLeave={(e) => { e.stopPropagation(); setDragOverTarget(null) }}
-              onDrop={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                setDragOverTarget(null)
-                const subjectId = Number(e.dataTransfer.getData("subjectId"))
-                if (subjectId) onDrop(subjectId, level.id, level.name, ser.id)
-              }}
-            >
-              <p className="text-[10px] font-medium text-muted-foreground px-1 mb-1">
-                Série {ser.name}
-              </p>
-              {seriesSubjects.length === 0 ? (
-                <p className="text-[10px] text-muted-foreground/60 italic px-1 py-2">Déposer ici</p>
-              ) : (
-                seriesSubjects.map((s) => (
-                  <SubjectCard key={s.id} subject={s} onEdit={() => onEdit(s.id)} onDelete={() => onDelete(s.id, s.name)} />
-                ))
-              )}
-            </div>
-          )
-        })}
-
-        {subjects.length === 0 && !hasSeries && (
-          <div className="py-8 text-center text-xs text-muted-foreground italic">
-            Déposer une matière ici
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Subject card
-// ---------------------------------------------------------------------------
-
-function SubjectCard({
-  subject,
-  isDraggable,
-  isCatalogue,
-  onEdit,
-  onDelete,
-}: {
-  subject: Subject
-  isDraggable?: boolean
-  isCatalogue?: boolean
-  onEdit: () => void
-  onDelete: () => void
-}) {
-  const color = getColor(subject.color)
-
-  return (
-    <div
-      className={`group rounded-lg border p-3 transition-all hover:shadow-md ${color.bg} ${color.border} ${
-        isDraggable ? "cursor-grab active:cursor-grabbing" : ""
-      }`}
-      draggable={isDraggable}
-      onDragStart={isDraggable ? (e) => {
-        e.dataTransfer.setData("subjectId", String(subject.id))
-        e.dataTransfer.effectAllowed = "copy"
-      } : undefined}
-    >
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-1.5">
-          {isDraggable && <GripVertical className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0" />}
-          <h4 className={`font-semibold text-sm leading-tight ${color.text}`}>
-            {subject.name}
-          </h4>
-        </div>
-        {!isCatalogue && (
-          <div className={`flex h-7 w-7 items-center justify-center rounded-full text-white text-xs font-bold shrink-0 ml-2 ${color.badge}`}>
-            {subject.coefficient}
-          </div>
-        )}
-        {isCatalogue && (
-          <div className={`h-3 w-3 rounded-full shrink-0 ml-2 ${color.badge}`} />
-        )}
-      </div>
-
-      {/* Only show coef/hours for assigned subjects (not catalogue) */}
-      {!isCatalogue && (
-        <div className="flex items-center gap-3 text-xs text-muted-foreground mt-2">
-          <div className="flex items-center gap-1">
-            <Clock className="h-3 w-3" />
-            <span>{subject.hours_per_week}h/sem</span>
-          </div>
-          <div className="flex items-center gap-1">
-            <Award className="h-3 w-3" />
-            <span>Coef. {subject.coefficient}</span>
-          </div>
-        </div>
-      )}
-      {!isCatalogue && subject.teacher_name && (
-        <p className="text-[10px] text-muted-foreground mt-1 truncate">
-          Prof. {subject.teacher_name}
-        </p>
-      )}
-
-      <div className="flex items-center justify-between mt-2">
-        {subject.series_name ? (
-          <Badge variant="outline" className="text-[10px]">Série {subject.series_name}</Badge>
-        ) : <span />}
-        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onEdit}>
-            <Pencil className="h-3 w-3" />
-          </Button>
-          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onDelete}>
-            <Trash2 className="h-3 w-3 text-destructive" />
-          </Button>
-        </div>
-      </div>
     </div>
   )
 }

--- a/components/admin/subjects/SubjectsTable.tsx
+++ b/components/admin/subjects/SubjectsTable.tsx
@@ -1,20 +1,11 @@
 "use client"
 
 import { useMemo, useState } from "react"
-import { Search } from "lucide-react"
 import { useSubjects, useDeleteSubject } from "@/lib/hooks/useSubjects"
 import { useLevels } from "@/lib/hooks/useLevels"
+import { useSeriesList } from "@/lib/hooks/useSeries"
 import type { Subject } from "@/lib/contracts/subject"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -26,20 +17,27 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { SubjectEditModal } from "./SubjectEditModal"
-import { SubjectGroupRow, SUBJECT_GRID_COLS, type SubjectGroup } from "./SubjectGroupRow"
+import { SubjectAssignModal, type AssignTarget } from "./SubjectAssignModal"
+import { SubjectGroupRow, SUBJECT_GRID_COLS } from "./SubjectGroupRow"
+import type { SubjectGroup } from "@/lib/contracts/subject-group"
+import { SubjectMobileCard } from "./SubjectMobileCard"
+import { SubjectsTableToolbar } from "./SubjectsTableToolbar"
 import { useDebounce } from "@/lib/hooks/useDebounce"
+import { filterSubjectGroups, groupSubjects } from "@/lib/utils/subject-groups"
 
 export function SubjectsTable() {
   const [search, setSearch] = useState("")
-  const [levelFilter, setLevelFilter] = useState<string>("all")
-  const [teacherFilter, setTeacherFilter] = useState<string>("all")
+  const [levelFilter, setLevelFilter] = useState("all")
+  const [teacherFilter, setTeacherFilter] = useState("all")
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [editId, setEditId] = useState<number | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<Subject | null>(null)
+  const [assignTarget, setAssignTarget] = useState<AssignTarget | null>(null)
 
   const debouncedSearch = useDebounce(search)
   const { data: subjectsData, isLoading } = useSubjects({ size: 100 })
   const { data: levelsData } = useLevels({ size: 100 })
+  const { data: seriesData } = useSeriesList({ size: 100 })
   const deleteMutation = useDeleteSubject()
 
   const subjects = useMemo(() => subjectsData?.items ?? [], [subjectsData])
@@ -47,75 +45,12 @@ export function SubjectsTable() {
     () => levelsData?.items?.slice().sort((a, b) => a.order - b.order) ?? [],
     [levelsData],
   )
-
-  // Group subjects by name. Catalogue (level_id null) is the anchor;
-  // every level-scoped row of the same name becomes an instance under it.
-  const groups = useMemo<SubjectGroup[]>(() => {
-    const levelOrder = new Map(levels.map((l, i) => [l.id, l.order ?? i]))
-    const map = new Map<string, SubjectGroup>()
-
-    for (const s of subjects) {
-      const existing = map.get(s.name)
-      const isCatalogue = s.level_id === null
-
-      if (!existing) {
-        map.set(s.name, {
-          name: s.name,
-          catalogue: isCatalogue ? s : null,
-          instances: isCatalogue ? [] : [s],
-          totalHours: isCatalogue ? 0 : s.hours_per_week,
-        })
-      } else if (isCatalogue) {
-        existing.catalogue = s
-      } else {
-        existing.instances.push(s)
-        existing.totalHours += s.hours_per_week
-      }
-    }
-
-    for (const group of map.values()) {
-      group.instances.sort(
-        (a, b) =>
-          (levelOrder.get(a.level_id ?? 0) ?? 99) -
-          (levelOrder.get(b.level_id ?? 0) ?? 99),
-      )
-    }
-
-    return Array.from(map.values()).sort((a, b) =>
-      a.name.localeCompare(b.name, "fr"),
-    )
-  }, [subjects, levels])
-
-  const filteredGroups = useMemo(() => {
-    const query = debouncedSearch.trim().toLowerCase()
-    return groups.filter((group) => {
-      if (query) {
-        const matchName = group.name.toLowerCase().includes(query)
-        const matchTeacher = group.instances.some((inst) =>
-          inst.teacher_name?.toLowerCase().includes(query),
-        )
-        if (!matchName && !matchTeacher) return false
-      }
-
-      if (levelFilter === "catalogue") {
-        if (group.catalogue === null) return false
-      } else if (levelFilter !== "all") {
-        const lid = Number(levelFilter)
-        if (!group.instances.some((inst) => inst.level_id === lid)) return false
-      }
-
-      if (teacherFilter === "with") {
-        if (!group.instances.some((inst) => inst.teacher_id !== null && inst.teacher_id !== undefined)) {
-          return false
-        }
-      } else if (teacherFilter === "without") {
-        if (group.instances.length === 0) return false
-        if (!group.instances.some((inst) => !inst.teacher_id)) return false
-      }
-
-      return true
-    })
-  }, [groups, debouncedSearch, levelFilter, teacherFilter])
+  const series = seriesData?.items ?? []
+  const groups = useMemo(() => groupSubjects(subjects, levels), [subjects, levels])
+  const filteredGroups = useMemo(
+    () => filterSubjectGroups(groups, debouncedSearch, levelFilter, teacherFilter),
+    [groups, debouncedSearch, levelFilter, teacherFilter],
+  )
 
   function toggleExpanded(name: string) {
     setExpanded((prev) => {
@@ -126,11 +61,13 @@ export function SubjectsTable() {
     })
   }
 
-  function expandAll() {
-    setExpanded(new Set(filteredGroups.filter((g) => g.instances.length > 0).map((g) => g.name)))
-  }
-  function collapseAll() {
-    setExpanded(new Set())
+  function startAssign(catalogue: Subject) {
+    setAssignTarget({
+      subjectId: catalogue.id,
+      subjectName: catalogue.name,
+      defaultCoef: catalogue.coefficient,
+      defaultHours: catalogue.hours_per_week,
+    })
   }
 
   if (isLoading) {
@@ -148,60 +85,40 @@ export function SubjectsTable() {
 
   return (
     <div className="space-y-4">
-      {/* Toolbar */}
-      <div className="flex flex-wrap items-center gap-2">
-        <div className="relative min-w-[240px] flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Rechercher matière ou enseignant..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-9 h-10"
-            aria-label="Rechercher une matière"
-          />
-        </div>
+      <SubjectsTableToolbar
+        value={{ search, levelFilter, teacherFilter }}
+        levels={levels}
+        handlers={{
+          onSearchChange: setSearch,
+          onLevelFilterChange: setLevelFilter,
+          onTeacherFilterChange: setTeacherFilter,
+          onExpandAll: () => setExpanded(new Set(filteredGroups.filter((g) => g.instances.length > 0).map((g) => g.name))),
+          onCollapseAll: () => setExpanded(new Set()),
+        }}
+      />
 
-        <Select value={levelFilter} onValueChange={setLevelFilter}>
-          <SelectTrigger className="h-10 min-w-[170px]" aria-label="Filtrer par niveau">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Tous niveaux</SelectItem>
-            <SelectItem value="catalogue">Catalogue seul</SelectItem>
-            {levels.map((l) => (
-              <SelectItem key={l.id} value={String(l.id)}>
-                {l.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select value={teacherFilter} onValueChange={setTeacherFilter}>
-          <SelectTrigger className="h-10 min-w-[180px]" aria-label="Filtrer par enseignant">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Tous enseignants</SelectItem>
-            <SelectItem value="with">Avec enseignant</SelectItem>
-            <SelectItem value="without">Sans enseignant</SelectItem>
-          </SelectContent>
-        </Select>
-
-        <div className="ml-auto flex items-center gap-1">
-          <Button variant="ghost" size="sm" onClick={expandAll}>
-            Tout déplier
-          </Button>
-          <Button variant="ghost" size="sm" onClick={collapseAll}>
-            Tout replier
-          </Button>
-        </div>
+      <div className="space-y-2 md:hidden">
+        {filteredGroups.length === 0 ? (
+          <p className="rounded-lg border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+            Aucune matière ne correspond à ces filtres.
+          </p>
+        ) : (
+          filteredGroups.map((group) => (
+            <SubjectMobileCard
+              key={group.name}
+              group={group}
+              expanded={expanded.has(group.name)}
+              onToggle={() => toggleExpanded(group.name)}
+              onEdit={setEditId}
+              onAssign={startAssign}
+              onDelete={setDeleteTarget}
+            />
+          ))
+        )}
       </div>
 
-      {/* Table */}
-      <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
-        <div
-          className={`grid ${SUBJECT_GRID_COLS} gap-3 border-b bg-muted/40 px-4 py-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground`}
-        >
+      <div className="hidden overflow-hidden rounded-lg border bg-card shadow-sm md:block">
+        <div className={`grid ${SUBJECT_GRID_COLS} gap-3 border-b bg-muted/40 px-4 py-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground`}>
           <div />
           <div>Matière</div>
           <div className="text-center">Coef.</div>
@@ -209,20 +126,20 @@ export function SubjectsTable() {
           <div>Statut / Enseignant</div>
           <div className="text-right">Actions</div>
         </div>
-
         {filteredGroups.length === 0 ? (
           <div className="px-4 py-12 text-center text-sm text-muted-foreground">
             Aucune matière ne correspond à ces filtres.
           </div>
         ) : (
           <ul className="divide-y">
-            {filteredGroups.map((group) => (
+            {filteredGroups.map((group: SubjectGroup) => (
               <SubjectGroupRow
                 key={group.name}
                 group={group}
                 expanded={expanded.has(group.name)}
                 onToggle={() => toggleExpanded(group.name)}
                 onEdit={setEditId}
+                onAssign={startAssign}
                 onDelete={setDeleteTarget}
               />
             ))}
@@ -230,18 +147,18 @@ export function SubjectsTable() {
         )}
       </div>
 
-      <SubjectEditModal
-        subjectId={editId}
-        open={editId !== null}
-        onClose={() => setEditId(null)}
+      <SubjectAssignModal
+        target={assignTarget}
+        levels={levels}
+        series={series}
+        instances={subjects}
+        open={assignTarget !== null}
+        onClose={() => setAssignTarget(null)}
+        onAssigned={(name) => setExpanded((prev) => new Set(prev).add(name))}
       />
+      <SubjectEditModal subjectId={editId} open={editId !== null} onClose={() => setEditId(null)} />
 
-      <AlertDialog
-        open={deleteTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null)
-        }}
-      >
+      <AlertDialog open={deleteTarget !== null} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Supprimer la matière</AlertDialogTitle>
@@ -257,9 +174,7 @@ export function SubjectsTable() {
               disabled={deleteMutation.isPending}
               onClick={() => {
                 if (deleteTarget) {
-                  deleteMutation.mutate(deleteTarget.id, {
-                    onSuccess: () => setDeleteTarget(null),
-                  })
+                  deleteMutation.mutate(deleteTarget.id, { onSuccess: () => setDeleteTarget(null) })
                 }
               }}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"

--- a/components/admin/subjects/SubjectsTableToolbar.tsx
+++ b/components/admin/subjects/SubjectsTableToolbar.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { Search } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+interface LevelOption {
+  id: number
+  name: string
+}
+
+interface ToolbarValue {
+  search: string
+  levelFilter: string
+  teacherFilter: string
+}
+
+interface ToolbarHandlers {
+  onSearchChange: (value: string) => void
+  onLevelFilterChange: (value: string) => void
+  onTeacherFilterChange: (value: string) => void
+  onExpandAll: () => void
+  onCollapseAll: () => void
+}
+
+interface Props {
+  value: ToolbarValue
+  levels: LevelOption[]
+  handlers: ToolbarHandlers
+}
+
+export function SubjectsTableToolbar({ value, levels, handlers }: Props) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="relative min-w-0 flex-1">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Rechercher matière ou enseignant..."
+          value={value.search}
+          onChange={(e) => handlers.onSearchChange(e.target.value)}
+          className="h-11 pl-9 md:h-10"
+          aria-label="Rechercher une matière"
+        />
+      </div>
+
+      <Select value={value.levelFilter} onValueChange={handlers.onLevelFilterChange}>
+        <SelectTrigger className="h-11 min-w-[170px] md:h-10" aria-label="Filtrer par niveau">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Tous niveaux</SelectItem>
+          <SelectItem value="catalogue">Catalogue seul</SelectItem>
+          {levels.map((level) => (
+            <SelectItem key={level.id} value={String(level.id)}>
+              {level.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select value={value.teacherFilter} onValueChange={handlers.onTeacherFilterChange}>
+        <SelectTrigger className="h-11 min-w-[180px] md:h-10" aria-label="Filtrer par enseignant">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Tous enseignants</SelectItem>
+          <SelectItem value="with">Avec enseignant</SelectItem>
+          <SelectItem value="without">Sans enseignant</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <div className="ml-auto hidden items-center gap-1 md:flex">
+        <Button variant="ghost" size="sm" onClick={handlers.onExpandAll}>Tout déplier</Button>
+        <Button variant="ghost" size="sm" onClick={handlers.onCollapseAll}>Tout replier</Button>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/subjects/subject-assign-types.ts
+++ b/components/admin/subjects/subject-assign-types.ts
@@ -1,0 +1,15 @@
+export interface AssignSeriesOption {
+  id: number
+  name: string
+  level_id: number
+}
+
+export interface AssignTarget {
+  subjectId: number
+  subjectName: string
+  levelId?: number
+  levelName?: string
+  seriesId?: number | null
+  defaultCoef: number
+  defaultHours: number
+}

--- a/components/forms/EnrollmentClassFields.tsx
+++ b/components/forms/EnrollmentClassFields.tsx
@@ -1,0 +1,189 @@
+"use client"
+
+import { Loader2 } from "lucide-react"
+import type { Class } from "@/lib/contracts/class"
+import type { FeeVariantOption } from "@/lib/contracts/enrollment"
+import { classCapacity, classCapacityLabel } from "@/lib/enrollment/classCapacity"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent } from "@/components/ui/card"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+interface ClassFeesFieldsProps {
+  classes: Class[]
+  classesLoading: boolean
+  feeVariants: FeeVariantOption[]
+  feeVariantsLoading: boolean
+  classId: number | undefined
+  feeVariantId: number | null | undefined
+  notes: string | null | undefined
+  onClassChange: (id: number) => void
+  onFeeVariantChange: (id: number | null) => void
+  onNotesChange: (val: string | null) => void
+  classError?: string
+}
+
+function formatXof(amount: number) {
+  return new Intl.NumberFormat("fr-FR", { style: "currency", currency: "XOF" }).format(amount)
+}
+
+function ClassCapacityHint({ classes, classId }: { classes: Class[]; classId: number }) {
+  const selected = classes.find((item) => item.id === classId)
+  if (!selected) return null
+  const { enrolled, max, available } = classCapacity(selected)
+  if (max == null || available == null) return null
+  if (available === 0) {
+    return (
+      <p className="text-sm text-destructive">
+        Cette classe est complète ({enrolled}/{max}). Choisissez une autre classe.
+      </p>
+    )
+  }
+  const tone = available / max <= 0.3 ? "text-amber-700" : "text-emerald-700"
+  const place = available > 1 ? "places" : "place"
+  const inscrit = enrolled > 1 ? "inscrits" : "inscrit"
+  return (
+    <p className={`text-sm ${tone}`}>
+      {available} {place} disponible{available > 1 ? "s" : ""} · {enrolled} {inscrit} sur {max}
+    </p>
+  )
+}
+
+export function ClassAndFeesFields({
+  classes,
+  classesLoading,
+  feeVariants,
+  feeVariantsLoading,
+  classId,
+  feeVariantId,
+  notes,
+  onClassChange,
+  onFeeVariantChange,
+  onNotesChange,
+  classError,
+}: ClassFeesFieldsProps) {
+  const mandatory = feeVariants.filter((variant) => variant.is_mandatory !== false)
+  const optional = feeVariants.filter((variant) => variant.is_mandatory === false)
+  const mandatoryTotal = mandatory.reduce((sum, variant) => sum + Number(variant.amount), 0)
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label className="text-sm font-medium leading-none">Classe *</label>
+        <Select
+          value={classId ? String(classId) : ""}
+          onValueChange={(value) => {
+            onClassChange(Number(value))
+            onFeeVariantChange(null)
+          }}
+        >
+          <SelectTrigger className="h-11">
+            <SelectValue placeholder={classesLoading ? "Chargement..." : "Sélectionner une classe"} />
+          </SelectTrigger>
+          <SelectContent>
+            {classes.map((item) => {
+              const capacity = classCapacity(item)
+              return (
+                <SelectItem key={item.id} value={String(item.id)} disabled={capacity.full}>
+                  {classCapacityLabel(item.name, capacity)}
+                </SelectItem>
+              )
+            })}
+          </SelectContent>
+        </Select>
+        {classId ? <ClassCapacityHint classes={classes} classId={classId} /> : null}
+        {classError ? <p className="text-sm font-medium text-destructive">{classError}</p> : null}
+      </div>
+
+      {feeVariantsLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Chargement des frais...
+        </div>
+      ) : null}
+
+      {mandatory.length > 0 ? (
+        <div className="space-y-2">
+          <label className="text-sm font-medium leading-none">
+            Frais obligatoires
+            <span className="ml-2 text-xs font-normal text-muted-foreground">(appliqués automatiquement)</span>
+          </label>
+          <Card className="border-border/50 bg-muted/30">
+            <CardContent className="p-0">
+              {mandatory.map((variant, index) => (
+                <div
+                  key={variant.id}
+                  className={cn(
+                    "flex items-center justify-between px-4 py-2.5",
+                    index < mandatory.length - 1 && "border-b border-border/30",
+                  )}
+                >
+                  <span className="text-sm">{variant.category_name ?? variant.description ?? "Frais"}</span>
+                  <Badge variant="secondary" className="font-mono text-xs">
+                    {formatXof(variant.amount)}
+                  </Badge>
+                </div>
+              ))}
+              <div className="flex items-center justify-between border-t border-border bg-primary/5 px-4 py-2.5">
+                <span className="text-sm font-semibold">Total obligatoire</span>
+                <span className="font-mono font-bold text-primary">{formatXof(mandatoryTotal)}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+
+      {optional.length > 0 ? (
+        <div className="space-y-2">
+          <label className="text-sm font-medium leading-none">Frais optionnels</label>
+          <div className="grid grid-cols-1 gap-2">
+            {optional.map((variant) => (
+              <Card
+                key={variant.id}
+                className={cn(
+                  "cursor-pointer transition-colors hover:border-primary/50",
+                  feeVariantId === variant.id && "border-primary ring-2 ring-primary/20",
+                )}
+                onClick={() => onFeeVariantChange(feeVariantId === variant.id ? null : variant.id)}
+              >
+                <CardContent className="flex items-center justify-between px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <div
+                      className={cn(
+                        "flex h-4 w-4 items-center justify-center rounded-sm border-2",
+                        feeVariantId === variant.id
+                          ? "border-primary bg-primary"
+                          : "border-muted-foreground/30",
+                      )}
+                    >
+                      {feeVariantId === variant.id ? (
+                        <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                      ) : null}
+                    </div>
+                    <span className="text-sm">{variant.category_name ?? variant.description ?? "Option"}</span>
+                  </div>
+                  <Badge variant="outline" className="font-mono text-xs">
+                    {formatXof(variant.amount)}
+                  </Badge>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium leading-none">Notes</label>
+        <Textarea
+          placeholder="Notes optionnelles"
+          className="min-h-24 resize-none"
+          value={notes ?? ""}
+          onChange={(event) => onNotesChange(event.target.value || null)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/forms/EnrollmentForm.tsx
+++ b/components/forms/EnrollmentForm.tsx
@@ -7,23 +7,16 @@ import {
   UserPlus,
   RefreshCw,
   GraduationCap,
-  CreditCard,
   Check,
   ChevronLeft,
   ChevronRight,
-  ChevronDown,
-  ChevronUp,
   Loader2,
-  Info,
-  Settings2,
-  ExternalLink,
 } from "lucide-react"
 import {
   NewEnrollmentSchema,
   ReEnrollmentSchema,
   type NewEnrollment,
   type ReEnrollment,
-  type FeeVariantOption,
 } from "@/lib/contracts/enrollment"
 import type { Student } from "@/lib/contracts/student"
 import type { Class } from "@/lib/contracts/class"
@@ -31,45 +24,22 @@ import { useCreateWithStudent, useReEnroll, useFeeVariants } from "@/lib/hooks/u
 import { useStudents } from "@/lib/hooks/useStudents"
 import { useClasses } from "@/lib/hooks/useClasses"
 import { Button } from "@/components/ui/button"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form"
-import { Checkbox } from "@/components/ui/checkbox"
-import { Separator } from "@/components/ui/separator"
 import { cn } from "@/lib/utils"
+import { EnrollmentNewStudentStep } from "@/components/forms/EnrollmentNewStudentStep"
+import { EnrollmentReenrollStep } from "@/components/forms/EnrollmentReenrollStep"
+import { EnrollmentSummaryStep } from "@/components/forms/EnrollmentSummaryStep"
+import { ClassAndFeesFields } from "@/components/forms/EnrollmentClassFields"
+import { useAttachStudentPhoto } from "@/lib/hooks/useStudentPhoto"
 
 type EnrollmentType = "new" | "re-enrollment"
 
 const STEPS = [
   { id: "type", label: "Type", icon: GraduationCap },
-  { id: "student", label: "Eleve", icon: UserPlus },
+  { id: "student", label: "Élève", icon: UserPlus },
   { id: "class", label: "Classe", icon: GraduationCap },
-  { id: "summary", label: "Resume", icon: Check },
-] as const
-
-const RELATIONSHIP_TYPES = [
-  { value: "father", label: "Père" },
-  { value: "mother", label: "Mère" },
-  { value: "guardian", label: "Tuteur" },
-  { value: "other", label: "Autre" },
+  { id: "summary", label: "Résumé", icon: Check },
 ] as const
 
 interface EnrollmentFormProps {
@@ -82,19 +52,18 @@ interface EnrollmentFormProps {
   preselectedStudentId?: number
 }
 
-// Unified type for the discriminated form
-type EnrollmentFormData = NewEnrollment | ReEnrollment
-
 export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFormProps) {
   const [step, setStep] = useState(0)
   const [enrollmentType, setEnrollmentType] = useState<EnrollmentType | null>(null)
   const [showParentFields, setShowParentFields] = useState(false)
   const [showParentAccount, setShowParentAccount] = useState(false)
   const [maxReachedStep, setMaxReachedStep] = useState(0)
+  const [photo, setPhoto] = useState<File | null>(null)
 
   // Mutations
   const createWithStudent = useCreateWithStudent()
   const reEnroll = useReEnroll()
+  const attachPhoto = useAttachStudentPhoto()
 
   // Data queries
   const { data: studentsData, isLoading: studentsLoading } = useStudents({ size: 100 })
@@ -165,7 +134,7 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
     [feeVariants, selectedFeeVariantId]
   )
 
-  const isPending = createWithStudent.isPending || reEnroll.isPending
+  const isPending = createWithStudent.isPending || reEnroll.isPending || attachPhoto.isPending
 
   // Bug #22 : Quand un student_id arrive via query (?student_id=X), on
   // pré-remplit le formulaire re-enrollment et on saute directement à la
@@ -236,8 +205,10 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
           data.parent = null
         }
         createWithStudent.mutate(data, {
-          onSuccess: () => {
+          onSuccess: async (enrollment) => {
+            await attachPhoto.mutateAsync({ studentId: enrollment.student_id, photo })
             newForm.reset()
+            setPhoto(null)
             onSuccess()
           },
         })
@@ -280,7 +251,7 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
       {step === 0 && (
         <div className="space-y-4">
           <p className="text-sm text-muted-foreground">
-            Choisissez le type d&apos;inscription a effectuer.
+            Choisissez le type d&apos;inscription à effectuer.
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <Card
@@ -300,7 +271,7 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
                 <div className="text-center">
                   <p className="font-semibold">Nouvelle inscription</p>
                   <p className="text-xs text-muted-foreground mt-1">
-                    Inscrire un nouvel eleve
+                    Inscrire un nouvel élève
                   </p>
                 </div>
               </CardContent>
@@ -321,9 +292,9 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
                   <RefreshCw className="h-6 w-6" />
                 </div>
                 <div className="text-center">
-                  <p className="font-semibold">Reinscription</p>
+                  <p className="font-semibold">Réinscription</p>
                   <p className="text-xs text-muted-foreground mt-1">
-                    Reinscrire un eleve existant
+                    Réinscrire un élève existant
                   </p>
                 </div>
               </CardContent>
@@ -334,506 +305,48 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
 
       {/* Step 1: Student info */}
       {step === 1 && enrollmentType === "new" && (
-        <Form {...newForm}>
-          <div className="space-y-4">
-            <p className="text-sm text-muted-foreground">
-              Renseignez les informations de l&apos;eleve.
-            </p>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <FormField
-                control={newForm.control}
-                name="first_name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Prenom *</FormLabel>
-                    <FormControl>
-                      <Input placeholder="Prenom de l'eleve" className="h-10" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={newForm.control}
-                name="last_name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Nom *</FormLabel>
-                    <FormControl>
-                      <Input placeholder="Nom de l'eleve" className="h-10" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <FormField
-                control={newForm.control}
-                name="birth_date"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Date de naissance</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="date"
-                        className="h-10"
-                        {...field}
-                        value={field.value ?? ""}
-                        onChange={(e) => field.onChange(e.target.value || null)}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={newForm.control}
-                name="genre"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Genre</FormLabel>
-                    <Select
-                      value={field.value ?? ""}
-                      onValueChange={(v) => field.onChange(v || null)}
-                    >
-                      <FormControl>
-                        <SelectTrigger className="h-10">
-                          <SelectValue placeholder="Selectionner" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="M">Masculin</SelectItem>
-                        <SelectItem value="F">Feminin</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <FormField
-              control={newForm.control}
-              name="enrollment_number"
-              render={({ field }) => (
-                <FormItem>
-                  <div className="flex items-center gap-2">
-                    <FormLabel>Matricule *</FormLabel>
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <button type="button" className="rounded-full p-0.5 hover:bg-muted transition-colors">
-                          <Info className="h-3.5 w-3.5 text-muted-foreground" />
-                        </button>
-                      </PopoverTrigger>
-                      <PopoverContent className="w-64 text-xs" side="top" align="start">
-                        <p className="font-medium mb-1">Configuration du matricule</p>
-                        <p className="text-muted-foreground">
-                          Le matricule peut etre genere automatiquement si un pattern est configure dans les parametres.
-                        </p>
-                        <a
-                          href="/admin/settings"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="mt-2 inline-flex items-center gap-1 text-primary hover:underline"
-                        >
-                          <Settings2 className="h-3 w-3" />
-                          Configurer le pattern
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
-                      </PopoverContent>
-                    </Popover>
-                  </div>
-                  <FormControl>
-                    <Input
-                      placeholder="Ex: KLASSCI-2026-0001"
-                      className="h-10"
-                      {...field}
-                      value={field.value ?? ""}
-                      onChange={(e) => field.onChange(e.target.value || null)}
-                    />
-                  </FormControl>
-                  <p className="text-xs text-muted-foreground">
-                    Laissez vide pour une generation automatique (si le pattern est configure).
-                  </p>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <FormField
-                control={newForm.control}
-                name="city"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Ville</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="Ex : Abidjan"
-                        className="h-10"
-                        {...field}
-                        value={field.value ?? ""}
-                        onChange={(e) => field.onChange(e.target.value || null)}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={newForm.control}
-                name="commune"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Commune</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="Ex : Cocody"
-                        className="h-10"
-                        {...field}
-                        value={field.value ?? ""}
-                        onChange={(e) => field.onChange(e.target.value || null)}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            <Separator />
-
-            {/* Parent section */}
-            <button
-              type="button"
-              className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-              onClick={() => {
-                setShowParentFields(!showParentFields)
-                if (showParentFields) {
-                  newForm.setValue("parent", null)
-                  setShowParentAccount(false)
-                } else {
-                  newForm.setValue("parent", {
-                    first_name: "",
-                    last_name: "",
-                    phone: null,
-                    email: null,
-                    password: null,
-                    relationship_type: "guardian",
-                    city: null,
-                    commune: null,
-                  })
-                }
-              }}
-            >
-              {showParentFields ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              Informations parent (optionnel)
-            </button>
-
-            {showParentFields && (
-              <div className="space-y-4 pl-2 border-l-2 border-muted">
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <FormField
-                    control={newForm.control}
-                    name="parent.first_name"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Prénom du parent *</FormLabel>
-                        <FormControl>
-                          <Input placeholder="Prénom" className="h-10" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={newForm.control}
-                    name="parent.last_name"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Nom du parent *</FormLabel>
-                        <FormControl>
-                          <Input placeholder="Nom" className="h-10" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <FormField
-                    control={newForm.control}
-                    name="parent.phone"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Téléphone</FormLabel>
-                        <FormControl>
-                          <Input
-                            placeholder="Numéro de téléphone"
-                            className="h-10"
-                            {...field}
-                            value={field.value ?? ""}
-                            onChange={(e) => field.onChange(e.target.value || null)}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={newForm.control}
-                    name="parent.email"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Email</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="email"
-                            placeholder="Adresse email"
-                            className="h-10"
-                            {...field}
-                            value={field.value ?? ""}
-                            onChange={(e) => field.onChange(e.target.value || null)}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <FormField
-                    control={newForm.control}
-                    name="parent.city"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Ville</FormLabel>
-                        <FormControl>
-                          <Input
-                            placeholder="Ex : Abidjan"
-                            className="h-10"
-                            {...field}
-                            value={field.value ?? ""}
-                            onChange={(e) => field.onChange(e.target.value || null)}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={newForm.control}
-                    name="parent.commune"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Commune</FormLabel>
-                        <FormControl>
-                          <Input
-                            placeholder="Ex : Cocody"
-                            className="h-10"
-                            {...field}
-                            value={field.value ?? ""}
-                            onChange={(e) => field.onChange(e.target.value || null)}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-
-                <FormField
-                  control={newForm.control}
-                  name="parent.relationship_type"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Lien de parenté</FormLabel>
-                      <Select
-                        value={field.value ?? "guardian"}
-                        onValueChange={field.onChange}
-                      >
-                        <FormControl>
-                          <SelectTrigger className="h-10">
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {RELATIONSHIP_TYPES.map((r) => (
-                            <SelectItem key={r.value} value={r.value}>
-                              {r.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                {/* Compte de connexion parent */}
-                <div className="space-y-3 rounded-md border p-3">
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="parent-create-account"
-                      checked={showParentAccount}
-                      onCheckedChange={(checked) => {
-                        setShowParentAccount(checked === true)
-                        if (!checked) {
-                          newForm.setValue("parent.password", null)
-                        }
-                      }}
-                    />
-                    <label
-                      htmlFor="parent-create-account"
-                      className="text-sm font-medium leading-none cursor-pointer"
-                    >
-                      Créer un compte de connexion pour le parent
-                    </label>
-                  </div>
-
-                  {showParentAccount && (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2">
-                      <FormField
-                        control={newForm.control}
-                        name="parent.email"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Email du compte *</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="email"
-                                placeholder="email@exemple.com"
-                                className="h-10"
-                                {...field}
-                                value={field.value ?? ""}
-                                onChange={(e) => field.onChange(e.target.value || null)}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FormField
-                        control={newForm.control}
-                        name="parent.password"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Mot de passe *</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="password"
-                                placeholder="8 caractères minimum"
-                                className="h-10"
-                                {...field}
-                                value={field.value ?? ""}
-                                onChange={(e) => field.onChange(e.target.value || null)}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-        </Form>
+        <EnrollmentNewStudentStep
+          form={newForm}
+          photo={photo}
+          onPhotoChange={setPhoto}
+          disabled={isPending}
+          showParentFields={showParentFields}
+          showParentAccount={showParentAccount}
+          onToggleParentFields={() => {
+            const next = !showParentFields
+            setShowParentFields(next)
+            if (!next) {
+              newForm.setValue("parent", null)
+              setShowParentAccount(false)
+            } else {
+              newForm.setValue("parent", {
+                first_name: "",
+                last_name: "",
+                phone: null,
+                email: null,
+                password: null,
+                relationship_type: "guardian",
+                city: null,
+                commune: null,
+              })
+            }
+          }}
+          onToggleParentAccount={(checked) => {
+            setShowParentAccount(checked)
+            if (!checked) {
+              newForm.setValue("parent.password", null)
+            }
+          }}
+        />
       )}
 
-      {/* Step 1: Re-enrollment - student selection */}
       {step === 1 && enrollmentType === "re-enrollment" && (
-        <Form {...reForm}>
-          <div className="space-y-4">
-            <p className="text-sm text-muted-foreground">
-              Selectionnez l&apos;eleve a reinscrire.
-            </p>
-
-            <FormField
-              control={reForm.control}
-              name="student_id"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Eleve *</FormLabel>
-                  <Select
-                    value={field.value ? String(field.value) : ""}
-                    onValueChange={(v) => field.onChange(Number(v))}
-                  >
-                    <FormControl>
-                      <SelectTrigger className="h-10">
-                        <SelectValue placeholder={studentsLoading ? "Chargement..." : "Selectionner un eleve"} />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {students.map((s) => (
-                        <SelectItem key={s.id} value={String(s.id)}>
-                          {s.first_name} {s.last_name}
-                          {s.enrollment_number ? ` (${s.enrollment_number})` : ""}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {selectedStudent && (
-              <Card>
-                <CardContent className="pt-4 pb-4">
-                  <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                    <dt className="text-muted-foreground">Nom complet</dt>
-                    <dd className="font-medium">{selectedStudent.first_name} {selectedStudent.last_name}</dd>
-                    {selectedStudent.enrollment_number && (
-                      <>
-                        <dt className="text-muted-foreground">Matricule</dt>
-                        <dd>{selectedStudent.enrollment_number}</dd>
-                      </>
-                    )}
-                    {selectedStudent.genre && (
-                      <>
-                        <dt className="text-muted-foreground">Genre</dt>
-                        <dd>{selectedStudent.genre === "M" ? "Masculin" : "Feminin"}</dd>
-                      </>
-                    )}
-                    {selectedStudent.birth_date && (
-                      <>
-                        <dt className="text-muted-foreground">Date de naissance</dt>
-                        <dd>{selectedStudent.birth_date}</dd>
-                      </>
-                    )}
-                  </dl>
-                </CardContent>
-              </Card>
-            )}
-
-            <FormField
-              control={reForm.control}
-              name="notes"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Notes</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      placeholder="Notes optionnelles"
-                      className="resize-none"
-                      {...field}
-                      value={field.value ?? ""}
-                      onChange={(e) => field.onChange(e.target.value || null)}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-        </Form>
+        <EnrollmentReenrollStep
+          form={reForm}
+          students={students}
+          studentsLoading={studentsLoading}
+          selectedStudent={selectedStudent}
+        />
       )}
 
       {/* Step 2: Class and fees */}
@@ -875,184 +388,40 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
         </div>
       )}
 
-      {/* Step 3: Summary */}
       {step === 3 && (
-        <div className="space-y-4">
-          <p className="text-sm text-muted-foreground">
-            Verifiez les informations avant de valider.
-          </p>
-
-          <Card>
-            <CardContent className="pt-4 pb-4 space-y-4">
-              {/* Student info */}
-              <div>
-                <h4 className="text-sm font-semibold text-primary mb-2 flex items-center gap-2">
-                  <UserPlus className="h-4 w-4" />
-                  Eleve
-                </h4>
-                <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                  {enrollmentType === "new" ? (
-                    <>
-                      <dt className="text-muted-foreground">Nom</dt>
-                      <dd className="font-medium">{newForm.getValues("first_name")} {newForm.getValues("last_name")}</dd>
-                      {newForm.getValues("birth_date") && (
-                        <>
-                          <dt className="text-muted-foreground">Date de naissance</dt>
-                          <dd>{newForm.getValues("birth_date")}</dd>
-                        </>
-                      )}
-                      {newForm.getValues("genre") && (
-                        <>
-                          <dt className="text-muted-foreground">Genre</dt>
-                          <dd>{newForm.getValues("genre") === "M" ? "Masculin" : "Feminin"}</dd>
-                        </>
-                      )}
-                      {newForm.getValues("enrollment_number") && (
-                        <>
-                          <dt className="text-muted-foreground">Matricule</dt>
-                          <dd>{newForm.getValues("enrollment_number")}</dd>
-                        </>
-                      )}
-                    </>
-                  ) : (
-                    <>
-                      <dt className="text-muted-foreground">Nom</dt>
-                      <dd className="font-medium">
-                        {selectedStudent ? `${selectedStudent.first_name} ${selectedStudent.last_name}` : `#${reForm.getValues("student_id")}`}
-                      </dd>
-                    </>
-                  )}
-                </dl>
-              </div>
-
-              {/* Parent info (new enrollment only) */}
-              {enrollmentType === "new" && showParentFields && newForm.getValues("parent") && (
-                <>
-                  <Separator />
-                  <div>
-                    <h4 className="text-sm font-semibold text-primary mb-2">Parent</h4>
-                    <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                      <dt className="text-muted-foreground">Nom</dt>
-                      <dd>{newForm.getValues("parent.first_name")} {newForm.getValues("parent.last_name")}</dd>
-                      {newForm.getValues("parent.phone") && (
-                        <>
-                          <dt className="text-muted-foreground">Telephone</dt>
-                          <dd>{newForm.getValues("parent.phone")}</dd>
-                        </>
-                      )}
-                      {newForm.getValues("parent.email") && (
-                        <>
-                          <dt className="text-muted-foreground">Email</dt>
-                          <dd>{newForm.getValues("parent.email")}</dd>
-                        </>
-                      )}
-                      <dt className="text-muted-foreground">Lien</dt>
-                      <dd>
-                        {RELATIONSHIP_TYPES.find(
-                          (r) => r.value === newForm.getValues("parent.relationship_type")
-                        )?.label ?? "Tuteur"}
-                      </dd>
-                    </dl>
-                  </div>
-                </>
-              )}
-
-              <Separator />
-
-              {/* Class info */}
-              <div>
-                <h4 className="text-sm font-semibold text-primary mb-2 flex items-center gap-2">
-                  <GraduationCap className="h-4 w-4" />
-                  Classe
-                </h4>
-                <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                  <dt className="text-muted-foreground">Classe</dt>
-                  <dd className="font-medium">{selectedClassName || `#${watchedClassId}`}</dd>
-                </dl>
-              </div>
-
-              {/* Fee info — mandatory + optional */}
-              {(feeVariants ?? []).length > 0 && (
-                <>
-                  <Separator />
-                  <div>
-                    <h4 className="text-sm font-semibold text-primary mb-2 flex items-center gap-2">
-                      <CreditCard className="h-4 w-4" />
-                      Frais
-                    </h4>
-                    {(feeVariants ?? []).filter((v) => v.is_mandatory !== false).map((v) => (
-                      <div key={v.id} className="flex justify-between text-sm py-0.5">
-                        <span className="text-muted-foreground">{v.category_name ?? "Frais"}</span>
-                        <span className="font-mono">{new Intl.NumberFormat("fr-FR", { style: "currency", currency: "XOF" }).format(Number(v.amount))}</span>
-                      </div>
-                    ))}
-                    {selectedFeeVariant && selectedFeeVariant.is_mandatory === false && (
-                      <div className="flex justify-between text-sm py-0.5">
-                        <span className="text-muted-foreground">{selectedFeeVariant.category_name ?? "Option"}</span>
-                        <span className="font-mono">{new Intl.NumberFormat("fr-FR", { style: "currency", currency: "XOF" }).format(Number(selectedFeeVariant.amount))}</span>
-                      </div>
-                    )}
-                    <div className="flex justify-between text-sm pt-1 mt-1 border-t border-border/50">
-                      <span className="font-semibold">Total</span>
-                      <span className="font-mono font-bold text-primary">
-                        {new Intl.NumberFormat("fr-FR", { style: "currency", currency: "XOF" }).format(
-                          (feeVariants ?? []).filter((v) => v.is_mandatory !== false).reduce((s, v) => s + Number(v.amount), 0) +
-                          (selectedFeeVariant && selectedFeeVariant.is_mandatory === false ? Number(selectedFeeVariant.amount) : 0)
-                        )}
-                      </span>
-                    </div>
-                  </div>
-                </>
-              )}
-
-              {/* Notes */}
-              {enrollmentType === "re-enrollment" && reForm.getValues("notes") && (
-                <>
-                  <Separator />
-                  <div>
-                    <h4 className="text-sm font-semibold text-muted-foreground mb-1">Notes</h4>
-                    <p className="text-sm">{reForm.getValues("notes")}</p>
-                  </div>
-                </>
-              )}
-              {enrollmentType === "new" && newForm.getValues("notes") && (
-                <>
-                  <Separator />
-                  <div>
-                    <h4 className="text-sm font-semibold text-muted-foreground mb-1">Notes</h4>
-                    <p className="text-sm">{newForm.getValues("notes")}</p>
-                  </div>
-                </>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Server errors */}
-          {(createWithStudent.error || reEnroll.error) && (
-            <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
-              <p className="text-sm text-destructive">
-                {createWithStudent.error?.message || reEnroll.error?.message}
-              </p>
-            </div>
-          )}
-        </div>
+        <EnrollmentSummaryStep
+          enrollmentType={enrollmentType === "re-enrollment" ? "re-enrollment" : "new"}
+          newValues={newForm.getValues()}
+          reValues={reForm.getValues()}
+          selectedStudent={selectedStudent}
+          selectedClassName={selectedClassName}
+          watchedClassId={watchedClassId}
+          feeVariants={feeVariants ?? []}
+          selectedFeeVariant={selectedFeeVariant}
+          photo={photo}
+          showParentFields={showParentFields}
+          createError={createWithStudent.error?.message}
+          reEnrollError={reEnroll.error?.message}
+        />
       )}
 
       {/* Navigation */}
-      <div className="flex items-center justify-between pt-2">
+      <div className="flex items-center justify-between gap-3 pt-2">
         <Button
           type="button"
           variant="outline"
+          className="h-11"
           onClick={handlePrevious}
           disabled={step === 0 || isPending}
         >
           <ChevronLeft className="mr-1.5 h-4 w-4" />
-          Precedent
+          Précédent
         </Button>
 
         {step < 3 ? (
           <Button
             type="button"
+            className="h-11"
             onClick={handleNext}
             disabled={step === 0 && !enrollmentType}
           >
@@ -1062,173 +431,14 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
         ) : (
           <Button
             type="button"
+            className="h-11"
             onClick={handleSubmit}
             disabled={isPending}
           >
             {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            {isPending ? "Enregistrement..." : "Enregistrer l'inscription"}
+            {attachPhoto.isPending ? "Envoi de la photo..." : isPending ? "Enregistrement..." : "Enregistrer l'inscription"}
           </Button>
         )}
-      </div>
-    </div>
-  )
-}
-
-// Shared fields for class selection, fee variant, and notes
-// Used by both new enrollment and re-enrollment forms in step 2
-interface ClassFeesFieldsProps {
-  classes: Class[]
-  classesLoading: boolean
-  feeVariants: FeeVariantOption[]
-  feeVariantsLoading: boolean
-  classId: number | undefined
-  feeVariantId: number | null | undefined
-  notes: string | null | undefined
-  onClassChange: (id: number) => void
-  onFeeVariantChange: (id: number | null) => void
-  onNotesChange: (val: string | null) => void
-  classError?: string
-}
-
-function ClassAndFeesFields({
-  classes,
-  classesLoading,
-  feeVariants,
-  feeVariantsLoading,
-  classId,
-  feeVariantId,
-  notes,
-  onClassChange,
-  onFeeVariantChange,
-  onNotesChange,
-  classError,
-}: ClassFeesFieldsProps) {
-  return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <label className="text-sm font-medium leading-none">Classe *</label>
-        <Select
-          value={classId ? String(classId) : ""}
-          onValueChange={(v) => {
-            onClassChange(Number(v))
-            onFeeVariantChange(null)
-          }}
-        >
-          <SelectTrigger className="h-10">
-            <SelectValue placeholder={classesLoading ? "Chargement..." : "Selectionner une classe"} />
-          </SelectTrigger>
-          <SelectContent>
-            {classes.map((c) => (
-              <SelectItem key={c.id} value={String(c.id)}>
-                {c.name}
-                {c.max_students != null ? ` (max: ${c.max_students})` : ""}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {classError && <p className="text-sm font-medium text-destructive">{classError}</p>}
-      </div>
-
-      {/* Fee variants loading */}
-      {feeVariantsLoading && (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Chargement des frais...
-        </div>
-      )}
-
-      {/* Mandatory fees — auto-applied, read-only summary */}
-      {(() => {
-        const mandatory = feeVariants.filter((v) => v.is_mandatory !== false)
-        const optional = feeVariants.filter((v) => v.is_mandatory === false)
-        const mandatoryTotal = mandatory.reduce((sum, v) => sum + Number(v.amount), 0)
-        const fmt = (n: number) => new Intl.NumberFormat("fr-FR", { style: "currency", currency: "XOF" }).format(Number(n))
-
-        return (
-          <>
-            {mandatory.length > 0 && (
-              <div className="space-y-2">
-                <label className="text-sm font-medium leading-none">
-                  Frais obligatoires
-                  <span className="ml-2 text-xs font-normal text-muted-foreground">(appliqués automatiquement)</span>
-                </label>
-                <Card className="border-border/50 bg-muted/30">
-                  <CardContent className="p-0">
-                    {mandatory.map((variant, i) => (
-                      <div
-                        key={variant.id}
-                        className={cn(
-                          "flex items-center justify-between px-4 py-2.5",
-                          i < mandatory.length - 1 && "border-b border-border/30"
-                        )}
-                      >
-                        <span className="text-sm">{variant.category_name ?? variant.description ?? "Frais"}</span>
-                        <Badge variant="secondary" className="font-mono text-xs">
-                          {fmt(variant.amount)}
-                        </Badge>
-                      </div>
-                    ))}
-                    <div className="flex items-center justify-between px-4 py-2.5 border-t border-border bg-primary/5">
-                      <span className="text-sm font-semibold">Total obligatoire</span>
-                      <span className="font-mono font-bold text-primary">{fmt(mandatoryTotal)}</span>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            )}
-
-            {/* Optional fees — selectable */}
-            {optional.length > 0 && (
-              <div className="space-y-2">
-                <label className="text-sm font-medium leading-none">Frais optionnels</label>
-                <div className="grid grid-cols-1 gap-2">
-                  {optional.map((variant) => (
-                    <Card
-                      key={variant.id}
-                      className={cn(
-                        "cursor-pointer transition-colors hover:border-primary/50",
-                        feeVariantId === variant.id && "border-primary ring-2 ring-primary/20"
-                      )}
-                      onClick={() => onFeeVariantChange(feeVariantId === variant.id ? null : variant.id)}
-                    >
-                      <CardContent className="flex items-center justify-between py-3 px-4">
-                        <div className="flex items-center gap-3">
-                          <div className={cn(
-                            "h-4 w-4 rounded-sm border-2 flex items-center justify-center",
-                            feeVariantId === variant.id
-                              ? "border-primary bg-primary"
-                              : "border-muted-foreground/30"
-                          )}>
-                            {feeVariantId === variant.id && (
-                              <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                              </svg>
-                            )}
-                          </div>
-                          <span className="text-sm">{variant.category_name ?? variant.description ?? "Option"}</span>
-                        </div>
-                        <Badge variant="outline" className="font-mono text-xs">
-                          {fmt(variant.amount)}
-                        </Badge>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-              </div>
-            )}
-          </>
-        )
-      })()}
-
-      {/* Notes */}
-      <div className="space-y-2">
-        <label className="text-sm font-medium leading-none">Notes</label>
-        <Textarea
-          placeholder="Notes optionnelles"
-          className="resize-none"
-          value={notes ?? ""}
-          onChange={(e) => onNotesChange(e.target.value || null)}
-        />
       </div>
     </div>
   )

--- a/components/forms/EnrollmentNewStudentStep.tsx
+++ b/components/forms/EnrollmentNewStudentStep.tsx
@@ -1,0 +1,233 @@
+"use client"
+
+import type { UseFormReturn } from "react-hook-form"
+import { ExternalLink, Info, Settings2 } from "lucide-react"
+import type { NewEnrollment } from "@/lib/contracts/enrollment"
+import { StudentPhotoField } from "@/components/admin/students/photo/StudentPhotoField"
+import { EnrollmentParentFields } from "@/components/forms/EnrollmentParentFields"
+import { Input } from "@/components/ui/input"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Separator } from "@/components/ui/separator"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+interface EnrollmentNewStudentStepProps {
+  form: UseFormReturn<NewEnrollment>
+  photo: File | null
+  onPhotoChange: (file: File | null) => void
+  disabled?: boolean
+  showParentFields: boolean
+  showParentAccount: boolean
+  onToggleParentFields: () => void
+  onToggleParentAccount: (checked: boolean) => void
+}
+
+export function EnrollmentNewStudentStep({
+  form,
+  photo,
+  onPhotoChange,
+  disabled = false,
+  showParentFields,
+  showParentAccount,
+  onToggleParentFields,
+  onToggleParentAccount,
+}: EnrollmentNewStudentStepProps) {
+  return (
+    <Form {...form}>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Renseignez les informations de l&apos;élève.
+        </p>
+
+        <StudentPhotoField value={photo} onChange={onPhotoChange} disabled={disabled} />
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="first_name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Prénom *</FormLabel>
+                <FormControl>
+                  <Input placeholder="Prénom de l'élève" className="h-11" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="last_name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nom *</FormLabel>
+                <FormControl>
+                  <Input placeholder="Nom de l'élève" className="h-11" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="birth_date"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Date de naissance</FormLabel>
+                <FormControl>
+                  <Input
+                    type="date"
+                    className="h-11"
+                    {...field}
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value || null)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="genre"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Genre</FormLabel>
+                <Select
+                  value={field.value ?? ""}
+                  onValueChange={(v) => field.onChange(v || null)}
+                >
+                  <FormControl>
+                    <SelectTrigger className="h-11">
+                      <SelectValue placeholder="Sélectionner" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="M">Masculin</SelectItem>
+                    <SelectItem value="F">Féminin</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <FormField
+          control={form.control}
+          name="enrollment_number"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center gap-2">
+                <FormLabel>Matricule *</FormLabel>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <button type="button" className="rounded-full p-0.5 hover:bg-muted transition-colors">
+                      <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-64 text-xs" side="top" align="start">
+                    <p className="font-medium mb-1">Configuration du matricule</p>
+                    <p className="text-muted-foreground">
+                      Le matricule peut être généré automatiquement si un pattern est configuré dans les paramètres.
+                    </p>
+                    <a
+                      href="/admin/settings"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center gap-1 text-primary hover:underline"
+                    >
+                      <Settings2 className="h-3 w-3" />
+                      Configurer le pattern
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  </PopoverContent>
+                </Popover>
+              </div>
+              <FormControl>
+                <Input
+                  placeholder="Ex: KLASSCI-2026-0001"
+                  className="h-11"
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+              <p className="text-xs text-muted-foreground">
+                Laissez vide pour une génération automatique (si le pattern est configuré).
+              </p>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="city"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Ville</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Ex : Abidjan"
+                    className="h-11"
+                    {...field}
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value || null)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="commune"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Commune</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Ex : Cocody"
+                    className="h-11"
+                    {...field}
+                    value={field.value ?? ""}
+                    onChange={(e) => field.onChange(e.target.value || null)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <Separator />
+
+        <EnrollmentParentFields
+          form={form}
+          showParentFields={showParentFields}
+          showParentAccount={showParentAccount}
+          onToggleParentFields={onToggleParentFields}
+          onToggleParentAccount={onToggleParentAccount}
+        />
+      </div>
+    </Form>
+  )
+}

--- a/components/forms/EnrollmentParentFields.tsx
+++ b/components/forms/EnrollmentParentFields.tsx
@@ -1,0 +1,264 @@
+"use client"
+
+import type { UseFormReturn } from "react-hook-form"
+import { ChevronDown, ChevronUp } from "lucide-react"
+import type { NewEnrollment } from "@/lib/contracts/enrollment"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const RELATIONSHIP_TYPES = [
+  { value: "father", label: "Père" },
+  { value: "mother", label: "Mère" },
+  { value: "guardian", label: "Tuteur" },
+  { value: "other", label: "Autre" },
+] as const
+
+interface EnrollmentParentFieldsProps {
+  form: UseFormReturn<NewEnrollment>
+  showParentFields: boolean
+  showParentAccount: boolean
+  onToggleParentFields: () => void
+  onToggleParentAccount: (checked: boolean) => void
+}
+
+export function EnrollmentParentFields({
+  form,
+  showParentFields,
+  showParentAccount,
+  onToggleParentFields,
+  onToggleParentAccount,
+}: EnrollmentParentFieldsProps) {
+  return (
+    <>
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-11 px-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+          onClick={onToggleParentFields}
+        >
+          {showParentFields ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          Informations parent (optionnel)
+        </Button>
+
+        {showParentFields && (
+          <div className="space-y-4 pl-2 border-l-2 border-muted">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="parent.first_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Prénom du parent *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Prénom" className="h-11" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="parent.last_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nom du parent *</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nom" className="h-11" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="parent.phone"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Téléphone</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Numéro de téléphone"
+                        className="h-11"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="parent.email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="Adresse email"
+                        className="h-11"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="parent.city"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Ville</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Ex : Abidjan"
+                        className="h-11"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="parent.commune"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Commune</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Ex : Cocody"
+                        className="h-11"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="parent.relationship_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Lien de parenté</FormLabel>
+                  <Select
+                    value={field.value ?? "guardian"}
+                    onValueChange={field.onChange}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="h-11">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {RELATIONSHIP_TYPES.map((r) => (
+                        <SelectItem key={r.value} value={r.value}>
+                          {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="space-y-3 rounded-md border p-3">
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="parent-create-account"
+                  checked={showParentAccount}
+                  onCheckedChange={(checked) => onToggleParentAccount(checked === true)}
+                />
+                <label
+                  htmlFor="parent-create-account"
+                  className="text-sm font-medium leading-none cursor-pointer"
+                >
+                  Créer un compte de connexion pour le parent
+                </label>
+              </div>
+
+              {showParentAccount && (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2">
+                  <FormField
+                    control={form.control}
+                    name="parent.email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email du compte *</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="email"
+                            placeholder="email@exemple.com"
+                            className="h-11"
+                            {...field}
+                            value={field.value ?? ""}
+                            onChange={(e) => field.onChange(e.target.value || null)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="parent.password"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Mot de passe *</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            placeholder="8 caractères minimum"
+                            className="h-11"
+                            {...field}
+                            value={field.value ?? ""}
+                            onChange={(e) => field.onChange(e.target.value || null)}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+    </>
+  )
+}

--- a/components/forms/EnrollmentReenrollStep.tsx
+++ b/components/forms/EnrollmentReenrollStep.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import type { UseFormReturn } from "react-hook-form"
+import type { ReEnrollment } from "@/lib/contracts/enrollment"
+import type { Student } from "@/lib/contracts/student"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+interface EnrollmentReenrollStepProps {
+  form: UseFormReturn<ReEnrollment>
+  students: Student[]
+  studentsLoading: boolean
+  selectedStudent?: Student
+}
+
+export function EnrollmentReenrollStep({
+  form,
+  students,
+  studentsLoading,
+  selectedStudent,
+}: EnrollmentReenrollStepProps) {
+  return (
+    <Form {...form}>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Sélectionnez l&apos;élève à réinscrire.
+        </p>
+
+        <FormField
+          control={form.control}
+          name="student_id"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Élève *</FormLabel>
+              <Select
+                value={field.value ? String(field.value) : ""}
+                onValueChange={(value) => field.onChange(Number(value))}
+              >
+                <FormControl>
+                  <SelectTrigger className="h-11">
+                    <SelectValue placeholder={studentsLoading ? "Chargement..." : "Sélectionner un élève"} />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {students.map((student) => (
+                    <SelectItem key={student.id} value={String(student.id)}>
+                      {student.first_name} {student.last_name}
+                      {student.enrollment_number ? ` (${student.enrollment_number})` : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {selectedStudent ? (
+          <Card>
+            <CardContent className="pt-4 pb-4">
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                <dt className="text-muted-foreground">Nom complet</dt>
+                <dd className="font-medium">
+                  {selectedStudent.first_name} {selectedStudent.last_name}
+                </dd>
+                {selectedStudent.enrollment_number ? (
+                  <>
+                    <dt className="text-muted-foreground">Matricule</dt>
+                    <dd>{selectedStudent.enrollment_number}</dd>
+                  </>
+                ) : null}
+                {selectedStudent.genre ? (
+                  <>
+                    <dt className="text-muted-foreground">Genre</dt>
+                    <dd>{selectedStudent.genre === "M" ? "Masculin" : "Féminin"}</dd>
+                  </>
+                ) : null}
+                {selectedStudent.birth_date ? (
+                  <>
+                    <dt className="text-muted-foreground">Date de naissance</dt>
+                    <dd>{selectedStudent.birth_date}</dd>
+                  </>
+                ) : null}
+              </dl>
+            </CardContent>
+          </Card>
+        ) : null}
+      </div>
+    </Form>
+  )
+}

--- a/components/forms/EnrollmentSummaryStep.tsx
+++ b/components/forms/EnrollmentSummaryStep.tsx
@@ -1,0 +1,197 @@
+"use client"
+
+import { CreditCard, GraduationCap, UserPlus } from "lucide-react"
+import type { NewEnrollment, ReEnrollment, FeeVariantOption } from "@/lib/contracts/enrollment"
+import type { Student } from "@/lib/contracts/student"
+import { Card, CardContent } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+
+const RELATIONSHIP_TYPES = [
+  { value: "father", label: "Père" },
+  { value: "mother", label: "Mère" },
+  { value: "guardian", label: "Tuteur" },
+  { value: "other", label: "Autre" },
+] as const
+
+function formatXof(amount: number) {
+  return new Intl.NumberFormat("fr-FR", { style: "currency", currency: "XOF" }).format(amount)
+}
+
+interface EnrollmentSummaryStepProps {
+  enrollmentType: "new" | "re-enrollment"
+  newValues: NewEnrollment
+  reValues: ReEnrollment
+  selectedStudent?: Student
+  selectedClassName: string
+  watchedClassId?: number
+  feeVariants: FeeVariantOption[]
+  selectedFeeVariant?: FeeVariantOption
+  photo: File | null
+  showParentFields: boolean
+  createError?: string
+  reEnrollError?: string
+}
+
+export function EnrollmentSummaryStep({
+  enrollmentType,
+  newValues,
+  reValues,
+  selectedStudent,
+  selectedClassName,
+  watchedClassId,
+  feeVariants,
+  selectedFeeVariant,
+  photo,
+  showParentFields,
+  createError,
+  reEnrollError,
+}: EnrollmentSummaryStepProps) {
+  const mandatory = feeVariants.filter((variant) => variant.is_mandatory !== false)
+  const optionalAmount =
+    selectedFeeVariant && selectedFeeVariant.is_mandatory === false ? Number(selectedFeeVariant.amount) : 0
+  const total = mandatory.reduce((sum, variant) => sum + Number(variant.amount), 0) + optionalAmount
+  const notes = enrollmentType === "new" ? newValues.notes : reValues.notes
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">Vérifiez les informations avant de valider.</p>
+      <Card>
+        <CardContent className="space-y-4 pb-4 pt-4">
+          <div>
+            <h4 className="mb-2 flex items-center gap-2 text-sm font-semibold text-primary">
+              <UserPlus className="h-4 w-4" />
+              Élève
+            </h4>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+              {enrollmentType === "new" ? (
+                <>
+                  <dt className="text-muted-foreground">Nom</dt>
+                  <dd className="font-medium">
+                    {newValues.first_name} {newValues.last_name}
+                  </dd>
+                  <dt className="text-muted-foreground">Photo</dt>
+                  <dd>{photo ? "Prête à enregistrer" : "Non fournie"}</dd>
+                  {newValues.birth_date ? (
+                    <>
+                      <dt className="text-muted-foreground">Date de naissance</dt>
+                      <dd>{newValues.birth_date}</dd>
+                    </>
+                  ) : null}
+                  {newValues.genre ? (
+                    <>
+                      <dt className="text-muted-foreground">Genre</dt>
+                      <dd>{newValues.genre === "M" ? "Masculin" : "Féminin"}</dd>
+                    </>
+                  ) : null}
+                  {newValues.enrollment_number ? (
+                    <>
+                      <dt className="text-muted-foreground">Matricule</dt>
+                      <dd>{newValues.enrollment_number}</dd>
+                    </>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <dt className="text-muted-foreground">Nom</dt>
+                  <dd className="font-medium">
+                    {selectedStudent
+                      ? `${selectedStudent.first_name} ${selectedStudent.last_name}`
+                      : `#${reValues.student_id}`}
+                  </dd>
+                </>
+              )}
+            </dl>
+          </div>
+
+          {enrollmentType === "new" && showParentFields && newValues.parent ? (
+            <>
+              <Separator />
+              <div>
+                <h4 className="mb-2 text-sm font-semibold text-primary">Parent</h4>
+                <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                  <dt className="text-muted-foreground">Nom</dt>
+                  <dd>
+                    {newValues.parent.first_name} {newValues.parent.last_name}
+                  </dd>
+                  {newValues.parent.phone ? (
+                    <>
+                      <dt className="text-muted-foreground">Téléphone</dt>
+                      <dd>{newValues.parent.phone}</dd>
+                    </>
+                  ) : null}
+                  {newValues.parent.email ? (
+                    <>
+                      <dt className="text-muted-foreground">Email</dt>
+                      <dd>{newValues.parent.email}</dd>
+                    </>
+                  ) : null}
+                  <dt className="text-muted-foreground">Lien</dt>
+                  <dd>
+                    {RELATIONSHIP_TYPES.find((item) => item.value === newValues.parent?.relationship_type)?.label ?? "Tuteur"}
+                  </dd>
+                </dl>
+              </div>
+            </>
+          ) : null}
+
+          <Separator />
+
+          <div>
+            <h4 className="mb-2 flex items-center gap-2 text-sm font-semibold text-primary">
+              <GraduationCap className="h-4 w-4" />
+              Classe
+            </h4>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+              <dt className="text-muted-foreground">Classe</dt>
+              <dd className="font-medium">{selectedClassName || `#${watchedClassId}`}</dd>
+            </dl>
+          </div>
+
+          {feeVariants.length > 0 ? (
+            <>
+              <Separator />
+              <div>
+                <h4 className="mb-2 flex items-center gap-2 text-sm font-semibold text-primary">
+                  <CreditCard className="h-4 w-4" />
+                  Frais
+                </h4>
+                {mandatory.map((variant) => (
+                  <div key={variant.id} className="flex justify-between py-0.5 text-sm">
+                    <span className="text-muted-foreground">{variant.category_name ?? "Frais"}</span>
+                    <span className="font-mono">{formatXof(Number(variant.amount))}</span>
+                  </div>
+                ))}
+                {selectedFeeVariant && selectedFeeVariant.is_mandatory === false ? (
+                  <div className="flex justify-between py-0.5 text-sm">
+                    <span className="text-muted-foreground">{selectedFeeVariant.category_name ?? "Option"}</span>
+                    <span className="font-mono">{formatXof(Number(selectedFeeVariant.amount))}</span>
+                  </div>
+                ) : null}
+                <div className="mt-1 flex justify-between border-t border-border/50 pt-1 text-sm">
+                  <span className="font-semibold">Total</span>
+                  <span className="font-mono font-bold text-primary">{formatXof(total)}</span>
+                </div>
+              </div>
+            </>
+          ) : null}
+
+          {notes ? (
+            <>
+              <Separator />
+              <div>
+                <h4 className="mb-1 text-sm font-semibold text-muted-foreground">Notes</h4>
+                <p className="text-sm">{notes}</p>
+              </div>
+            </>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      {createError || reEnrollError ? (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
+          <p className="text-sm text-destructive">{createError || reEnrollError}</p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/forms/LoginForm.test.tsx
+++ b/components/forms/LoginForm.test.tsx
@@ -1,0 +1,66 @@
+﻿import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { LoginForm } from "@/components/forms/LoginForm"
+
+const push = vi.fn()
+const refresh = vi.fn()
+const signIn = vi.fn()
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  signIn: (...args: unknown[]) => signIn(...args),
+}))
+
+describe("LoginForm school code", () => {
+  beforeEach(() => {
+    push.mockReset()
+    refresh.mockReset()
+    signIn.mockReset()
+    document.cookie = "tenant_code=; max-age=0; path=/"
+    document.cookie = "school_code=; max-age=0; path=/"
+  })
+
+  it("sends the Rostan tenant when the school types ROSTAN", async () => {
+    signIn.mockResolvedValue({ error: undefined })
+    render(<LoginForm />)
+
+    fireEvent.change(screen.getByPlaceholderText("ROSTAN"), { target: { value: "ROSTAN" } })
+    fireEvent.change(screen.getByPlaceholderText("nom@etablissement.ci"), {
+      target: { value: "admin@rostan-bouake.ci" },
+    })
+    fireEvent.change(screen.getByPlaceholderText("Entrez votre mot de passe"), {
+      target: { value: "R0svHXt2znVDUPaC34!" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /Se connecter/i }))
+
+    await waitFor(() => {
+      expect(signIn).toHaveBeenCalledWith("credentials", {
+        email: "admin@rostan-bouake.ci",
+        password: "R0svHXt2znVDUPaC34!",
+        tenant_code: "rostan-bouake",
+        redirect: false,
+      })
+    })
+    expect(push).toHaveBeenCalledWith("/")
+  })
+
+  it("blocks an unknown school code", async () => {
+    render(<LoginForm />)
+
+    fireEvent.change(screen.getByPlaceholderText("ROSTAN"), { target: { value: "???" } })
+    fireEvent.change(screen.getByPlaceholderText("nom@etablissement.ci"), {
+      target: { value: "admin@rostan-bouake.ci" },
+    })
+    fireEvent.change(screen.getByPlaceholderText("Entrez votre mot de passe"), {
+      target: { value: "secret" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /Se connecter/i }))
+
+    expect(signIn).not.toHaveBeenCalled()
+    expect(await screen.findByText(/Code établissement inconnu/i)).toBeInTheDocument()
+  })
+})

--- a/components/forms/StudentForm.tsx
+++ b/components/forms/StudentForm.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { StudentCreateSchema, type StudentCreate } from "@/lib/contracts/student"
@@ -21,12 +22,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { StudentPhotoField } from "@/components/admin/students/photo/StudentPhotoField"
+import { useAttachStudentPhoto } from "@/lib/hooks/useStudentPhoto"
 
 interface StudentFormProps {
   onSuccess: () => void
 }
 
 export function StudentForm({ onSuccess }: StudentFormProps) {
+  const [photo, setPhoto] = useState<File | null>(null)
   const form = useForm<StudentCreate>({
     resolver: zodResolver(StudentCreateSchema),
     defaultValues: {
@@ -43,11 +47,14 @@ export function StudentForm({ onSuccess }: StudentFormProps) {
   })
 
   const { mutate, isPending, error } = useCreateStudent()
+  const attachPhoto = useAttachStudentPhoto()
 
   function onSubmit(data: StudentCreate) {
     mutate(data, {
-      onSuccess: () => {
+      onSuccess: async (student) => {
+        await attachPhoto.mutateAsync({ studentId: student.id, photo })
         form.reset()
+        setPhoto(null)
         onSuccess()
       },
     })
@@ -56,6 +63,8 @@ export function StudentForm({ onSuccess }: StudentFormProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+        <StudentPhotoField value={photo} onChange={setPhoto} disabled={isPending || attachPhoto.isPending} />
+
         <div className="grid grid-cols-2 gap-4">
           <FormField
             control={form.control}
@@ -204,8 +213,8 @@ export function StudentForm({ onSuccess }: StudentFormProps) {
           </div>
         )}
 
-        <Button type="submit" size="lg" className="w-full h-11 font-semibold" disabled={isPending}>
-          {isPending ? "Enregistrement..." : "Enregistrer l'élève"}
+        <Button type="submit" size="lg" className="w-full h-11 font-semibold" disabled={isPending || attachPhoto.isPending}>
+          {attachPhoto.isPending ? "Envoi de la photo..." : isPending ? "Enregistrement..." : "Enregistrer l'élève"}
         </Button>
       </form>
     </Form>

--- a/components/shared/CreateModal.tsx
+++ b/components/shared/CreateModal.tsx
@@ -13,12 +13,31 @@ interface CreateModalProps {
   title: string
   children: React.ReactNode
   className?: string
+  persistOnOutsideClick?: boolean
 }
 
-export function CreateModal({ open, onClose, title, children, className = "max-w-lg" }: CreateModalProps) {
+export function CreateModal({
+  open,
+  onClose,
+  title,
+  children,
+  className = "max-w-lg",
+  persistOnOutsideClick = false,
+}: CreateModalProps) {
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className={className} aria-describedby={undefined}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+    >
+      <DialogContent
+        className={className}
+        aria-describedby={undefined}
+        onPointerDownOutside={persistOnOutsideClick ? (event) => event.preventDefault() : undefined}
+        onInteractOutside={persistOnOutsideClick ? (event) => event.preventDefault() : undefined}
+        onFocusOutside={persistOnOutsideClick ? (event) => event.preventDefault() : undefined}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/lib/api/enrollments.ts
+++ b/lib/api/enrollments.ts
@@ -1,7 +1,7 @@
 import { EnrollmentSchema } from "@/lib/contracts/enrollment"
 import type { Enrollment, EnrollmentCreate, EnrollmentUpdate, NewEnrollment, ReEnrollment, FeeVariantOption } from "@/lib/contracts/enrollment"
 import { createCrudApi } from "./createCrudApi"
-import { apiFetch } from "./client"
+import { apiFetch, safeValidate } from "./client"
 
 export const enrollmentsApi = {
   ...createCrudApi<Enrollment, EnrollmentCreate, EnrollmentUpdate>(
@@ -11,10 +11,11 @@ export const enrollmentsApi = {
 
   createWithStudent: async (data: NewEnrollment) => {
     const { type, ...payload } = data
-    return apiFetch<Enrollment>("/enrollments/with-student", {
+    const res = await apiFetch<unknown>("/enrollments/with-student", {
       method: "POST",
       body: JSON.stringify(payload),
     })
+    return safeValidate(EnrollmentSchema, res, "POST /enrollments/with-student")
   },
 
   reEnroll: async (data: ReEnrollment) => {

--- a/lib/contracts/subject-group.ts
+++ b/lib/contracts/subject-group.ts
@@ -1,0 +1,8 @@
+import type { Subject } from "@/lib/contracts/subject"
+
+export interface SubjectGroup {
+  name: string
+  catalogue: Subject | null
+  instances: Subject[]
+  totalHours: number
+}

--- a/lib/enrollment/classCapacity.test.ts
+++ b/lib/enrollment/classCapacity.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { classCapacity, classCapacityLabel } from "./classCapacity"
+
+describe("classCapacity", () => {
+  it("shows remaining seats from max minus enrolled", () => {
+    expect(classCapacity({ enrolled_count: 32, max_students: 40 })).toEqual({
+      enrolled: 32,
+      max: 40,
+      available: 8,
+      full: false,
+    })
+  })
+
+  it("treats a class as full when enrolled reaches max", () => {
+    expect(classCapacity({ enrolled_count: 40, max_students: 40 }).full).toBe(true)
+    expect(classCapacityLabel("6e A", classCapacity({ enrolled_count: 40, max_students: 40 }))).toBe(
+      "6e A \u00b7 compl\u00e8te (40/40)",
+    )
+  })
+
+  it("keeps the class name only when capacity is unknown", () => {
+    expect(classCapacityLabel("6e A", classCapacity({ enrolled_count: 12, max_students: null }))).toBe("6e A")
+  })
+})

--- a/lib/enrollment/classCapacity.ts
+++ b/lib/enrollment/classCapacity.ts
@@ -1,0 +1,23 @@
+﻿import type { Class } from "@/lib/contracts/class"
+
+export interface ClassCapacity {
+  enrolled: number
+  max: number | null
+  available: number | null
+  full: boolean
+}
+
+export function classCapacity(cls: Pick<Class, "enrolled_count" | "max_students">): ClassCapacity {
+  const enrolled = cls.enrolled_count ?? 0
+  const max = cls.max_students ?? null
+  const available = max != null ? Math.max(0, max - enrolled) : null
+  return { enrolled, max, available, full: available === 0 }
+}
+
+export function classCapacityLabel(name: string, capacity: ClassCapacity): string {
+  const { enrolled, max, available, full } = capacity
+  if (available == null || max == null) return name
+  if (full) return `${name} · complète (${enrolled}/${max})`
+  const place = available > 1 ? "places" : "place"
+  return `${name} · ${available} ${place} (${enrolled}/${max})`
+}

--- a/lib/hooks/useKanbanAutoScroll.ts
+++ b/lib/hooks/useKanbanAutoScroll.ts
@@ -1,0 +1,70 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState, type DragEvent as ReactDragEvent } from "react"
+import { computeKanbanScrollDeltas } from "@/lib/utils/kanban-auto-scroll"
+
+function listUnderPointer(x: number, y: number, root: ParentNode | null): HTMLElement | null {
+  const lists = (root ?? document).querySelectorAll<HTMLElement>("[data-kanban-scroll]")
+  for (const list of lists) {
+    const rect = list.getBoundingClientRect()
+    if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+      return list
+    }
+  }
+  return null
+}
+
+export function useKanbanAutoScroll() {
+  const boardRef = useRef<HTMLDivElement>(null)
+  const catalogueRef = useRef<HTMLDivElement>(null)
+  const pointerRef = useRef({ x: 0, y: 0 })
+  const [isDragging, setIsDragging] = useState(false)
+
+  const start = useCallback((event?: ReactDragEvent) => {
+    if (event) pointerRef.current = { x: event.clientX, y: event.clientY }
+    setIsDragging(true)
+  }, [])
+  const stop = useCallback(() => setIsDragging(false), [])
+
+  useEffect(() => {
+    if (!isDragging) return
+
+    const onDragOver = (event: DragEvent) => {
+      event.preventDefault()
+      pointerRef.current = { x: event.clientX, y: event.clientY }
+    }
+    const onEnd = () => stop()
+
+    document.addEventListener("dragover", onDragOver)
+    document.addEventListener("dragend", onEnd)
+    window.addEventListener("drop", onEnd)
+
+    let frame = 0
+    const loop = () => {
+      const board = boardRef.current
+      if (board) {
+        const list = listUnderPointer(pointerRef.current.x, pointerRef.current.y, board)
+        const { x, y } = computeKanbanScrollDeltas({
+          pointerX: pointerRef.current.x,
+          pointerY: pointerRef.current.y,
+          viewportWidth: window.innerWidth,
+          leftBoundaryX: catalogueRef.current?.getBoundingClientRect().right ?? 0,
+          listRect: list?.getBoundingClientRect() ?? null,
+        })
+        if (x) board.scrollLeft += x
+        if (y && list) list.scrollTop += y
+      }
+      frame = window.requestAnimationFrame(loop)
+    }
+    frame = window.requestAnimationFrame(loop)
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+      document.removeEventListener("dragover", onDragOver)
+      document.removeEventListener("dragend", onEnd)
+      window.removeEventListener("drop", onEnd)
+    }
+  }, [isDragging, stop])
+
+  return { boardRef, catalogueRef, isDragging, start, stop }
+}

--- a/lib/hooks/useLiveCamera.ts
+++ b/lib/hooks/useLiveCamera.ts
@@ -1,0 +1,95 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  CameraCaptureError,
+  canUseLiveCamera,
+  captureVideoFrame,
+  mapCameraError,
+  openUserCamera,
+  stopMediaStream,
+} from "@/lib/photo/camera"
+
+export type LiveCameraStatus = "idle" | "requesting" | "live" | "error"
+
+export function useLiveCamera() {
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const sessionRef = useRef(0)
+  const [status, setStatus] = useState<LiveCameraStatus>("idle")
+  const [error, setError] = useState<CameraCaptureError | null>(null)
+  const available = canUseLiveCamera()
+
+  const releaseStream = useCallback(() => {
+    stopMediaStream(streamRef.current)
+    streamRef.current = null
+    if (videoRef.current) {
+      videoRef.current.srcObject = null
+    }
+  }, [])
+
+  const stop = useCallback(() => {
+    sessionRef.current += 1
+    releaseStream()
+    setStatus("idle")
+  }, [releaseStream])
+
+  const fail = useCallback((caught: unknown, session: number) => {
+    if (session !== sessionRef.current) return
+    releaseStream()
+    const mapped = mapCameraError(caught)
+    setError(mapped)
+    setStatus("error")
+  }, [releaseStream])
+
+  const start = useCallback(async () => {
+    stop()
+    setError(null)
+    setStatus("requesting")
+    const session = sessionRef.current
+    try {
+      const stream = await openUserCamera()
+      if (session !== sessionRef.current) {
+        stopMediaStream(stream)
+        return
+      }
+      streamRef.current = stream
+      const video = videoRef.current
+      if (video) {
+        video.srcObject = stream
+        video.muted = true
+        video.playsInline = true
+        await video.play()
+      }
+      if (session !== sessionRef.current) {
+        stopMediaStream(stream)
+        streamRef.current = null
+        return
+      }
+      setStatus("live")
+    } catch (caught) {
+      fail(caught, session)
+    }
+  }, [fail, stop])
+
+  const capture = useCallback(async () => {
+    const session = sessionRef.current
+    const video = videoRef.current
+    if (!video) {
+      fail(new Error("preview missing"), session)
+      return null
+    }
+    try {
+      const file = await captureVideoFrame(video)
+      stop()
+      return file
+    } catch (caught) {
+      fail(caught, session)
+      return null
+    }
+  }, [fail, stop])
+
+  useEffect(() => stop, [stop])
+
+  return { available, videoRef, status, error, start, stop, capture }
+}

--- a/lib/hooks/useStudentPhoto.ts
+++ b/lib/hooks/useStudentPhoto.ts
@@ -1,0 +1,27 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { studentKeys } from "@/lib/hooks/useStudents"
+import { photoOutcomeMessage, uploadStudentAvatar } from "@/lib/photo/uploadStudentAvatar"
+import type { PhotoSaveOutcome } from "@/lib/photo/uploadStudentAvatar"
+
+export function useAttachStudentPhoto() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ studentId, photo }: { studentId?: number; photo: File | null }) =>
+      uploadStudentAvatar(studentId, photo),
+    onSuccess: async (outcome: PhotoSaveOutcome, variables) => {
+      const message = photoOutcomeMessage(outcome)
+      if (outcome === "saved") {
+        await queryClient.invalidateQueries({ queryKey: studentKeys.all })
+        if (variables.studentId) {
+          await queryClient.invalidateQueries({ queryKey: studentKeys.detail(variables.studentId) })
+        }
+        if (message) toast.success(message)
+      }
+      if (outcome === "failed" && message) toast.error(message)
+    },
+  })
+}

--- a/lib/photo/camera.test.ts
+++ b/lib/photo/camera.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  CameraCaptureError,
+  canUseLiveCamera,
+  mapCameraError,
+  stopMediaStream,
+  validatePhotoFile,
+} from "./camera"
+import { photoOutcomeMessage, uploadStudentAvatar } from "./uploadStudentAvatar"
+
+describe("camera helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("refuses live camera outside a secure context", () => {
+    vi.stubGlobal("window", { isSecureContext: false })
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: vi.fn() } })
+    expect(canUseLiveCamera()).toBe(false)
+    expect(mapCameraError(new Error("nope")).code).toBe("insecure")
+  })
+
+  it("maps a permission denial to a French recovery message", () => {
+    vi.stubGlobal("window", { isSecureContext: true })
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: vi.fn() } })
+    const error = mapCameraError(new DOMException("denied", "NotAllowedError"))
+    expect(error).toBeInstanceOf(CameraCaptureError)
+    expect(error.code).toBe("denied")
+    expect(error.message).toMatch(/Autorisez la caméra|importez une photo/i)
+  })
+
+  it("stops every media track", () => {
+    const stop = vi.fn()
+    stopMediaStream({ getTracks: () => [{ stop }, { stop }] } as unknown as MediaStream)
+    expect(stop).toHaveBeenCalledTimes(2)
+  })
+
+  it("rejects unsupported photo types and oversized files", () => {
+    expect(validatePhotoFile(new File(["x"], "notes.pdf", { type: "application/pdf" }))).toMatch(/JPEG/)
+    const huge = new File([new Uint8Array(5 * 1024 * 1024 + 1)], "face.jpg", { type: "image/jpeg" })
+    expect(validatePhotoFile(huge)).toMatch(/5 Mo/)
+    expect(validatePhotoFile(new File(["ok"], "face.jpg", { type: "image/jpeg" }))).toBeNull()
+  })
+})
+
+describe("uploadStudentAvatar", () => {
+  it("skips upload when no photo was captured", async () => {
+    await expect(uploadStudentAvatar(12, null)).resolves.toBe("none")
+  })
+
+  it("fails closed when the student id is missing after create", async () => {
+    await expect(uploadStudentAvatar(undefined, new File(["x"], "a.jpg", { type: "image/jpeg" }))).resolves.toBe("failed")
+    expect(photoOutcomeMessage("failed")).toMatch(/fiche élève/i)
+  })
+
+  it("returns failed when the photo upload rejects", async () => {
+    const { studentsApi } = await import("@/lib/api/students")
+    vi.spyOn(studentsApi, "uploadPhoto").mockRejectedValueOnce(new Error("Upload failed"))
+    await expect(
+      uploadStudentAvatar(12, new File(["x"], "a.jpg", { type: "image/jpeg" })),
+    ).resolves.toBe("failed")
+  })
+
+  it("returns saved when the photo upload succeeds", async () => {
+    const { studentsApi } = await import("@/lib/api/students")
+    vi.spyOn(studentsApi, "uploadPhoto").mockResolvedValueOnce({ photo_url: "/uploads/a.jpg" })
+    await expect(
+      uploadStudentAvatar(12, new File(["x"], "a.jpg", { type: "image/jpeg" })),
+    ).resolves.toBe("saved")
+  })
+})

--- a/lib/photo/camera.ts
+++ b/lib/photo/camera.ts
@@ -1,0 +1,146 @@
+export type CameraErrorCode =
+  | "insecure"
+  | "unsupported"
+  | "denied"
+  | "not_found"
+  | "busy"
+  | "unknown"
+
+export class CameraCaptureError extends Error {
+  readonly code: CameraErrorCode
+
+  constructor(code: CameraErrorCode, message: string) {
+    super(message)
+    this.name = "CameraCaptureError"
+    this.code = code
+  }
+}
+
+export function isSecureCameraContext(): boolean {
+  if (typeof window === "undefined") return false
+  return window.isSecureContext === true
+}
+
+export function canUseLiveCamera(): boolean {
+  return (
+    isSecureCameraContext() &&
+    typeof navigator !== "undefined" &&
+    Boolean(navigator.mediaDevices?.getUserMedia)
+  )
+}
+
+export function stopMediaStream(stream: MediaStream | null | undefined): void {
+  if (!stream) return
+  for (const track of stream.getTracks()) {
+    track.stop()
+  }
+}
+
+export function mapCameraError(error: unknown): CameraCaptureError {
+  if (error instanceof CameraCaptureError) return error
+
+  if (!isSecureCameraContext()) {
+    return new CameraCaptureError(
+      "insecure",
+      "La caméra nécessite une connexion sécurisée. Importez une photo ou ouvrez le site en HTTPS.",
+    )
+  }
+
+  if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+    return new CameraCaptureError(
+      "unsupported",
+      "Ce téléphone ne permet pas d'ouvrir la caméra ici. Importez une photo depuis la galerie.",
+    )
+  }
+
+  const name = error instanceof DOMException ? error.name : ""
+  if (name === "NotAllowedError" || name === "PermissionDeniedError" || name === "SecurityError") {
+    return new CameraCaptureError(
+      "denied",
+      "Accès caméra refusé. Autorisez la caméra dans les réglages du navigateur, ou importez une photo.",
+    )
+  }
+  if (name === "NotFoundError" || name === "OverconstrainedError" || name === "DevicesNotFoundError") {
+    return new CameraCaptureError(
+      "not_found",
+      "Aucune caméra n'est disponible. Importez une photo depuis la galerie.",
+    )
+  }
+  if (name === "NotReadableError" || name === "TrackStartError" || name === "AbortError") {
+    return new CameraCaptureError(
+      "busy",
+      "La caméra est occupée par une autre application. Fermez-la, puis réessayez.",
+    )
+  }
+
+  return new CameraCaptureError(
+    "unknown",
+    "Impossible d'ouvrir la caméra. Réessayez ou importez une photo.",
+  )
+}
+
+export async function openUserCamera(): Promise<MediaStream> {
+  if (!canUseLiveCamera()) {
+    throw mapCameraError(new Error("camera unavailable"))
+  }
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: false,
+      video: {
+        facingMode: { ideal: "user" },
+        width: { ideal: 720 },
+        height: { ideal: 720 },
+      },
+    })
+  } catch (error) {
+    throw mapCameraError(error)
+  }
+}
+
+const MAX_CAPTURE_EDGE = 960
+
+export async function captureVideoFrame(video: HTMLVideoElement): Promise<File> {
+  const sourceWidth = video.videoWidth
+  const sourceHeight = video.videoHeight
+  if (!sourceWidth || !sourceHeight) {
+    throw new CameraCaptureError("unknown", "L'aperçu caméra n'est pas prêt. Réessayez.")
+  }
+
+  const scale = Math.min(1, MAX_CAPTURE_EDGE / Math.max(sourceWidth, sourceHeight))
+  const width = Math.round(sourceWidth * scale)
+  const height = Math.round(sourceHeight * scale)
+  const canvas = document.createElement("canvas")
+  canvas.width = width
+  canvas.height = height
+  const context = canvas.getContext("2d")
+  if (!context) {
+    throw new CameraCaptureError("unknown", "Impossible de capturer la photo. Importez un fichier.")
+  }
+  context.drawImage(video, 0, 0, width, height)
+
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (result) => {
+        if (result) resolve(result)
+        else reject(new CameraCaptureError("unknown", "La photo n'a pas pu être enregistrée."))
+      },
+      "image/jpeg",
+      0.86,
+    )
+  })
+
+  return new File([blob], `eleve-${Date.now()}.jpg`, { type: "image/jpeg" })
+}
+
+const ALLOWED_PHOTO_TYPES = new Set(["image/jpeg", "image/png", "image/webp"])
+const MAX_PHOTO_BYTES = 5 * 1024 * 1024
+
+export function validatePhotoFile(file: File): string | null {
+  if (!ALLOWED_PHOTO_TYPES.has(file.type)) {
+    return "Format invalide. Utilisez une photo JPEG, PNG ou WebP."
+  }
+  if (file.size > MAX_PHOTO_BYTES) {
+    return "Cette photo dépasse 5 Mo. Choisissez une image plus légère."
+  }
+  return null
+}

--- a/lib/photo/uploadStudentAvatar.ts
+++ b/lib/photo/uploadStudentAvatar.ts
@@ -1,0 +1,25 @@
+import { studentsApi } from "@/lib/api/students"
+
+export type PhotoSaveOutcome = "none" | "saved" | "failed"
+
+export async function uploadStudentAvatar(
+  studentId: number | undefined,
+  photo: File | null,
+): Promise<PhotoSaveOutcome> {
+  if (!photo) return "none"
+  if (!studentId) return "failed"
+  try {
+    await studentsApi.uploadPhoto(studentId, photo)
+    return "saved"
+  } catch {
+    return "failed"
+  }
+}
+
+export function photoOutcomeMessage(outcome: PhotoSaveOutcome): string | null {
+  if (outcome === "saved") return "Photo enregistrée sur le profil."
+  if (outcome === "failed") {
+    return "Fiche créée, mais la photo n'a pas pu être enregistrée. Réessayez depuis la fiche élève."
+  }
+  return null
+}

--- a/lib/utils/allowed-hosts.ts
+++ b/lib/utils/allowed-hosts.ts
@@ -33,7 +33,7 @@ const EXTRA_ALLOWED_HOSTS = (process.env.NEXT_PUBLIC_EXTRA_ALLOWED_HOSTS ?? "")
  *   - hostnames matchant le pattern (ex: lycee-x.college.klassci.com)
  *   - hostnames listés explicitement dans EXTRA_ALLOWED_HOSTS
  *   - hôtes locaux (localhost, 127.0.0.1) en dev
- *   - IPs numériques (16.58.132.68) en dev
+ *   - IPs numériques (94.72.96.119) en démo
  */
 export function isHostAllowed(hostname: string): boolean {
   if (LOCAL_HOSTS.has(hostname)) return true

--- a/lib/utils/kanban-auto-scroll.test.ts
+++ b/lib/utils/kanban-auto-scroll.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import {
+  EDGE_ZONE_PX,
+  MAX_SCROLL_PX,
+  MIN_SCROLL_PX,
+  computeKanbanScrollDeltas,
+} from "./kanban-auto-scroll"
+
+const VIEWPORT = 1000
+const LEFT_BOUNDARY = 300
+const LIST = { left: 320, right: 520, top: 100, bottom: 500 }
+
+describe("computeKanbanScrollDeltas", () => {
+  it("returns no delta at the center of the board", () => {
+    expect(
+      computeKanbanScrollDeltas({
+        pointerX: 600,
+        pointerY: 300,
+        viewportWidth: VIEWPORT,
+        leftBoundaryX: LEFT_BOUNDARY,
+        listRect: LIST,
+      }),
+    ).toEqual({ x: 0, y: 0 })
+  })
+
+  it("scrolls right at the window edge and faster when closer to it", () => {
+    const inner = computeKanbanScrollDeltas({
+      pointerX: VIEWPORT - EDGE_ZONE_PX,
+      pointerY: 300,
+      viewportWidth: VIEWPORT,
+      leftBoundaryX: LEFT_BOUNDARY,
+      listRect: null,
+    })
+    const outer = computeKanbanScrollDeltas({
+      pointerX: VIEWPORT,
+      pointerY: 300,
+      viewportWidth: VIEWPORT,
+      leftBoundaryX: LEFT_BOUNDARY,
+      listRect: null,
+    })
+
+    expect(inner.x).toBe(MIN_SCROLL_PX)
+    expect(outer.x).toBe(MAX_SCROLL_PX)
+    expect(inner.y).toBe(0)
+    expect(outer.y).toBe(0)
+  })
+
+  it("scrolls left only at the catalogue / levels frontier", () => {
+    const inner = computeKanbanScrollDeltas({
+      pointerX: LEFT_BOUNDARY + EDGE_ZONE_PX,
+      pointerY: 300,
+      viewportWidth: VIEWPORT,
+      leftBoundaryX: LEFT_BOUNDARY,
+      listRect: null,
+    })
+    const outer = computeKanbanScrollDeltas({
+      pointerX: LEFT_BOUNDARY,
+      pointerY: 300,
+      viewportWidth: VIEWPORT,
+      leftBoundaryX: LEFT_BOUNDARY,
+      listRect: null,
+    })
+    const overCatalogue = computeKanbanScrollDeltas({
+      pointerX: LEFT_BOUNDARY - 1,
+      pointerY: 300,
+      viewportWidth: VIEWPORT,
+      leftBoundaryX: LEFT_BOUNDARY,
+      listRect: null,
+    })
+
+    expect(inner.x).toBe(-MIN_SCROLL_PX)
+    expect(outer.x).toBe(-MAX_SCROLL_PX)
+    expect(overCatalogue.x).toBe(0)
+  })
+
+  it("scrolls a column vertically only when the pointer is in its top or bottom band", () => {
+    const top = computeKanbanScrollDeltas({
+      pointerX: 400,
+      pointerY: LIST.top,
+      viewportWidth: VIEWPORT,
+      leftBoundaryX: LEFT_BOUNDARY,
+      listRect: LIST,
+    })
+    const bottom = computeKanbanScrollDeltas({
+      pointerX: 400,
+      pointerY: LIST.bottom,
+      viewportWidth: VIEWPORT,
+      leftBoundaryX: LEFT_BOUNDARY,
+      listRect: LIST,
+    })
+    const outsideX = computeKanbanScrollDeltas({
+      pointerX: LIST.right + 10,
+      pointerY: LIST.top,
+      viewportWidth: VIEWPORT,
+      leftBoundaryX: LEFT_BOUNDARY,
+      listRect: LIST,
+    })
+
+    expect(top.y).toBe(-MAX_SCROLL_PX)
+    expect(bottom.y).toBe(MAX_SCROLL_PX)
+    expect(outsideX.y).toBe(0)
+  })
+})

--- a/lib/utils/kanban-auto-scroll.ts
+++ b/lib/utils/kanban-auto-scroll.ts
@@ -1,0 +1,69 @@
+export const EDGE_ZONE_PX = 64
+export const MIN_SCROLL_PX = 8
+export const MAX_SCROLL_PX = 28
+
+export interface ScrollRect {
+  left: number
+  right: number
+  top: number
+  bottom: number
+}
+
+export interface KanbanScrollInput {
+  pointerX: number
+  pointerY: number
+  viewportWidth: number
+  leftBoundaryX: number
+  listRect: ScrollRect | null
+}
+
+function speedFromInnerEdge(distanceFromInner: number): number {
+  const t = Math.min(Math.max(distanceFromInner, 0) / EDGE_ZONE_PX, 1)
+  return MIN_SCROLL_PX + t * (MAX_SCROLL_PX - MIN_SCROLL_PX)
+}
+
+export function computeHorizontalDelta(
+  pointerX: number,
+  viewportWidth: number,
+  leftBoundaryX: number,
+): number {
+  const rightInner = viewportWidth - EDGE_ZONE_PX
+  if (pointerX >= rightInner) {
+    return speedFromInnerEdge(pointerX - rightInner)
+  }
+
+  const leftInner = leftBoundaryX + EDGE_ZONE_PX
+  if (pointerX >= leftBoundaryX && pointerX <= leftInner) {
+    return -speedFromInnerEdge(leftInner - pointerX)
+  }
+
+  return 0
+}
+
+export function computeVerticalDelta(
+  pointerX: number,
+  pointerY: number,
+  listRect: ScrollRect | null,
+): number {
+  if (!listRect) return 0
+  if (pointerX < listRect.left || pointerX > listRect.right) return 0
+  if (pointerY < listRect.top || pointerY > listRect.bottom) return 0
+
+  const topInner = listRect.top + EDGE_ZONE_PX
+  const bottomInner = listRect.bottom - EDGE_ZONE_PX
+  const inTop = pointerY <= topInner
+  const inBottom = pointerY >= bottomInner
+
+  const topSpeed = inTop ? speedFromInnerEdge(topInner - pointerY) : 0
+  const bottomSpeed = inBottom ? speedFromInnerEdge(pointerY - bottomInner) : 0
+
+  if (topSpeed >= bottomSpeed) return topSpeed ? -topSpeed : 0
+  return bottomSpeed
+}
+
+export function computeKanbanScrollDeltas(input: KanbanScrollInput): { x: number; y: number } {
+  return {
+    x: computeHorizontalDelta(input.pointerX, input.viewportWidth, input.leftBoundaryX),
+    y: computeVerticalDelta(input.pointerX, input.pointerY, input.listRect),
+  }
+}

--- a/lib/utils/subject-assignment.test.ts
+++ b/lib/utils/subject-assignment.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import {
+  firstFreeSeriesSlot,
+  isLevelAssignable,
+  isSeriesSlotTaken,
+} from "./subject-assignment"
+
+describe("subject assignment occupancy", () => {
+  it("blocks a level without series once any instance exists", () => {
+    expect(isLevelAssignable([], [])).toBe(true)
+    expect(isLevelAssignable([{ level_id: 1, series_id: null }], [])).toBe(false)
+  })
+
+  it("keeps a series level open while a slot is still free", () => {
+    const series = [{ id: 10 }, { id: 11 }]
+    const takenA = [{ level_id: 2, series_id: 10 }]
+
+    expect(isLevelAssignable(takenA, series)).toBe(true)
+    expect(isSeriesSlotTaken(takenA, 10)).toBe(true)
+    expect(isSeriesSlotTaken(takenA, 11)).toBe(false)
+    expect(isSeriesSlotTaken(takenA, null)).toBe(false)
+    expect(firstFreeSeriesSlot(takenA, series)).toBe(null)
+  })
+
+  it("blocks a series level only when every slot is taken", () => {
+    const series = [{ id: 10 }, { id: 11 }]
+    const full = [
+      { level_id: 2, series_id: null },
+      { level_id: 2, series_id: 10 },
+      { level_id: 2, series_id: 11 },
+    ]
+
+    expect(isLevelAssignable(full, series)).toBe(false)
+    expect(firstFreeSeriesSlot(full, series)).toBeUndefined()
+  })
+
+  it("picks the first free series when Toutes series is taken", () => {
+    const series = [{ id: 10 }, { id: 11 }]
+    const takenAll = [{ level_id: 2, series_id: null }]
+    expect(firstFreeSeriesSlot(takenAll, series)).toBe(10)
+  })
+})

--- a/lib/utils/subject-assignment.ts
+++ b/lib/utils/subject-assignment.ts
@@ -1,0 +1,40 @@
+export interface AssignableSeries {
+  id: number
+}
+
+export interface AssignableInstance {
+  level_id: number | null
+  series_id: number | null
+}
+
+export function instancesForLevel(
+  instances: AssignableInstance[],
+  levelId: number,
+): AssignableInstance[] {
+  return instances.filter((instance) => instance.level_id === levelId)
+}
+
+export function isSeriesSlotTaken(
+  levelInstances: AssignableInstance[],
+  seriesId: number | null,
+): boolean {
+  return levelInstances.some((instance) => instance.series_id === seriesId)
+}
+
+export function seriesSlots(series: AssignableSeries[]): Array<number | null> {
+  return series.length === 0 ? [null] : [null, ...series.map((item) => item.id)]
+}
+
+export function isLevelAssignable(
+  levelInstances: AssignableInstance[],
+  series: AssignableSeries[],
+): boolean {
+  return seriesSlots(series).some((slot) => !isSeriesSlotTaken(levelInstances, slot))
+}
+
+export function firstFreeSeriesSlot(
+  levelInstances: AssignableInstance[],
+  series: AssignableSeries[],
+): number | null | undefined {
+  return seriesSlots(series).find((slot) => !isSeriesSlotTaken(levelInstances, slot))
+}

--- a/lib/utils/subject-groups.ts
+++ b/lib/utils/subject-groups.ts
@@ -1,0 +1,75 @@
+import type { Subject } from "@/lib/contracts/subject"
+import type { SubjectGroup } from "@/lib/contracts/subject-group"
+
+interface LevelOrder {
+  id: number
+  order?: number
+}
+
+export function groupSubjects(subjects: Subject[], levels: LevelOrder[]): SubjectGroup[] {
+  const levelOrder = new Map(levels.map((level, index) => [level.id, level.order ?? index]))
+  const map = new Map<string, SubjectGroup>()
+
+  for (const subject of subjects) {
+    const existing = map.get(subject.name)
+    const isCatalogue = subject.level_id === null
+
+    if (!existing) {
+      map.set(subject.name, {
+        name: subject.name,
+        catalogue: isCatalogue ? subject : null,
+        instances: isCatalogue ? [] : [subject],
+        totalHours: isCatalogue ? 0 : subject.hours_per_week,
+      })
+    } else if (isCatalogue) {
+      existing.catalogue = subject
+    } else {
+      existing.instances.push(subject)
+      existing.totalHours += subject.hours_per_week
+    }
+  }
+
+  for (const group of map.values()) {
+    group.instances.sort(
+      (a, b) => (levelOrder.get(a.level_id ?? 0) ?? 99) - (levelOrder.get(b.level_id ?? 0) ?? 99),
+    )
+  }
+
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name, "fr"))
+}
+
+export function filterSubjectGroups(
+  groups: SubjectGroup[],
+  query: string,
+  levelFilter: string,
+  teacherFilter: string,
+): SubjectGroup[] {
+  const needle = query.trim().toLowerCase()
+  return groups.filter((group) => {
+    if (needle) {
+      const matchName = group.name.toLowerCase().includes(needle)
+      const matchTeacher = group.instances.some((inst) =>
+        inst.teacher_name?.toLowerCase().includes(needle),
+      )
+      if (!matchName && !matchTeacher) return false
+    }
+
+    if (levelFilter === "catalogue") {
+      if (group.catalogue === null) return false
+    } else if (levelFilter !== "all") {
+      const lid = Number(levelFilter)
+      if (!group.instances.some((inst) => inst.level_id === lid)) return false
+    }
+
+    if (teacherFilter === "with") {
+      if (!group.instances.some((inst) => inst.teacher_id !== null && inst.teacher_id !== undefined)) {
+        return false
+      }
+    } else if (teacherFilter === "without") {
+      if (group.instances.length === 0) return false
+      if (!group.instances.some((inst) => !inst.teacher_id)) return false
+    }
+
+    return true
+  })
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -55,9 +55,10 @@ const SECURITY_HEADERS = [
     // micro pour NOTRE origine. `microphone=()` le bloquait au niveau document,
     // AU-DESSUS de la permission utilisateur → `not-allowed` partout. `(self)`
     // est le défaut navigateur (origine propre seulement, pas les iframes tiers).
-    // camera / geolocation restent bloqués (non utilisés).
+    // camera=(self) : prise de photo à l'inscription (caméra frontale).
+    // geolocation reste bloquée.
     key: 'Permissions-Policy',
-    value: 'camera=(), microphone=(self), geolocation=(), interest-cohort=()',
+    value: 'camera=(self), microphone=(self), geolocation=(), interest-cohort=()',
   },
 ];
 


### PR DESCRIPTION
## Ce que ca change

**Inscription eleve**
- Prise de photo directe (camera, apercu, reprise) avec import de fichier en repli, envoyee sur le profil apres creation. Etats permission refusee / chargement / erreur / succes couverts.
- `Permissions-Policy` passe a `camera=(self)` : sans ca la camera etait bloquee au niveau document, au-dessus de la permission utilisateur.
- Le modal "Nouvelle inscription" ne se ferme plus au clic exterieur : la saisie n'est plus perdue.
- Etape eleve et selection de classe lisibles sur telephone, cibles tactiles h-11. La liste des classes affiche les places restantes, plus seulement le maximum.

**Refactor (no-god-code)**
- `EnrollmentForm` : 942 -> 445 lignes (etapes eleve / classe / parents / recapitulatif extraites).
- `SubjectsKanbanView` : 517 -> 194 lignes, `SubjectsTable` : ~350 -> 189 (colonnes, cartes, toolbar, actions, modal d'affectation extraits).
- Logique metier sortie dans `lib/enrollment`, `lib/photo`, `lib/utils` avec tests unitaires.

**Deploiement**
- Dockerfile multi-stage + `.dockerignore` pour la production Contabo (build d'image hors conteneur live, puis recreate).
- Regle de deploiement mise a jour : demo Windows native, production Contabo.

## Verification

- `tsc --noEmit` : OK
- `next lint` : aucune erreur (warnings preexistants seulement)
- `vitest run` : 44 tests / 8 fichiers, tous verts (dont `camera.test.ts`, `classCapacity.test.ts`, `subject-assignment.test.ts`, `kanban-auto-scroll.test.ts`)

## Contrat API

`enrollmentsApi.createWithStudent` valide desormais la reponse via `safeValidate` au lieu d'un cast.