### PR TITLE
feat(frais): editeur de tranches et echeancier sur la fiche inscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Added
 
+- Écran « Tranches de paiement » : l'établissement découpe le total des frais obligatoires en tranches exprimées en part du total, avec leur date limite. Le total des parts doit faire 100 %, et l'écran le signale en direct tant que ce n'est pas le cas *(comptable)*.
+- Échéancier sur la fiche inscription, sous la synthèse des frais : ce qui est dû, à quelle date, ce qui est déjà exigible, et la prochaine échéance. Une famille qui respecte son calendrier est affichée « à jour », même si elle n'a pas encore tout versé *(admin, comptable)*.
 - Écran « Ma caisse » pour le caissier : ce qu'il a encaissé aujourd'hui, ventilé par moyen de paiement, et la clôture de journée. Il compte son tiroir, saisit le montant, l'écart s'affiche avant validation et la journée se verrouille *(caissier)*.
 - Écran « Point journalier » pour le comptable : chaque caisse de la journée avec son total, son écart et son état de clôture, sur n'importe quelle date. Une caisse restée ouverte est signalée *(comptable)*.
 

--- a/app/(admin)/admin/installments/page.tsx
+++ b/app/(admin)/admin/installments/page.tsx
@@ -1,0 +1,7 @@
+import { InstallmentsPageClient } from "@/components/admin/installments/InstallmentsPageClient"
+
+export const metadata = { title: "Tranches de paiement | KLASSCI" }
+
+export default function InstallmentsPage() {
+  return <InstallmentsPageClient />
+}

--- a/components/admin/enrollments/tabs/EnrollmentPaymentsTab.tsx
+++ b/components/admin/enrollments/tabs/EnrollmentPaymentsTab.tsx
@@ -10,6 +10,7 @@ import { FeeSummaryHero } from "@/components/shared/fees/FeeSummaryHero"
 import { EnrollmentFeesBreakdown, type EnrollmentFeeItem } from "@/components/admin/payments/EnrollmentFeesBreakdown"
 import { PaymentHistoryList } from "@/components/admin/payments/PaymentHistoryList"
 import { StudentPaymentModal } from "@/components/admin/students/tabs/StudentPaymentModal"
