### PR TITLE
feat(documents): show the payment lock before the download button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Écran « Tranches de paiement » : l'établissement découpe le total des frais obligatoires en tranches exprimées en part du total, avec leur date limite. Le total des parts doit faire 100 %, et l'écran le signale en direct tant que ce n'est pas le cas *(comptable)*.
 - Échéancier sur la fiche inscription, sous la synthèse des frais : ce qui est dû, à quelle date, ce qui est déjà exigible, et la prochaine échéance. Une famille qui respecte son calendrier est affichée « à jour », même si elle n'a pas encore tout versé *(admin, comptable)*.
 - Écran « Ma caisse » pour le caissier : ce qu'il a encaissé aujourd'hui, ventilé par moyen de paiement, et la clôture de journée. Il compte son tiroir, saisit le montant, l'écart s'affiche avant validation et la journée se verrouille *(caissier)*.
+- Cadenas sur les documents officiels : quand des échéances arrivées à terme restent dues, le certificat de scolarité, l'attestation de fréquentation et le bulletin affichent le montant exact à régler au lieu d'un bouton qui échoue. Le parent voit où aller payer *(parent, admin)*.
+- Dérogation depuis la fiche élève : le chef d'établissement délivre le document malgré la dette après avoir saisi un motif, et l'écran prévient que la décision est enregistrée *(admin, directeur)*.
 - Écran « Point journalier » pour le comptable : chaque caisse de la journée avec son total, son écart et son état de clôture, sur n'importe quelle date. Une caisse restée ouverte est signalée *(comptable)*.
 
 ### Changed

--- a/components/admin/students/tabs/DocumentsTab.tsx
+++ b/components/admin/students/tabs/DocumentsTab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Award, FileCheck2, FileText, Loader2, Download } from "lucide-react"
+import { Award, FileCheck2, FileText, Loader2, Download, Lock } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { PdfPreviewButton } from "@/components/shared/PdfPreviewButton"
@@ -9,6 +9,10 @@ import { StudentAttachmentsSection } from "../attachments/StudentAttachmentsSect
 import { studentDocumentsApi } from "@/lib/api/student-documents"
 import { downloadBlob } from "@/lib/utils"
 import { SectionCard, StatusPill } from "./_primitives"
