### PR TITLE
feat(ui): bouton Archiver sur les cinq fiches detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Bouton « Archiver » sur les fiches élève, parent, enseignant, personnel et inscription : la fiche quitte les listes après un motif et cinq secondes de maintien, et reste récupérable dans la corbeille *(admin, directeur)*.
 - Écran « Corbeille » : les fiches retirées des écrans restent conservées, avec qui les a archivées, quand et pourquoi, et se restaurent en un clic *(admin, directeur)*.
 - Les gestes qui ne se rattrapent pas demandent un motif et se confirment en maintenant le bouton appuyé, cinq secondes pour archiver, dix pour supprimer définitivement. Le motif part au journal et à la direction *(admin, directeur)*.
 - Affectation de l'élève à l'inscription : affecté, réaffecté ou non affecté, avec le numéro de décision demandé uniquement quand il sert. Le montant des frais suit automatiquement *(secrétariat, éducateur)*.

--- a/components/admin/enrollments/EnrollmentDetailClient.tsx
+++ b/components/admin/enrollments/EnrollmentDetailClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import {
+  Archive,
   ExternalLink,
   Pencil,
   Trash2,
@@ -34,6 +35,8 @@ import {
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
+import { ArchiveActionDialog, ARCHIVE_MENU_LABEL } from "@/components/shared/ArchiveActionDialog"
+import { useArchiveAction } from "@/lib/hooks/useArchiveAction"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { EnrollmentEditModal } from "./EnrollmentEditModal"
 import { EnrollmentOverviewTab } from "./tabs/EnrollmentOverviewTab"
@@ -60,6 +63,11 @@ export function EnrollmentDetailClient({ enrollmentId }: EnrollmentDetailClientP
 
   const { data: enrollment, isLoading, isError, refetch } = useEnrollment(enrollmentId)
   const { mutate: deleteEnrollment, isPending: deleting } = useDeleteEnrollment()
+  const archiveAction = useArchiveAction({
+    entity: "enrollment",
+    id: enrollmentId,
+    listRoute: "/admin/enrollments",
+  })
 
   const handleDelete = () => {
     deleteEnrollment(enrollmentId, {
@@ -119,6 +127,16 @@ export function EnrollmentDetailClient({ enrollmentId }: EnrollmentDetailClientP
                 Modifier l&apos;inscription
               </DropdownMenuItem>
               <DropdownMenuSeparator />
+              {/* Archiver d'abord : c'est le geste réversible, donc celui que
+                  l'on veut voir avant la suppression définitive. Le serveur
+                  refuse par ailleurs d'archiver une inscription qui porte des
+                  versements, et explique pourquoi. */}
+              {archiveAction.canArchive && (
+                <DropdownMenuItem onClick={archiveAction.open}>
+                  <Archive className="mr-2 h-4 w-4" />
+                  {ARCHIVE_MENU_LABEL.enrollment}
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={() => setDeleteOpen(true)}
                 className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -155,6 +173,13 @@ export function EnrollmentDetailClient({ enrollmentId }: EnrollmentDetailClientP
 
       {/* Edit modal */}
       <EnrollmentEditModal enrollmentId={enrollmentId} open={editOpen} onClose={() => setEditOpen(false)} />
+
+      {/* Archivage — hors du menu déroulant, qui se démonte à la fermeture */}
+      <ArchiveActionDialog
+        action={archiveAction}
+        entity="enrollment"
+        subject={[studentName, className, academicYear].filter(Boolean).join(" · ")}
+      />
 
       {/* Delete confirmation */}
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>

--- a/components/admin/parents/ParentDetailClient.tsx
+++ b/components/admin/parents/ParentDetailClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
 import {
+  Archive,
   Pencil,
   Trash2,
   Users,
@@ -41,6 +42,8 @@ import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
 import { AccountSection } from "@/components/shared/account/AccountSection"
 import { ContactActions } from "@/components/shared/ContactActions"
+import { ArchiveActionDialog, ARCHIVE_MENU_LABEL } from "@/components/shared/ArchiveActionDialog"
+import { useArchiveAction } from "@/lib/hooks/useArchiveAction"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { useParent, useParentFull, useDeleteParent, useUnlinkParent } from "@/lib/hooks/useParents"
 import { formatXof } from "@/lib/export/format"
@@ -61,6 +64,11 @@ export function ParentDetailClient({ parentId }: { parentId: number }) {
   const { data: full } = useParentFull(parentId)
   const { mutate: deleteParent, isPending: deleting } = useDeleteParent()
   const { mutate: unlink, isPending: unlinking } = useUnlinkParent()
+  const archiveAction = useArchiveAction({
+    entity: "parent",
+    id: parentId,
+    listRoute: "/admin/parents",
+  })
 
   if (isLoading) return <DetailSkeleton />
   if (isError) return <DataError message="Impossible de charger la fiche parent." onRetry={() => refetch()} />
@@ -136,6 +144,14 @@ export function ParentDetailClient({ parentId }: { parentId: number }) {
                 Lier un enfant
               </DropdownMenuItem>
               <DropdownMenuSeparator />
+              {/* Archiver d'abord : c'est le geste réversible, donc celui que
+                  l'on veut voir avant la suppression définitive. */}
+              {archiveAction.canArchive && (
+                <DropdownMenuItem onClick={archiveAction.open}>
+                  <Archive className="mr-2 h-4 w-4" />
+                  {ARCHIVE_MENU_LABEL.parent}
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={() => setDeleteOpen(true)}
                 className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -212,6 +228,9 @@ export function ParentDetailClient({ parentId }: { parentId: number }) {
       <AccountSection entityType="parent" entityId={parentId} />
 
       <ParentEditModal parentId={parentId} open={editOpen} onClose={() => setEditOpen(false)} />
+
+      {/* Archivage — hors du menu déroulant, qui se démonte à la fermeture */}
+      <ArchiveActionDialog action={archiveAction} entity="parent" subject={fullName} />
       <ParentLinkChildModal
         parentId={parentId}
         linkedStudentIds={children.map((c) => c.student_id)}

--- a/components/admin/staff/StaffDetailClient.tsx
+++ b/components/admin/staff/StaffDetailClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import {
+  Archive,
   Pencil,
   Trash2,
   User,
@@ -36,6 +37,8 @@ import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
 import { AccountSection } from "@/components/shared/account/AccountSection"
 import { ContactActions } from "@/components/shared/ContactActions"
+import { ArchiveActionDialog, ARCHIVE_MENU_LABEL } from "@/components/shared/ArchiveActionDialog"
+import { useArchiveAction } from "@/lib/hooks/useArchiveAction"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { StaffEditModal } from "./StaffEditModal"
 import { StaffProfileTab } from "./tabs/StaffProfileTab"
@@ -56,6 +59,11 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
   const { data: staff, isLoading, isError, refetch } = useStaffMember(staffId)
   const { data: fullData } = useStaffFull(staffId)
   const { mutate: deleteStaff, isPending: deleting } = useDeleteStaff()
+  const archiveAction = useArchiveAction({
+    entity: "staff",
+    id: staffId,
+    listRoute: "/admin/staff",
+  })
 
   const handleDelete = () =>
     deleteStaff(staffId, { onSuccess: () => router.push("/admin/staff") })
@@ -120,6 +128,14 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
                 Modifier les infos
               </DropdownMenuItem>
               <DropdownMenuSeparator />
+              {/* Archiver d'abord : c'est le geste réversible, donc celui que
+                  l'on veut voir avant la suppression définitive. */}
+              {archiveAction.canArchive && (
+                <DropdownMenuItem onClick={archiveAction.open}>
+                  <Archive className="mr-2 h-4 w-4" />
+                  {ARCHIVE_MENU_LABEL.staff}
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={() => setDeleteOpen(true)}
                 className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -170,6 +186,13 @@ export function StaffDetailClient({ staffId }: { staffId: number }) {
       <AccountSection entityType="staff" entityId={staffId} />
 
       <StaffEditModal staffId={staffId} open={editOpen} onClose={() => setEditOpen(false)} />
+
+      {/* Archivage — hors du menu déroulant, qui se démonte à la fermeture */}
+      <ArchiveActionDialog
+        action={archiveAction}
+        entity="staff"
+        subject={`${fullName} · ${staffRoleLabel(staff.role)}`}
+      />
 
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>

--- a/components/admin/students/StudentDetailClient.tsx
+++ b/components/admin/students/StudentDetailClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import {
+  Archive,
   Camera,
   Pencil,
   Trash2,
@@ -45,6 +46,8 @@ import {
 } from "@/components/ui/alert-dialog"
 import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
+import { ArchiveActionDialog, ARCHIVE_MENU_LABEL } from "@/components/shared/ArchiveActionDialog"
+import { useArchiveAction } from "@/lib/hooks/useArchiveAction"
 import { AccountSection } from "@/components/shared/account/AccountSection"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { PaymentStatusBadge } from "@/components/shared/finance/PaymentStatusBadge"
@@ -88,6 +91,11 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
   const { data: student, isLoading, isError, refetch } = useStudent(studentId)
   const { data: full } = useStudentFull(studentId)
   const { mutate: deleteStudent, isPending: deleting } = useDeleteStudent()
+  const archiveAction = useArchiveAction({
+    entity: "student",
+    id: studentId,
+    listRoute: "/admin/students",
+  })
 
   const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -203,6 +211,14 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
                 </DropdownMenuItem>
               )}
               <DropdownMenuSeparator />
+              {/* Archiver est le geste courant, il précède donc la suppression
+                  définitive, qu'on ne veut pas rencontrer en premier. */}
+              {archiveAction.canArchive && (
+                <DropdownMenuItem onClick={archiveAction.open}>
+                  <Archive className="mr-2 h-4 w-4" />
+                  {ARCHIVE_MENU_LABEL.student}
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={() => setDeleteOpen(true)}
                 className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -344,6 +360,15 @@ export function StudentDetailClient({ studentId }: StudentDetailClientProps) {
 
       {/* Edit modal */}
       <StudentEditModal studentId={studentId} open={editOpen} onClose={() => setEditOpen(false)} />
+
+      {/* Archivage — hors du menu déroulant, qui se démonte à la fermeture */}
+      <ArchiveActionDialog
+        action={archiveAction}
+        entity="student"
+        subject={
+          student.enrollment_number ? `${fullName} · ${student.enrollment_number}` : fullName
+        }
+      />
 
       {/* Delete confirmation */}
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>

--- a/components/admin/teachers/TeacherDetailClient.tsx
+++ b/components/admin/teachers/TeacherDetailClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import {
+  Archive,
   BookOpen,
   Pencil,
   Trash2,
@@ -39,6 +40,8 @@ import { DataError } from "@/components/shared/DataError"
 import { DetailHero } from "@/components/shared/DetailHero"
 import { AccountSection } from "@/components/shared/account/AccountSection"
 import { ContactActions } from "@/components/shared/ContactActions"
+import { ArchiveActionDialog, ARCHIVE_MENU_LABEL } from "@/components/shared/ArchiveActionDialog"
+import { useArchiveAction } from "@/lib/hooks/useArchiveAction"
 import type { HeroKpi } from "@/components/shared/PageHero"
 import { TeacherEditModal } from "./TeacherEditModal"
 import { TeacherOverviewTab } from "./tabs/TeacherOverviewTab"
@@ -67,6 +70,11 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
   const { data: teacher, isLoading, isError, refetch } = useTeacher(teacherId)
   const { data: fullData } = useTeacherFull(teacherId)
   const { mutate: deleteTeacher, isPending: deleting } = useDeleteTeacher()
+  const archiveAction = useArchiveAction({
+    entity: "teacher",
+    id: teacherId,
+    listRoute: "/admin/teachers",
+  })
 
   const handleDelete = () => {
     deleteTeacher(teacherId, {
@@ -115,6 +123,14 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
                 Modifier les infos
               </DropdownMenuItem>
               <DropdownMenuSeparator />
+              {/* Archiver d'abord : c'est le geste réversible, donc celui que
+                  l'on veut voir avant la suppression définitive. */}
+              {archiveAction.canArchive && (
+                <DropdownMenuItem onClick={archiveAction.open}>
+                  <Archive className="mr-2 h-4 w-4" />
+                  {ARCHIVE_MENU_LABEL.teacher}
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={() => setDeleteOpen(true)}
                 className="text-destructive focus:bg-destructive/10 focus:text-destructive"
@@ -214,6 +230,9 @@ export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
 
       {/* Edit modal */}
       <TeacherEditModal teacherId={teacherId} open={editOpen} onClose={() => setEditOpen(false)} />
+
+      {/* Archivage — hors du menu déroulant, qui se démonte à la fermeture */}
+      <ArchiveActionDialog action={archiveAction} entity="teacher" subject={fullName} />
 
       {/* Delete confirmation */}
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>

--- a/components/shared/ArchiveActionDialog.tsx
+++ b/components/shared/ArchiveActionDialog.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { DestructiveActionDialog } from "@/components/shared/DestructiveActionDialog"
+import type { ArchivableEntity } from "@/lib/contracts/archive"
+import type { ArchiveAction } from "@/lib/hooks/useArchiveAction"
+
+/**
+ * Libellé du geste, accordé au genre de chaque fiche.
+ *
+ * Sert à la fois l'entrée de menu et le titre du dialogue : la personne doit
+ * relire exactement la phrase sur laquelle elle vient de cliquer, sinon elle
+ * doute d'avoir ouvert la bonne fenêtre.
+ */
+export const ARCHIVE_MENU_LABEL: Record<ArchivableEntity, string> = {
+  student: "Archiver l'élève",
+  parent: "Archiver le parent",
+  teacher: "Archiver l'enseignant",
+  staff: "Archiver le membre du personnel",
+  enrollment: "Archiver l'inscription",
+}
+
+interface ArchiveActionDialogProps {
+  action: ArchiveAction
+  entity: ArchivableEntity
+  /** Le libellé de la fiche visée, rappelé pour éviter l'erreur de ligne. */
+  subject: string
+}
+
+/**
+ * La confirmation d'archivage, réglée sur cinq secondes de maintien.
+ *
+ * Cinq et non dix : archiver se répare depuis la corbeille. Les dix secondes
+ * restent réservées à la suppression définitive, qui, elle, ne se rattrape pas.
+ */
+export function ArchiveActionDialog({ action, entity, subject }: ArchiveActionDialogProps) {
+  return (
+    <DestructiveActionDialog
+      open={action.isOpen}
+      onOpenChange={action.setOpen}
+      title={ARCHIVE_MENU_LABEL[entity]}
+      description="La fiche quitte les listes et les écrans, sans rien supprimer. Elle reste restaurable depuis la corbeille."
+      subject={subject}
+      seconds={5}
+      confirmLabel="Maintenir pour archiver"
+      holdingLabel="Ne relâchez pas"
+      tone="warning"
+      isPending={action.isPending}
+      onConfirm={action.confirm}
+    />
+  )
+}

--- a/lib/api/archive.ts
+++ b/lib/api/archive.ts
@@ -33,7 +33,9 @@ function unwrap(json: unknown): unknown {
 }
 
 function basePath(entity: ArchivableEntity, id: number): string {
-  return `/admin/${ARCHIVABLE_ENTITIES[entity].path}/${id}`
+  // Le préfixe vient du catalogue, il n'est pas déductible : les inscriptions
+  // sont servies hors de `/admin`, contrairement aux personnes.
+  return `${ARCHIVABLE_ENTITIES[entity].apiBase}/${id}`
 }
 
 export const archiveApi = {

--- a/lib/contracts/archive.ts
+++ b/lib/contracts/archive.ts
@@ -41,17 +41,51 @@ export interface ArchiveQuery {
  * Le type d'entité renvoyé par la corbeille commande l'URL d'appel : on ne
  * devine pas un chemin en collant un « s » derrière le type, une faute de
  * pluriel enverrait une purge sur la mauvaise ressource.
+ *
+ * `apiBase` porte le chemin complet, préfixe compris, parce qu'il n'est pas
+ * uniforme : les personnes vivent sous `/admin`, les inscriptions non. Le
+ * reconstruire à partir d'un préfixe commun enverrait les inscriptions sur une
+ * route qui n'existe pas.
+ *
+ * `deletePermission` est le droit exigé par le backend pour archiver ou
+ * restaurer. On le déclare ici pour que le bouton et l'appel parlent du même
+ * droit : un bouton visible qui finit en 403 est pire que pas de bouton.
  */
 export const ARCHIVABLE_ENTITIES = {
-  student: { path: "students", label: "Élève", plural: "Élèves", queryKey: "students" },
-  parent: { path: "parents", label: "Parent", plural: "Parents", queryKey: "parents" },
-  teacher: { path: "teachers", label: "Enseignant", plural: "Enseignants", queryKey: "teachers" },
-  staff: { path: "staff", label: "Personnel", plural: "Personnel", queryKey: "staff" },
+  student: {
+    apiBase: "/admin/students",
+    label: "Élève",
+    plural: "Élèves",
+    queryKey: "students",
+    deletePermission: "admin:students:delete",
+  },
+  parent: {
+    apiBase: "/admin/parents",
+    label: "Parent",
+    plural: "Parents",
+    queryKey: "parents",
+    deletePermission: "admin:parents:delete",
+  },
+  teacher: {
+    apiBase: "/admin/teachers",
+    label: "Enseignant",
+    plural: "Enseignants",
+    queryKey: "teachers",
+    deletePermission: "admin:teachers:delete",
+  },
+  staff: {
+    apiBase: "/admin/staff",
+    label: "Personnel",
+    plural: "Personnel",
+    queryKey: "staff",
+    deletePermission: "admin:staff:delete",
+  },
   enrollment: {
-    path: "enrollments",
+    apiBase: "/enrollments",
     label: "Inscription",
     plural: "Inscriptions",
     queryKey: "enrollments",
+    deletePermission: "enrollments:delete",
   },
 } as const
 

--- a/lib/hooks/useArchive.ts
+++ b/lib/hooks/useArchive.ts
@@ -55,8 +55,11 @@ export function useArchiveEntity() {
       archiveApi.archive(entity, id, reason),
     onSuccess: (_data, variables) => {
       invalidate(variables.entity)
-      toast.success("Fiche archivée", {
-        description: "Elle a quitté les écrans. Rien n'est perdu, la corbeille la garde.",
+      // Le message nomme l'endroit exact où la fiche est retrouvable : sans
+      // cela, la personne qui vient de la voir disparaître croit l'avoir
+      // perdue et appelle le secrétariat.
+      toast.success("Fiche placée dans la corbeille", {
+        description: "Vous pouvez la restaurer depuis Système › Corbeille.",
       })
     },
     onError: (error) => {

--- a/lib/hooks/useArchiveAction.ts
+++ b/lib/hooks/useArchiveAction.ts
@@ -1,0 +1,67 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import type { Route } from "next"
+import { useArchiveEntity } from "./useArchive"
+import { usePermissions } from "./usePermissions"
+import { ARCHIVABLE_ENTITIES, type ArchivableEntity } from "@/lib/contracts/archive"
+
+export interface ArchiveAction {
+  /** Faux tant que le droit n'est pas confirmé : on masque plutôt que griser. */
+  canArchive: boolean
+  isOpen: boolean
+  setOpen: (open: boolean) => void
+  open: () => void
+  isPending: boolean
+  confirm: (reason: string) => void
+}
+
+interface UseArchiveActionParams {
+  entity: ArchivableEntity
+  id: number
+  /** Où repartir une fois la fiche archivée, puisqu'elle n'existe plus ici. */
+  listRoute: Route
+}
+
+/**
+ * Le geste « archiver » d'une fiche détail : le droit, l'état du dialogue, la
+ * mutation et le retour à la liste, en un seul endroit.
+ *
+ * Regroupé dans un hook parce que les cinq fiches en ont exactement besoin :
+ * dupliquer ces quinze lignes cinq fois garantit qu'un jour l'une d'elles
+ * oubliera le contrôle de droit ou la redirection.
+ *
+ * Le toast de succès et le message d'erreur du serveur viennent de
+ * `useArchiveEntity` : le refus d'archiver une inscription qui porte des
+ * versements doit s'afficher tel que le backend l'a écrit, pas reformulé ici.
+ */
+export function useArchiveAction({ entity, id, listRoute }: UseArchiveActionParams): ArchiveAction {
+  const router = useRouter()
+  const [isOpen, setOpen] = useState(false)
+  const { has } = usePermissions()
+  const archive = useArchiveEntity()
+
+  return {
+    canArchive: has(ARCHIVABLE_ENTITIES[entity].deletePermission),
+    isOpen,
+    setOpen,
+    open: () => setOpen(true),
+    isPending: archive.isPending,
+    confirm: (reason: string) => {
+      archive.mutate(
+        { entity, id, reason },
+        {
+          onSuccess: () => {
+            setOpen(false)
+            // La fiche vient de quitter tous les écrans : rester dessus
+            // afficherait une page vidée de son objet, ou une erreur.
+            router.push(listRoute)
+          },
+          // En cas de refus du serveur on laisse le dialogue ouvert : le motif
+          // déjà saisi reste disponible pour une seconde tentative.
+        },
+      )
+    },
+  }
+}


### PR DESCRIPTION
## Le geste d'entrée de la corbeille

La corbeille à deux temps était livrée des deux côtés, mais on ne pouvait y mettre une fiche que par appel direct à l'API. Cette PR ajoute le bouton « Archiver » sur les cinq fiches détail.

Closes #267

## Ce que voit l'utilisateur

Dans le menu d'actions en haut à droite de la fiche, une entrée « Archiver … » apparaît juste avant « Supprimer », séparée du reste. Elle n'est visible que pour qui détient le droit de suppression de cette entité.

Le clic ouvre le dialogue de motif déjà en place, réglé sur **cinq secondes** de maintien. Cinq et non dix : archiver se répare depuis la corbeille, les dix secondes restent réservées à la suppression définitive.

Après succès, le message dit ce qui s'est passé et où retrouver la fiche : « Fiche placée dans la corbeille. Vous pouvez la restaurer depuis Système › Corbeille. » Puis retour à la liste, puisque la fiche vient de disparaître de tous les écrans.

Quand le serveur refuse (inscription validée portant des versements), son message s'affiche tel quel, le dialogue reste ouvert et le motif déjà saisi n'est pas perdu.

## Fiches équipées

| Fiche | Droit exigé |
|---|---|
| Élève | `admin:students:delete` |
| Parent | `admin:parents:delete` |
| Enseignant | `admin:teachers:delete` |
| Personnel | `admin:staff:delete` |
| Inscription | `enrollments:delete` |

## Correction de chemin trouvée en route

`lib/api/archive.ts` reconstruisait l'URL en collant `/admin/` devant le nom de la ressource. Or les inscriptions sont servies sous `/enrollments`, pas `/admin/enrollments` : archiver, **restaurer** ou purger une inscription partait sur une route inexistante. La restauration d'inscription depuis l'écran corbeille était donc cassée.

Le catalogue `ARCHIVABLE_ENTITIES` porte désormais le chemin complet (`apiBase`) et le droit requis (`deletePermission`), au lieu d'un fragment que l'appelant devait préfixer.

## Découpage

- `lib/hooks/useArchiveAction.ts` : le droit, l'état du dialogue, la mutation et le retour à la liste. Les cinq fiches en ont exactement besoin ; dupliquer ces lignes cinq fois garantissait qu'une d'elles oublierait un jour le contrôle de droit.
- `components/shared/ArchiveActionDialog.tsx` : `DestructiveActionDialog` réutilisé tel quel, avec les libellés accordés au genre de chaque fiche. Aucune modification du composant partagé.

Le dialogue est rendu hors du menu déroulant, qui se démonte à la fermeture.

## Invalidation

Le hook existant invalide la corbeille et la racine de l'entité, ce qui couvre la liste comme la fiche détail.

## Vérifications

- `npx --no-install tsc --noEmit` : propre
- `npx --no-install next lint --dir components --dir lib` : aucune alerte nouvelle
