### PR TITLE
refactor(ui): un seul formateur de montants

### DIFF
--- a/components/admin/cash/cash-ui.tsx
+++ b/components/admin/cash/cash-ui.tsx
@@ -2,11 +2,9 @@
 
 import { Badge } from "@/components/ui/badge"
 import type { CashMethodTotal } from "@/lib/contracts/cash-session"
+import { formatFcfa } from "@/lib/utils/money"
 
-/** Montants en FCFA, séparateur de milliers français, jamais de décimales. */
-export function formatFcfa(amount: number): string {
-  return `${Math.round(amount).toLocaleString("fr-FR")} FCFA`
-}
+export { formatFcfa }
 
 /**
  * L'écart de caisse est l'information que le comptable cherche en premier.

--- a/components/shared/fees/FeeSummaryHero.tsx
+++ b/components/shared/fees/FeeSummaryHero.tsx
@@ -1,3 +1,4 @@
+import { formatFcfa } from "@/lib/utils/money"
 import { cn } from "@/lib/utils"
 
 /**
@@ -15,7 +16,7 @@ interface FeeSummaryHeroProps {
   className?: string
 }
 
-const fmt = (n: number) => `${n.toLocaleString("fr-FR")} FCFA`
+const fmt = formatFcfa
 
 export function FeeSummaryHero({
   totalExpected,

--- a/lib/utils/money.ts
+++ b/lib/utils/money.ts
@@ -1,0 +1,18 @@
+/**
+ * Formatage des montants, en un seul endroit.
+ *
+ * Le FCFA n'a pas de subdivision en usage courant : on n'affiche jamais de
+ * décimales, et on arrondit plutôt que de laisser fuir un `,00` ou un
+ * `1234.5678` venu d'un calcul de répartition.
+ *
+ * Le séparateur de milliers français (espace insécable fine) vient de
+ * `toLocaleString("fr-FR")`, cohérent avec le reste de l'interface.
+ */
+export function formatFcfa(amount: number): string {
+  return `${Math.round(amount).toLocaleString("fr-FR")} FCFA`
+}
+
+/** Montant nu, sans devise — pour les tableaux où la colonne porte déjà l'unité. */
+export function formatAmount(amount: number): string {
+  return Math.round(amount).toLocaleString("fr-FR")
+}


### PR DESCRIPTION
Suite de la revue qualite. Les ecrans caisse ajoutaient une **troisieme** copie du meme formateur de montants, apres `FeeSummaryHero` et un `toLocaleString` en dur dans `usePayments`.

L'arrondi et le separateur de milliers vivent desormais dans `lib/utils/money.ts`. Le FCFA n'ayant pas de subdivision en usage courant, on n'affiche jamais de decimales et on arrondit, plutot que de laisser fuir un `,00` ou un `1234.5678` venu d'un calcul de repartition.

`tsc --noEmit` et `vitest` (44 tests) verts.