### PR TITLE
feat(enrollments): rendre le statut d'affectation visible et modifiable partout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ### Added
 - Affectation de l'élève à l'inscription : affecté, réaffecté ou non affecté, avec le numéro de décision demandé uniquement quand il sert. Le montant des frais suit automatiquement *(secrétariat, éducateur)*.
 - Un montant de frais peut ne valoir que pour les affectés ou que pour les non affectés. L'arbre des frais affiche la portée, si bien que deux montants sur le même niveau ne passent plus pour un doublon *(comptable)*.
+- L'affectation se lit et se corrige partout : pastille de couleur dans la liste des inscriptions, rappel sur la fiche avec le numéro de décision, et modification depuis l'inscription quand la décision du ministère arrive après coup. La liste se filtre par affectés, non affectés ou non renseigné, pour retrouver les dossiers dont l'affectation reste à saisir *(secrétariat, comptable)*.
+- Copie de montants de frais : la portée d'affectation suit désormais le montant copié, et les lignes du même niveau se distinguent à l'écran. Un tarif réservé aux affectés ne devient plus applicable à tout le monde à la copie *(comptable)*.
 
 - Écran « Tranches de paiement » : l'établissement découpe le total des frais obligatoires en tranches exprimées en part du total, avec leur date limite. Le total des parts doit faire 100 %, et l'écran le signale en direct tant que ce n'est pas le cas *(comptable)*.
 - Échéancier sur la fiche inscription, sous la synthèse des frais : ce qui est dû, à quelle date, ce qui est déjà exigible, et la prochaine échéance. Une famille qui respecte son calendrier est affichée « à jour », même si elle n'a pas encore tout versé *(admin, comptable)*.

