### PR TITLE
feat(caisse): ecrans Ma caisse et Point journalier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Added
+
+- Écran « Ma caisse » pour le caissier : ce qu'il a encaissé aujourd'hui, ventilé par moyen de paiement, et la clôture de journée. Il compte son tiroir, saisit le montant, l'écart s'affiche avant validation et la journée se verrouille *(caissier)*.
+- Écran « Point journalier » pour le comptable : chaque caisse de la journée avec son total, son écart et son état de clôture, sur n'importe quelle date. Une caisse restée ouverte est signalée *(comptable)*.
+
 ### Changed
 
 - Fiche Personnel : le rôle d'accès propose désormais six métiers (secrétariat, caissier, éducateur, comptable, directeur des études, directeur), chacun accompagné d'une phrase qui dit ce que la personne pourra faire. « Personnel administratif » devient « Secrétariat » *(admin, directeur)*.

--- a/app/(admin)/admin/cash-point/page.tsx
+++ b/app/(admin)/admin/cash-point/page.tsx
@@ -1,0 +1,7 @@
+import { DailyCashPointClient } from "@/components/admin/cash/DailyCashPointClient"
+
+export const metadata = { title: "Point journalier | KLASSCI" }
+
+export default function DailyCashPointPage() {
+  return <DailyCashPointClient />
+}

--- a/app/(admin)/admin/cash/page.tsx
+++ b/app/(admin)/admin/cash/page.tsx
@@ -1,0 +1,7 @@
+import { MyCashSessionClient } from "@/components/admin/cash/MyCashSessionClient"
+
+export const metadata = { title: "Ma caisse | KLASSCI" }
+
+export default function MyCashPage() {
+  return <MyCashSessionClient />
+}

