### PR TITLE
feat(ui): corbeille avec confirmation par appui maintenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Écran « Corbeille » : les fiches retirées des écrans restent conservées, avec qui les a archivées, quand et pourquoi, et se restaurent en un clic *(admin, directeur)*.
+- Les gestes qui ne se rattrapent pas demandent un motif et se confirment en maintenant le bouton appuyé, cinq secondes pour archiver, dix pour supprimer définitivement. Le motif part au journal et à la direction *(admin, directeur)*.
 - Affectation de l'élève à l'inscription : affecté, réaffecté ou non affecté, avec le numéro de décision demandé uniquement quand il sert. Le montant des frais suit automatiquement *(secrétariat, éducateur)*.
 - Un montant de frais peut ne valoir que pour les affectés ou que pour les non affectés. L'arbre des frais affiche la portée, si bien que deux montants sur le même niveau ne passent plus pour un doublon *(comptable)*.
 

--- a/app/(admin)/admin/archive/page.tsx
+++ b/app/(admin)/admin/archive/page.tsx
@@ -1,0 +1,7 @@
+import { ArchiveClient } from "@/components/admin/archive/ArchiveClient"
+
+export const metadata = { title: "Corbeille | KLASSCI" }
+
+export default function ArchivePage() {
+  return <ArchiveClient />
+}