--- a/components/admin/enrollments/EnrollmentEditModal.tsx
+++ b/components/admin/enrollments/EnrollmentEditModal.tsx
@@ -29,6 +29,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
+import { AssignmentStatusField } from "@/components/forms/AssignmentStatusField"
 
 interface EnrollmentEditModalProps {
   enrollmentId: number | null
@@ -63,10 +64,16 @@ function EditForm({ enrollmentId, onClose }: { enrollmentId: number; onClose: ()
       ? {
           class_id: enrollment.class_id,
           status: enrollment.status,
+          assignment_status: enrollment.assignment_status ?? null,
+          assignment_decision_number: enrollment.assignment_decision_number ?? null,
           notes: enrollment.notes,
         }
       : undefined,
   })
+
+  // La décision d'affectation arrive parfois après l'inscription : on suit la
+  // valeur en direct pour révéler le numéro de décision dès qu'il devient utile.
+  const assignmentStatus = form.watch("assignment_status")
 
   if (isLoading || !enrollment) return <EditFormSkeleton />
 
@@ -106,6 +113,13 @@ function EditForm({ enrollmentId, onClose }: { enrollmentId: number; onClose: ()
               <FormMessage />
             </FormItem>
           )}
+        />
+
+        <AssignmentStatusField
+          control={form.control}
+          statusName="assignment_status"
+          decisionName="assignment_decision_number"
+          status={assignmentStatus}
         />
 
         <FormField

--- a/components/admin/enrollments/EnrollmentEditModal.tsx
+++ b/components/admin/enrollments/EnrollmentEditModal.tsx
@@ -120,6 +120,7 @@ function EditForm({ enrollmentId, onClose }: { enrollmentId: number; onClose: ()
           statusName="assignment_status"
           decisionName="assignment_decision_number"
           status={assignmentStatus}
+          onDecisionCleared={() => form.setValue("assignment_decision_number", null)}
         />
 
         <FormField

--- a/components/admin/enrollments/EnrollmentViewModal.tsx
+++ b/components/admin/enrollments/EnrollmentViewModal.tsx
@@ -4,6 +4,7 @@ import { useEnrollment } from "@/lib/hooks/useEnrollments"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
+import { AssignmentStatusBadge } from "@/components/shared/AssignmentStatusBadge"
 
 const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
   prospect: { label: "Prospect", variant: "secondary" },
@@ -65,6 +66,20 @@ function ViewContent({ enrollmentId }: { enrollmentId: number }) {
           </Badge>
         </div>
       </div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-muted-foreground">Affectation</p>
+        <div>
+          <AssignmentStatusBadge status={enrollment.assignment_status} />
+        </div>
+      </div>
+      {/* Le numéro n'existe que pour un affecté ou un réaffecté : afficher un
+          tiret pour les autres laisserait croire à une saisie oubliée. */}
+      {enrollment.assignment_decision_number ? (
+        <DetailField
+          label="Numéro de décision"
+          value={enrollment.assignment_decision_number}
+        />
+      ) : null}
       <DetailField label="Notes" value={enrollment.notes ?? "—"} />
       <DetailField label="Créé le" value={formatDate(enrollment.created_at)} />
     </div>

--- a/components/admin/enrollments/EnrollmentsTable.tsx
+++ b/components/admin/enrollments/EnrollmentsTable.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { CrudTable } from "@/components/shared/CrudTable"
 import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
+import { AssignmentStatusBadge } from "@/components/shared/AssignmentStatusBadge"
 import { useDebounce } from "@/lib/hooks/useDebounce"
 import { cn } from "@/lib/utils"
 
@@ -107,11 +108,29 @@ function FilterChip({
 
 type ChipKey = "a_valider" | "validees"
 
+type AssignmentChipKey = "tous" | "affectes" | "non_affectes" | "non_renseigne"
+
+// Affecté et réaffecté sont tous deux subventionnés par l'État : côté filtre
+// ils forment une seule cohorte, celle dont l'école ne facture qu'une part.
+function matchesAssignmentChip(enrollment: Enrollment, chip: AssignmentChipKey): boolean {
+  switch (chip) {
+    case "affectes":
+      return enrollment.assignment_status === "affecte" || enrollment.assignment_status === "reaffecte"
+    case "non_affectes":
+      return enrollment.assignment_status === "non_affecte"
+    case "non_renseigne":
+      return !enrollment.assignment_status
+    default:
+      return true
+  }
+}
+
 export function EnrollmentsTable() {
   const router = useRouter()
   const [page, setPage] = useState(1)
   const [search, setSearch] = useState("")
   const [activeChip, setActiveChip] = useState<ChipKey>("a_valider")
+  const [assignmentChip, setAssignmentChip] = useState<AssignmentChipKey>("tous")
   const [validateTarget, setValidateTarget] = useState<Enrollment | null>(null)
   const debouncedSearch = useDebounce(search)
 
@@ -144,12 +163,31 @@ export function EnrollmentsTable() {
     return { aValider, validees }
   }, [allItems])
 
-  const filteredItems = useMemo(() => {
+  // Cohorte de statut d'abord : les compteurs d'affectation doivent refléter
+  // la liste qu'on regarde, pas tout le tenant.
+  const statusFilteredItems = useMemo(() => {
     if (activeChip === "a_valider") {
       return allItems.filter((e) => TO_VALIDATE_STATUSES.has(e.status))
     }
     return allItems.filter((e) => e.status === "valide")
   }, [allItems, activeChip])
+
+  const assignmentCounts = useMemo(() => {
+    let affectes = 0
+    let nonAffectes = 0
+    let nonRenseigne = 0
+    for (const e of statusFilteredItems) {
+      if (matchesAssignmentChip(e, "affectes")) affectes += 1
+      else if (matchesAssignmentChip(e, "non_affectes")) nonAffectes += 1
+      else nonRenseigne += 1
+    }
+    return { tous: statusFilteredItems.length, affectes, nonAffectes, nonRenseigne }
+  }, [statusFilteredItems])
+
+  const filteredItems = useMemo(
+    () => statusFilteredItems.filter((e) => matchesAssignmentChip(e, assignmentChip)),
+    [statusFilteredItems, assignmentChip],
+  )
 
   const paginatedItems = useMemo(
     () => filteredItems.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
@@ -166,6 +204,11 @@ export function EnrollmentsTable() {
     setPage(1)
   }, [])
 
+  const handleAssignmentChipClick = useCallback((key: AssignmentChipKey) => {
+    setAssignmentChip(key)
+    setPage(1)
+  }, [])
+
   const handleValidate = useCallback(() => {
     if (!validateTarget) return
     validateMutation.mutate(validateTarget.id, {
@@ -174,6 +217,13 @@ export function EnrollmentsTable() {
   }, [validateMutation, validateTarget])
 
   const isToValidate = (e: Enrollment) => TO_VALIDATE_STATUSES.has(e.status)
+
+  // Une liste vide à cause du filtre d'affectation n'est pas une absence de
+  // données : sans cette nuance l'admin croit avoir perdu ses inscriptions.
+  const emptyMessage =
+    assignmentChip === "tous"
+      ? "Aucune inscription trouvée"
+      : "Aucune inscription ne correspond à cette affectation"
 
   const columns: ColumnDef<Enrollment>[] = useMemo(
     () => [
@@ -208,6 +258,11 @@ export function EnrollmentsTable() {
             {row.original.class_name ?? `#${row.original.class_id}`}
           </Badge>
         ),
+      },
+      {
+        accessorKey: "assignment_status",
+        header: "Affectation",
+        cell: ({ row }) => <AssignmentStatusBadge status={row.original.assignment_status} />,
       },
       {
         accessorKey: "status",
@@ -264,6 +319,38 @@ export function EnrollmentsTable() {
         />
       </div>
 
+      {/* Second axe : l'affectation. Séparé du pipeline de validation parce
+          qu'il répond à une autre question — non pas « que dois-je traiter »
+          mais « qui l'État subventionne », ce que le comptable croise avec la
+          grille tarifaire. */}
+      <div className="flex items-center gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-x-visible">
+        <span className="shrink-0 text-xs font-medium text-muted-foreground">Affectation</span>
+        <FilterChip
+          label="Tous"
+          count={assignmentCounts.tous}
+          isActive={assignmentChip === "tous"}
+          onClick={() => handleAssignmentChipClick("tous")}
+        />
+        <FilterChip
+          label="Affectés"
+          count={assignmentCounts.affectes}
+          isActive={assignmentChip === "affectes"}
+          onClick={() => handleAssignmentChipClick("affectes")}
+        />
+        <FilterChip
+          label="Non affectés"
+          count={assignmentCounts.nonAffectes}
+          isActive={assignmentChip === "non_affectes"}
+          onClick={() => handleAssignmentChipClick("non_affectes")}
+        />
+        <FilterChip
+          label="Non renseigné"
+          count={assignmentCounts.nonRenseigne}
+          isActive={assignmentChip === "non_renseigne"}
+          onClick={() => handleAssignmentChipClick("non_renseigne")}
+        />
+      </div>
+
       {/* Desktop : table dense via CrudTable. Mobile : liste minimaliste +
           bouton Valider distinct (Wave-style — la zone tap-to-drill n'avale
           pas l'action). */}
@@ -285,7 +372,7 @@ export function EnrollmentsTable() {
           onRowClick={(item) => router.push(`/admin/enrollments/${item.id}`)}
           renderEditModal={() => null}
           getItemLabel={(e) => `#${e.id}`}
-          emptyMessage="Aucune inscription trouvée"
+          emptyMessage={emptyMessage}
           errorMessage="Impossible de charger les inscriptions"
           deleteTitle="Supprimer l'inscription"
           deleteDescription="Cette action est irréversible. L'inscription sera définitivement supprimée."
@@ -305,7 +392,7 @@ export function EnrollmentsTable() {
         )}
         {!isLoading && paginatedItems.length === 0 && (
           <p className="rounded-lg border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
-            Aucune inscription trouvée
+            {emptyMessage}
           </p>
         )}
         {paginatedItems.map((e) => (
@@ -326,9 +413,12 @@ export function EnrollmentsTable() {
               }
               secondary={`${e.class_name ?? `#${e.class_id}`} · ${e.academic_year_name}`}
               status={
-                <Badge variant="secondary" className="text-[10px]">
-                  {statusLabels[e.status] ?? e.status}
-                </Badge>
+                <div className="flex flex-col items-end gap-1">
+                  <Badge variant="secondary" className="text-[10px]">
+                    {statusLabels[e.status] ?? e.status}
+                  </Badge>
+                  <AssignmentStatusBadge status={e.assignment_status} className="text-[10px]" />
+                </div>
               }
             />
             {isToValidate(e) && (

--- a/components/admin/enrollments/tabs/EnrollmentOverviewTab.tsx
+++ b/components/admin/enrollments/tabs/EnrollmentOverviewTab.tsx
@@ -5,10 +5,12 @@ import {
   CalendarDays,
   FileText,
   ClipboardCheck,
+  Landmark,
   User,
 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
+import { AssignmentStatusBadge } from "@/components/shared/AssignmentStatusBadge"
 import type { Enrollment } from "@/lib/contracts/enrollment"
 
 const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
@@ -102,6 +104,23 @@ export function EnrollmentOverviewTab({ enrollment }: EnrollmentOverviewTabProps
               </p>
               <div>
                 <Badge variant={status.variant}>{status.label}</Badge>
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                <Landmark className="h-3.5 w-3.5" />
+                Affectation
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <AssignmentStatusBadge status={enrollment.assignment_status} />
+                {/* Le numéro de décision ne vaut que pour un élève pris en
+                    charge par l'État : on ne l'affiche que s'il existe. */}
+                {enrollment.assignment_decision_number ? (
+                  <span className="text-sm font-medium tabular-nums">
+                    {enrollment.assignment_decision_number}
+                  </span>
+                ) : null}
               </div>
             </div>
 

--- a/components/admin/fees/FeeVariantCopyModal.tsx
+++ b/components/admin/fees/FeeVariantCopyModal.tsx
@@ -5,6 +5,7 @@ import { Copy, Loader2, ArrowRight } from "lucide-react"
 import { toast } from "sonner"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Select,
@@ -15,6 +16,16 @@ import {
 } from "@/components/ui/select"
 import { useCreateFeeVariant } from "@/lib/hooks/useFees"
 import type { FeeCategory, FeeVariant } from "@/lib/contracts/fee"
+
+/**
+ * Un niveau peut porter plusieurs montants pour la même catégorie, un par
+ * portée d'affectation. La clé les distingue, sinon copier une grille
+ * « affecté + non affecté » n'en retiendrait qu'une moitié en croyant à un
+ * doublon.
+ */
+function variantKey(levelId: number, scope: string | null | undefined): string {
+  return `${levelId}:${scope ?? "tous"}`
+}
 
 interface FeeVariantCopyModalProps {
   open: boolean
@@ -67,9 +78,17 @@ export function FeeVariantCopyModal({
     }
   }, [open])
 
-  // Niveaux déjà configurés sur la cible : on évite de proposer un doublon.
-  const targetLevelIds = useMemo(
-    () => new Set(targetId ? variants.filter((v) => v.fee_category_id === targetId).map((v) => v.level_id) : []),
+  // Couples niveau + portée déjà configurés sur la cible : on évite de
+  // proposer un doublon.
+  const targetKeys = useMemo(
+    () =>
+      new Set(
+        targetId
+          ? variants
+              .filter((v) => v.fee_category_id === targetId)
+              .map((v) => variantKey(v.level_id, v.assignment_scope))
+          : [],
+      ),
     [targetId, variants],
   )
 
@@ -83,7 +102,7 @@ export function FeeVariantCopyModal({
   }
 
   const chosen = sourceVariants.filter((v) => selected.has(v.id))
-  const willSkip = chosen.filter((v) => targetLevelIds.has(v.level_id)).length
+  const willSkip = chosen.filter((v) => targetKeys.has(variantKey(v.level_id, v.assignment_scope))).length
   const willCopy = chosen.length - willSkip
   const canSubmit = !!sourceId && !!targetId && sourceId !== targetId && willCopy > 0 && !busy
 
@@ -93,11 +112,15 @@ export function FeeVariantCopyModal({
     let ok = 0
     let failed = 0
     for (const v of chosen) {
-      if (targetLevelIds.has(v.level_id)) continue // doublon niveau -> on saute
+      if (targetKeys.has(variantKey(v.level_id, v.assignment_scope))) continue // doublon -> on saute
       try {
         await mutateAsync({
           fee_category_id: targetId,
           level_id: v.level_id,
+          // Sans la portée, un montant réservé aux affectés serait recopié
+          // comme applicable à tous : les non affectés paieraient le tarif
+          // subventionné et l'école perdrait la différence.
+          assignment_scope: v.assignment_scope ?? null,
           amount: v.amount,
           academic_year_id: academicYearId,
         })
@@ -154,8 +177,24 @@ export function FeeVariantCopyModal({
                       className="flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-muted/50"
                     >
                       <Checkbox checked={selected.has(v.id)} onCheckedChange={() => toggle(v.id)} />
-                      <span className="flex-1 text-sm">{levelNameMap.get(v.level_id) ?? `#${v.level_id}`}</span>
-                      <span className="text-sm font-semibold tabular-nums">
+                      <span className="min-w-0 flex-1 truncate text-sm">
+                        {levelNameMap.get(v.level_id) ?? `#${v.level_id}`}
+                      </span>
+                      {v.assignment_scope ? (
+                        // Même repère que l'arbre des frais : deux lignes sur
+                        // le même niveau visent des élèves différents.
+                        <Badge
+                          variant="outline"
+                          className={
+                            v.assignment_scope === "affecte"
+                              ? "h-5 shrink-0 border-emerald-300 text-[10px] text-emerald-700 dark:border-emerald-800 dark:text-emerald-300"
+                              : "h-5 shrink-0 border-amber-300 text-[10px] text-amber-700 dark:border-amber-800 dark:text-amber-300"
+                          }
+                        >
+                          {v.assignment_scope === "affecte" ? "affecté" : "non affecté"}
+                        </Badge>
+                      ) : null}
+                      <span className="shrink-0 text-sm font-semibold tabular-nums">
                         {v.amount.toLocaleString("fr-FR")} FCFA
                       </span>
                     </label>

--- a/components/forms/AssignmentStatusField.tsx
+++ b/components/forms/AssignmentStatusField.tsx
@@ -18,6 +18,12 @@ interface AssignmentStatusFieldProps<T extends FieldValues> {
   decisionName: Path<T>
   /** Statut courant, pour n'afficher le numéro de décision que s'il sert. */
   status: string | null | undefined
+  /**
+   * Appelé quand le statut cesse d'être subventionné : le formulaire parent
+   * doit alors vider le numéro de décision, sans quoi une valeur périmée
+   * continue de voyager.
+   */
+  onDecisionCleared?: () => void
 }
 
 /**
@@ -36,6 +42,7 @@ export function AssignmentStatusField<T extends FieldValues>({
   statusName,
   decisionName,
   status,
+  onDecisionCleared,
 }: AssignmentStatusFieldProps<T>) {
   const subsidised = status === "affecte" || status === "reaffecte"
 
@@ -49,7 +56,17 @@ export function AssignmentStatusField<T extends FieldValues>({
             <FormLabel>Affectation</FormLabel>
             <Select
               value={field.value ?? "non_renseigne"}
-              onValueChange={(v) => field.onChange(v === "non_renseigne" ? null : v)}
+              onValueChange={(v) => {
+                const next = v === "non_renseigne" ? null : v
+                field.onChange(next)
+                // Repasser en « non affecté » masque le numéro de décision
+                // mais laissait sa valeur dans le formulaire : un numéro
+                // périmé partait alors au serveur, rattaché à un élève qui
+                // n'est plus affecté. On le vide avec le statut.
+                if (next !== "affecte" && next !== "reaffecte") {
+                  onDecisionCleared?.()
+                }
+              }}
             >
               <FormControl>
                 <SelectTrigger className="h-11 sm:h-10">

--- a/components/forms/EnrollmentForm.tsx
+++ b/components/forms/EnrollmentForm.tsx
@@ -399,6 +399,7 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
               statusName="assignment_status"
               decisionName="assignment_decision_number"
               status={newForm.watch("assignment_status")}
+              onDecisionCleared={() => newForm.setValue("assignment_decision_number", null)}
             />
           ) : (
             <AssignmentStatusField
@@ -406,6 +407,7 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
               statusName="assignment_status"
               decisionName="assignment_decision_number"
               status={reForm.watch("assignment_status")}
+              onDecisionCleared={() => reForm.setValue("assignment_decision_number", null)}
             />
           )}
         </div>

--- a/components/shared/AssignmentStatusBadge.tsx
+++ b/components/shared/AssignmentStatusBadge.tsx
@@ -1,0 +1,42 @@
+import { Badge } from "@/components/ui/badge"
+import { assignmentStatusLabel } from "@/lib/contracts/enrollment"
+import { cn } from "@/lib/utils"
+
+interface AssignmentStatusBadgeProps {
+  status: string | null | undefined
+  className?: string
+}
+
+/**
+ * Repère visuel du statut d'affectation.
+ *
+ * L'affectation décide de qui paie : un affecté est subventionné par l'État,
+ * un non affecté a toute sa scolarité à la charge de la famille. Le caissier
+ * doit voir cet écart sans ouvrir la fiche, sinon il réclame le mauvais
+ * montant. Le réaffecté partage le ton de l'affecté parce qu'il est
+ * subventionné pareil, seule l'étiquette les distingue pour les dossiers du
+ * ministère.
+ *
+ * « Non renseigné » reste volontairement neutre : c'est une information qui
+ * manque, pas une alerte, et la teindre reviendrait à accuser une famille.
+ */
+export function AssignmentStatusBadge({ status, className }: AssignmentStatusBadgeProps) {
+  const subsidised = status === "affecte" || status === "reaffecte"
+  const unassigned = status === "non_affecte"
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "text-[11px] font-medium",
+        subsidised &&
+          "border-emerald-300 text-emerald-700 dark:border-emerald-800 dark:text-emerald-300",
+        unassigned && "border-amber-300 text-amber-700 dark:border-amber-800 dark:text-amber-300",
+        !subsidised && !unassigned && "border-dashed text-muted-foreground",
+        className,
+      )}
+    >
+      {assignmentStatusLabel(status)}
+    </Badge>
+  )
+}


### PR DESCRIPTION
## Ce qui manquait

Le statut d'affectation décide de ce qu'une famille paie : un élève affecté par l'État dans un établissement privé est subventionné, un non affecté prend toute la scolarité à sa charge, un réaffecté est subventionné comme un affecté.

Le backend et les contrats portaient déjà l'information, mais côté écran elle n'existait qu'à un seul endroit : le wizard de création. Concrètement, une fois l'inscription créée, le secrétariat ne pouvait ni la lire dans la liste, ni la retrouver sur la fiche, ni la corriger quand la décision du ministère arrivait après coup. Le champ existait, le système autour n'existait pas.

## Ce que ça change

**Lecture.** Nouveau composant partagé `AssignmentStatusBadge`, avec trois tons : vert émeraude pour les subventionnés (affecté et réaffecté, qui partagent le ton parce qu'ils partagent le tarif), ambre pour les non affectés, gris pointillé discret pour un statut non renseigné. Le non renseigné reste neutre : c'est une information qui manque, pas une alerte.

La pastille apparaît dans la liste des inscriptions (colonne sur ordinateur, carte sur téléphone), dans le modal de consultation et dans l'onglet Aperçu de la fiche, avec le numéro de décision quand il existe.

**Correction.** Le modal de modification expose désormais le statut et le numéro de décision via le `AssignmentStatusField` déjà en place. C'est le vrai besoin métier : la décision d'affectation arrive souvent après l'inscription.

**Filtre.** Pastilles « Tous / Affectés / Non affectés / Non renseigné » sur la liste. « Non renseigné » sert surtout à retrouver les dossiers dont l'affectation reste à saisir avant l'édition des frais.

**Frais.** `FeeVariantCopyModal` recopiait les montants sans leur portée d'affectation. Un tarif réservé aux affectés devenait un montant applicable à tout le monde, et les non affectés se seraient vus facturer le tarif subventionné. La portée est maintenant transmise, la détection de doublon tient compte du couple niveau + portée (sinon copier une grille « affecté + non affecté » n'en gardait qu'une moitié), et chaque ligne affiche sa portée comme dans l'arbre des frais.

## À savoir pour la revue

`GET /enrollments` n'accepte pas de paramètre `assignment_status` (vérifié dans `app/routers/enrollments.py` : `class_id`, `student_id`, `status`, `academic_year_id`, `search`, `page`, `size`). Le filtre est donc **côté client**, sur les 100 lignes déjà chargées, exactement comme les pastilles « À valider / Validées » existantes. Aucun paramètre inventé n'est envoyé au backend. Si la volumétrie dépasse 100 inscriptions par tenant, il faudra un filtre serveur, comme déjà noté dans le commentaire du composant.

Les pastilles vivent dans `EnrollmentsTable` et non dans `EnrollmentsPageClient` : c'est la table qui détient les données et les pastilles existantes, et les compteurs par affectation ont besoin de la liste chargée. Les compteurs sont calculés sur la cohorte de statut sélectionnée, pour refléter la liste effectivement affichée.

## Vérifications

- `tsc --noEmit` : propre.
- `next lint --dir components --dir lib` : aucune erreur, aucun avertissement nouveau (les deux avertissements `allItems` de `EnrollmentsTable` préexistaient et leur nombre est inchangé).
