### PR TITLE
fix(inscriptions): eviter le debordement des actions photo

### DIFF
--- a/components/admin/students/photo/StudentPhotoField.tsx
+++ b/components/admin/students/photo/StudentPhotoField.tsx
@@ -64,7 +64,7 @@ export function StudentPhotoField({ value, onChange, disabled = false }: Student
               ? "Ouvrez la caméra, vérifiez l'aperçu, puis enregistrez. L'import reste disponible."
               : "La caméra n'est pas disponible ici. Importez une photo JPEG, PNG ou WebP."}
           </p>
-          <div className="flex flex-col gap-2 sm:flex-row">
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
             <Button
               type="button"
               className="h-11"


### PR DESCRIPTION
Constate au test E2E sur le serveur de demo (http://94.72.96.119/admin/enrollments, etape Eleve du wizard).

Sur HTTP la camera live est indisponible, donc trois boutons sont rendus : `Prendre une photo` (desactive), `Ouvrir l'appareil`, `Importer une photo`. Dans le modal `max-w-2xl` la rangee `sm:flex-row` depassait la largeur disponible : `Importer une photo` etait coupe et une barre de defilement horizontale apparaissait dans le modal.

Sur HTTPS (production Contabo) seuls deux boutons sont rendus, donc le probleme ne s'y voyait pas.

Correctif : `sm:flex-wrap` sur la rangee, les boutons reviennent a la ligne au lieu de deborder.

`tsc --noEmit` : OK.