### PR TITLE
feat(fees): let the school price affected and non-affected students apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Affectation de l'élève à l'inscription : affecté, réaffecté ou non affecté, avec le numéro de décision demandé uniquement quand il sert. Le montant des frais suit automatiquement *(secrétariat, éducateur)*.
+- Un montant de frais peut ne valoir que pour les affectés ou que pour les non affectés. L'arbre des frais affiche la portée, si bien que deux montants sur le même niveau ne passent plus pour un doublon *(comptable)*.
 
 - Écran « Tranches de paiement » : l'établissement découpe le total des frais obligatoires en tranches exprimées en part du total, avec leur date limite. Le total des parts doit faire 100 %, et l'écran le signale en direct tant que ce n'est pas le cas *(comptable)*.
 - Échéancier sur la fiche inscription, sous la synthèse des frais : ce qui est dû, à quelle date, ce qui est déjà exigible, et la prochaine échéance. Une famille qui respecte son calendrier est affichée « à jour », même si elle n'a pas encore tout versé *(admin, comptable)*.

--- a/components/admin/fees/FeeVariantCreateModal.tsx
+++ b/components/admin/fees/FeeVariantCreateModal.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "zod"
 import { Loader2 } from "lucide-react"
+import { ASSIGNMENT_SCOPES } from "@/lib/contracts/fee"
 import { toast } from "sonner"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
@@ -24,6 +25,9 @@ import { useQueryClient } from "@tanstack/react-query"
 
 const FormSchema = z.object({
   fee_category_id: z.number({ required_error: "La catégorie est requise" }).positive(),
+  // `null` = ce montant vaut pour tout le monde. Un montant réservé aux
+  // affectés et un autre aux non affectés coexistent sur le même niveau.
+  assignment_scope: z.enum(["affecte", "non_affecte"]).nullable().default(null),
   amount: z.number({ required_error: "Le montant est requis" }).positive("Le montant doit être positif"),
 })
 
@@ -80,6 +84,7 @@ export function FeeVariantCreateModal({ open, onClose, academicYearId }: FeeVari
         await mutateAsync({
           fee_category_id: data.fee_category_id,
           level_id: levelId,
+          assignment_scope: data.assignment_scope,
           academic_year_id: academicYearId,
           amount: data.amount,
         })
@@ -169,6 +174,37 @@ export function FeeVariantCreateModal({ open, onClose, academicYearId }: FeeVari
                 </p>
               )}
             </div>
