### PR TITLE
fix(fees): load every page of the fee lists, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- La grille des frais n'affichait que les vingt premiers montants et donnait le reste pour inexistant : des niveaux apparaissaient avec moins de frais qu'ils n'en portent, le total par élève était faux, et recréer un montant manquant se soldait par « doublon possible ». Tous les montants sont désormais chargés *(admin, comptable)*
 - Le motif d'une suppression définitive n'apparaît plus dans l'adresse de la requête, donc plus dans les journaux du serveur ni chez les intermédiaires. « Élève exclu pour vol » n'a rien à y faire *(admin)*
 
 - Page Paiements : le bouton « Exporter » est désormais bien visible sur le bandeau bleu (il était blanc sur blanc, invisible tant qu'on ne le survolait pas) *(admin)*.

--- a/lib/api/fees.ts
+++ b/lib/api/fees.ts
@@ -19,12 +19,49 @@ const FeeCategoryArraySchema = z.array(FeeCategorySchema)
 const FeeVariantArraySchema = z.array(FeeVariantSchema)
 const OptionalFeeOptionArraySchema = z.array(OptionalFeeOptionSchema)
 
+/**
+ * Ramène TOUTES les pages d'une liste paginée.
+ *
+ * Le backend renvoie 20 éléments par défaut et plafonne à 100. Une grille de
+ * frais qui n'affiche que la première page ne se signale pas : elle montre des
+ * niveaux avec moins de lignes qu'ils n'en portent, et le total par élève est
+ * faux. C'est arrivé en production sur une école de sept niveaux, où les frais
+ * d'inscription de quatre niveaux étaient invisibles alors qu'ils existaient
+ * bel et bien, si bien que les recréer se soldait par « doublon possible ».
+ */
+async function fetchEveryPage<T>(path: string, params: URLSearchParams): Promise<T[]> {
+  const MAX_SIZE = 100
+  const tout: T[] = []
+  let page = 1
+
+  for (;;) {
+    params.set("page", String(page))
+    params.set("size", String(MAX_SIZE))
+    const json = await apiFetch<{ items?: T[]; data?: T[]; total?: number } | T[]>(
+      `${path}?${params.toString()}`,
+    )
+
+    if (Array.isArray(json)) return json // le point d'entrée ne pagine pas
+
+    const lot = json.items ?? json.data ?? []
+    tout.push(...lot)
+
+    const total = json.total
+    // S'arrêter sur une page incomplète autant que sur le total : si le
+    // backend cessait un jour de renvoyer `total`, la boucle doit finir quand
+    // même plutôt que de tourner sans fin.
+    if (lot.length < MAX_SIZE || (typeof total === "number" && tout.length >= total)) break
+    page += 1
+  }
+
+  return tout
+}
+
 export const feesApi = {
   // --- Catégories de frais ---
 
   listCategories: async (): Promise<FeeCategory[]> => {
-    const json = await apiFetch<{ items?: FeeCategory[]; data?: FeeCategory[] } | FeeCategory[]>("/admin/fee-categories")
-    const arr = Array.isArray(json) ? json : (json as { items?: FeeCategory[]; data?: FeeCategory[] }).items ?? (json as { data?: FeeCategory[] }).data ?? []
+    const arr = await fetchEveryPage<FeeCategory>("/admin/fee-categories", new URLSearchParams())
     return safeValidate(FeeCategoryArraySchema, arr, "GET /admin/fee-categories")
   },
 
@@ -53,9 +90,9 @@ export const feesApi = {
   // --- Variantes de frais ---
 
   listVariants: async (academicYearId?: number): Promise<FeeVariant[]> => {
-    const query = academicYearId ? `?academic_year_id=${academicYearId}` : ""
-    const json = await apiFetch<{ items?: FeeVariant[]; data?: FeeVariant[] } | FeeVariant[]>(`/admin/fee-variants${query}`)
-    const arr = Array.isArray(json) ? json : (json as { items?: FeeVariant[]; data?: FeeVariant[] }).items ?? (json as { data?: FeeVariant[] }).data ?? []
+    const params = new URLSearchParams()
+    if (academicYearId) params.set("academic_year_id", String(academicYearId))
+    const arr = await fetchEveryPage<FeeVariant>("/admin/fee-variants", params)
     return safeValidate(FeeVariantArraySchema, arr, "GET /admin/fee-variants")
   },
 
@@ -86,8 +123,7 @@ export const feesApi = {
   listOptions: async (categoryId: number, academicYearId?: number): Promise<OptionalFeeOption[]> => {
     const params = new URLSearchParams({ category_id: String(categoryId) })
     if (academicYearId) params.set("academic_year_id", String(academicYearId))
-    const json = await apiFetch<{ items?: OptionalFeeOption[] } | OptionalFeeOption[]>(`/admin/fee-options?${params}`)
-    const arr = Array.isArray(json) ? json : (json as { items?: OptionalFeeOption[] }).items ?? []
+    const arr = await fetchEveryPage<OptionalFeeOption>("/admin/fee-options", params)
     return safeValidate(OptionalFeeOptionArraySchema, arr, "GET /admin/fee-options")
   },
 


### PR DESCRIPTION
Signalé en production sur l'école Rostan : la grille des frais de la 6e n'affichait qu'un seul montant, et tenter de saisir les frais d'inscription manquants répondait « doublon possible ».

## Ce qui se passait

Le backend renvoie **20 éléments par page**. `listVariants` ne demandait aucune taille, donc recevait la première page et la rendait comme si c'était la liste entière. Sans le moindre signal.

L'école a 25 tarifs. Les cinq absents de la page étaient exactement les cinq invisibles à l'écran :

| Tarif | Montant |
|---|---|
| Inscription 6e | 37 000 |
| Inscription 5e | 37 000 |
| Inscription 4e | 25 000 |
| Inscription 3e | 37 000 |
| Scolarité 6e | 70 000 |

D'où la carte « Inscription, 3 niveaux, 111 000 » — soit 37 000 × 3, les seuls niveaux qui tenaient dans la page — et un total 6e affiché à 18 000 au lieu de 125 000.

Le message de doublon était donc **exact** : la ligne existait, l'écran ne la montrait pas. L'utilisateur se retrouvait devant une application qui refuse de créer ce qu'elle affirme ne pas avoir.

## Le correctif

Un helper `fetchEveryPage` qui parcourt toutes les pages, utilisé par les trois listes de frais. Il s'arrête sur le total **et** sur une page incomplète : si le backend cessait un jour de renvoyer `total`, la boucle se termine quand même au lieu de tourner sans fin. Une réponse qui n'est pas paginée est rendue telle quelle.

Les catégories et les options souffraient du même défaut et n'y échappaient que parce qu'elles sont aujourd'hui sous les vingt. Corrigées aussi.

## Vérification

- `tsc --noEmit --incremental false` : 0 erreur
- `eslint` sur le fichier touché : 0 erreur
- Diagnostic établi contre la base de production : 25 variantes en base, 25 renvoyées avec `size=100`, 20 sans, et les 5 manquantes correspondent une à une aux lignes absentes de la capture d'écran