+import { DocumentLockNotice } from "@/components/shared/documents/DocumentLockNotice"
+import { DocumentOverrideDialog } from "@/components/shared/documents/DocumentOverrideDialog"
+import { useDocumentReleaseStatus } from "@/lib/hooks/useDocumentRelease"
+import { asDocumentBlocked } from "@/lib/contracts/document-release"
 
 interface DocumentsTabProps {
   studentId: number
@@ -22,7 +26,7 @@ const DOCS: {
   title: string
   description: string
   icon: typeof Award
-  download: (id: number) => Promise<Blob>
+  download: (id: number, overrideReason?: string) => Promise<Blob>
   filenameBase: string
   tone: "primary" | "accent"
 }[] = [
@@ -48,22 +52,49 @@ const DOCS: {
 
 export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) {
   const [downloading, setDownloading] = useState<DocKind | null>(null)
+  const [overrideTarget, setOverrideTarget] = useState<(typeof DOCS)[number] | null>(null)
 
-  async function handleDownload(doc: (typeof DOCS)[number]) {
+  // Retenue pour impayé, interrogée avant d'afficher les boutons. `can_override`
+  // vient de la permission `documents:release:override` : la direction peut
+  // délivrer malgré la dette, le secrétariat non.
+  const { data: release, refetch: refetchRelease } = useDocumentReleaseStatus(studentId)
+  const isBlocked = release?.blocked ?? false
+  const canOverride = release?.can_override ?? false
+
+  async function runDownload(doc: (typeof DOCS)[number], overrideReason?: string) {
     setDownloading(doc.kind)
     try {
-      const blob = await doc.download(studentId)
+      const blob = await doc.download(studentId, overrideReason)
       const safeName = (studentLastName ?? `eleve_${studentId}`)
         .toUpperCase()
         .replace(/\s+/g, "_")
       downloadBlob(blob, `${doc.filenameBase}_${safeName}.pdf`)
-      toast.success(`${doc.title} téléchargé`)
+      toast.success(
+        overrideReason
+          ? `${doc.title} délivré par dérogation — la décision est journalisée`
+          : `${doc.title} téléchargé`,
+      )
+      setOverrideTarget(null)
     } catch (err) {
+      // L'état de retenue est mis en cache : un versement encaissé entre-temps
+      // le rend faux dans les deux sens. Si le backend refuse, on resynchronise
+      // pour que le bandeau annonce le vrai montant.
+      if (asDocumentBlocked(err)) void refetchRelease()
       const message = err instanceof Error ? err.message : "Erreur lors du téléchargement"
       toast.error(message)
     } finally {
       setDownloading(null)
     }
+  }
+
+  function handleDownload(doc: (typeof DOCS)[number]) {
+    // Retenu et on peut déroger : on demande le motif avant de générer quoi
+    // que ce soit, plutôt que de laisser le backend refuser puis rejouer.
+    if (isBlocked && canOverride) {
+      setOverrideTarget(doc)
+      return
+    }
+    void runDownload(doc)
   }
 
   return (
@@ -73,12 +104,25 @@ export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) 
         title="Documents officiels"
         description="Génération à la demande, signés par le chef d'établissement"
         action={
-          <StatusPill tone="success">
-            <FileCheck2 className="h-3 w-3" />
-            Disponibles
-          </StatusPill>
+          isBlocked ? (
+            <StatusPill tone="warning">
+              <Lock className="h-3 w-3" />
+              Retenus
+            </StatusPill>
+          ) : (
+            <StatusPill tone="success">
+              <FileCheck2 className="h-3 w-3" />
+              Disponibles
+            </StatusPill>
+          )
         }
       >
+        {isBlocked && release ? (
+          <div className="mb-4">
+            <DocumentLockNotice lateAmount={release.late_amount} canOverride={canOverride} />
+          </div>
+        ) : null}
+
         <div className="grid gap-3 sm:grid-cols-2">
           {DOCS.map((doc) => {
             const Icon = doc.icon
@@ -110,13 +154,14 @@ export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) 
                     fetchBlob={() => doc.download(studentId)}
                     label={doc.title}
                     size="sm"
+                    disabled={isBlocked}
                     className="h-11 flex-1 sm:h-10"
                   />
                   <Button
                     size="sm"
                     variant="outline"
                     onClick={() => handleDownload(doc)}
-                    disabled={isDownloading}
+                    disabled={isDownloading || (isBlocked && !canOverride)}
                     aria-label={`Télécharger ${doc.title}`}
                     className="h-11 flex-1 gap-2 sm:h-10"
                   >
@@ -124,6 +169,11 @@ export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) 
                       <>
                         <Loader2 className="h-4 w-4 animate-spin" />
                         Génération…
+                      </>
+                    ) : isBlocked ? (
+                      <>
+                        <Lock className="h-4 w-4" />
+                        {canOverride ? "Déroger" : "Retenu"}
                       </>
                     ) : (
                       <>
@@ -140,6 +190,19 @@ export function DocumentsTab({ studentId, studentLastName }: DocumentsTabProps) 
       </SectionCard>
 
       <StudentAttachmentsSection studentId={studentId} />
+
+      <DocumentOverrideDialog
+        open={overrideTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setOverrideTarget(null)
+        }}
+        documentLabel={overrideTarget?.title ?? "Le document"}
+        lateAmount={release?.late_amount ?? 0}
+        pending={downloading !== null}
+        onConfirm={(reason) => {
+          if (overrideTarget) void runDownload(overrideTarget, reason)
+        }}
+      />
     </div>
   )
 }

--- a/components/parent/ParentChildDocumentsClient.tsx
+++ b/components/parent/ParentChildDocumentsClient.tsx
@@ -11,6 +11,9 @@ import { studentDocumentsApi } from "@/lib/api/student-documents"
 import { downloadBlob } from "@/lib/utils"
 import { useParentChildren } from "@/lib/hooks/useParentPortal"
 import { isEnrolledFromClassName } from "@/lib/utils/enrollment-status"
+import { useDocumentReleaseStatus } from "@/lib/hooks/useDocumentRelease"
+import { DocumentLockNotice } from "@/components/shared/documents/DocumentLockNotice"
+import { asDocumentBlocked } from "@/lib/contracts/document-release"
 
 interface ParentChildDocumentsClientProps {
   childId: number
@@ -61,6 +64,15 @@ export function ParentChildDocumentsClient({
   // pour ne pas masquer l'UI pendant le fetch initial — le guard apparaît
   // une fois la donnée arrivée si pertinent.
 
+  // Retenue pour impayé. On l'interroge avant d'afficher les boutons : voir le
+  // montant et où le régler vaut mieux que cliquer et se prendre un refus.
+  // Inutile de demander pour un enfant pas encore inscrit — ce cas relève des
+  // règles d'inscription, pas du recouvrement.
+  const { data: release, refetch: refetchRelease } = useDocumentReleaseStatus(
+    isEnrolled ? childId : null,
+  )
+  const isBlocked = release?.blocked ?? false
+
   async function handleDownload(doc: (typeof DOCS)[number]) {
     setDownloading(doc.kind)
     try {
@@ -68,6 +80,10 @@ export function ParentChildDocumentsClient({
       downloadBlob(blob, `${doc.filenameBase}_enfant_${childId}.pdf`)
       toast.success(`${doc.title} téléchargé(e)`)
     } catch (err) {
+      // Un versement encaissé au secrétariat il y a deux minutes peut avoir
+      // levé la retenue : on resynchronise plutôt que de laisser le bandeau
+      // mentir dans un sens ou dans l'autre.
+      if (asDocumentBlocked(err)) void refetchRelease()
       const message =
         err instanceof Error
           ? err.message
@@ -114,11 +130,18 @@ export function ParentChildDocumentsClient({
         </Card>
       )}
 
+      {isEnrolled && isBlocked && release ? (
+        <DocumentLockNotice
+          lateAmount={release.late_amount}
+          studentName={child?.full_name}
+        />
+      ) : null}
+
       <div className="space-y-3">
         {DOCS.map((doc) => {
           const Icon = doc.icon
           const isDownloading = downloading === doc.kind
-          const disabled = isDownloading || !isEnrolled
+          const disabled = isDownloading || !isEnrolled || isBlocked
           return (
             <div
               key={doc.kind}
@@ -157,6 +180,8 @@ export function ParentChildDocumentsClient({
                     </>
                   ) : !isEnrolled ? (
                     "Disponible après inscription"
+                  ) : isBlocked ? (
+                    "Retenu jusqu'au règlement"
                   ) : (
                     "Télécharger PDF"
                   )}

--- a/components/shared/documents/DocumentLockNotice.tsx
+++ b/components/shared/documents/DocumentLockNotice.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { Lock } from "lucide-react"
+import { formatFcfa } from "@/lib/utils/money"
+
+interface DocumentLockNoticeProps {
+  lateAmount: number
+  /** Nom de l'élève, quand le lecteur peut en suivre plusieurs (portail parent). */
+  studentName?: string
+  /** L'utilisateur peut lever la retenue : le message change de ton. */
+  canOverride?: boolean
+}
+
+/**
+ * Cadenas affiché avant le clic quand des échéances arrivées à terme restent
+ * dues.
+ *
+ * Le montant est toujours dit : « payez » sans chiffre n'aide personne à
+ * préparer sa visite au secrétariat. Le ton reste factuel — la famille en
+ * retard n'a pas besoin d'un message accusateur en plus.
+ */
+export function DocumentLockNotice({
+  lateAmount,
+  studentName,
+  canOverride = false,
+}: DocumentLockNoticeProps) {
+  const subject = studentName ? `de ${studentName}` : "de cet élève"
+
+  return (
+    <div
+      role="alert"
+      className="rounded-xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/50 dark:bg-amber-950/30"
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+          <Lock aria-hidden="true" className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 space-y-1.5">
+          <p className="text-sm font-semibold text-amber-900 dark:text-amber-100">
+            Documents retenus {subject}
+          </p>
+          <p className="text-2xl font-bold tabular-nums text-amber-900 dark:text-amber-100">
+            {formatFcfa(lateAmount)}
+          </p>
+          <p className="text-xs leading-relaxed text-amber-800 dark:text-amber-200/90">
+            Ce montant correspond aux échéances déjà arrivées à terme et non
+            réglées. Les échéances à venir ne sont pas comptées.{" "}
+            {canOverride
+              ? "Vous pouvez délivrer le document malgré la dette en indiquant un motif."
+              : "Rendez-vous au secrétariat de l'école pour régulariser."}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/shared/documents/DocumentOverrideDialog.tsx
+++ b/components/shared/documents/DocumentOverrideDialog.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useState } from "react"
+import { Loader2, ShieldAlert } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { formatFcfa } from "@/lib/utils/money"
+
+const MIN_REASON_LENGTH = 10
+
+interface DocumentOverrideDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  documentLabel: string
+  lateAmount: number
+  pending?: boolean
+  onConfirm: (reason: string) => void
+}
+
+/**
+ * Demande le motif avant de délivrer un document malgré la dette.
+ *
+ * Le motif est obligatoire : sans lui, le journal dirait qu'on a passé outre
+ * sans dire pourquoi, ce qui ne vaut guère mieux que pas de trace du tout. Le
+ * texte prévient explicitement que la dérogation est enregistrée — personne ne
+ * doit découvrir après coup que son nom y figure.
+ */
+export function DocumentOverrideDialog({
+  open,
+  onOpenChange,
+  documentLabel,
+  lateAmount,
+  pending = false,
+  onConfirm,
+}: DocumentOverrideDialogProps) {
+  const [reason, setReason] = useState("")
+  const trimmed = reason.trim()
+  const tooShort = trimmed.length < MIN_REASON_LENGTH
+
+  function handleOpenChange(next: boolean) {
+    if (!next) setReason("")
+    onOpenChange(next)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldAlert aria-hidden="true" className="h-5 w-5 text-accent" />
+            Délivrer malgré la dette
+          </DialogTitle>
+          <DialogDescription>
+            {documentLabel} sera délivré alors que {formatFcfa(lateAmount)}{" "}
+            d&apos;échéances arrivées à terme restent impayées.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="override-reason">Motif de la dérogation *</Label>
+          <Textarea
+            id="override-reason"
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            placeholder="Exemple : cas social validé en conseil de direction du 12 janvier."
+            rows={3}
+            maxLength={500}
+            className="resize-none"
+          />
+          <p className="text-xs text-muted-foreground">
+            Votre nom, la date et ce motif sont enregistrés dans le journal de
+            l&apos;établissement.
+          </p>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            className="h-11 sm:h-10"
+            onClick={() => handleOpenChange(false)}
+          >
+            Annuler
+          </Button>
+          <Button
+            className="h-11 bg-accent text-accent-foreground hover:bg-accent/90 sm:h-10"
+            disabled={tooShort || pending}
+            onClick={() => onConfirm(trimmed)}
+          >
+            {pending ? (
+              <>
+                <Loader2 aria-hidden="true" className="mr-2 h-4 w-4 animate-spin" />
+                Génération...
+              </>
+            ) : (
+              "Délivrer et journaliser"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/api/bulletins.ts
+++ b/lib/api/bulletins.ts
@@ -76,7 +76,13 @@ export const bulletinsApi = {
     })
   },
 
-  downloadPdf: async (id: number): Promise<Blob> => {
-    return apiFetchBlob(`/reports/bulletins/${id}/pdf`)
+  /**
+   * Le bulletin est retenu quand la famille est en retard sur son échéancier.
+   * `overrideReason` lève la retenue, à condition d'avoir le droit de déroger.
+   */
+  downloadPdf: async (id: number, overrideReason?: string): Promise<Blob> => {
+    const reason = overrideReason?.trim()
+    const query = reason ? `?override_reason=${encodeURIComponent(reason)}` : ""
+    return apiFetchBlob(`/reports/bulletins/${id}/pdf${query}`)
   },
 }

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -110,6 +110,34 @@ async function authHeaders(): Promise<Record<string, string>> {
 }
 
 /** Fetch authentifié retournant un Blob (pour téléchargement PDF, Excel, etc.) */
+/**
+ * Erreur HTTP portant le `detail` du backend tel quel.
+ *
+ * FastAPI renvoie soit une chaine (`{detail: "..."}`), soit un objet quand le
+ * front doit pouvoir agir dessus, par exemple un montant a payer et le droit
+ * de deroger. On garde l'objet intact ici : le client HTTP n'a pas a connaitre
+ * la semantique de chaque code, chaque module la lit lui-meme.
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly detail: unknown,
+  ) {
+    super(message)
+    this.name = "ApiError"
+  }
+}
+
+function apiErrorFrom(status: number, detail: unknown, fallback: string): ApiError {
+  if (typeof detail === "string") return new ApiError(detail, status, detail)
+  if (detail !== null && typeof detail === "object") {
+    const message = (detail as { message?: unknown }).message
+    return new ApiError(typeof message === "string" ? message : fallback, status, detail)
+  }
+  return new ApiError(fallback, status, detail)
+}
+
 export async function apiFetchBlob(path: string): Promise<Blob> {
   const headers = await authHeaders()
   delete headers["Content-Type"]
@@ -130,11 +158,12 @@ export async function apiFetchBlob(path: string): Promise<Blob> {
     // Surface the BE detail when available so the caller can toast a useful
     // message — see app/routers/_pdf_helpers.py for the JSON {detail} contract.
     const contentType = res.headers.get("content-type") ?? ""
+    const fallback = `Erreur ${res.status} lors du téléchargement`
     if (contentType.includes("application/json")) {
-      const body = (await res.json().catch(() => null)) as { detail?: string } | null
-      if (body?.detail) throw new Error(body.detail)
+      const body = (await res.json().catch(() => null)) as { detail?: unknown } | null
+      if (body?.detail) throw apiErrorFrom(res.status, body.detail, fallback)
     }
-    throw new Error(`Erreur ${res.status} lors du téléchargement`)
+    throw new Error(fallback)
   }
   return res.blob()
 }

--- a/lib/api/document-release.ts
+++ b/lib/api/document-release.ts
@@ -1,0 +1,17 @@
+import {
+  DocumentReleaseStatusSchema,
+  type DocumentReleaseStatus,
+} from "@/lib/contracts/document-release"
+import { apiFetch, safeValidate } from "./client"
+
+export const documentReleaseApi = {
+  /** Dit si les documents de cet élève sortiraient, et sinon de combien. */
+  status: async (studentId: number): Promise<DocumentReleaseStatus> => {
+    const json = await apiFetch<unknown>(`/students/${studentId}/documents/release-status`)
+    return safeValidate(
+      DocumentReleaseStatusSchema,
+      json,
+      `GET /students/${studentId}/documents/release-status`,
+    )
+  },
+}

--- a/lib/api/student-documents.ts
+++ b/lib/api/student-documents.ts
@@ -1,16 +1,30 @@
 import { apiFetchBlob } from "./client"
 
 /**
+ * Le motif de dérogation voyage en query : ces endpoints sont des GET qui
+ * renvoient un PDF, pas des mutations. Le backend refuse en 402 tant que le
+ * motif manque ou que l'appelant n'a pas `documents:release:override`.
+ */
+function withOverride(path: string, overrideReason?: string): string {
+  const reason = overrideReason?.trim()
+  return reason ? `${path}?override_reason=${encodeURIComponent(reason)}` : path
+}
+
+/**
  * Documents officiels par eleve (certificat de scolarite, attestation
  * de frequentation). Le backend expose ces endpoints via le router
  * student_documents (#107, #109).
  */
 export const studentDocumentsApi = {
   /** Telecharge le PDF du certificat de scolarite. */
-  downloadCertificateScolarite: (studentId: number): Promise<Blob> =>
-    apiFetchBlob(`/students/${studentId}/documents/certificat-scolarite.pdf`),
+  downloadCertificateScolarite: (studentId: number, overrideReason?: string): Promise<Blob> =>
+    apiFetchBlob(
+      withOverride(`/students/${studentId}/documents/certificat-scolarite.pdf`, overrideReason),
+    ),
 
   /** Telecharge le PDF de l'attestation de frequentation (avec stats). */
-  downloadAttestationFrequentation: (studentId: number): Promise<Blob> =>
-    apiFetchBlob(`/students/${studentId}/documents/attestation-frequentation.pdf`),
+  downloadAttestationFrequentation: (studentId: number, overrideReason?: string): Promise<Blob> =>
+    apiFetchBlob(
+      withOverride(`/students/${studentId}/documents/attestation-frequentation.pdf`, overrideReason),
+    ),
 }

--- a/lib/contracts/document-release.ts
+++ b/lib/contracts/document-release.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+
+/**
+ * Etat de la porte de paiement sur les documents officiels d'un eleve.
+ *
+ * Le declencheur est le retard sur l'echeancier, jamais le solde de l'annee :
+ * une famille a jour de sa premiere tranche en novembre doit pouvoir obtenir
+ * un certificat pour une bourse ou une carte de transport.
+ */
+export const DocumentReleaseStatusSchema = z.object({
+  blocked: z.boolean(),
+  late_amount: z.coerce.number(),
+  reason: z.string().nullish(),
+  /** L'utilisateur courant a la permission `documents:release:override`. */
+  can_override: z.boolean(),
+})
+
+export type DocumentReleaseStatus = z.infer<typeof DocumentReleaseStatusSchema>
+
+/** Code renvoye par le backend dans le `detail` d'un 402. */
+export const DOCUMENT_BLOCKED_CODE = "DOCUMENT_BLOCKED_BY_ARREARS"
+
+export interface DocumentBlockedDetail {
+  code: typeof DOCUMENT_BLOCKED_CODE
+  message: string
+  late_amount: number
+  student_id: number
+  can_override: boolean
+}
+
+/**
+ * Reconnait le refus pour impaye parmi les erreurs d'un telechargement.
+ *
+ * Le client HTTP ne connait pas la semantique des codes metier : c'est ici
+ * qu'on la lit, pour que la porte de paiement reste un seul concept.
+ */
+export function asDocumentBlocked(error: unknown): DocumentBlockedDetail | null {
+  const detail = (error as { detail?: unknown } | null)?.detail
+  if (detail === null || typeof detail !== "object") return null
+  const candidate = detail as Record<string, unknown>
+  if (candidate.code !== DOCUMENT_BLOCKED_CODE) return null
+  return {
+    code: DOCUMENT_BLOCKED_CODE,
+    message: String(candidate.message ?? "Document retenu pour impayé."),
+    late_amount: Number(candidate.late_amount ?? 0),
+    student_id: Number(candidate.student_id ?? 0),
+    can_override: Boolean(candidate.can_override),
+  }
+}

--- a/lib/hooks/useDocumentRelease.ts
+++ b/lib/hooks/useDocumentRelease.ts
@@ -1,0 +1,24 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { documentReleaseApi } from "@/lib/api/document-release"
+
+export const documentReleaseKeys = {
+  status: (studentId: number) => ["document-release", studentId] as const,
+}
+
+/**
+ * Etat de la porte de paiement d'un élève.
+ *
+ * Appelé avant d'afficher les boutons de téléchargement : voir « Retenu :
+ * 75 000 FCFA d'échéances en retard » vaut mieux que cliquer et se prendre
+ * un refus.
+ */
+export function useDocumentReleaseStatus(studentId: number | null) {
+  return useQuery({
+    queryKey: documentReleaseKeys.status(studentId ?? 0),
+    queryFn: () => documentReleaseApi.status(studentId as number),
+    enabled: studentId !== null,
+    staleTime: 60_000,
+  })
+}


### PR DESCRIPTION
Front du blocage des documents sur impayé. Backend : African-DC/klassci-college-backend#244.

## Ce que voit le parent

Quand des échéances **arrivées à terme** restent dues, la page Documents de l'enfant affiche un cadenas avec le montant exact et où le régler. Les boutons passent à « Retenu jusqu'au règlement » au lieu d'échouer au clic.

Le montant est toujours dit : « payez » sans chiffre n'aide personne à préparer sa visite au secrétariat. Le ton reste factuel — une famille en retard n'a pas besoin d'un message accusateur en plus.

## Ce que voit la direction

Sur la fiche élève, onglet Documents : même cadenas, mais le bouton devient « Déroger ». Un dialogue demande le motif (10 caractères minimum) et prévient noir sur blanc que **le nom, la date et le motif partent au journal** — personne ne doit découvrir après coup que son nom y figure.

Le secrétariat et le comptable voient le cadenas mais le bouton reste désactivé : `can_override` vient de la permission, pas d'un test de rôle en dur.

## Le contrat d'erreur

`apiFetchBlob` ne savait porter qu'un `detail` texte : un `detail` objet serait devenu `[object Object]` dans le toast. Nouvelle `ApiError` qui transporte le detail **tel quel**, avec un message lisible extrait quand il existe. Le client HTTP n'a pas à connaître la sémantique de chaque code métier — c'est `asDocumentBlocked()`, dans le module documents, qui reconnaît `DOCUMENT_BLOCKED_BY_ARREARS`.

## Le cache qui ment

L'état de retenue est mis en cache 60 s. Un versement encaissé au guichet il y a deux minutes le rend faux — dans les deux sens. Quand le backend refuse un téléchargement, on resynchronise le bandeau au lieu de laisser l'écran afficher un montant périmé.

## Écran non couvert

Les portails élève et parent appellent des routes de téléchargement de bulletin qui n'existent pas (`/student/bulletins/{id}/pdf`) ou leur sont interdites (`/reports/bulletins/{id}/pdf`, gardée par `reports:read`). Bug pré-existant, hors périmètre ici, signalé séparément.

## Vérifications

`tsc --noEmit` propre, `next lint` sans erreur nouvelle (seuls des warnings pré-existants sur des fichiers non touchés).