+
+            <FormField
+              control={form.control}
+              name="assignment_scope"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>À qui s&apos;applique ce montant</FormLabel>
+                  <Select
+                    value={field.value ?? "tous"}
+                    onValueChange={(v) => field.onChange(v === "tous" ? null : v)}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="h-11 sm:h-10">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {ASSIGNMENT_SCOPES.map((scope) => (
+                        <SelectItem key={scope.value ?? "tous"} value={scope.value ?? "tous"}>
+                          {scope.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    {ASSIGNMENT_SCOPES.find((s) => s.value === (field.value ?? null))?.hint}
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
             <FormField
               control={form.control}

--- a/components/admin/fees/FeeVariantEditModal.tsx
+++ b/components/admin/fees/FeeVariantEditModal.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react"
 import { useForm } from "react-hook-form"
+import { ASSIGNMENT_SCOPES } from "@/lib/contracts/fee"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
@@ -30,6 +31,7 @@ export function FeeVariantEditModal({ variant, onClose }: FeeVariantEditModalPro
       fee_category_id: variant.fee_category_id,
       level_id: variant.level_id,
       series_id: variant.series_id,
+      assignment_scope: variant.assignment_scope ?? null,
       amount: variant.amount,
       academic_year_id: variant.academic_year_id,
     } : undefined,
@@ -121,6 +123,34 @@ export function FeeVariantEditModal({ variant, onClose }: FeeVariantEditModalPro
                 </FormItem>
               )}
             />
+            <FormField
+              control={form.control}
+              name="assignment_scope"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>À qui s&apos;applique ce montant</FormLabel>
+                  <Select
+                    value={field.value ?? "tous"}
+                    onValueChange={(v) => field.onChange(v === "tous" ? null : v)}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="h-11 sm:h-10">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {ASSIGNMENT_SCOPES.map((scope) => (
+                        <SelectItem key={scope.value ?? "tous"} value={scope.value ?? "tous"}>
+                          {scope.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
             <FormField
               control={form.control}
               name="amount"

--- a/components/admin/fees/FeesByLevelTree.tsx
+++ b/components/admin/fees/FeesByLevelTree.tsx
@@ -136,6 +136,21 @@ export function FeesByLevelTree({
                           série
                         </Badge>
                       )}
+                      {v.assignment_scope ? (
+                        // Sans ce repere, deux montants sur le meme niveau
+                        // passent pour un doublon alors qu'ils visent des
+                        // eleves differents.
+                        <Badge
+                          variant="outline"
+                          className={
+                            v.assignment_scope === "affecte"
+                              ? "h-5 border-emerald-300 text-[10px] text-emerald-700 dark:border-emerald-800 dark:text-emerald-300"
+                              : "h-5 border-amber-300 text-[10px] text-amber-700 dark:border-amber-800 dark:text-amber-300"
+                          }
+                        >
+                          {v.assignment_scope === "affecte" ? "affecté" : "non affecté"}
+                        </Badge>
+                      ) : null}
                       <span className="text-sm font-semibold tabular-nums">
                         {v.amount.toLocaleString("fr-FR")}{" "}
                         <span className="text-[11px] font-normal text-muted-foreground">FCFA</span>

--- a/components/forms/AssignmentStatusField.tsx
+++ b/components/forms/AssignmentStatusField.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import type { Control, FieldValues, Path } from "react-hook-form"
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { ASSIGNMENT_STATUSES } from "@/lib/contracts/enrollment"
+
+interface AssignmentStatusFieldProps<T extends FieldValues> {
+  control: Control<T>
+  statusName: Path<T>
+  decisionName: Path<T>
+  /** Statut courant, pour n'afficher le numéro de décision que s'il sert. */
+  status: string | null | undefined
+}
+
+/**
+ * Statut d'affectation et numéro de décision.
+ *
+ * Le statut décide du tarif appliqué : un élève affecté est subventionné par
+ * l'État et paie sensiblement moins. Il est donc saisi à la création, pas
+ * après coup, sinon l'inscription se crée avec les mauvais frais et la
+ * famille peut recevoir un montant erroné avant qu'on le corrige.
+ *
+ * Le numéro de décision n'apparaît que pour un affecté ou un réaffecté : le
+ * demander à une famille non affectée n'aurait aucun sens.
+ */
+export function AssignmentStatusField<T extends FieldValues>({
+  control,
+  statusName,
+  decisionName,
+  status,
+}: AssignmentStatusFieldProps<T>) {
+  const subsidised = status === "affecte" || status === "reaffecte"
+
+  return (
+    <div className="space-y-3">
+      <FormField
+        control={control}
+        name={statusName}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Affectation</FormLabel>
+            <Select
+              value={field.value ?? "non_renseigne"}
+              onValueChange={(v) => field.onChange(v === "non_renseigne" ? null : v)}
+            >
+              <FormControl>
+                <SelectTrigger className="h-11 sm:h-10">
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="non_renseigne">Non renseigné</SelectItem>
+                {ASSIGNMENT_STATUSES.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {ASSIGNMENT_STATUSES.find((o) => o.value === status)?.hint ??
+                "Tant que ce n'est pas renseigné, les montants communs à tous s'appliquent."}
+            </p>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {subsidised ? (
+        <FormField
+          control={control}
+          name={decisionName}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Numéro de décision d&apos;affectation</FormLabel>
+              <FormControl>
+                <Input
+                  className="h-11 sm:h-10"
+                  placeholder="Ex : 2025-DRENA-04521"
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+              <p className="text-xs text-muted-foreground">
+                Réclamé par le rapport de fin de trimestre.
+              </p>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/components/forms/EnrollmentForm.tsx
+++ b/components/forms/EnrollmentForm.tsx
@@ -23,6 +23,7 @@ import type { Class } from "@/lib/contracts/class"
 import { useCreateWithStudent, useReEnroll, useFeeVariants } from "@/lib/hooks/useEnrollments"
 import { useStudents } from "@/lib/hooks/useStudents"
 import { useClasses } from "@/lib/hooks/useClasses"
+import { AssignmentStatusField } from "@/components/forms/AssignmentStatusField"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -86,6 +87,8 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
       commune: null,
       parent: null,
       class_id: undefined,
+      assignment_status: null,
+      assignment_decision_number: null,
       fee_variant_id: null,
       notes: null,
     },
@@ -98,6 +101,8 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
       type: "re-enrollment",
       student_id: undefined,
       class_id: undefined,
+      assignment_status: null,
+      assignment_decision_number: null,
       fee_variant_id: null,
       notes: null,
     },
@@ -383,6 +388,24 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
               onFeeVariantChange={(id) => reForm.setValue("fee_variant_id", id)}
               onNotesChange={(val) => reForm.setValue("notes", val)}
               classError={reForm.formState.errors.class_id?.message}
+            />
+          )}
+
+          {/* L'affectation decide du tarif : elle se saisit ici, avec la
+              classe, et non apres coup sur une inscription deja creee. */}
+          {enrollmentType === "new" ? (
+            <AssignmentStatusField
+              control={newForm.control}
+              statusName="assignment_status"
+              decisionName="assignment_decision_number"
+              status={newForm.watch("assignment_status")}
+            />
+          ) : (
+            <AssignmentStatusField
+              control={reForm.control}
+              statusName="assignment_status"
+              decisionName="assignment_decision_number"
+              status={reForm.watch("assignment_status")}
             />
           )}
         </div>

--- a/lib/contracts/enrollment.ts
+++ b/lib/contracts/enrollment.ts
@@ -2,6 +2,26 @@ import { z } from "zod"
 
 // Miroir de app/schemas/enrollment.py (backend)
 
+/**
+ * Affectation par l'État. Un élève affecté dans un établissement privé est
+ * subventionné : sa famille paie sensiblement moins. Le réaffecté — réorienté
+ * vers un autre établissement — reste pris en charge, donc payé comme un
+ * affecté ; on garde la distinction parce que les dossiers du ministère et le
+ * rapport de fin de trimestre la réclament.
+ */
+export const AssignmentStatusSchema = z.enum(["affecte", "reaffecte", "non_affecte"])
+
+export const ASSIGNMENT_STATUSES = [
+  { value: "affecte" as const, label: "Affecté", hint: "Subventionné par l'État" },
+  { value: "reaffecte" as const, label: "Réaffecté", hint: "Réorienté, subventionné également" },
+  { value: "non_affecte" as const, label: "Non affecté", hint: "Scolarité à la charge de la famille" },
+]
+
+export function assignmentStatusLabel(status: string | null | undefined): string {
+  if (!status) return "Non renseigné"
+  return ASSIGNMENT_STATUSES.find((s) => s.value === status)?.label ?? status
+}
+
 export const EnrollmentStatusSchema = z.enum(["prospect", "en_validation", "valide", "rejete", "annule"])
 
 export const EnrollmentSchema = z.object({
@@ -11,6 +31,9 @@ export const EnrollmentSchema = z.object({
   academic_year_id: z.number(),
   academic_year_name: z.string(),
   status: EnrollmentStatusSchema,
+  /** `null` tant que l'école ne l'a pas renseigné : on ne devine pas. */
+  assignment_status: AssignmentStatusSchema.nullish(),
+  assignment_decision_number: z.string().nullish(),
   fee_variant_id: z.number().nullable(),
   notes: z.string().nullable(),
   created_by: z.number().nullable(),
@@ -24,6 +47,8 @@ export const EnrollmentSchema = z.object({
 export const EnrollmentCreateSchema = z.object({
   student_id: z.number({ required_error: "L'élève est requis" }).positive("L'élève est requis"),
   class_id: z.number({ required_error: "La classe est requise" }).positive("La classe est requise"),
+  assignment_status: AssignmentStatusSchema.nullable().optional(),
+  assignment_decision_number: z.string().nullable().optional(),
   academic_year_id: z.number({ required_error: "L'année académique est requise" }).positive("L'année académique est requise"),
   fee_variant_id: z.number().positive().optional().nullable(),
   notes: z.string().optional().nullable(),
@@ -31,6 +56,8 @@ export const EnrollmentCreateSchema = z.object({
 
 export const EnrollmentUpdateSchema = z.object({
   class_id: z.number().positive().optional(),
+  assignment_status: AssignmentStatusSchema.nullable().optional(),
+  assignment_decision_number: z.string().nullable().optional(),
   status: EnrollmentStatusSchema.optional(),
   notes: z.string().optional().nullable(),
 })
@@ -76,6 +103,9 @@ export const NewEnrollmentSchema = z.object({
   parent: ParentInputSchema.nullable().optional(),
   // Class
   class_id: z.number({ required_error: "La classe est requise" }).positive(),
+  // Decide du tarif applique : saisi a la creation, pas apres coup.
+  assignment_status: AssignmentStatusSchema.nullable().optional(),
+  assignment_decision_number: z.string().nullable().optional(),
   fee_variant_id: z.number().positive().nullable().optional(),
   notes: z.string().nullable().optional(),
 })
@@ -84,6 +114,9 @@ export const ReEnrollmentSchema = z.object({
   type: z.literal("re-enrollment"),
   student_id: z.number({ required_error: "L'eleve est requis" }).positive(),
   class_id: z.number({ required_error: "La classe est requise" }).positive(),
+  // Decide du tarif applique : saisi a la creation, pas apres coup.
+  assignment_status: AssignmentStatusSchema.nullable().optional(),
+  assignment_decision_number: z.string().nullable().optional(),
   fee_variant_id: z.number().positive().nullable().optional(),
   notes: z.string().nullable().optional(),
 })

--- a/lib/contracts/fee.ts
+++ b/lib/contracts/fee.ts
@@ -20,6 +20,12 @@ export const FeeVariantSchema = z.object({
   fee_category_id: z.number(),
   level_id: z.number(),
   series_id: z.number().nullable(),
+  /**
+   * `null` = ce montant s'applique à tout le monde. Sinon il ne vaut que
+   * pour les élèves affectés, ou que pour les non affectés. En Côte d'Ivoire
+   * un affecté est subventionné par l'État : il paie sensiblement moins.
+   */
+  assignment_scope: z.enum(["affecte", "non_affecte"]).nullish(),
   academic_year_id: z.number(),
   amount: z.coerce.number(),
   description: z.string().nullable(),
@@ -31,12 +37,15 @@ export const FeeCategoryCreateSchema = z.object({
   name: z.string({ required_error: "Le nom est requis" }).min(1, "Le nom est requis"),
   description: z.string().nullable().optional(),
   is_mandatory: z.boolean().default(true),
+  /** Ordre d'imputation des versements : plus petit = servi en premier. */
+  priority: z.number().int().min(0).max(999).optional(),
 })
 
 export const FeeVariantCreateSchema = z.object({
   fee_category_id: z.number({ required_error: "La catégorie est requise" }).positive(),
   level_id: z.number({ required_error: "Le niveau est requis" }).positive(),
   series_id: z.number().positive().nullable().optional(),
+  assignment_scope: z.enum(["affecte", "non_affecte"]).nullable().optional(),
   amount: z.number({ required_error: "Le montant est requis" }).positive("Le montant doit être positif"),
   academic_year_id: z.number({ required_error: "L'année académique est requise" }).positive(),
   description: z.string().nullable().optional(),
@@ -86,3 +95,33 @@ export type OptionalFeeOptionUpdate = z.infer<typeof OptionalFeeOptionUpdateSche
 
 /** Niveaux du systeme scolaire ivoirien (college) */
 export const LEVELS = ["6eme", "5eme", "4eme", "3eme"] as const
+
+
+export type AssignmentScope = "affecte" | "non_affecte" | null
+
+/** Portées d'affectation d'un montant, dans l'ordre d'affichage. */
+export const ASSIGNMENT_SCOPES: {
+  value: AssignmentScope
+  label: string
+  hint: string
+}[] = [
+  {
+    value: null,
+    label: "Tous les élèves",
+    hint: "S'applique aussi bien aux affectés qu'aux non affectés",
+  },
+  {
+    value: "affecte",
+    label: "Élèves affectés",
+    hint: "Subventionnés par l'État — les réaffectés sont inclus",
+  },
+  {
+    value: "non_affecte",
+    label: "Élèves non affectés",
+    hint: "La famille prend la scolarité entièrement à sa charge",
+  },
+]
+
+export function assignmentScopeLabel(scope: string | null | undefined): string {
+  return ASSIGNMENT_SCOPES.find((s) => s.value === (scope ?? null))?.label ?? "Tous les élèves"
+}


### PR DESCRIPTION
Front du statut d'affectation. Backend : African-DC/klassci-college-backend#251 et #253.

## Dans la configuration des frais

Un montant porte désormais une portée : **tous les élèves**, **élèves affectés** ou **élèves non affectés**. L'école saisit « Scolarité 6ème affecté : 90 000 » et « Scolarité 6ème non affecté : 150 000 » sur le même niveau, et l'inscription prend automatiquement le bon.

L'arbre par niveau affiche la portée en pastille. Sans ce repère, deux montants sur une même ligne passeraient pour un doublon — d'autant que c'est exactement le bug qu'on vient de corriger côté base.

## Dans le formulaire d'inscription

Le statut se saisit **avec la classe**, à l'étape où se décide le tarif. Le renseigner après coup laisserait l'inscription se créer avec les mauvais frais, et la famille pourrait recevoir un montant erroné avant qu'on le corrige.

Le numéro de décision d'affectation n'apparaît que pour un affecté ou un réaffecté : le demander à une famille non affectée n'aurait aucun sens. Il est réclamé par le rapport de fin de trimestre, l'aide sous le champ le dit.

Par défaut, « Non renseigné », avec l'explication : *« Tant que ce n'est pas renseigné, les montants communs à tous s'appliquent. »* Aucune école ne voit son fonctionnement changer tant qu'elle n'a rien saisi.

## Vérifications

`tsc --noEmit` propre, `next lint` sans erreur nouvelle.