### PR TITLE
feat(staff): six roles metier au selecteur d'acces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Fiche Personnel : le rôle d'accès propose désormais six métiers (secrétariat, caissier, éducateur, comptable, directeur des études, directeur), chacun accompagné d'une phrase qui dit ce que la personne pourra faire. « Personnel administratif » devient « Secrétariat » *(admin, directeur)*.
 - Wizard Nouvelle inscription : le modal ne se ferme plus si on appuie hors du cadre (la saisie n'est plus perdue). L'étape élève et la sélection de classe sont lisibles sur téléphone, avec des boutons assez grands. La liste des classes montre les places encore disponibles, pas seulement le maximum *(admin)*.
 - Publication Windows : le frontend standalone est désormais compilé hors production par la CI puis livré comme artefact versionné.
 - Déploiement : l'ancien workflow EC2 est retiré. La démo reste sur le serveur Windows, la production vise le VPS Contabo (artefact + restart, aucun build sur le serveur).

--- a/components/admin/leave/LeaveManagementClient.tsx
+++ b/components/admin/leave/LeaveManagementClient.tsx
@@ -24,15 +24,22 @@ import {
 import { useLeaveRequests, useReviewLeaveRequest, useSetInterim } from "@/lib/hooks/useLeave"
 import { useTeachers } from "@/lib/hooks/useTeachers"
 import { leaveTypeLabel } from "@/lib/contracts/leave"
+import { staffRoleLabel } from "@/lib/contracts/staff"
 import { LeaveStatusBadge, formatDateRange, dayCount } from "@/components/shared/leave/leave-ui"
 import { cn } from "@/lib/utils"
 
-const ROLE_LABELS: Record<string, string> = {
+// Rôles qui ne sont pas assignables depuis la fiche Personnel. Tous les autres
+// (secrétariat, caissier, éducateur, comptable, directeur des études, directeur)
+// sont libellés par staffRoleLabel : une seule source de vérité, sinon un
+// nouveau rôle s'affiche ici sous son slug technique.
+const NON_STAFF_ROLE_LABELS: Record<string, string> = {
   teacher: "Enseignant",
-  staff: "Personnel",
   admin: "Administrateur",
-  director: "Directeur",
-  accountant: "Comptable",
+}
+
+function requesterRoleLabel(role?: string | null): string {
+  if (!role) return "—"
+  return NON_STAFF_ROLE_LABELS[role] ?? staffRoleLabel(role)
 }
 
 const FILTERS = [
@@ -114,7 +121,7 @@ export function LeaveManagementClient() {
                     <div className="flex flex-wrap items-center gap-2">
                       <p className="font-medium">{r.requester_name ?? "—"}</p>
                       <span className="text-xs text-muted-foreground">
-                        {ROLE_LABELS[r.requester_role ?? ""] ?? r.requester_role ?? ""}
+                        {requesterRoleLabel(r.requester_role)}
                       </span>
                       <LeaveStatusBadge status={r.status} />
                     </div>

--- a/components/admin/staff/StaffEditModal.tsx
+++ b/components/admin/staff/StaffEditModal.tsx
@@ -2,7 +2,8 @@
 
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { StaffUpdateSchema, STAFF_ROLE_OPTIONS, type StaffUpdate } from "@/lib/contracts/staff"
+import { StaffUpdateSchema, type StaffUpdate } from "@/lib/contracts/staff"
+import { StaffRoleOptions } from "./StaffRoleOptions"
 import { useStaffMember, useUpdateStaff } from "@/lib/hooks/useStaff"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
@@ -135,11 +136,7 @@ function EditForm({ staffId, onClose }: { staffId: number; onClose: () => void }
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {STAFF_ROLE_OPTIONS.map((o) => (
-                    <SelectItem key={o.value} value={o.value}>
-                      {o.label}
-                    </SelectItem>
-                  ))}
+                  <StaffRoleOptions />
                 </SelectContent>
               </Select>
               <FormMessage />

--- a/components/admin/staff/StaffRoleOptions.tsx
+++ b/components/admin/staff/StaffRoleOptions.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { SelectItem } from "@/components/ui/select"
+import { STAFF_ROLE_OPTIONS } from "@/lib/contracts/staff"
+
+/**
+ * Options du sélecteur de rôle d'accès, partagées par la création et l'édition
+ * d'un membre du personnel.
+ *
+ * Le libellé seul ne suffit plus depuis qu'il y a six rôles : « Directeur » et
+ * « Directeur des études » se ressemblent alors que leurs droits n'ont rien à
+ * voir. Chaque entrée porte donc une phrase qui dit ce que la personne pourra
+ * faire.
+ */
+export function StaffRoleOptions() {
+  return (
+    <>
+      {STAFF_ROLE_OPTIONS.map((option) => (
+        <SelectItem key={option.value} value={option.value} className="py-2.5">
+          <span className="flex flex-col gap-0.5">
+            <span className="font-medium">{option.label}</span>
+            <span className="text-xs text-muted-foreground">{option.hint}</span>
+          </span>
+        </SelectItem>
+      ))}
+    </>
+  )
+}

--- a/components/forms/StaffForm.tsx
+++ b/components/forms/StaffForm.tsx
@@ -4,7 +4,8 @@ import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Eye, EyeOff, KeyRound } from "lucide-react"
-import { StaffCreateSchema, STAFF_ROLE_OPTIONS, type StaffCreate } from "@/lib/contracts/staff"
+import { StaffCreateSchema, type StaffCreate } from "@/lib/contracts/staff"
+import { StaffRoleOptions } from "@/components/admin/staff/StaffRoleOptions"
 import { useCreateStaff } from "@/lib/hooks/useStaff"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -131,11 +132,7 @@ export function StaffForm({ onSuccess }: StaffFormProps) {
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {STAFF_ROLE_OPTIONS.map((o) => (
-                    <SelectItem key={o.value} value={o.value}>
-                      {o.label}
-                    </SelectItem>
-                  ))}
+                  <StaffRoleOptions />
                 </SelectContent>
               </Select>
               <FormDescription className="text-xs">

--- a/lib/contracts/staff.ts
+++ b/lib/contracts/staff.ts
@@ -3,20 +3,21 @@ import { z } from "zod"
 // Rôles d'accès assignables à un membre du personnel (miroir de
 // STAFF_ASSIGNABLE_ROLES côté backend). Jamais admin / super_admin.
 export const STAFF_ROLE_OPTIONS = [
-  { value: "staff", label: "Personnel" },
-  { value: "accountant", label: "Comptable" },
-  { value: "director", label: "Directeur" },
+  { value: "staff", label: "Secrétariat", hint: "Inscriptions, élèves, parents, encaissements" },
+  { value: "cashier", label: "Caissier", hint: "Encaisse au guichet, ne voit que sa propre caisse" },
+  { value: "educator", label: "Éducateur", hint: "Monte et valide les inscriptions" },
+  { value: "accountant", label: "Comptable", hint: "Frais, tranches et point journalier de toutes les caisses" },
+  { value: "studies_director", label: "Directeur des études", hint: "Pédagogie uniquement, aucun accès aux finances" },
+  { value: "director", label: "Directeur", hint: "Accès complet à l'établissement" },
 ] as const
 
-const STAFF_ROLE_LABELS: Record<string, string> = {
-  staff: "Personnel",
-  accountant: "Comptable",
-  director: "Directeur",
-}
+const STAFF_ROLE_LABELS: Record<string, string> = Object.fromEntries(
+  STAFF_ROLE_OPTIONS.map((option) => [option.value, option.label]),
+)
 
-/** Libellé français du rôle d'accès (défaut : Personnel). */
+/** Libellé français du rôle d'accès (défaut : Secrétariat). */
 export function staffRoleLabel(role?: string | null): string {
-  if (!role) return "Personnel"
+  if (!role) return "Secrétariat"
   return STAFF_ROLE_LABELS[role] ?? role
 }
 


### PR DESCRIPTION
Accompagne la PR backend `feat(permissions): add cashier, educator and studies director roles`.

## Ce que ca change

- Le selecteur de role d'acces de la fiche Personnel liste six metiers : **Secretariat**, **Caissier**, **Educateur**, **Comptable**, **Directeur des etudes**, **Directeur**.
- Chaque entree porte une phrase qui dit ce que la personne pourra faire. Avec six roles, `Directeur` et `Directeur des etudes` se retrouvent cote a cote alors que leurs droits n'ont rien a voir : le libelle seul est un piege.
- `Personnel administratif` devient `Secretariat`. **Seul le libelle change**, le slug reste `staff` : il est porte par des comptes en production, present dans le JWT et dans l'historique d'audit.
- Les options sont rendues par un composant partage (`StaffRoleOptions`) au lieu d'etre dupliquees dans le formulaire de creation et la modal d'edition.
- L'ecran Conges tenait sa propre table de libelles de roles : il aurait affiche `cashier` en brut pour un caissier qui demande un conge. Il derive maintenant du meme referentiel.

## Routage portail

Aucun changement necessaire : les trois nouveaux roles sont crees avec `users.role = staff`, qui n'est pas dans `ROLE_TO_PORTAL` et retombe donc sur `/admin/dashboard`. La navigation se filtre ensuite toute seule sur les permissions (`anyOf`), donc un caissier ne voit que ce qu'il peut ouvrir.

## Verification

- `tsc --noEmit` : OK
- `vitest run` : 44 tests / 8 fichiers, verts