### PR TITLE
fix(archive): send the deletion reason in the body, not the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Le motif d'une suppression définitive n'apparaît plus dans l'adresse de la requête, donc plus dans les journaux du serveur ni chez les intermédiaires. « Élève exclu pour vol » n'a rien à y faire *(admin)*
 
 - Page Paiements : le bouton « Exporter » est désormais bien visible sur le bandeau bleu (il était blanc sur blanc, invisible tant qu'on ne le survolait pas) *(admin)*.
 - Page Frais : à la modification d'un montant, la catégorie est correctement pré-remplie dans le formulaire *(admin)*.

--- a/lib/api/archive.ts
+++ b/lib/api/archive.ts
@@ -61,14 +61,14 @@ export const archiveApi = {
   /**
    * Suppression définitive, sans retour possible.
    *
-   * Le motif voyage en paramètre d'URL, pas dans un corps : c'est le contrat
-   * du backend pour un DELETE. Il est encodé, un motif contenant « & » ou un
-   * accent ne doit pas casser la requête ni tronquer la justification.
+   * Le motif voyage dans le corps, jamais dans l'URL : une URL finit dans les
+   * journaux d'accès du serveur et chez les intermédiaires, et « exclu pour
+   * vol » n'a rien à y faire.
    */
   purge: async (entity: ArchivableEntity, id: number, reason: string): Promise<void> => {
-    const params = new URLSearchParams({ reason })
-    await apiFetch<unknown>(`${basePath(entity, id)}?${params.toString()}`, {
+    await apiFetch<unknown>(basePath(entity, id), {
       method: "DELETE",
+      body: JSON.stringify({ reason }),
     })
   },
 }


### PR DESCRIPTION
Suit le changement de contrat du backend, arrivé avec la refonte de l'archivage.

Le motif d'une suppression définitive voyageait en paramètre d'URL. Une URL finit dans les journaux d'accès du serveur, chez les intermédiaires et dans l'historique du navigateur : « Élève exclu pour vol » n'a rien à y faire. Le backend l'attend désormais dans le corps de la requête.

**Sans ce correctif, toute suppression définitive renvoie 422.** C'est le seul appelant concerné, `archiveApi.purge`, utilisé par l'écran de corbeille.

`apiFetch` conserve son en-tête `Content-Type` dès qu'un corps est présent, y compris sur un `DELETE` : rien d'autre à adapter.

## Vérification

- `tsc --noEmit --incremental false` : 0 erreur
- `eslint` sur le fichier touché : 0 erreur
- Recherche exhaustive des appelants de `purge` : un seul, déjà couvert
