### PR TITLE
fix(staff): garder la description du role lisible sur la ligne selectionnee

### DIFF
--- a/components/admin/staff/StaffRoleOptions.tsx
+++ b/components/admin/staff/StaffRoleOptions.tsx
@@ -19,7 +19,11 @@ export function StaffRoleOptions() {
         <SelectItem key={option.value} value={option.value} className="py-2.5">
           <span className="flex flex-col gap-0.5">
             <span className="font-medium">{option.label}</span>
-            <span className="text-xs text-muted-foreground">{option.hint}</span>
+            {/* `opacity` plutôt que `text-muted-foreground` : la ligne survolée
+                ou sélectionnée passe sur fond accent, et une couleur figée y
+                perdrait son contraste. En héritant du texte courant, la phrase
+                reste lisible sur les deux fonds, y compris en plein soleil. */}
+            <span className="text-xs opacity-70">{option.hint}</span>
           </span>
         </SelectItem>
       ))}


### PR DESCRIPTION
Constate au visual-check sur la demo Windows, modal Nouveau personnel, selecteur de role ouvert.

La phrase sous chaque role etait figee en `text-muted-foreground`. Sur la ligne survolee ou selectionnee — qui passe sur le fond orange accent — elle gardait un gris prevu pour le fond carte et perdait son contraste.

Lisible sur un bon ecran, marginal sur l'ecran d'entree de gamme en plein soleil sur lequel nos utilisateurs travaillent reellement (cf. rule `ux-target-user-reality`).

Correctif : `opacity` au lieu d'une couleur figee, la phrase herite du texte courant et reste lisible sur les deux fonds.

`tsc --noEmit` : OK.