### PR TITLE
feat(teachers): let admins record teacher gender and contract type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Sexe et type de contrat de l'enseignant, permanent, vacataire ou fonctionnaire, à la création comme à la modification de sa fiche. Les deux se lisent sur la fiche, le contrat apparaît aussi dans la liste des enseignants, et l'un comme l'autre s'affichent « Non renseigné » tant qu'ils ne sont pas saisis *(admin)*.
 - Bouton « Archiver » sur les fiches élève, parent, enseignant, personnel et inscription : la fiche quitte les listes après un motif et cinq secondes de maintien, et reste récupérable dans la corbeille *(admin, directeur)*.
 - Écran « Corbeille » : les fiches retirées des écrans restent conservées, avec qui les a archivées, quand et pourquoi, et se restaurent en un clic *(admin, directeur)*.
 - Les gestes qui ne se rattrapent pas demandent un motif et se confirment en maintenant le bouton appuyé, cinq secondes pour archiver, dix pour supprimer définitivement. Le motif part au journal et à la direction *(admin, directeur)*.

--- a/components/admin/teachers/TeacherEditModal.tsx
+++ b/components/admin/teachers/TeacherEditModal.tsx
@@ -2,11 +2,23 @@
 
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { TeacherUpdateSchema, type TeacherUpdate } from "@/lib/contracts/teacher"
+import {
+  TeacherUpdateSchema,
+  TEACHER_CONTRACT_OPTIONS,
+  TEACHER_GENRE_OPTIONS,
+  type TeacherUpdate,
+} from "@/lib/contracts/teacher"
 import { useTeacher, useUpdateTeacher } from "@/lib/hooks/useTeachers"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Form,
@@ -43,6 +55,8 @@ function EditForm({ teacherId, onClose }: { teacherId: number; onClose: () => vo
           last_name: teacher.last_name,
           speciality: teacher.speciality ?? undefined,
           phone: teacher.phone ?? undefined,
+          genre: teacher.genre ?? undefined,
+          contract_type: teacher.contract_type ?? undefined,
         }
       : undefined,
   })
@@ -108,6 +122,60 @@ function EditForm({ teacherId, onClose }: { teacherId: number; onClose: () => vo
                 <FormControl>
                   <Input className="h-11" {...field} value={field.value ?? ""} />
                 </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* Sexe et type de contrat alimentent la répartition du personnel
+            enseignant du rapport de fin de trimestre de la DEEP. */}
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="genre"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Sexe</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger className="h-11">
+                      <SelectValue placeholder="Non renseigné" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {TEACHER_GENRE_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="contract_type"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Type de contrat</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger className="h-11">
+                      <SelectValue placeholder="Non renseigné" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {TEACHER_CONTRACT_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
                 <FormMessage />
               </FormItem>
             )}

--- a/components/admin/teachers/TeachersTable.tsx
+++ b/components/admin/teachers/TeachersTable.tsx
@@ -6,7 +6,8 @@ import type { Route } from "next"
 import type { ColumnDef } from "@tanstack/react-table"
 import { Phone, MessageCircle, Mail } from "lucide-react"
 import { useTeachers, useDeleteTeacher } from "@/lib/hooks/useTeachers"
-import type { Teacher } from "@/lib/contracts/teacher"
+import { teacherContractLabel, type Teacher } from "@/lib/contracts/teacher"
+import { Badge } from "@/components/ui/badge"
 import { CrudTable, type FilterConfig } from "@/components/shared/CrudTable"
 import { MobileEntityListItem } from "@/components/shared/MobileEntityListItem"
 import { useDebounce } from "@/lib/hooks/useDebounce"
@@ -134,6 +135,21 @@ export function TeachersTable() {
       cell: ({ row }) => (
         <span className="text-sm text-muted-foreground tabular-nums">{row.original.phone ?? "—"}</span>
       ),
+    },
+    {
+      accessorKey: "contract_type",
+      header: "Contrat",
+      cell: ({ row }) => {
+        const label = teacherContractLabel(row.original.contract_type)
+        if (!label) {
+          return <span className="text-sm text-muted-foreground">—</span>
+        }
+        return (
+          <Badge variant="secondary" className="text-xs font-normal">
+            {label}
+          </Badge>
+        )
+      },
     },
     {
       id: "actions_contact",

--- a/components/admin/teachers/tabs/TeacherProfileTab.tsx
+++ b/components/admin/teachers/tabs/TeacherProfileTab.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { User, BookOpen, Phone, CalendarDays, Mail, ShieldCheck } from "lucide-react"
+import { User, Users, Briefcase, BookOpen, Phone, CalendarDays, Mail, ShieldCheck } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent } from "@/components/ui/card"
-import type { Teacher } from "@/lib/contracts/teacher"
+import { teacherContractLabel, teacherGenreLabel, type Teacher } from "@/lib/contracts/teacher"
 
 interface TeacherProfileTabProps {
   teacher: Teacher
@@ -85,7 +85,13 @@ export function TeacherProfileTab({ teacher, fullData }: TeacherProfileTabProps)
           <div className="grid gap-5 sm:grid-cols-3">
             <InfoField label="Nom" value={teacher.last_name} icon={User} />
             <InfoField label="Prénom" value={teacher.first_name} icon={User} />
+            <InfoField label="Sexe" value={teacherGenreLabel(teacher.genre)} icon={Users} />
             <InfoField label="Spécialité" value={teacher.speciality} icon={BookOpen} />
+            <InfoField
+              label="Type de contrat"
+              value={teacherContractLabel(teacher.contract_type)}
+              icon={Briefcase}
+            />
             <InfoField label="Téléphone" value={teacher.phone} icon={Phone} />
             <InfoField label="Créé le" value={createdAt} icon={CalendarDays} />
           </div>

--- a/components/forms/TeacherForm.tsx
+++ b/components/forms/TeacherForm.tsx
@@ -2,10 +2,22 @@
 
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { TeacherCreateSchema, type TeacherCreate } from "@/lib/contracts/teacher"
+import {
+  TeacherCreateSchema,
+  TEACHER_CONTRACT_OPTIONS,
+  TEACHER_GENRE_OPTIONS,
+  type TeacherCreate,
+} from "@/lib/contracts/teacher"
 import { useCreateTeacher } from "@/lib/hooks/useTeachers"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   Form,
   FormControl,
@@ -29,6 +41,8 @@ export function TeacherForm({ onSuccess }: TeacherFormProps) {
       password: "",
       speciality: "",
       phone: "",
+      genre: undefined,
+      contract_type: undefined,
     },
   })
 