--- a/components/admin/cash/CloseCashDialog.tsx
+++ b/components/admin/cash/CloseCashDialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useState } from "react"
+import { AlertTriangle, Lock } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { useCloseMyCashSession } from "@/lib/hooks/useCashSessions"
+import { formatFcfa } from "./cash-ui"
+
+interface CloseCashDialogProps {
+  open: boolean
+  onClose: () => void
+  /** Espèces théoriques du jour : ce que le tiroir devrait contenir. */
+  expectedCash: number
+  businessDate?: string
+}
+
+/**
+ * Clôture de journée. Le caissier compte son tiroir et saisit ce qu'il y
+ * trouve — on ne pré-remplit surtout pas avec le théorique, sinon il
+ * validerait sans compter et l'écart ne voudrait plus rien dire.
+ */
+export function CloseCashDialog({
+  open,
+  onClose,
+  expectedCash,
+  businessDate,
+}: CloseCashDialogProps) {
+  const [counted, setCounted] = useState("")
+  const [notes, setNotes] = useState("")
+  const { mutate, isPending } = useCloseMyCashSession(businessDate)
+
+  const countedValue = counted.trim() === "" ? null : Number(counted)
+  const isValid = countedValue !== null && Number.isFinite(countedValue) && countedValue >= 0
+  const variance = isValid ? countedValue - expectedCash : null
+
+  function handleClose() {
+    if (!isValid) return
+    mutate(
+      { counted_amount: countedValue, notes: notes.trim() || undefined },
+      {
+        onSuccess: () => {
+          setCounted("")
+          setNotes("")
+          onClose()
+        },
+      },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Clôturer ma journée</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Espèces attendues dans le tiroir
+            </p>
+            <p className="mt-1 text-2xl font-bold tabular-nums">{formatFcfa(expectedCash)}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Les paiements Wave, Orange Money, chèque et virement ne passent pas par le tiroir.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="counted-amount">Espèces comptées *</Label>
+            <Input
+              id="counted-amount"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={1}
+              className="h-11 text-lg tabular-nums"
+              placeholder="Comptez le tiroir puis saisissez le total"
+              value={counted}
+              onChange={(e) => setCounted(e.target.value)}
+              disabled={isPending}
+            />
+          </div>
+
+          {variance !== null && variance !== 0 && (
+            <div
+              role="alert"
+              className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3"
+            >
+              <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+              <div className="min-w-0 text-sm">
+                <p className="font-medium">
+                  {variance < 0 ? "Manquant" : "Excédent"} de {formatFcfa(Math.abs(variance))}
+                </p>
+                <p className="mt-0.5 text-muted-foreground">
+                  Expliquez l&apos;écart dans la note ci-dessous. La clôture reste possible.
+                </p>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="cash-notes">Note {variance ? "(recommandée)" : "(facultative)"}</Label>
+            <Textarea
+              id="cash-notes"
+              placeholder="Remise à la direction, incident, explication d'un écart..."
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              disabled={isPending}
+              rows={3}
+            />
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Une fois clôturée, la journée est verrouillée : vous ne pourrez plus encaisser ni
+            annuler dessus. Toute correction passera par la comptabilité.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" className="h-11" onClick={onClose} disabled={isPending}>
+            Annuler
+          </Button>
+          <Button className="h-11 gap-2" onClick={handleClose} disabled={!isValid || isPending}>
+            <Lock aria-hidden="true" className="h-4 w-4" />
+            {isPending ? "Clôture..." : "Clôturer la journée"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/cash/DailyCashPointClient.tsx
+++ b/components/admin/cash/DailyCashPointClient.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import { useState } from "react"
+import { Banknote, ClipboardCheck, Lock, Scale, Wallet } from "lucide-react"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useDailyCashPoint } from "@/lib/hooks/useCashSessions"
+import { CashStatusBadge, VarianceBadge, formatFcfa } from "./cash-ui"
+
+function todayIso(): string {
+  const now = new Date()
+  const month = String(now.getMonth() + 1).padStart(2, "0")
+  const day = String(now.getDate()).padStart(2, "0")
+  return `${now.getFullYear()}-${month}-${day}`
+}
+
+/**
+ * Point journalier du comptable : chaque caisse de la journée, son total,
+ * son écart, et si elle est déjà clôturée. Une caisse encore ouverte en fin
+ * de journée est l'information la plus utile de l'écran, d'où le compteur
+ * dédié dans le bandeau.
+ */
+export function DailyCashPointClient() {
+  const [businessDate, setBusinessDate] = useState(todayIso())
+  const { data, isLoading, isError, error, refetch } = useDailyCashPoint(businessDate)
+
+  const kpis: HeroKpi[] = [
+    { label: "Total encaissé", value: formatFcfa(data?.total_collected ?? 0), icon: Wallet },
+    { label: "Dont espèces", value: formatFcfa(data?.cash_collected ?? 0), icon: Banknote },
+    { label: "Caisses ouvertes", value: data?.open_count ?? 0, icon: ClipboardCheck },
+    { label: "Écart cumulé", value: formatFcfa(data?.total_variance ?? 0), icon: Scale },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        icon={ClipboardCheck}
+        title="Point journalier"
+        subtitle="Toutes les caisses de la journée, clôturées ou non"
+        kpis={kpis}
+      />
+
+      <Card className="rounded-xl border shadow-sm">
+        <CardContent className="p-5">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="cash-point-date">Journée</Label>
+              <Input
+                id="cash-point-date"
+                type="date"
+                className="h-11 w-full sm:w-56"
+                value={businessDate}
+                onChange={(e) => setBusinessDate(e.target.value || todayIso())}
+              />
+            </div>
+            <Button
+              variant="outline"
+              className="h-11"
+              onClick={() => setBusinessDate(todayIso())}
+              disabled={businessDate === todayIso()}
+            >
+              Aujourd&apos;hui
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-20 rounded-xl" />
+          <Skeleton className="h-20 rounded-xl" />
+        </div>
+      ) : isError ? (
+        <Card className="rounded-xl border shadow-sm">
+          <CardContent className="space-y-3 p-10 text-center">
+            <p className="text-sm text-muted-foreground">
+              {error instanceof Error ? error.message : "Impossible de charger le point journalier."}
+            </p>
+            <Button variant="outline" className="h-11" onClick={() => refetch()}>
+              Réessayer
+            </Button>
+          </CardContent>
+        </Card>
+      ) : !data || data.items.length === 0 ? (
+        <Card className="rounded-xl border shadow-sm">
+          <CardContent className="p-10 text-center text-sm text-muted-foreground">
+            Aucun encaissement enregistré sur cette journée.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {data.items.map((session) => (
+            <Card key={`${session.cashier_user_id}-${session.business_date}`} className="rounded-xl border shadow-sm">
+              <CardContent className="p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="font-medium">{session.cashier_name}</p>
+                      <CashStatusBadge status={session.status} />
+                      {session.status === "closed" && <VarianceBadge variance={session.variance} />}
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {session.payments_count} versement{session.payments_count > 1 ? "s" : ""} ·{" "}
+                      {formatFcfa(session.cash_collected)} en espèces
+                    </p>
+                    {session.notes && (
+                      <p className="mt-0.5 text-xs text-muted-foreground">Note : {session.notes}</p>
+                    )}
+                  </div>
+                  <div className="shrink-0 text-left sm:text-right">
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                      Total encaissé
+                    </p>
+                    <p className="text-lg font-bold tabular-nums">
+                      {formatFcfa(session.total_collected)}
+                    </p>
+                  </div>
+                </div>
+
+                {session.status !== "closed" && (
+                  <p className="mt-3 flex items-center gap-2 border-t pt-3 text-xs text-muted-foreground">
+                    <Lock aria-hidden="true" className="h-3.5 w-3.5" />
+                    Journée non clôturée : le montant compté et l&apos;écart ne sont pas encore
+                    connus.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/admin/cash/MyCashSessionClient.tsx
+++ b/components/admin/cash/MyCashSessionClient.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useState } from "react"
+import { Banknote, CheckCircle2, Lock, Receipt, Wallet } from "lucide-react"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useMyCashSession } from "@/lib/hooks/useCashSessions"
+import { isClosed } from "@/lib/contracts/cash-session"
+import { CashStatusBadge, MethodBreakdown, VarianceBadge, formatFcfa } from "./cash-ui"
+import { CloseCashDialog } from "./CloseCashDialog"
+
+/**
+ * « Ma caisse » — la journée du caissier connecté.
+ *
+ * Un seul écran, une seule action : voir ce qu'on a encaissé, puis clôturer.
+ * Le caissier ne voit ici que ses propres versements, le backend filtrant sur
+ * l'absence de `payments:read:all`.
+ */
+export function MyCashSessionClient() {
+  const [closeOpen, setCloseOpen] = useState(false)
+  const { data: session, isLoading, isError, error, refetch } = useMyCashSession()
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-44 rounded-2xl" />
+        <Skeleton className="h-64 rounded-xl" />
+      </div>
+    )
+  }
+
+  if (isError || !session) {
+    return (
+      <Card className="rounded-xl border shadow-sm">
+        <CardContent className="space-y-3 p-10 text-center">
+          <p className="text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : "Impossible de charger votre caisse."}
+          </p>
+          <Button variant="outline" className="h-11" onClick={() => refetch()}>
+            Réessayer
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const closed = isClosed(session)
+
+  const kpis: HeroKpi[] = [
+    { label: "Encaissé aujourd'hui", value: formatFcfa(session.total_collected), icon: Wallet },
+    { label: "Dont espèces", value: formatFcfa(session.cash_collected), icon: Banknote },
+    { label: "Versements", value: session.payments_count, icon: Receipt },
+    {
+      label: "État",
+      value: closed ? "Clôturée" : "Ouverte",
+      icon: closed ? Lock : CheckCircle2,
+    },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        icon={Wallet}
+        title="Ma caisse"
+        subtitle={`${session.cashier_name} · journée du ${session.business_date}`}
+        kpis={kpis}
+        actions={
+          !closed ? (
+            <button
+              type="button"
+              onClick={() => setCloseOpen(true)}
+              className="inline-flex h-11 items-center gap-2 rounded-md bg-accent px-4 text-sm font-semibold text-accent-foreground ring-1 ring-white/40 transition-colors hover:bg-accent/90"
+            >
+              <Lock aria-hidden="true" className="h-4 w-4" />
+              Clôturer ma journée
+            </button>
+          ) : null
+        }
+      />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card className="rounded-xl border shadow-sm">
+          <CardContent className="space-y-4 p-5">
+            <div className="flex items-center justify-between border-b pb-3">
+              <h2 className="text-sm font-semibold">Détail par moyen de paiement</h2>
+              <CashStatusBadge status={session.status} />
+            </div>
+            <MethodBreakdown methods={session.by_method} />
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-xl border shadow-sm">
+          <CardContent className="space-y-4 p-5">
+            <h2 className="border-b pb-3 text-sm font-semibold">Clôture</h2>
+
+            {closed ? (
+              <dl className="space-y-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <dt className="text-muted-foreground">Espèces attendues</dt>
+                  <dd className="font-medium tabular-nums">
+                    {formatFcfa(session.expected_amount ?? 0)}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between">
+                  <dt className="text-muted-foreground">Espèces comptées</dt>
+                  <dd className="font-medium tabular-nums">
+                    {formatFcfa(session.counted_amount ?? 0)}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between border-t pt-3">
+                  <dt className="text-muted-foreground">Écart</dt>
+                  <dd>
+                    <VarianceBadge variance={session.variance} />
+                  </dd>
+                </div>
+                {session.notes && (
+                  <div className="rounded-lg border border-border/60 bg-muted/40 p-3">
+                    <dt className="text-xs uppercase tracking-wide text-muted-foreground">Note</dt>
+                    <dd className="mt-1 text-sm">{session.notes}</dd>
+                  </div>
+                )}
+              </dl>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-sm text-muted-foreground">
+                  En fin de journée, comptez votre tiroir et saisissez le montant. Le système
+                  affiche l&apos;écart avec le théorique, puis verrouille la journée.
+                </p>
+                <Button className="h-11 w-full gap-2" onClick={() => setCloseOpen(true)}>
+                  <Lock aria-hidden="true" className="h-4 w-4" />
+                  Clôturer ma journée
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <CloseCashDialog
+        open={closeOpen}
+        onClose={() => setCloseOpen(false)}
+        expectedCash={session.cash_collected}
+      />
+    </div>
+  )
+}

--- a/components/admin/cash/cash-ui.tsx
+++ b/components/admin/cash/cash-ui.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import type { CashMethodTotal } from "@/lib/contracts/cash-session"
+
+/** Montants en FCFA, séparateur de milliers français, jamais de décimales. */
+export function formatFcfa(amount: number): string {
+  return `${Math.round(amount).toLocaleString("fr-FR")} FCFA`
+}
+
+/**
+ * L'écart de caisse est l'information que le comptable cherche en premier.
+ * Le signe porte le sens : négatif = manquant, positif = excédent. Un écart
+ * nul n'est pas neutre, c'est une bonne nouvelle — d'où le vert.
+ */
+export function VarianceBadge({ variance }: { variance: number | null | undefined }) {
+  if (variance === null || variance === undefined) {
+    return <span className="text-sm text-muted-foreground">—</span>
+  }
+  if (variance === 0) {
+    return <Badge className="bg-emerald-600 text-white hover:bg-emerald-600/90">Juste</Badge>
+  }
+  const isShort = variance < 0
+  return (
+    <Badge
+      variant={isShort ? "destructive" : "secondary"}
+      className={isShort ? undefined : "bg-amber-500 text-white hover:bg-amber-500/90"}
+    >
+      {isShort ? "Manquant" : "Excédent"} {formatFcfa(Math.abs(variance))}
+    </Badge>
+  )
+}
+
+export function CashStatusBadge({ status }: { status: string }) {
+  if (status === "closed") {
+    return <Badge variant="secondary">Clôturée</Badge>
+  }
+  return <Badge className="bg-primary text-primary-foreground hover:bg-primary/90">Ouverte</Badge>
+}
+
+/**
+ * Ventilation par moyen de paiement. Seuls les moyens réellement utilisés
+ * sont rendus : afficher « Chèque 0 » sur une école qui n'en accepte pas
+ * ajoute du bruit sans rien apprendre.
+ */
+export function MethodBreakdown({ methods }: { methods: CashMethodTotal[] }) {
+  if (methods.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Aucun encaissement pour l&apos;instant sur cette journée.
+      </p>
+    )
+  }
+  return (
+    <ul className="space-y-2">
+      {methods.map((m) => (
+        <li
+          key={m.method}
+          className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/40 px-3 py-2.5"
+        >
+          <span className="min-w-0">
+            <span className="text-sm font-medium">{m.label}</span>
+            <span className="ml-2 text-xs text-muted-foreground">
+              {m.count} versement{m.count > 1 ? "s" : ""}
+            </span>
+          </span>
+          <span className="shrink-0 text-sm font-semibold tabular-nums">
+            {formatFcfa(m.total)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -28,6 +28,8 @@ import {
   ShieldCheck,
   Settings,
   X,
+  Banknote,
+  ClipboardCheck,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Separator } from "@/components/ui/separator"
@@ -36,6 +38,8 @@ import { usePermissions } from "@/lib/hooks/usePermissions"
 import { filterAdminNavigation } from "@/lib/navigation/adminNav"
 
 const ICONS = {
+  Banknote,
+  ClipboardCheck,
   ArrowUpFromLine,
   LayoutDashboard,
   UserPlus,

--- a/lib/api/cash-sessions.ts
+++ b/lib/api/cash-sessions.ts
@@ -1,0 +1,36 @@
+import {
+  CashSessionListSchema,
+  CashSessionSchema,
+  type CashSession,
+  type CashSessionClose,
+  type CashSessionList,
+} from "@/lib/contracts/cash-session"
+import { apiFetch, safeValidate } from "./client"
+
+/** Journée demandée, ou aujourd'hui si non précisée. */
+function dateQuery(businessDate?: string): string {
+  return businessDate ? `?date=${encodeURIComponent(businessDate)}` : ""
+}
+
+export const cashSessionsApi = {
+  /** Ma caisse : ce que le caissier connecté a encaissé ce jour-là. */
+  mine: async (businessDate?: string): Promise<CashSession> => {
+    const json = await apiFetch<unknown>(`/cash-sessions/me${dateQuery(businessDate)}`)
+    return safeValidate(CashSessionSchema, json, "GET /cash-sessions/me")
+  },
+
+  /** Clôture : fige le théorique, calcule l'écart avec le montant compté. */
+  close: async (data: CashSessionClose, businessDate?: string): Promise<CashSession> => {
+    const json = await apiFetch<unknown>(`/cash-sessions/me/close${dateQuery(businessDate)}`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(CashSessionSchema, json, "POST /cash-sessions/me/close")
+  },
+
+  /** Point journalier : toutes les caisses d'une date (comptable). */
+  dailyPoint: async (businessDate?: string): Promise<CashSessionList> => {
+    const json = await apiFetch<unknown>(`/cash-sessions${dateQuery(businessDate)}`)
+    return safeValidate(CashSessionListSchema, json, "GET /cash-sessions")
+  },
+}

--- a/lib/contracts/cash-session.ts
+++ b/lib/contracts/cash-session.ts
@@ -1,0 +1,62 @@
+import { z } from "zod"
+
+/**
+ * Une journée de caisse : ce qu'un caissier a encaissé un jour donné, et si
+ * cette journée est encore ouverte ou déjà clôturée.
+ *
+ * Les montants sont attendus en `number`. Le backend les sérialise
+ * explicitement en float pour cette raison : un `Decimal` Pydantic arrive
+ * sous forme de chaîne et ferait échouer la validation
+ * (cf. rule `api-client-zod-validation`).
+ */
+export const CashMethodTotalSchema = z.object({
+  method: z.string(),
+  label: z.string(),
+  count: z.number(),
+  total: z.number(),
+})
+
+export const CashSessionSchema = z.object({
+  id: z.number(),
+  cashier_user_id: z.number(),
+  cashier_name: z.string(),
+  business_date: z.string(),
+  status: z.string(),
+  opened_at: z.string(),
+  closed_at: z.string().nullish(),
+  counted_amount: z.number().nullish(),
+  expected_amount: z.number().nullish(),
+  variance: z.number().nullish(),
+  notes: z.string().nullish(),
+  payments_count: z.number(),
+  total_collected: z.number(),
+  cash_collected: z.number(),
+  by_method: z.array(CashMethodTotalSchema),
+})
+
+export const CashSessionListSchema = z.object({
+  items: z.array(CashSessionSchema),
+  business_date: z.string(),
+  total_collected: z.number(),
+  cash_collected: z.number(),
+  total_variance: z.number(),
+  open_count: z.number(),
+  closed_count: z.number(),
+})
+
+export const CashSessionCloseSchema = z.object({
+  counted_amount: z
+    .number({ invalid_type_error: "Saisissez le montant compté" })
+    .min(0, "Le montant ne peut pas être négatif"),
+  notes: z.string().max(1000, "1000 caractères maximum").optional(),
+})
+
+export type CashMethodTotal = z.infer<typeof CashMethodTotalSchema>
+export type CashSession = z.infer<typeof CashSessionSchema>
+export type CashSessionList = z.infer<typeof CashSessionListSchema>
+export type CashSessionClose = z.infer<typeof CashSessionCloseSchema>
+
+/** `true` quand la journée est verrouillée : plus d'encaissement ni d'annulation. */
+export function isClosed(session: Pick<CashSession, "status">): boolean {
+  return session.status === "closed"
+}

--- a/lib/hooks/useCashSessions.ts
+++ b/lib/hooks/useCashSessions.ts
@@ -1,0 +1,52 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { cashSessionsApi } from "@/lib/api/cash-sessions"
+import type { CashSessionClose } from "@/lib/contracts/cash-session"
+
+export const cashSessionKeys = {
+  all: ["cash-sessions"] as const,
+  mine: (businessDate?: string) => ["cash-sessions", "me", businessDate ?? "today"] as const,
+  dailyPoint: (businessDate?: string) => ["cash-sessions", "point", businessDate ?? "today"] as const,
+}
+
+/** Ma caisse du jour. Rafraîchie souvent : le total bouge à chaque encaissement. */
+export function useMyCashSession(businessDate?: string) {
+  return useQuery({
+    queryKey: cashSessionKeys.mine(businessDate),
+    queryFn: () => cashSessionsApi.mine(businessDate),
+    staleTime: 1000 * 30,
+  })
+}
+
+export function useDailyCashPoint(businessDate?: string) {
+  return useQuery({
+    queryKey: cashSessionKeys.dailyPoint(businessDate),
+    queryFn: () => cashSessionsApi.dailyPoint(businessDate),
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useCloseMyCashSession(businessDate?: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: CashSessionClose) => cashSessionsApi.close(data, businessDate),
+    onSuccess: (session) => {
+      queryClient.invalidateQueries({ queryKey: cashSessionKeys.all })
+      const variance = session.variance ?? 0
+      if (variance === 0) {
+        toast.success("Journée clôturée", { description: "La caisse tombe juste." })
+        return
+      }
+      // L'écart n'est pas une erreur : il doit être vu et expliqué, pas masqué.
+      const label = variance < 0 ? "Manquant" : "Excédent"
+      const amount = Math.abs(variance).toLocaleString("fr-FR")
+      toast.warning("Journée clôturée", { description: `${label} de ${amount} FCFA.` })
+    },
+    onError: (err) => {
+      toast.error("Clôture impossible", { description: err.message })
+    },
+  })
+}

--- a/lib/navigation/adminNav.ts
+++ b/lib/navigation/adminNav.ts
@@ -43,6 +43,10 @@ export const ADMIN_NAVIGATION: AdminNavSection[] = [
     items: [
       { label: "Frais", href: "/admin/fees", iconName: "Wallet", anyOf: ["admin:fee-categories:read", "admin:fee-variants:read"] },
       { label: "Paiements", href: "/admin/payments", iconName: "CreditCard", anyOf: ["payments:read"] },
+      // Ma caisse : réservée à qui tient un guichet. Le comptable ne l'a pas,
+      // il supervise depuis le point journalier.
+      { label: "Ma caisse", href: "/admin/cash" as Route, iconName: "Banknote", anyOf: ["cash-session:manage"] },
+      { label: "Point journalier", href: "/admin/cash-point" as Route, iconName: "ClipboardCheck", anyOf: ["cash-session:read:all"] },
     ],
   },
   {


### PR DESCRIPTION
Accompagne la PR backend `feat(payments): add cash sessions with cashier-scoped access`.

## Ma caisse (caissier)

Ce qu'il a encaisse aujourd'hui, ventile par moyen de paiement, et la cloture de journee.

Le montant attendu **n'est jamais pre-rempli** dans le champ de saisie : le caissier validerait sans compter et l'ecart ne voudrait plus rien dire. Il est affiche a cote, en lecture. Seules les **especes** sont comparees, puisque Wave, Orange Money, cheque et virement ne passent pas par le tiroir.

L'ecart s'affiche **avant** de valider, avec une invitation a l'expliquer en note. Il ne bloque pas la cloture : un ecart constate et explique vaut mieux qu'un ecart cache.

## Point journalier (comptable)

Chaque caisse d'une date choisie, avec son total, son ecart et son etat de cloture. Une caisse restee **ouverte** est l'information la plus utile de l'ecran en fin de journee, d'ou son compteur dedie dans le bandeau.

## Cloisonnement

Les deux entrees de navigation sont filtrees par permission : le comptable ne voit pas Ma caisse (il ne tient pas de guichet), le caissier ne voit pas le point journalier. Le filtrage cote serveur reste la seule vraie barriere, la navigation ne fait que ne pas proposer l'impossible.

## Verification

- `tsc --noEmit` : OK
- `next lint` : aucune erreur
- `vitest run` : 44 tests verts