+import { EnrollmentScheduleCard } from "@/components/admin/installments/EnrollmentScheduleCard"
 
 interface EnrollmentPaymentsTabProps {
   enrollmentId: number
@@ -59,6 +60,11 @@ export function EnrollmentPaymentsTab({ enrollmentId, enrollment }: EnrollmentPa
   return (
     <div className="space-y-4">
       <FeeSummaryHero totalExpected={totalExpected} totalPaid={totalPaid} totalRemaining={totalRemaining} />
+
+      {/* Placé juste sous la synthèse : « combien reste-t-il ? » appelle
+          immédiatement « et pour quand ? ». Le retard affiché compare ce qui
+          est déjà exigible au versé, jamais le total de l'année. */}
+      <EnrollmentScheduleCard enrollmentId={enrollmentId} />
 
       {studentId && totalRemaining > 0 && (
         <div className="flex justify-end">

--- a/components/admin/installments/EnrollmentScheduleCard.tsx
+++ b/components/admin/installments/EnrollmentScheduleCard.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { CalendarClock, CheckCircle2, Clock } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { scheduleSourceLabel } from "@/lib/contracts/installment"
+import { useEnrollmentSchedule } from "@/lib/hooks/useInstallments"
+import { formatFcfa } from "@/lib/utils/money"
+
+function formatDate(iso: string): string {
+  const [year, month, day] = iso.split("-")
+  return `${day}/${month}/${year}`
+}
+
+/**
+ * Échéancier d'une inscription et état de retard.
+ *
+ * Le retard affiché compare ce qui est **déjà exigible** à ce qui a été versé,
+ * jamais le total de l'année : une famille qui respecte son calendrier ne doit
+ * pas être présentée comme en impayé.
+ */
+export function EnrollmentScheduleCard({ enrollmentId }: { enrollmentId: number }) {
+  const { data, isLoading } = useEnrollmentSchedule(enrollmentId)
+
+  if (isLoading) {
+    return <Skeleton className="h-56 rounded-xl" />
+  }
+
+  if (!data || data.source === "none") {
+    return (
+      <Card className="rounded-xl border shadow-sm">
+        <CardContent className="p-6 text-center">
+          <p className="text-sm text-muted-foreground">
+            Aucune tranche configurée pour cette année scolaire.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Tant qu&apos;aucun calendrier n&apos;est défini, aucun retard ne peut être constaté.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="rounded-xl border shadow-sm">
+      <CardContent className="space-y-4 p-5">
+        <div className="flex items-center gap-2.5 border-b pb-3">
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
+            <CalendarClock aria-hidden="true" className="h-4 w-4" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-sm font-semibold">Échéancier</h2>
+            <p className="text-xs text-muted-foreground">{scheduleSourceLabel(data.source)}</p>
+          </div>
+          {data.is_late ? (
+            <Badge variant="destructive">En retard de {formatFcfa(data.late_amount)}</Badge>
+          ) : (
+            <Badge className="bg-emerald-600 text-white hover:bg-emerald-600/90">À jour</Badge>
+          )}
+        </div>
+
+        <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Total dû</dt>
+            <dd className="mt-0.5 font-semibold tabular-nums">
+              {formatFcfa(data.total_mandatory)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">Déjà versé</dt>
+            <dd className="mt-0.5 font-semibold tabular-nums">{formatFcfa(data.total_paid)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+              Exigible à ce jour
+            </dt>
+            <dd className="mt-0.5 font-semibold tabular-nums">{formatFcfa(data.due_so_far)}</dd>
+          </div>
+        </dl>
+
+        <ul className="space-y-2">
+          {data.lines.map((line) => (
+            <li
+              key={line.position}
+              className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/40 px-3 py-2.5"
+            >
+              <span className="flex min-w-0 items-center gap-2">
+                {line.is_due ? (
+                  <CheckCircle2 aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <Clock aria-hidden="true" className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <span className="min-w-0">
+                  <span className="text-sm font-medium">{line.name}</span>
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    {line.is_due ? "échue le" : "à payer avant le"} {formatDate(line.due_date)}
+                  </span>
+                </span>
+              </span>
+              <span className="shrink-0 text-sm font-semibold tabular-nums">
+                {formatFcfa(line.amount)}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        {data.next_due_date && data.next_due_amount !== null && (
+          <p className="border-t pt-3 text-sm text-muted-foreground">
+            Prochaine échéance : {formatFcfa(data.next_due_amount ?? 0)} avant le{" "}
+            {formatDate(data.next_due_date)}.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/installments/InstallmentGridEditor.tsx
+++ b/components/admin/installments/InstallmentGridEditor.tsx
@@ -1,0 +1,224 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { AlertTriangle, CalendarClock, Plus, Save, Trash2 } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  isGridComplete,
+  percentageTotal,
+  type FeeInstallment,
+  type InstallmentDraft,
+} from "@/lib/contracts/installment"
+import { useInstallmentGrid, useReplaceInstallmentGrid } from "@/lib/hooks/useInstallments"
+
+function toDraft(row: FeeInstallment): InstallmentDraft {
+  return {
+    name: row.name,
+    position: row.position,
+    percentage: row.percentage,
+    due_date: row.due_date,
+  }
+}
+
+/** Grille proposée à une école qui n'a rien configuré : trois tranches usuelles. */
+function defaultDrafts(): InstallmentDraft[] {
+  return [
+    { name: "Tranche 1", position: 1, percentage: 40, due_date: "" },
+    { name: "Tranche 2", position: 2, percentage: 30, due_date: "" },
+    { name: "Tranche 3", position: 3, percentage: 30, due_date: "" },
+  ]
+}
+
+/**
+ * Éditeur de la grille de tranches d'une année scolaire.
+ *
+ * La grille se saisit d'un bloc et se remplace d'un bloc : la somme doit faire
+ * 100 %, donc une grille n'est valide que prise entièrement. Éditer une
+ * tranche isolément la laisserait forcément invalide entre deux appels.
+ */
+export function InstallmentGridEditor({ academicYearId }: { academicYearId: number | undefined }) {
+  const { data, isLoading } = useInstallmentGrid(academicYearId)
+  const { mutate, isPending } = useReplaceInstallmentGrid(academicYearId)
+  const [drafts, setDrafts] = useState<InstallmentDraft[]>([])
+
+  useEffect(() => {
+    if (!data) return
+    setDrafts(data.length > 0 ? data.map(toDraft) : defaultDrafts())
+  }, [data])
+
+  const total = percentageTotal(drafts)
+  const complete = isGridComplete(drafts)
+  const allDated = drafts.every((d) => d.due_date !== "")
+  const allNamed = drafts.every((d) => d.name.trim() !== "")
+  const canSave = complete && allDated && allNamed && !isPending
+
+  function update(index: number, patch: Partial<InstallmentDraft>) {
+    setDrafts((prev) => prev.map((d, i) => (i === index ? { ...d, ...patch } : d)))
+  }
+
+  function addLine() {
+    setDrafts((prev) => [
+      ...prev,
+      { name: `Tranche ${prev.length + 1}`, position: prev.length + 1, percentage: 0, due_date: "" },
+    ])
+  }
+
+  function removeLine(index: number) {
+    // Les rangs doivent rester consécutifs : ils portent l'ordre des échéances.
+    setDrafts((prev) =>
+      prev.filter((_, i) => i !== index).map((d, i) => ({ ...d, position: i + 1 })),
+    )
+  }
+
+  if (isLoading) {
+    return <Skeleton className="h-64 rounded-xl" />
+  }
+
+  if (!academicYearId) {
+    return (
+      <Card className="rounded-xl border shadow-sm">
+        <CardContent className="p-10 text-center text-sm text-muted-foreground">
+          Sélectionnez une année scolaire pour configurer ses tranches.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="rounded-xl border shadow-sm">
+      <CardContent className="space-y-4 p-5">
+        <div className="flex items-center gap-2.5 border-b pb-3">
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-[#f5821f] to-[#f9a826] text-white shadow-sm">
+            <CalendarClock aria-hidden="true" className="h-4 w-4" />
+          </span>
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold">Tranches de paiement</h2>
+            <p className="text-xs text-muted-foreground">
+              Chaque tranche est une part du total des frais obligatoires. Le montant attendu
+              s&apos;adapte donc au niveau de chaque élève, sans ressaisie.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {drafts.map((draft, index) => (
+            <div
+              key={index}
+              className="grid gap-2 rounded-lg border border-border/60 bg-muted/40 p-3 sm:grid-cols-[1fr_7rem_11rem_auto] sm:items-end"
+            >
+              <div className="space-y-1.5">
+                <Label htmlFor={`name-${index}`} className="text-xs">
+                  Nom
+                </Label>
+                <Input
+                  id={`name-${index}`}
+                  className="h-11"
+                  value={draft.name}
+                  onChange={(e) => update(index, { name: e.target.value })}
+                  disabled={isPending}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`pct-${index}`} className="text-xs">
+                  Part (%)
+                </Label>
+                <Input
+                  id={`pct-${index}`}
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  max={100}
+                  step="0.01"
+                  className="h-11 tabular-nums"
+                  value={draft.percentage}
+                  onChange={(e) => update(index, { percentage: Number(e.target.value) })}
+                  disabled={isPending}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`due-${index}`} className="text-xs">
+                  À payer avant le
+                </Label>
+                <Input
+                  id={`due-${index}`}
+                  type="date"
+                  className="h-11"
+                  value={draft.due_date}
+                  onChange={(e) => update(index, { due_date: e.target.value })}
+                  disabled={isPending}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-11 text-destructive hover:bg-destructive/10"
+                onClick={() => removeLine(index)}
+                disabled={isPending || drafts.length <= 1}
+                aria-label={`Supprimer ${draft.name}`}
+              >
+                <Trash2 aria-hidden="true" className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3">
+          <Button
+            type="button"
+            variant="outline"
+            className="h-11 gap-2"
+            onClick={addLine}
+            disabled={isPending || drafts.length >= 24}
+          >
+            <Plus aria-hidden="true" className="h-4 w-4" />
+            Ajouter une tranche
+          </Button>
+
+          <div className="text-sm">
+            <span className="text-muted-foreground">Total : </span>
+            <span className={complete ? "font-semibold text-emerald-600" : "font-semibold text-amber-600"}>
+              {total} %
+            </span>
+          </div>
+        </div>
+
+        {!complete && (
+          <div
+            role="alert"
+            className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3"
+          >
+            <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <p className="text-sm">
+              Les tranches totalisent {total} % au lieu de 100 %.{" "}
+              {total < 100
+                ? "Une part des frais resterait sans échéance."
+                : "La grille réclamerait plus que le montant dû."}
+            </p>
+          </div>
+        )}
+
+        {complete && (!allDated || !allNamed) && (
+          <p className="text-sm text-muted-foreground">
+            {!allDated
+              ? "Chaque tranche a besoin d'une date limite."
+              : "Chaque tranche a besoin d'un nom."}
+          </p>
+        )}
+
+        <Button
+          type="button"
+          className="h-11 w-full gap-2"
+          onClick={() => mutate(drafts)}
+          disabled={!canSave}
+        >
+          <Save aria-hidden="true" className="h-4 w-4" />
+          {isPending ? "Enregistrement..." : "Enregistrer la grille"}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/installments/InstallmentsPageClient.tsx
+++ b/components/admin/installments/InstallmentsPageClient.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { CalendarClock } from "lucide-react"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
+import { Card, CardContent } from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useState } from "react"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { useInstallmentGrid } from "@/lib/hooks/useInstallments"
+import { percentageTotal } from "@/lib/contracts/installment"
+import { InstallmentGridEditor } from "./InstallmentGridEditor"
+
+/**
+ * Configuration des tranches d'une année scolaire.
+ *
+ * Une tranche découpe le TOTAL des frais obligatoires, elle n'est pas une
+ * catégorie de frais : le trimestre est un moment de paiement, pas une nature.
+ */
+export function InstallmentsPageClient() {
+  const { data: yearsData } = useAcademicYears({ size: 100 })
+  const years = yearsData?.items ?? []
+  const currentYear = years.find((y) => y.is_current) ?? years[0]
+
+  const [selectedId, setSelectedId] = useState<number | undefined>(undefined)
+  const yearId = selectedId ?? currentYear?.id
+  const { data: grid } = useInstallmentGrid(yearId)
+
+  const total = grid ? percentageTotal(grid) : 0
+  const kpis: HeroKpi[] = [
+    { label: "Tranches", value: grid?.length ?? 0, icon: CalendarClock },
+    { label: "Couverture", value: `${total} %`, hint: total === 100 ? "Grille complète" : "À compléter" },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        icon={CalendarClock}
+        title="Tranches de paiement"
+        subtitle="Découpage du total des frais obligatoires dans le temps"
+        kpis={kpis}
+      />
+
+      <Card className="rounded-xl border shadow-sm">
+        <CardContent className="p-5">
+          <div className="space-y-2 sm:max-w-xs">
+            <Label htmlFor="installment-year">Année scolaire</Label>
+            <Select
+              value={yearId ? String(yearId) : undefined}
+              onValueChange={(v) => setSelectedId(Number(v))}
+            >
+              <SelectTrigger id="installment-year" className="h-11">
+                <SelectValue placeholder="Choisir une année" />
+              </SelectTrigger>
+              <SelectContent>
+                {years.map((y) => (
+                  <SelectItem key={y.id} value={String(y.id)}>
+                    {y.name}
+                    {y.is_current ? " (courante)" : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <InstallmentGridEditor academicYearId={yearId} />
+    </div>
+  )
+}

--- a/lib/api/installments.ts
+++ b/lib/api/installments.ts
@@ -1,0 +1,37 @@
+import {
+  EnrollmentScheduleSchema,
+  FeeInstallmentSchema,
+  type EnrollmentSchedule,
+  type FeeInstallment,
+  type InstallmentDraft,
+} from "@/lib/contracts/installment"
+import { apiFetch, safeValidate } from "./client"
+import { z } from "zod"
+
+const FeeInstallmentArraySchema = z.array(FeeInstallmentSchema)
+
+export const installmentsApi = {
+  /** Grille de tranches d'une année scolaire. */
+  grid: async (academicYearId: number): Promise<FeeInstallment[]> => {
+    const json = await apiFetch<unknown>(`/admin/fee-installments?academic_year_id=${academicYearId}`)
+    return safeValidate(FeeInstallmentArraySchema, json, "GET /admin/fee-installments")
+  },
+
+  /** Remplacement intégral : la somme des pourcentages doit faire 100 %. */
+  replaceGrid: async (
+    academicYearId: number,
+    installments: InstallmentDraft[],
+  ): Promise<FeeInstallment[]> => {
+    const json = await apiFetch<unknown>(
+      `/admin/fee-installments?academic_year_id=${academicYearId}`,
+      { method: "PUT", body: JSON.stringify({ installments }) },
+    )
+    return safeValidate(FeeInstallmentArraySchema, json, "PUT /admin/fee-installments")
+  },
+
+  /** Échéancier applicable à une inscription, avec son état de retard. */
+  schedule: async (enrollmentId: number): Promise<EnrollmentSchedule> => {
+    const json = await apiFetch<unknown>(`/enrollments/${enrollmentId}/schedule`)
+    return safeValidate(EnrollmentScheduleSchema, json, "GET /enrollments/{id}/schedule")
+  },
+}

--- a/lib/contracts/installment.ts
+++ b/lib/contracts/installment.ts
@@ -1,0 +1,75 @@
+import { z } from "zod"
+
+/**
+ * Une tranche découpe le **total des frais obligatoires** dans le temps.
+ *
+ * Ce n'est pas une catégorie de frais : le trimestre est un moment de
+ * paiement, pas une nature de frais. La grille de l'établissement est en
+ * pourcentages pour suivre automatiquement le total de chaque élève ; un
+ * accord négocié avec une famille est en montants fermes.
+ */
+export const FeeInstallmentSchema = z.object({
+  id: z.number(),
+  academic_year_id: z.number(),
+  name: z.string(),
+  position: z.number(),
+  percentage: z.number(),
+  due_date: z.string(),
+})
+
+export const ScheduleLineSchema = z.object({
+  name: z.string(),
+  position: z.number(),
+  amount: z.number(),
+  due_date: z.string(),
+  is_due: z.boolean(),
+})
+
+export const EnrollmentScheduleSchema = z.object({
+  enrollment_id: z.number(),
+  /** `negotiated`, `standard`, ou `none` quand l'école n'a rien configuré. */
+  source: z.string(),
+  total_mandatory: z.number(),
+  total_paid: z.number(),
+  due_so_far: z.number(),
+  late_amount: z.number(),
+  is_late: z.boolean(),
+  next_due_date: z.string().nullish(),
+  next_due_amount: z.number().nullish(),
+  lines: z.array(ScheduleLineSchema),
+})
+
+export type FeeInstallment = z.infer<typeof FeeInstallmentSchema>
+export type ScheduleLine = z.infer<typeof ScheduleLineSchema>
+export type EnrollmentSchedule = z.infer<typeof EnrollmentScheduleSchema>
+
+export interface InstallmentDraft {
+  name: string
+  position: number
+  percentage: number
+  due_date: string
+}
+
+/** Total des pourcentages saisis, arrondi au centième pour éviter les 99.99999. */
+export function percentageTotal(drafts: InstallmentDraft[]): number {
+  return Math.round(drafts.reduce((sum, d) => sum + (d.percentage || 0), 0) * 100) / 100
+}
+
+/**
+ * Une grille n'est valide que complète : une somme inférieure laisserait une
+ * part des frais sans échéance, une somme supérieure réclamerait plus que le
+ * montant dû.
+ */
+export function isGridComplete(drafts: InstallmentDraft[]): boolean {
+  return drafts.length > 0 && percentageTotal(drafts) === 100
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  negotiated: "Échéancier négocié avec la famille",
+  standard: "Grille de l'établissement",
+  none: "Aucune tranche configurée",
+}
+
+export function scheduleSourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? source
+}

--- a/lib/hooks/useInstallments.ts
+++ b/lib/hooks/useInstallments.ts
@@ -1,0 +1,48 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { installmentsApi } from "@/lib/api/installments"
+import type { InstallmentDraft } from "@/lib/contracts/installment"
+
+export const installmentKeys = {
+  all: ["installments"] as const,
+  grid: (yearId: number) => ["installments", "grid", yearId] as const,
+  schedule: (enrollmentId: number) => ["installments", "schedule", enrollmentId] as const,
+}
+
+export function useInstallmentGrid(academicYearId: number | undefined) {
+  return useQuery({
+    queryKey: installmentKeys.grid(academicYearId ?? 0),
+    queryFn: () => installmentsApi.grid(academicYearId as number),
+    enabled: Boolean(academicYearId),
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useEnrollmentSchedule(enrollmentId: number | undefined) {
+  return useQuery({
+    queryKey: installmentKeys.schedule(enrollmentId ?? 0),
+    queryFn: () => installmentsApi.schedule(enrollmentId as number),
+    enabled: Boolean(enrollmentId),
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useReplaceInstallmentGrid(academicYearId: number | undefined) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (installments: InstallmentDraft[]) =>
+      installmentsApi.replaceGrid(academicYearId as number, installments),
+    onSuccess: () => {
+      // Les échéanciers dérivent de la grille : les invalider tous, sinon une
+      // fiche déjà ouverte continuerait d'afficher l'ancien calendrier.
+      queryClient.invalidateQueries({ queryKey: installmentKeys.all })
+      toast.success("Tranches enregistrées")
+    },
+    onError: (err) => {
+      toast.error("Enregistrement impossible", { description: err.message })
+    },
+  })
+}

--- a/lib/navigation/adminNav.ts
+++ b/lib/navigation/adminNav.ts
@@ -43,6 +43,7 @@ export const ADMIN_NAVIGATION: AdminNavSection[] = [
     items: [
       { label: "Frais", href: "/admin/fees", iconName: "Wallet", anyOf: ["admin:fee-categories:read", "admin:fee-variants:read"] },
       { label: "Paiements", href: "/admin/payments", iconName: "CreditCard", anyOf: ["payments:read"] },
+      { label: "Tranches", href: "/admin/installments" as Route, iconName: "CalendarClock", anyOf: ["admin:fee-installments:read"] },
       // Ma caisse : réservée à qui tient un guichet. Le comptable ne l'a pas,
       // il supervise depuis le point journalier.
       { label: "Ma caisse", href: "/admin/cash" as Route, iconName: "Banknote", anyOf: ["cash-session:manage"] },


### PR DESCRIPTION
Accompagne la PR backend `feat(fees): split the mandatory total into instalments, not categories`.

## Ecran Tranches (comptable)

Le comptable decoupe le total des frais obligatoires en tranches exprimees en **part du total**, chacune avec sa date limite. Le total doit faire 100 % et l'ecran le dit en direct, en precisant **dans quel sens** c'est faux : en dessous, une part des frais resterait sans echeance ; au-dessus, la grille reclamerait plus que le montant du.

La grille s'enregistre **d'un bloc** et non ligne a ligne : une grille n'est valide que prise entierement, editer une tranche isolement la laisserait forcement invalide entre deux appels.

Une ecole qui n'a rien configure se voit proposer trois tranches 40/30/30, le decoupage le plus courant — a ajuster, pas a subir.

## Echeancier sur la fiche inscription

Place **juste sous la synthese des frais** : « combien reste-t-il ? » appelle immediatement « et pour quand ? ».

Il montre le total du, le deja verse, **ce qui est exigible a ce jour**, chaque echeance avec sa date, et la prochaine. Une famille qui respecte son calendrier est affichee « a jour » meme si l'annee n'est pas entierement payee — c'est tout l'objet du lot.

Sans grille configuree, etat vide explicite : « tant qu'aucun calendrier n'est defini, aucun retard ne peut etre constate ». On n'accuse personne sur la base d'un calendrier que l'ecole n'a pas pose.

## Cloisonnement

L'entree de navigation est filtree sur `admin:fee-installments:read`. Caissier, educateur et secretariat **lisent** les echeances — au guichet, un parent demande « je dois combien et pour quand ? » — mais seul le comptable peut les **fixer**.

## Verification

- `tsc --noEmit` : OK
- `next lint` : aucune erreur
- `vitest run` : 44 tests verts