@@ -130,6 +144,61 @@ export function TeacherForm({ onSuccess }: TeacherFormProps) {
                 <FormControl>
                   <Input placeholder="Ex : +243 812 345 678" className="h-11" {...field} value={field.value ?? ""} />
                 </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* Sexe et type de contrat alimentent la répartition du personnel
+            enseignant du rapport de fin de trimestre de la DEEP. Facultatifs :
+            la fiche se crée sans, et se complète plus tard. */}
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="genre"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Sexe</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger className="h-11">
+                      <SelectValue placeholder="Sélectionner" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {TEACHER_GENRE_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="contract_type"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Type de contrat</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger className="h-11">
+                      <SelectValue placeholder="Sélectionner" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {TEACHER_CONTRACT_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
                 <FormMessage />
               </FormItem>
             )}

--- a/lib/contracts/teacher.ts
+++ b/lib/contracts/teacher.ts
@@ -1,5 +1,42 @@
 import { z } from "zod"
 
+// Type de contrat tel que la DRENA le distingue (miroir de l'enum
+// TeacherContract côté backend). Alimente les tableaux 18 à 21 du rapport de
+// fin de trimestre de la DEEP : sans cette information, ils sortent vierges.
+export const TEACHER_CONTRACT_OPTIONS = [
+  { value: "permanent", label: "Permanent" },
+  { value: "vacataire", label: "Vacataire" },
+  { value: "fonctionnaire", label: "Fonctionnaire" },
+] as const
+
+export const TEACHER_GENRE_OPTIONS = [
+  { value: "M", label: "Masculin" },
+  { value: "F", label: "Féminin" },
+] as const
+
+const TEACHER_CONTRACT_LABELS: Record<string, string> = Object.fromEntries(
+  TEACHER_CONTRACT_OPTIONS.map((option) => [option.value, option.label]),
+)
+
+const TEACHER_GENRE_LABELS: Record<string, string> = Object.fromEntries(
+  TEACHER_GENRE_OPTIONS.map((option) => [option.value, option.label]),
+)
+
+/** Libellé français du type de contrat, `null` tant qu'il n'est pas renseigné. */
+export function teacherContractLabel(contract?: string | null): string | null {
+  if (!contract) return null
+  return TEACHER_CONTRACT_LABELS[contract] ?? contract
+}
+
+/** Libellé français du sexe, `null` tant qu'il n'est pas renseigné. */
+export function teacherGenreLabel(genre?: string | null): string | null {
+  if (!genre) return null
+  return TEACHER_GENRE_LABELS[genre] ?? genre
+}
+
+const TeacherGenreEnum = z.enum(["M", "F"])
+const TeacherContractEnum = z.enum(["permanent", "vacataire", "fonctionnaire"])
+
 export const TeacherSchema = z.object({
   id: z.number(),
   user_id: z.number(),
@@ -7,6 +44,8 @@ export const TeacherSchema = z.object({
   last_name: z.string(),
   speciality: z.string().nullable(),
   phone: z.string().nullish(),
+  genre: TeacherGenreEnum.nullish(),
+  contract_type: TeacherContractEnum.nullish(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 }).passthrough()
@@ -18,6 +57,8 @@ export const TeacherCreateSchema = z.object({
   password: z.string({ required_error: "Le mot de passe est requis" }).min(8, "8 caractères minimum"),
   speciality: z.string().optional(),
   phone: z.string().optional(),
+  genre: TeacherGenreEnum.optional(),
+  contract_type: TeacherContractEnum.optional(),
 })
 
 export const TeacherUpdateSchema = z.object({
@@ -25,6 +66,8 @@ export const TeacherUpdateSchema = z.object({
   last_name: z.string().min(1).optional(),
   speciality: z.string().optional(),
   phone: z.string().optional(),
+  genre: TeacherGenreEnum.optional(),
+  contract_type: TeacherContractEnum.optional(),
 })
 
 export const TeacherListParamsSchema = z.object({


### PR DESCRIPTION
## Pourquoi

Le rapport de fin de trimestre de la DEEP demande la repartition du personnel enseignant par type de contrat et par sexe (tableaux 18 a 21). Les colonnes existaient en base, mais aucun ecran ne permettait de les renseigner : les tableaux du rapport officiel sortaient vierges, et personne dans l'etablissement n'avait de moyen de les remplir.

## Ce que voit l'utilisateur

- **Creation d'un enseignant** : deux listes deroulantes « Sexe » (Masculin / Feminin) et « Type de contrat » (Permanent / Vacataire / Fonctionnaire), sur une ligne dediee sous Specialite et Telephone. Les deux sont facultatives, la fiche se cree sans.
- **Modification** : les deux memes listes, pre-remplies avec ce qui est deja saisi. Tant que rien n'est renseigne, le champ affiche « Non renseigne » plutot qu'une case vide.
- **Fiche detail**, onglet Profil : « Sexe » et « Type de contrat » rejoignent les informations personnelles, avec le meme etat « Non renseigne » que les autres champs facultatifs.
- **Liste des enseignants** : une colonne « Contrat » affiche le contrat en pastille, ou un tiret quand il n'est pas saisi. C'est ce qui permet a l'administration de reperer d'un coup d'oeil les fiches qu'il reste a completer avant de sortir le rapport.

Selects shadcn, hauteur `h-11` comme les champs voisins, memes grilles deux colonnes, donc rien de nouveau a apprendre.

## Cote technique

- `lib/contracts/teacher.ts` porte les deux champs sur `TeacherSchema`, `TeacherCreateSchema` et `TeacherUpdateSchema`, plus les listes d'options et les helpers de libelle, sur le modele de `lib/contracts/staff.ts`. Les enums Zod refletent l'enum `TeacherContract` du backend.
- Les champs sont `nullish()` en lecture : l'ecran ne casse pas si l'API repond sans eux.
- Aucun cast TypeScript, aucun `.default()` sur un schema passe a `safeValidate`.

## Depend de

`African-DC/klassci-college-backend#263`, qui expose `genre` et `contract_type` sur `/admin/teachers`. Le backend portait les colonnes mais aucun schema Pydantic ne les acceptait : sans cette PR-la, la saisie serait ignoree en silence. **A merger en premier.**

## Verification

Le disque du poste de dev est plein (moins de 2 % libres) et un `next build` qui manque d'espace tronque les fichiers qu'il est en train d'ecrire. La verification a donc ete faite sans build local :

- `tsc --noEmit` sur la branche : **0 erreur**.
- `eslint` sur les 5 fichiers touches : **0 erreur**, 1 avertissement `no-img-element` pre-existant (`TeachersTable.tsx:24`, l'avatar, hors de mon diff).
- Relecture des contrats Zod contre les schemas Pydantic : `genre` = `"M" | "F"` des deux cotes, `contract_type` = `permanent | vacataire | fonctionnaire` des deux cotes, facultatifs a l'ecriture, `nullish` a la lecture.
- Aucune route nouvelle n'est creee, donc pas de `as Route` a prevoir pour `typedRoutes`.

**Le build complet reste a faire sur le serveur de demo Windows apres le merge.**
