### PR TITLE
fix(permissions): count the session boot as loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Les écrans réservés à certains rôles s'ouvraient sur « Accès refusé » pendant une fraction de seconde, y compris pour un administrateur, le temps que la session s'établisse *(admin, éducateur, directeur des études)*
 - La grille des frais n'affichait que les vingt premiers montants et donnait le reste pour inexistant : des niveaux apparaissaient avec moins de frais qu'ils n'en portent, le total par élève était faux, et recréer un montant manquant se soldait par « doublon possible ». Tous les montants sont désormais chargés *(admin, comptable)*
 - Le motif d'une suppression définitive n'apparaît plus dans l'adresse de la requête, donc plus dans les journaux du serveur ni chez les intermédiaires. « Élève exclu pour vol » n'a rien à y faire *(admin)*
 

--- a/lib/hooks/usePermissions.ts
+++ b/lib/hooks/usePermissions.ts
@@ -38,7 +38,12 @@ export function usePermissions() {
     has: (slug: string) => (set ? set.has(slug) : false),
     hasAny: (slugs: string[]) => (set ? slugs.some((s) => set.has(s)) : false),
     hasAll: (slugs: string[]) => (set ? slugs.every((s) => set.has(s)) : false),
-    isLoading: enabled && isLoading,
+    // La session compte comme un chargement. Sans cela, pendant que NextAuth
+    // s'amorce, `enabled` est faux, donc `isLoading` est faux, et `has()` rend
+    // faux faute de données : un écran qui teste « pas en chargement ET pas le
+    // droit » affiche « Accès refusé » à tout le monde, y compris à un
+    // administrateur, avant de basculer sur le vrai contenu.
+    isLoading: status === "loading" || (enabled && isLoading),
     isFetching,
   }
 }


### PR DESCRIPTION
Trois écrans neufs s'ouvraient sur « Accès refusé » avant de basculer sur leur contenu, pour tout le monde, administrateur compris.

## La cause n'était pas dans les écrans

`usePermissions` rendait `isLoading: enabled && isLoading`, avec `enabled = status === "authenticated"`. Pendant l'amorçage de NextAuth, `status` vaut `"loading"` : `enabled` est donc faux, `isLoading` est faux **aussi**, et `has()` rend faux faute de données.

Un écran qui teste « pas en chargement ET pas le droit » — la formulation naturelle — voit donc les deux conditions réunies et affiche son refus.

Le correctif va dans le crochet partagé, pas dans les trois appelants : le piège était tendu pour tout appelant futur, pas seulement pour ceux qui sont tombés dedans. Il y a treize consommateurs du crochet dans le projet.

## Vérification

- `tsc --noEmit --incremental false` : 0 erreur
- `eslint` sur le fichier touché : 0 erreur
- Les treize appelants relus : aucun ne dépend du fait que `isLoading` soit faux pendant l'amorçage de la session
