### PR TITLE
feat(reports): add the DEEP end-of-trimester report screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Rapport de fin de trimestre de la DEEP téléchargeable depuis Rapports : on choisit l'année et le trimestre, on obtient le canevas officiel des vingt-sept tableaux, avec aperçu avant impression *(admin, directeur)*
 - Bouton « Demande de dossier scolaire » sur la fiche élève : le courrier réclamant le dossier à l'établissement d'origine se télécharge en un clic, scellé pour être vérifiable *(admin)*.
 - Billet d'entrée depuis l'écran des présences : sur une absence non régularisée, l'éducateur saisit la date de reprise et le motif, l'absence passe en excusée dans le cahier d'appel et le billet s'imprime *(admin)*.
 - Écran « Convocations de parent » : le registre montre qui a été convoqué, quand, et qui est venu. Une convocation s'émet en trois champs, la suite donnée se consigne après le rendez-vous, la convocation se télécharge pour la famille *(admin)*.

--- a/app/(admin)/admin/reports/deep/error.tsx
+++ b/app/(admin)/admin/reports/deep/error.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function DeepReportError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+        <AlertTriangle className="h-8 w-8 text-destructive" />
+      </div>
+      <div className="text-center space-y-1">
+        <h2 className="text-lg font-semibold">Une erreur est survenue</h2>
+        <p className="text-sm text-muted-foreground max-w-md">
+          {error.message || "Impossible de charger les statistiques. Veuillez réessayer."}
+        </p>
+      </div>
+      <Button onClick={reset} variant="outline">
+        Réessayer
+      </Button>
+    </div>
+  )
+}

--- a/app/(admin)/admin/reports/deep/loading.tsx
+++ b/app/(admin)/admin/reports/deep/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function DeepReportLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <Skeleton className="h-7 w-56" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-lg" />
+        ))}
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Skeleton className="h-80 rounded-lg" />
+        <Skeleton className="h-80 rounded-lg" />
+      </div>
+      <Skeleton className="h-64 rounded-lg" />
+    </div>
+  )
+}

--- a/app/(admin)/admin/reports/deep/page.tsx
+++ b/app/(admin)/admin/reports/deep/page.tsx
@@ -1,0 +1,7 @@
+import { DeepReportPageClient } from "@/components/admin/reports/deep/DeepReportPageClient"
+
+export const metadata = { title: "Rapport de fin de trimestre | KLASSCI" }
+
+export default function DeepReportPage() {
+  return <DeepReportPageClient />
+}