--- a/components/admin/archive/ArchiveCards.tsx
+++ b/components/admin/archive/ArchiveCards.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { entityLabel, formatStamp } from "@/components/admin/audit/audit-labels"
+import type { ArchiveEntry } from "@/lib/contracts/archive"
+import { ArchiveRowActions } from "./ArchiveRowActions"
+
+interface ArchiveCardsProps {
+  items: ArchiveEntry[]
+  canPurge: boolean
+}
+
+/**
+ * Vue tactile de la corbeille.
+ *
+ * Un tableau à six colonnes sur un écran de six centimètres force le zoom et
+ * le défilement latéral. Ici chaque fiche est une carte, et les deux actions
+ * sont posées en bas, à portée du pouce.
+ */
+export function ArchiveCards({ items, canPurge }: ArchiveCardsProps) {
+  return (
+    <div className="space-y-3 md:hidden">
+      {items.map((entry) => {
+        const stamp = entry.archived_at ? formatStamp(entry.archived_at) : null
+        return (
+          <div
+            key={`${entry.entity_type}-${entry.entity_id}`}
+            className="rounded-lg border bg-card p-4 shadow-sm"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold">
+                  {entry.label ?? `Fiche nº ${entry.entity_id}`}
+                </p>
+                <p className="text-xs text-muted-foreground">nº {entry.entity_id}</p>
+              </div>
+              <Badge variant="secondary" className="shrink-0">
+                {entityLabel(entry.entity_type)}
+              </Badge>
+            </div>
+
+            <div className="mt-3 rounded-md border border-border/60 bg-muted/40 p-3">
+              <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Motif
+              </p>
+              <p className="mt-0.5 text-sm">
+                {entry.archive_reason ?? "Aucun motif enregistré"}
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Par {entry.archived_by_name ?? "auteur inconnu"}
+                {stamp ? ` le ${stamp.date} à ${stamp.time}` : ""}
+              </p>
+            </div>
+
+            <div className="mt-3">
+              <ArchiveRowActions entry={entry} canPurge={canPurge} stacked />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/admin/archive/ArchiveClient.tsx
+++ b/components/admin/archive/ArchiveClient.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Archive, CalendarClock, GraduationCap, Trash2, Users } from "lucide-react"
+import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useArchiveList } from "@/lib/hooks/useArchive"
+import { usePermissions } from "@/lib/hooks/usePermissions"
+import { PERSON_ENTITIES, type ArchiveQuery } from "@/lib/contracts/archive"
+import { formatStamp } from "@/components/admin/audit/audit-labels"
+import { ArchiveCards } from "./ArchiveCards"
+import { ArchiveFilterChips } from "./ArchiveFilterChips"
+import { ArchiveTable } from "./ArchiveTable"
+
+const PAGE_SIZE = 25
+
+/**
+ * La corbeille de l'établissement.
+ *
+ * Archiver retire une fiche des écrans sans rien détruire : cet écran est la
+ * porte de sortie de ce geste. Il doit donc rester lisible même quand le
+ * backend renvoie des lignes incomplètes, parce que c'est précisément quand
+ * quelque chose s'est mal passé qu'on vient ici.
+ */
+export function ArchiveClient() {
+  const [entityType, setEntityType] = useState<string | undefined>(undefined)
+  const [page, setPage] = useState(1)
+
+  const { has } = usePermissions()
+  const canPurge = has("archive:purge")
+
+  const query: ArchiveQuery = useMemo(
+    () => ({ page, size: PAGE_SIZE, ...(entityType ? { entity_type: entityType } : {}) }),
+    [page, entityType],
+  )
+  const { data, isLoading, isError, error, refetch, isFetching } = useArchiveList(query)
+
+  const items = useMemo(() => data?.items ?? [], [data])
+  const total = data?.total ?? 0
+  const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  const kpis: HeroKpi[] = useMemo(() => {
+    const students = items.filter((entry) => entry.entity_type === "student").length
+    const people = items.filter((entry) => PERSON_ENTITIES.includes(entry.entity_type)).length
+    // Le plus ancien de la page affichée : on ne prétend pas connaître le plus
+    // ancien de toute la corbeille, on n'en a que cette page sous les yeux.
+    const oldest = items
+      .map((entry) => entry.archived_at)
+      .filter((value): value is string => Boolean(value))
+      .sort()
+      .at(0)
+    return [
+      { label: "Éléments archivés", value: total, icon: Archive },
+      { label: "Dont élèves", value: students, icon: GraduationCap, hint: "sur cette page" },
+      { label: "Dont personnes", value: people, icon: Users, hint: "sur cette page" },
+      {
+        label: "Plus ancien",
+        value: oldest ? formatStamp(oldest).date : "—",
+        icon: CalendarClock,
+        hint: "sur cette page",
+      },
+    ]
+  }, [items, total])
+
+  function changeFilter(next: string | undefined) {
+    // Changer de filtre ramène en page 1 : rester en page 4 d'un résultat qui
+    // n'en compte plus qu'une donne un écran vide sans explication.
+    setEntityType(next)
+    setPage(1)
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        icon={Archive}
+        title="Corbeille"
+        subtitle="Les fiches retirées des écrans, conservées et restaurables"
+        kpis={kpis}
+      />
+
+      <Card className="rounded-xl border shadow-sm">
+        <CardContent className="space-y-5 p-5">
+          <ArchiveFilterChips value={entityType} onChange={changeFilter} />
+
+          {isLoading ? (
+            <div className="space-y-2" aria-live="polite" aria-busy="true">
+              <span className="sr-only">Chargement de la corbeille</span>
+              {Array.from({ length: 5 }).map((_, index) => (
+                <Skeleton key={index} className="h-20 w-full rounded-lg" />
+              ))}
+            </div>
+          ) : isError ? (
+            <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-center dark:border-rose-900/50 dark:bg-rose-950/30">
+              <p className="text-sm font-medium text-rose-900 dark:text-rose-100">
+                {error instanceof Error ? error.message : "La corbeille n'a pas pu être chargée."}
+              </p>
+              <p className="mt-1 text-xs text-rose-800/80 dark:text-rose-200/80">
+                Rien n&apos;est perdu : les fiches archivées restent conservées.
+              </p>
+              <Button
+                variant="outline"
+                className="mt-3 h-11 sm:h-10"
+                onClick={() => void refetch()}
+                disabled={isFetching}
+              >
+                Réessayer
+              </Button>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="rounded-lg border border-dashed p-10 text-center">
+              <Trash2 aria-hidden="true" className="mx-auto h-8 w-8 text-muted-foreground" />
+              <p className="mt-3 text-sm font-medium">
+                {entityType ? "Rien d'archivé pour ce type de fiche" : "La corbeille est vide"}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {entityType
+                  ? "Choisissez « Tout » pour voir le reste de la corbeille."
+                  : "Une fiche archivée depuis son écran apparaîtra ici, prête à être restaurée."}
+              </p>
+            </div>
+          ) : (
+            <>
+              <ArchiveTable items={items} canPurge={canPurge} />
+              <ArchiveCards items={items} canPurge={canPurge} />
+
+              <div className="flex flex-col items-center justify-between gap-3 sm:flex-row">
+                <p className="text-xs text-muted-foreground">
+                  Page {page} sur {lastPage} · {total} élément{total > 1 ? "s" : ""}
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    className="h-11 sm:h-10"
+                    disabled={page <= 1 || isFetching}
+                    onClick={() => setPage((current) => Math.max(1, current - 1))}
+                  >
+                    Précédent
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="h-11 sm:h-10"
+                    disabled={page >= lastPage || isFetching}
+                    onClick={() => setPage((current) => Math.min(lastPage, current + 1))}
+                  >
+                    Suivant
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/admin/archive/ArchiveFilterChips.tsx
+++ b/components/admin/archive/ArchiveFilterChips.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { ARCHIVABLE_ENTITIES } from "@/lib/contracts/archive"
+import { cn } from "@/lib/utils"
+
+interface ArchiveFilterChipsProps {
+  /** `undefined` = aucun filtre, on montre toute la corbeille. */
+  value: string | undefined
+  onChange: (entityType: string | undefined) => void
+}
+
+const CHIPS: Array<{ value: string | undefined; label: string }> = [
+  { value: undefined, label: "Tout" },
+  ...Object.entries(ARCHIVABLE_ENTITIES).map(([key, meta]) => ({
+    value: key,
+    label: meta.plural,
+  })),
+]
+
+/**
+ * Pastilles de filtre par type de fiche.
+ *
+ * Des boutons plutôt qu'une liste déroulante : sur un téléphone d'entrée de
+ * gamme, un menu qui s'ouvre coûte deux gestes et masque l'écran. Ici tout
+ * est visible d'un coup, et la pastille active se lit à la couleur.
+ */
+export function ArchiveFilterChips({ value, onChange }: ArchiveFilterChipsProps) {
+  return (
+    <div
+      className="flex flex-wrap gap-2"
+      role="group"
+      aria-label="Filtrer la corbeille par type de fiche"
+    >
+      {CHIPS.map((chip) => {
+        const isActive = chip.value === value
+        return (
+          <button
+            key={chip.label}
+            type="button"
+            onClick={() => onChange(chip.value)}
+            aria-pressed={isActive}
+            className={cn(
+              "inline-flex h-11 items-center rounded-full border px-4 text-sm font-medium transition-colors sm:h-9",
+              isActive
+                ? "border-transparent bg-accent text-accent-foreground shadow-sm"
+                : "border-input bg-background text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+            )}
+          >
+            {chip.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/admin/archive/ArchiveRowActions.tsx
+++ b/components/admin/archive/ArchiveRowActions.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useState } from "react"
+import { RotateCcw, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { DestructiveActionDialog } from "@/components/shared/DestructiveActionDialog"
+import { usePurgeEntity, useRestoreEntity } from "@/lib/hooks/useArchive"
+import { isArchivableEntity, type ArchiveEntry } from "@/lib/contracts/archive"
+import { entityLabel } from "@/components/admin/audit/audit-labels"
+import { cn } from "@/lib/utils"
+
+interface ArchiveRowActionsProps {
+  entry: ArchiveEntry
+  /** Vrai seulement pour qui détient `archive:purge`. */
+  canPurge: boolean
+  /** `true` sur les cartes tactiles : les boutons occupent toute la largeur. */
+  stacked?: boolean
+}
+
+/**
+ * Les deux issues possibles pour une fiche archivée.
+ *
+ * Restaurer est un bouton simple : ce geste répare, il ne détruit rien, et
+ * l'entourer de confirmations le rendrait aussi intimidant que la purge.
+ * Supprimer définitivement passe, lui, par le motif puis le maintien de dix
+ * secondes.
+ */
+export function ArchiveRowActions({ entry, canPurge, stacked = false }: ArchiveRowActionsProps) {
+  const [purgeOpen, setPurgeOpen] = useState(false)
+  const restore = useRestoreEntity()
+  const purge = usePurgeEntity()
+
+  // Un type inconnu du frontend ne doit pas devenir une URL devinée : on
+  // n'affiche aucune action plutôt que d'appeler une route au hasard.
+  if (!isArchivableEntity(entry.entity_type)) return null
+  const entity = entry.entity_type
+
+  const subject = entry.label ?? `${entityLabel(entity)} nº ${entry.entity_id}`
+  const isBusy = restore.isPending || purge.isPending
+  const buttonWidth = stacked && "flex-1"
+
+  return (
+    <div className={cn("flex gap-2", !stacked && "justify-end")}>
+      <Button
+        type="button"
+        variant="outline"
+        className={cn("h-11 sm:h-9", buttonWidth)}
+        disabled={isBusy}
+        onClick={() => restore.mutate({ entity, id: entry.entity_id })}
+      >
+        <RotateCcw className="h-4 w-4" aria-hidden="true" />
+        <span>Restaurer</span>
+        <span className="sr-only"> {subject}</span>
+      </Button>
+
+      {canPurge && (
+        <Button
+          type="button"
+          variant="ghost"
+          className={cn(
+            "h-11 text-destructive hover:bg-destructive/10 hover:text-destructive sm:h-9",
+            buttonWidth,
+          )}
+          disabled={isBusy}
+          onClick={() => setPurgeOpen(true)}
+        >
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
+          <span>Supprimer</span>
+          <span className="sr-only"> définitivement {subject}</span>
+        </Button>
+      )}
+
+      <DestructiveActionDialog
+        open={purgeOpen}
+        onOpenChange={setPurgeOpen}
+        title="Supprimer définitivement"
+        description="Cette fiche et son historique quitteront l'établissement pour de bon."
+        subject={subject}
+        consequence="Aucune restauration ne sera possible, ni par vous, ni par la direction, ni par KLASSCI."
+        seconds={10}
+        confirmLabel="Maintenir pour supprimer"
+        holdingLabel="Ne relâchez pas"
+        tone="danger"
+        isPending={purge.isPending}
+        onConfirm={(reason) => {
+          purge.mutate(
+            { entity, id: entry.entity_id, reason },
+            { onSuccess: () => setPurgeOpen(false) },
+          )
+        }}
+      />
+    </div>
+  )
+}

--- a/components/admin/archive/ArchiveTable.tsx
+++ b/components/admin/archive/ArchiveTable.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { entityLabel, formatStamp } from "@/components/admin/audit/audit-labels"
+import type { ArchiveEntry } from "@/lib/contracts/archive"
+import { ArchiveRowActions } from "./ArchiveRowActions"
+
+interface ArchiveTableProps {
+  items: ArchiveEntry[]
+  canPurge: boolean
+}
+
+/** Vue large. La version tactile de la même liste vit dans `ArchiveCards`. */
+export function ArchiveTable({ items, canPurge }: ArchiveTableProps) {
+  return (
+    <div className="hidden overflow-x-auto rounded-lg border md:block">
+      <Table>
+        <TableHeader className="bg-muted/60">
+          <TableRow>
+            <TableHead>Fiche</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Archivée par</TableHead>
+            <TableHead>Quand</TableHead>
+            <TableHead>Motif</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.map((entry) => {
+            const stamp = entry.archived_at ? formatStamp(entry.archived_at) : null
+            return (
+              <TableRow key={`${entry.entity_type}-${entry.entity_id}`}>
+                <TableCell className="font-medium">
+                  {entry.label ?? `Fiche nº ${entry.entity_id}`}
+                  <p className="text-xs font-normal text-muted-foreground">
+                    nº {entry.entity_id}
+                  </p>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="secondary">{entityLabel(entry.entity_type)}</Badge>
+                </TableCell>
+                <TableCell>{entry.archived_by_name ?? "Auteur inconnu"}</TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {stamp ? (
+                    <>
+                      <p>{stamp.date}</p>
+                      <p className="text-xs text-muted-foreground">{stamp.time}</p>
+                    </>
+                  ) : (
+                    <span className="text-muted-foreground">Date inconnue</span>
+                  )}
+                </TableCell>
+                <TableCell className="max-w-xs">
+                  {/* Le motif est la seule trace de la décision : on le montre
+                      en entier au survol plutôt que de le couper en silence. */}
+                  <p
+                    className="line-clamp-2 text-sm text-muted-foreground"
+                    title={entry.archive_reason ?? undefined}
+                  >
+                    {entry.archive_reason ?? "Aucun motif enregistré"}
+                  </p>
+                </TableCell>
+                <TableCell>
+                  <ArchiveRowActions entry={entry} canPurge={canPurge} />
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/components/shared/DestructiveActionDialog.tsx
+++ b/components/shared/DestructiveActionDialog.tsx
@@ -1,0 +1,197 @@
+"use client"
+
+import { useEffect, useId, useState } from "react"
+import { AlertTriangle, Mail, ScrollText } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { HoldToConfirmButton } from "@/components/shared/HoldToConfirmButton"
+import { ARCHIVE_REASON_MIN_LENGTH } from "@/lib/contracts/archive"
+import { cn } from "@/lib/utils"
+
+export type DestructiveTone = "warning" | "danger"
+
+interface DestructiveActionDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Titre du dialogue, par exemple « Archiver cette fiche ». */
+  title: string
+  /** Ce que le geste va réellement faire, en une phrase. */
+  description: string
+  /** Le libellé de la fiche visée, rappelé pour éviter l'erreur de ligne. */
+  subject?: string | null
+  /** Durée du maintien : 5 s pour archiver, 10 s pour supprimer. */
+  seconds: number
+  confirmLabel: string
+  holdingLabel: string
+  /** `warning` pour un geste réversible, `danger` pour l'irréversible. */
+  tone?: DestructiveTone
+  /** Phrase supplémentaire affichée en encadré, pour l'irréversible. */
+  consequence?: string
+  isPending?: boolean
+  onConfirm: (reason: string) => void
+}
+
+/**
+ * Demande un motif avant un geste destructeur, puis n'ouvre la confirmation
+ * qu'une fois ce motif écrit.
+ *
+ * Le motif n'est pas une formalité : il part au journal et par courriel à la
+ * direction. Le dialogue le dit avant la saisie, pas après, parce qu'une
+ * personne qui sait que sa phrase sera lue en écrit une vraie.
+ */
+export function DestructiveActionDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  subject,
+  seconds,
+  confirmLabel,
+  holdingLabel,
+  tone = "danger",
+  consequence,
+  isPending = false,
+  onConfirm,
+}: DestructiveActionDialogProps) {
+  const [reason, setReason] = useState("")
+  const reasonId = useId()
+  const hintId = useId()
+
+  // À chaque ouverture on repart d'un motif vide : réutiliser celui de la
+  // fiche précédente ferait signer une justification qui ne la concerne pas.
+  useEffect(() => {
+    if (open) setReason("")
+  }, [open])
+
+  const trimmedLength = reason.trim().length
+  const isReasonValid = trimmedLength >= ARCHIVE_REASON_MIN_LENGTH
+  const missing = ARCHIVE_REASON_MIN_LENGTH - trimmedLength
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-lg"
+        // On ne ferme pas sur un appui à côté : le motif déjà tapé serait
+        // perdu, et sur téléphone le doigt sort du cadre très facilement.
+        onInteractOutside={(event) => event.preventDefault()}
+      >
+        <DialogHeader>
+          <div className="flex items-start gap-3">
+            <span
+              className={cn(
+                "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-white shadow-sm",
+                tone === "danger"
+                  ? "bg-gradient-to-br from-rose-600 to-rose-500"
+                  : "bg-gradient-to-br from-amber-500 to-amber-400",
+              )}
+            >
+              <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0 space-y-1">
+              <DialogTitle className="text-base">{title}</DialogTitle>
+              <DialogDescription>{description}</DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {subject && (
+            <div className="rounded-lg border border-border/60 bg-muted/40 p-3">
+              <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Fiche concernée
+              </p>
+              <p className="mt-0.5 truncate text-sm font-semibold">{subject}</p>
+            </div>
+          )}
+
+          {consequence && (
+            <div className="rounded-lg border border-rose-200 bg-rose-50 p-3 dark:border-rose-900/50 dark:bg-rose-950/30">
+              <p className="text-sm font-medium text-rose-900 dark:text-rose-100">{consequence}</p>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor={reasonId} className="text-sm font-medium">
+              Motif <span className="text-muted-foreground">(obligatoire)</span>
+            </Label>
+            <Textarea
+              id={reasonId}
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              aria-describedby={hintId}
+              aria-invalid={!isReasonValid}
+              placeholder="Expliquez en une phrase pourquoi cette décision est prise."
+              className="min-h-24 resize-none"
+              disabled={isPending}
+            />
+            <div id={hintId} className="flex items-center justify-between gap-3">
+              <p className="text-xs text-muted-foreground">
+                {isReasonValid
+                  ? "Motif suffisant."
+                  : `Encore ${missing} caractère${missing > 1 ? "s" : ""} au minimum.`}
+              </p>
+              <p
+                className={cn(
+                  "shrink-0 text-xs tabular-nums",
+                  isReasonValid ? "text-muted-foreground" : "text-amber-600 dark:text-amber-400",
+                )}
+              >
+                {trimmedLength} / {ARCHIVE_REASON_MIN_LENGTH}
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-1.5 rounded-lg border border-border/60 bg-muted/40 p-3">
+            <p className="flex items-start gap-2 text-xs text-muted-foreground">
+              <ScrollText className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              Votre nom, la date et ce motif seront enregistrés au journal de
+              l&apos;établissement.
+            </p>
+            <p className="flex items-start gap-2 text-xs text-muted-foreground">
+              <Mail className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              Un courriel sera envoyé à la direction.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            className="h-11 sm:h-10"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            Annuler
+          </Button>
+
+          {/* Le bouton de confirmation n'existe pas tant que le motif n'est
+              pas écrit : un bouton grisé invite à chercher comment l'activer,
+              un bouton absent dit clairement qu'il manque quelque chose. */}
+          {isReasonValid ? (
+            <HoldToConfirmButton
+              seconds={seconds}
+              label={confirmLabel}
+              holdingLabel={holdingLabel}
+              variant={tone === "danger" ? "destructive" : "default"}
+              disabled={isPending}
+              onConfirm={() => onConfirm(reason.trim())}
+            />
+          ) : (
+            <p className="flex h-11 items-center justify-center rounded-md border border-dashed px-4 text-xs text-muted-foreground sm:h-10">
+              Saisissez un motif pour débloquer la confirmation
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/shared/HoldToConfirmButton.tsx
+++ b/components/shared/HoldToConfirmButton.tsx
@@ -1,0 +1,212 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Button, type ButtonProps } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface HoldToConfirmButtonProps {
+  /** Durée du maintien, en secondes. 5 pour archiver, 10 pour supprimer. */
+  seconds: number
+  /** Ce que fait le bouton au repos. */
+  label: string
+  /** Ce qu'affiche le bouton pendant le maintien. */
+  holdingLabel: string
+  onConfirm: () => void
+  variant?: ButtonProps["variant"]
+  disabled?: boolean
+  className?: string
+}
+
+/**
+ * Bouton qu'il faut maintenir enfoncé pour confirmer.
+ *
+ * Pourquoi pas un simple clic : ces gestes ne se rattrapent pas. Une seconde
+ * d'attention involontaire suffit à cliquer, pas à tenir cinq secondes le
+ * doigt sur un bouton qui décompte. Le geste devient une décision.
+ *
+ * Relâcher avant la fin annule sans rien envoyer, et l'anneau repart de zéro :
+ * on ne cumule pas les maintiens successifs, sinon trois hésitations vaudraient
+ * une confirmation.
+ */
+export function HoldToConfirmButton({
+  seconds,
+  label,
+  holdingLabel,
+  onConfirm,
+  variant = "destructive",
+  disabled = false,
+  className,
+}: HoldToConfirmButtonProps) {
+  const [progress, setProgress] = useState(0)
+  const [holding, setHolding] = useState(false)
+
+  const frameRef = useRef<number | null>(null)
+  const startedAtRef = useRef(0)
+  // Miroir en ref de `holding` : la boucle d'animation lit une valeur fraîche
+  // à chaque image, là où l'état React de la fermeture serait figé.
+  const holdingRef = useRef(false)
+  // On appelle toujours le dernier `onConfirm` reçu sans relancer la boucle.
+  const onConfirmRef = useRef(onConfirm)
+
+  useEffect(() => {
+    onConfirmRef.current = onConfirm
+  }, [onConfirm])
+
+  const cancel = useCallback(() => {
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+    }
+    holdingRef.current = false
+    setHolding(false)
+    setProgress(0)
+  }, [])
+
+  const start = useCallback(() => {
+    if (disabled || holdingRef.current) return
+    holdingRef.current = true
+    setHolding(true)
+    setProgress(0)
+    startedAtRef.current = performance.now()
+
+    const tick = (now: number) => {
+      // Le composant a pu être démonté ou le maintien annulé entre deux
+      // images : sans cette garde, une image en vol déclencherait une
+      // suppression définitive sur un écran qui n'existe plus.
+      if (!holdingRef.current) return
+      const ratio = Math.min(1, (now - startedAtRef.current) / (seconds * 1000))
+      setProgress(ratio)
+      if (ratio >= 1) {
+        holdingRef.current = false
+        frameRef.current = null
+        setHolding(false)
+        setProgress(0)
+        onConfirmRef.current()
+        return
+      }
+      frameRef.current = requestAnimationFrame(tick)
+    }
+
+    frameRef.current = requestAnimationFrame(tick)
+  }, [disabled, seconds])
+
+  // Démontage : on coupe la boucle et on neutralise la garde, pour qu'aucune
+  // image déjà programmée ne confirme quoi que ce soit après coup.
+  useEffect(() => {
+    return () => {
+      holdingRef.current = false
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current)
+        frameRef.current = null
+      }
+    }
+  }, [])
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
+    if (event.key === "Escape") {
+      // On n'intercepte Échap que si un maintien est en cours : sinon la
+      // touche doit continuer à fermer le dialogue qui contient le bouton.
+      if (holdingRef.current) {
+        event.stopPropagation()
+        cancel()
+      }
+      return
+    }
+    if (event.key !== " " && event.key !== "Enter") return
+    // Sans cela, le navigateur émettrait un clic natif au relâchement :
+    // le maintien deviendrait un simple appui.
+    event.preventDefault()
+    if (event.repeat) return
+    start()
+  }
+
+  function handleKeyUp(event: React.KeyboardEvent<HTMLButtonElement>) {
+    if (event.key !== " " && event.key !== "Enter") return
+    event.preventDefault()
+    cancel()
+  }
+
+  const remaining = Math.max(1, Math.ceil(seconds * (1 - progress)))
+  const circumference = 2 * Math.PI * 9
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant={variant}
+        disabled={disabled}
+        aria-label={`${label}. Maintenir le bouton appuyé pendant ${seconds} secondes pour confirmer.`}
+        onPointerDown={start}
+        onPointerUp={cancel}
+        onPointerLeave={cancel}
+        onPointerCancel={cancel}
+        // Le doigt qui glisse hors du bouton, la fenêtre qui perd le focus
+        // alors qu'une touche est encore enfoncée : dans les deux cas le
+        // relâchement n'arrive jamais, il faut annuler soi-même.
+        onBlur={cancel}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        // Sur Android, l'appui long ouvre le menu contextuel et vole le geste.
+        onContextMenu={(event) => event.preventDefault()}
+        className={cn(
+          // Largeur minimale figée : le libellé change au moment du maintien
+          // et le décompte perd un chiffre en route. Sans cela le bouton
+          // rétrécirait sous le doigt qui est en train de le tenir.
+          "relative h-11 min-w-[13.5rem] select-none overflow-hidden px-4 font-semibold",
+          // `touch-none` empêche le navigateur mobile d'interpréter le maintien
+          // comme un défilement et d'annuler le pointeur en cours de route.
+          "touch-none",
+          className,
+        )}
+      >
+        {/* Remplissage qui progresse sous le libellé. `bg-current` suit la
+            couleur du texte du bouton : lisible sur rouge plein comme sur
+            un contour clair, en thème clair comme en sombre. */}
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-0 bg-current opacity-25 transition-[width] duration-75 ease-linear"
+          style={{ width: `${progress * 100}%` }}
+        />
+
+        <span className="relative z-10 flex items-center gap-2">
+          {/* Anneau de progression. Le décompte chiffré est posé dans le
+              libellé plutôt qu'au centre de l'anneau : un chiffre de neuf
+              pixels ne se lit pas sur un écran d'entrée de gamme en plein
+              soleil, alors qu'un « 4 s » à la taille du texte se lit. */}
+          <svg viewBox="0 0 24 24" className="-rotate-90" aria-hidden="true">
+            <circle
+              cx="12"
+              cy="12"
+              r="9"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              className="opacity-30"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              r="9"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={circumference * (1 - progress)}
+            />
+          </svg>
+          <span className="truncate">
+            {holding ? `${holdingLabel} · ${remaining} s` : label}
+          </span>
+        </span>
+      </Button>
+
+      {/* Le décompte doit être entendu, pas seulement vu. `assertive` parce
+          qu'un compte à rebours périmé n'a plus aucune valeur : chaque
+          annonce doit remplacer la précédente. */}
+      <span role="status" aria-live="assertive" className="sr-only">
+        {holding ? `Maintenez encore ${remaining} seconde${remaining > 1 ? "s" : ""}.` : ""}
+      </span>
+    </>
+  )
+}

--- a/components/shared/Sidebar.tsx
+++ b/components/shared/Sidebar.tsx
@@ -4,6 +4,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import {
+  Archive,
   ArrowUpFromLine,
   LayoutDashboard,
   UserPlus,
@@ -39,6 +40,7 @@ import { usePermissions } from "@/lib/hooks/usePermissions"
 import { filterAdminNavigation } from "@/lib/navigation/adminNav"
 
 const ICONS = {
+  Archive,
   Banknote,
   ClipboardCheck,
   ArrowUpFromLine,

--- a/lib/api/archive.ts
+++ b/lib/api/archive.ts
@@ -1,0 +1,72 @@
+import {
+  ARCHIVABLE_ENTITIES,
+  ArchiveListSchema,
+  type ArchivableEntity,
+  type ArchiveList,
+  type ArchiveQuery,
+} from "@/lib/contracts/archive"
+import { apiFetch, safeValidate } from "./client"
+
+function toSearchParams(query: ArchiveQuery): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null && value !== "") {
+      params.set(key, String(value))
+    }
+  }
+  const qs = params.toString()
+  return qs ? `?${qs}` : ""
+}
+
+/**
+ * Le backend peut renvoyer la page telle quelle ou l'emballer dans `{data}`.
+ * On déballe avant de valider : sinon le schéma échoue sur une enveloppe et
+ * l'écran affiche une erreur alors que les données sont là.
+ */
+function unwrap(json: unknown): unknown {
+  if (json !== null && typeof json === "object") {
+    const obj = json as Record<string, unknown>
+    if (obj.items !== undefined) return obj
+    if (obj.data !== undefined) return obj.data
+  }
+  return json
+}
+
+function basePath(entity: ArchivableEntity, id: number): string {
+  return `/admin/${ARCHIVABLE_ENTITIES[entity].path}/${id}`
+}
+
+export const archiveApi = {
+  /** La corbeille, paginée, éventuellement restreinte à un type de fiche. */
+  list: async (query: ArchiveQuery = {}): Promise<ArchiveList> => {
+    const json = await apiFetch<unknown>(`/admin/archive${toSearchParams(query)}`)
+    return safeValidate(ArchiveListSchema, unwrap(json), "GET /admin/archive")
+  },
+
+  /** Retire la fiche des écrans sans rien détruire. Le motif part au journal. */
+  archive: async (entity: ArchivableEntity, id: number, reason: string): Promise<void> => {
+    await apiFetch<unknown>(`${basePath(entity, id)}/archive`, {
+      method: "POST",
+      body: JSON.stringify({ reason }),
+    })
+  },
+
+  /** Remet la fiche en circulation. Réparer ne demande pas de justification. */
+  restore: async (entity: ArchivableEntity, id: number): Promise<void> => {
+    await apiFetch<unknown>(`${basePath(entity, id)}/restore`, { method: "POST" })
+  },
+
+  /**
+   * Suppression définitive, sans retour possible.
+   *
+   * Le motif voyage en paramètre d'URL, pas dans un corps : c'est le contrat
+   * du backend pour un DELETE. Il est encodé, un motif contenant « & » ou un
+   * accent ne doit pas casser la requête ni tronquer la justification.
+   */
+  purge: async (entity: ArchivableEntity, id: number, reason: string): Promise<void> => {
+    const params = new URLSearchParams({ reason })
+    await apiFetch<unknown>(`${basePath(entity, id)}?${params.toString()}`, {
+      method: "DELETE",
+    })
+  },
+}

--- a/lib/contracts/archive.ts
+++ b/lib/contracts/archive.ts
@@ -1,0 +1,68 @@
+import { z } from "zod"
+
+/**
+ * La corbeille de l'établissement : tout ce qui a été retiré des écrans sans
+ * être détruit.
+ *
+ * Le backend est en cours de livraison : chaque champ non structurant est
+ * `.nullish()`. Une fiche archivée dont le motif ou l'auteur manquerait à
+ * l'exécution doit s'afficher dégradée, jamais faire tomber l'écran, sinon la
+ * seule porte de sortie d'un archivage accidentel se referme.
+ */
+export const ArchiveEntrySchema = z.object({
+  entity_type: z.string(),
+  entity_id: z.number(),
+  label: z.string().nullish(),
+  archived_at: z.string().nullish(),
+  archived_by: z.number().nullish(),
+  archived_by_name: z.string().nullish(),
+  archive_reason: z.string().nullish(),
+})
+
+export const ArchiveListSchema = z.object({
+  items: z.array(ArchiveEntrySchema),
+  total: z.number(),
+  page: z.number(),
+  size: z.number(),
+})
+
+export type ArchiveEntry = z.infer<typeof ArchiveEntrySchema>
+export type ArchiveList = z.infer<typeof ArchiveListSchema>
+
+export interface ArchiveQuery {
+  entity_type?: string
+  page?: number
+  size?: number
+}
+
+/**
+ * Les familles d'objets archivables et leur route backend.
+ *
+ * Le type d'entité renvoyé par la corbeille commande l'URL d'appel : on ne
+ * devine pas un chemin en collant un « s » derrière le type, une faute de
+ * pluriel enverrait une purge sur la mauvaise ressource.
+ */
+export const ARCHIVABLE_ENTITIES = {
+  student: { path: "students", label: "Élève", plural: "Élèves", queryKey: "students" },
+  parent: { path: "parents", label: "Parent", plural: "Parents", queryKey: "parents" },
+  teacher: { path: "teachers", label: "Enseignant", plural: "Enseignants", queryKey: "teachers" },
+  staff: { path: "staff", label: "Personnel", plural: "Personnel", queryKey: "staff" },
+  enrollment: {
+    path: "enrollments",
+    label: "Inscription",
+    plural: "Inscriptions",
+    queryKey: "enrollments",
+  },
+} as const
+
+export type ArchivableEntity = keyof typeof ARCHIVABLE_ENTITIES
+
+export function isArchivableEntity(value: string): value is ArchivableEntity {
+  return Object.hasOwn(ARCHIVABLE_ENTITIES, value)
+}
+
+/** Le motif part au journal et par courriel : trop court, il n'explique rien. */
+export const ARCHIVE_REASON_MIN_LENGTH = 10
+
+/** Personnes physiques : sert au décompte « dont personnes » de la corbeille. */
+export const PERSON_ENTITIES: readonly string[] = ["parent", "teacher", "staff"]

--- a/lib/hooks/useArchive.ts
+++ b/lib/hooks/useArchive.ts
@@ -1,0 +1,102 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { archiveApi } from "@/lib/api/archive"
+import {
+  ARCHIVABLE_ENTITIES,
+  type ArchivableEntity,
+  type ArchiveQuery,
+} from "@/lib/contracts/archive"
+
+export const archiveKeys = {
+  all: ["archive"] as const,
+  list: (query: ArchiveQuery) => ["archive", "list", query] as const,
+}
+
+/**
+ * La corbeille. Volontairement peu de cache : après un archivage fait depuis
+ * une autre fiche, l'écran doit montrer l'élément qui vient d'arriver, sinon
+ * l'utilisateur croit que son geste n'a pas abouti et le refait.
+ */
+export function useArchiveList(query: ArchiveQuery) {
+  return useQuery({
+    queryKey: archiveKeys.list(query),
+    queryFn: () => archiveApi.list(query),
+    staleTime: 15_000,
+  })
+}
+
+/**
+ * Après un archivage, une restauration ou une purge, la fiche concernée a
+ * changé d'état des deux côtés : la corbeille et la liste métier d'origine.
+ * On invalide donc précisément ces deux racines, pas tout le cache, pour ne
+ * pas relancer l'ensemble des écrans ouverts.
+ */
+function useArchiveInvalidation() {
+  const queryClient = useQueryClient()
+  return (entity: ArchivableEntity) => {
+    queryClient.invalidateQueries({ queryKey: archiveKeys.all })
+    queryClient.invalidateQueries({ queryKey: [ARCHIVABLE_ENTITIES[entity].queryKey] })
+  }
+}
+
+interface ArchiveVariables {
+  entity: ArchivableEntity
+  id: number
+  reason: string
+}
+
+export function useArchiveEntity() {
+  const invalidate = useArchiveInvalidation()
+
+  return useMutation({
+    mutationFn: ({ entity, id, reason }: ArchiveVariables) =>
+      archiveApi.archive(entity, id, reason),
+    onSuccess: (_data, variables) => {
+      invalidate(variables.entity)
+      toast.success("Fiche archivée", {
+        description: "Elle a quitté les écrans. Rien n'est perdu, la corbeille la garde.",
+      })
+    },
+    onError: (error) => {
+      toast.error("Archivage impossible", { description: error.message })
+    },
+  })
+}
+
+export function useRestoreEntity() {
+  const invalidate = useArchiveInvalidation()
+
+  return useMutation({
+    mutationFn: ({ entity, id }: { entity: ArchivableEntity; id: number }) =>
+      archiveApi.restore(entity, id),
+    onSuccess: (_data, variables) => {
+      invalidate(variables.entity)
+      toast.success("Fiche restaurée", {
+        description: "Elle réapparaît dans les listes.",
+      })
+    },
+    onError: (error) => {
+      toast.error("Restauration impossible", { description: error.message })
+    },
+  })
+}
+
+export function usePurgeEntity() {
+  const invalidate = useArchiveInvalidation()
+
+  return useMutation({
+    mutationFn: ({ entity, id, reason }: ArchiveVariables) =>
+      archiveApi.purge(entity, id, reason),
+    onSuccess: (_data, variables) => {
+      invalidate(variables.entity)
+      toast.success("Suppression définitive effectuée", {
+        description: "Le motif a été enregistré et transmis à la direction.",
+      })
+    },
+    onError: (error) => {
+      toast.error("Suppression impossible", { description: error.message })
+    },
+  })
+}

--- a/lib/navigation/adminNav.ts
+++ b/lib/navigation/adminNav.ts
@@ -67,6 +67,10 @@ export const ADMIN_NAVIGATION: AdminNavSection[] = [
       { label: "Notifications", href: "/admin/notifications", iconName: "Bell", anyOf: [] },
       { label: "Rôles & Permissions", href: "/admin/roles", iconName: "ShieldCheck", anyOf: ["admin:roles:read"] },
       { label: "Journal d'audit", href: "/admin/audit" as Route, iconName: "ScrollText", anyOf: ["audit:read", "audit:read:financial"] },
+      // La corbeille n'a de sens que pour qui peut la lire : la donner à tout
+      // le monde laisserait croire qu'une fiche disparue est récupérable par
+      // n'importe qui, alors que restaurer et purger sont des droits distincts.
+      { label: "Corbeille", href: "/admin/archive" as Route, iconName: "Archive", anyOf: ["archive:read"] },
       { label: "Paramètres", href: "/admin/settings" as Route, iconName: "Settings", anyOf: ["admin:academic-years:read"] },
     ],
   },


### PR DESCRIPTION
## Ce que ça apporte

Une corbeille à deux temps côté portail admin.

**Archiver** retire une fiche de tous les écrans sans rien détruire. **Restaurer** la ramène, sans motif : ce geste répare, l'entourer de confirmations le rendrait aussi intimidant que la suppression. **Supprimer définitivement** ne se fait que depuis la corbeille et ne se rattrape pas.

Les deux gestes destructeurs exigent un motif d'au moins 10 caractères, et le dialogue prévient **avant la saisie** que le nom, la date et le motif partent au journal et par courriel à la direction. Une personne qui sait que sa phrase sera lue en écrit une vraie.

## Le bouton à maintenir

`components/shared/HoldToConfirmButton.tsx`. Cinq secondes pour archiver, dix pour supprimer définitivement, avec anneau de progression et décompte visible.

Choix d'ergonomie :

- **Le décompte est dans le libellé, pas au centre de l'anneau.** Un chiffre de neuf pixels ne se lit pas sur un Itel S661 en plein soleil ; « Ne relâchez pas · 4 s » à la taille du texte se lit.
- **Largeur minimale figée.** Le libellé change au moment du maintien et le décompte perd un chiffre en route : sans cette largeur, le bouton rétrécirait sous le doigt qui le tient.
- **Souris et tactile** via `onPointerDown` / `onPointerUp` / `onPointerLeave` / `onPointerCancel`, plus `touch-none` pour que le navigateur mobile ne prenne pas le maintien pour un défilement, et le menu contextuel Android neutralisé.
- **Clavier** : `Espace` ou `Entrée` maintenus lancent le même décompte, `Échap` annule. Le clic natif est bloqué au `keydown`, sinon un simple appui vaudrait un maintien. `Échap` n'est intercepté que pendant un maintien, pour continuer à fermer le dialogue le reste du temps.
- **Perte de focus** : le doigt qui glisse, la fenêtre qui passe en arrière-plan alors qu'une touche est enfoncée, dans les deux cas le relâchement n'arrive jamais, donc `onBlur` annule.
- **Démontage** : la boucle d'animation lit une garde en ref remise à zéro au démontage. Une image déjà programmée ne peut pas déclencher une suppression définitive sur un écran qui n'existe plus.
- **Annonce vocale** en `aria-live="assertive"` : un compte à rebours périmé n'a aucune valeur, chaque annonce doit remplacer la précédente.

## L'écran corbeille

`PageHero` avec ses KPIs (éléments archivés, dont élèves, dont personnes, plus ancien archivage), pastilles de filtre par type, tableau sur écran large et cartes tactiles sur mobile, chargement en Skeleton, vide, erreur avec « Réessayer ».

Les compteurs dérivés de la page affichée portent la mention « sur cette page » : la corbeille est paginée, prétendre connaître le plus ancien archivage de tout l'établissement serait faux.

L'entrée de menu n'apparaît que pour qui a `archive:read`, le bouton de suppression définitive que pour qui a `archive:purge`.

## Ce qui reste à brancher

Le backend est en cours de livraison, rien n'a été testé contre un serveur.

- Les contrats Zod supposent la forme annoncée, tout champ non structurant est `.nullish()` : une ligne incomplète s'affiche dégradée au lieu de faire tomber l'écran. C'est précisément quand quelque chose s'est mal passé qu'on vient ici.
- L'enveloppe de `GET /admin/archive` est déballée si le backend répond `{data}` plutôt que la page brute.
- Un `entity_type` inconnu du frontend n'affiche aucune action plutôt qu'une URL devinée.
- Le motif de la purge voyage en paramètre d'URL encodé, conformément au contrat `DELETE ?reason=`.
- **Reste à faire une fois le backend déployé** : brancher le bouton « Archiver » sur les fiches élève, parent, enseignant, personnel et inscription (le dialogue et le bouton 5 s sont prêts, il ne manque que l'appel depuis chaque fiche), puis vérifier de bout en bout sur données réelles.

## Vérifications

`tsc --noEmit` propre, `next lint` sans avertissement nouveau sur les fichiers touchés.