--- a/components/admin/reports/ReportsNav.tsx
+++ b/components/admin/reports/ReportsNav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import type { Route } from "next"
-import { FileText, Gavel, BarChart3 } from "lucide-react"
+import { FileText, Gavel, BarChart3, FileCheck2 } from "lucide-react"
 
 interface ReportsNavLink {
   href: Route
@@ -14,9 +14,10 @@ const LINKS: ReportsNavLink[] = [
   { href: "/admin/reports" as Route, icon: FileText, label: "Bulletins" },
   { href: "/admin/reports/council" as Route, icon: Gavel, label: "Conseil de classe" },
   { href: "/admin/reports/dren" as Route, icon: BarChart3, label: "Statistiques DREN" },
+  { href: "/admin/reports/deep" as Route, icon: FileCheck2, label: "Fin de trimestre" },
 ]
 
-export function ReportsNav({ current }: { current: "bulletins" | "council" | "dren" }) {
+export function ReportsNav({ current }: { current: "bulletins" | "council" | "dren" | "deep" }) {
   const currentHref = current === "bulletins" ? "/admin/reports" : `/admin/reports/${current}`
 
   return (

--- a/components/admin/reports/deep/DeepReportPageClient.tsx
+++ b/components/admin/reports/deep/DeepReportPageClient.tsx
@@ -1,0 +1,194 @@
+"use client"
+
+import { useCallback, useState } from "react"
+import { Download, Eye, FileCheck2, Loader2 } from "lucide-react"
+import { toast } from "sonner"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Card, CardContent } from "@/components/ui/card"
+import { PageHero, heroAccentBtn, heroGlassBtn } from "@/components/shared/PageHero"
+import { ReportsNav } from "../ReportsNav"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { usePermissions } from "@/lib/hooks/usePermissions"
+import { deepReportApi } from "@/lib/api/deep-report"
+import { openPdfPreview } from "@/lib/pdf/preview"
+import { downloadBlob } from "@/lib/utils"
+
+const TRIMESTRES = [1, 2, 3] as const
+
+export function DeepReportPageClient() {
+  const { has, isLoading: permissionsLoading } = usePermissions()
+  const { data: academicYearsData, isLoading: yearsLoading } = useAcademicYears()
+  const academicYears = academicYearsData?.items
+
+  const [academicYearId, setAcademicYearId] = useState<number | undefined>(undefined)
+  const [trimester, setTrimester] = useState<number>(1)
+  const [downloading, setDownloading] = useState(false)
+  const [previewing, setPreviewing] = useState(false)
+
+  // L'année en cours d'abord : c'est celle qu'on dépose neuf fois sur dix.
+  const activeYearId =
+    academicYearId ?? academicYears?.find((y) => y.is_current)?.id ?? academicYears?.[0]?.id
+  const activeYear = academicYears?.find((y) => y.id === activeYearId)
+
+  const handleDownload = useCallback(async () => {
+    if (!activeYearId) return
+    setDownloading(true)
+    try {
+      const blob = await deepReportApi.downloadPdf(activeYearId, trimester)
+      downloadBlob(blob, `rapport-deep-trimestre-${trimester}-${activeYearId}.pdf`)
+      toast.success(`Rapport du trimestre ${trimester} téléchargé`)
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Impossible de générer le rapport",
+      )
+    } finally {
+      setDownloading(false)
+    }
+  }, [activeYearId, trimester])
+
+  const handlePreview = useCallback(async () => {
+    if (!activeYearId) return
+    setPreviewing(true)
+    try {
+      await openPdfPreview(() => deepReportApi.downloadPdf(activeYearId, trimester))
+    } finally {
+      setPreviewing(false)
+    }
+  }, [activeYearId, trimester])
+
+  if (!permissionsLoading && !has("reports:read")) {
+    return (
+      <div className="space-y-6">
+        <ReportsNav current="deep" />
+        <Card>
+          <CardContent className="py-12 text-center">
+            <p className="text-base font-medium text-foreground">Accès refusé</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Le rapport de fin de trimestre est réservé à la direction. Demandez le
+              droit « Consulter les rapports » à votre administrateur.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const pretA = Boolean(activeYearId)
+
+  return (
+    <div className="space-y-6">
+      <PageHero
+        icon={FileCheck2}
+        title="Rapport de fin de trimestre"
+        subtitle="Le canevas officiel de la DEEP, ses vingt-sept tableaux remplis depuis vos données. Les tableaux qu'aucun écran ne permet encore de renseigner portent la mention « à compléter manuellement » plutôt qu'une grille de zéros."
+        actions={
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handlePreview}
+              disabled={!pretA || previewing}
+              className={heroGlassBtn}
+            >
+              {previewing ? (
+                <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+              ) : (
+                <Eye aria-hidden="true" className="h-4 w-4" />
+              )}
+              Aperçu
+            </button>
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={!pretA || downloading}
+              className={heroAccentBtn}
+            >
+              {downloading ? (
+                <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+              ) : (
+                <Download aria-hidden="true" className="h-4 w-4" />
+              )}
+              Télécharger le rapport
+            </button>
+          </div>
+        }
+      />
+
+      <ReportsNav current="deep" />
+
+      <Card>
+        <CardContent className="grid gap-4 py-6 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <label
+              htmlFor="deep-annee"
+              className="text-sm font-medium text-foreground"
+            >
+              Année scolaire
+            </label>
+            <Select
+              value={activeYearId ? String(activeYearId) : undefined}
+              onValueChange={(v) => setAcademicYearId(Number(v))}
+              disabled={yearsLoading || !academicYears?.length}
+            >
+              <SelectTrigger id="deep-annee" className="h-11">
+                <SelectValue
+                  placeholder={yearsLoading ? "Chargement…" : "Choisir une année"}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {(academicYears ?? []).map((y) => (
+                  <SelectItem key={y.id} value={String(y.id)}>
+                    {y.name}
+                    {y.is_current ? " (en cours)" : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label
+              htmlFor="deep-trimestre"
+              className="text-sm font-medium text-foreground"
+            >
+              Trimestre
+            </label>
+            <Select
+              value={String(trimester)}
+              onValueChange={(v) => setTrimester(Number(v))}
+            >
+              <SelectTrigger id="deep-trimestre" className="h-11">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {TRIMESTRES.map((t) => (
+                  <SelectItem key={t} value={String(t)}>
+                    Trimestre {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {!yearsLoading && !academicYears?.length ? (
+            <p className="sm:col-span-2 text-sm text-muted-foreground">
+              Aucune année scolaire n'est encore créée. Ouvrez-en une depuis
+              Paramètres pour pouvoir produire le rapport.
+            </p>
+          ) : (
+            <p className="sm:col-span-2 text-sm text-muted-foreground">
+              Le document sera produit pour {activeYear?.name ?? "l'année choisie"},
+              trimestre {trimester}. Comptez quelques secondes : les vingt-sept
+              tableaux sont calculés à la demande.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/lib/api/deep-report.ts
+++ b/lib/api/deep-report.ts
@@ -1,0 +1,12 @@
+import { apiFetchBlob } from "./client"
+
+/**
+ * Rapport de fin de trimestre de la DEEP.
+ *
+ * Un seul verbe : le document se dépose à la direction régionale, il n'a pas
+ * d'écran de consultation. Le backend force d'ailleurs le téléchargement.
+ */
+export const deepReportApi = {
+  downloadPdf: (academicYearId: number, trimester: number): Promise<Blob> =>
+    apiFetchBlob(`/reports/deep-trimester/${academicYearId}?trimester=${trimester}`),
+}


### PR DESCRIPTION
Le backend sert le rapport de fin de trimestre de la DEEP depuis le lot documents, et rien dans l'interface n'y menait. La fonctionnalité existait, aucun utilisateur ne pouvait s'en servir.

## L'écran

Un quatrième onglet dans Rapports, « Fin de trimestre », calqué sur l'écran des statistiques DREN dont il reprend la mécanique sans rien réinventer : sélection de l'année scolaire et du trimestre, aperçu avant impression, téléchargement.

L'année en cours est présélectionnée : c'est celle qu'on dépose neuf fois sur dix.

## Ce qui est géré

- **Droit d'accès** : l'écran affiche « Accès refusé » avec la marche à suivre plutôt qu'un formulaire inerte, quand `reports:read` manque.
- **Chargement** : le sélecteur d'année indique « Chargement… », les deux boutons restent inactifs tant qu'aucune année n'est résolue.
- **Vide** : si aucune année scolaire n'existe, une phrase dit où en créer une, pas une liste vide.
- **Erreur** : le message du backend remonte tel quel dans un toast, et la page a son propre `error.tsx`.
- **Succès** : toast de confirmation nommant le trimestre téléchargé.

Une phrase sous les sélecteurs prévient que la génération prend quelques secondes, les vingt-sept tableaux étant calculés à la demande.

## Vérification

- `tsc --noEmit --incremental false` : 0 erreur
- `eslint` sur les fichiers touchés : 0 erreur
- Le téléchargement passe par `apiFetchBlob`, comme tous les autres PDF authentifiés du projet
- La nouvelle route porte son `as Route`, exigé par `typedRoutes`

Le build complet est fait par la CI, le disque de la machine de développement étant saturé.
