### PR TITLE
fix(grades): stop the absence checkbox from corrupting grades, and search students instead of listing 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Le choix de l’élève se fait par recherche, dans les convocations, les autorisations de reprise et les versements : on tape deux lettres, nom ou matricule, au lieu de faire défiler une liste tronquée aux cent premiers *(admin, secrétariat, caissier)*.
 - Fiche Personnel : le rôle d'accès propose désormais six métiers (secrétariat, caissier, éducateur, comptable, directeur des études, directeur), chacun accompagné d'une phrase qui dit ce que la personne pourra faire. « Personnel administratif » devient « Secrétariat » *(admin, directeur)*.
 - Wizard Nouvelle inscription : le modal ne se ferme plus si on appuie hors du cadre (la saisie n'est plus perdue). L'étape élève et la sélection de classe sont lisibles sur téléphone, avec des boutons assez grands. La liste des classes montre les places encore disponibles, pas seulement le maximum *(admin)*.
 - Publication Windows : le frontend standalone est désormais compilé hors production par la CI puis livré comme artefact versionné.
@@ -53,6 +54,11 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Décocher « Abs. » sur la feuille de notes ne transforme plus le zéro d’office en note de 0/20, et ne le fait plus disparaître du bulletin. La case explique désormais qu’un billet de reprise est nécessaire *(enseignant, admin)*.
+- Cocher « Abs. » sur un élève déjà noté demande confirmation : sa note ne disparaît plus sans avertissement *(enseignant)*.
+- Taper « absent » dans la case de note marque enfin l’absence, comme la case cochée et comme le mot dit à voix haute *(enseignant)*.
+- Le mode dictée ne demande plus « Quitter sans enregistrer ? » alors que rien n’a été touché, dès qu’un élève est absent *(enseignant)*.
+- Registre des convocations : « Suite donnée » reste éteint tant que le rendez-vous n’a pas eu lieu, avec la raison affichée, au lieu d’échouer au clic *(éducateur)*.
 - La grille des frais n'affichait que les vingt premiers montants et donnait le reste pour inexistant : des niveaux apparaissaient avec moins de frais qu'ils n'en portent, le total par élève était faux, et recréer un montant manquant se soldait par « doublon possible ». Tous les montants sont désormais chargés *(admin, comptable)*
 - Le motif d'une suppression définitive n'apparaît plus dans l'adresse de la requête, donc plus dans les journaux du serveur ni chez les intermédiaires. « Élève exclu pour vol » n'a rien à y faire *(admin)*
 

--- a/app/(admin)/admin/grades/[evaluationId]/page.tsx
+++ b/app/(admin)/admin/grades/[evaluationId]/page.tsx
@@ -60,6 +60,7 @@ export default async function AdminGradeEntryPage({
             ? `/admin/grades/${evaluationId}/dictee?classId=${classId}`
             : undefined
         }
+        retakesHref="/admin/retakes"
       />
     </div>
   )

--- a/components/admin/payments/PaymentCreateWizard.tsx
+++ b/components/admin/payments/PaymentCreateWizard.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { ArrowLeft, Search, User, BookOpen, Receipt, Loader2, Check } from "lucide-react"
+import { ArrowLeft, BookOpen, Receipt, Loader2, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
@@ -15,10 +15,10 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { useStudents, useStudentFees } from "@/lib/hooks/useStudents"
+import { useStudentFees } from "@/lib/hooks/useStudents"
 import { useEnrollments } from "@/lib/hooks/useEnrollments"
 import { useCreatePayment } from "@/lib/hooks/usePayments"
-import { useDebounce } from "@/lib/hooks/useDebounce"
+import { StudentPicker } from "@/components/shared/StudentPicker"
 import type { Student } from "@/lib/contracts/student"
 import type { Enrollment } from "@/lib/contracts/enrollment"
 import type { StudentEnrollmentFee } from "@/lib/api/students"
@@ -117,7 +117,7 @@ export function PaymentCreateWizard({ open, onClose }: PaymentCreateWizardProps)
         )}
 
         {/* Steps */}
-        {wizard.step === 1 && <StepSearchStudent onSelect={selectStudent} />}
+        {wizard.step === 1 && <StudentPicker onSelect={selectStudent} autoFocus />}
         {wizard.step === 2 && wizard.student && (
           <StepSelectEnrollment student={wizard.student} onSelect={selectEnrollment} />
         )}
@@ -174,82 +174,6 @@ function StepProgress({ currentStep }: { currentStep: number }) {
           )
         })}
       </div>
-    </div>
-  )
-}
-
-// --- Step 1: Search student ---
-
-function StepSearchStudent({ onSelect }: { onSelect: (s: Student) => void }) {
-  const [search, setSearch] = useState("")
-  const debouncedSearch = useDebounce(search, 300)
-
-  const { data, isLoading } = useStudents(
-    debouncedSearch.length >= 2 ? { search: debouncedSearch } : {},
-  )
-
-  const students = useMemo(() => data?.items ?? [], [data])
-
-  return (
-    <div className="space-y-4">
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          placeholder="Rechercher un eleve (nom, prenom, matricule)..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="pl-10"
-          autoFocus
-        />
-      </div>
-
-      {search.length > 0 && search.length < 2 && (
-        <p className="text-sm text-muted-foreground text-center py-4">
-          Saisissez au moins 2 caracteres pour rechercher
-        </p>
-      )}
-
-      {isLoading && debouncedSearch.length >= 2 && (
-        <div className="flex items-center justify-center py-8">
-          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-        </div>
-      )}
-
-      {!isLoading && debouncedSearch.length >= 2 && students.length === 0 && (
-        <p className="text-sm text-muted-foreground text-center py-8">
-          Aucun eleve trouve pour &laquo;{debouncedSearch}&raquo;
-        </p>
-      )}
-
-      {students.length > 0 && (
-        <div className="space-y-2 max-h-[40vh] overflow-y-auto">
-          {students.map((student) => (
-            <Card
-              key={student.id}
-              className="cursor-pointer transition-colors hover:bg-muted/50"
-              onClick={() => onSelect(student)}
-            >
-              <CardContent className="flex items-center gap-3 p-3">
-                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary">
-                  {student.first_name[0]}{student.last_name[0]}
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium truncate">
-                    {student.last_name} {student.first_name}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {student.enrollment_number
-                      ? `Matricule : ${student.enrollment_number}`
-                      : "Pas de matricule"}
-                    {student.genre && ` - ${student.genre === "M" ? "Garcon" : "Fille"}`}
-                  </p>
-                </div>
-                <User className="h-4 w-4 text-muted-foreground shrink-0" />
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
     </div>
   )
 }

--- a/components/admin/retakes/RetakeCreateModal.tsx
+++ b/components/admin/retakes/RetakeCreateModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 import { CalendarRange, Loader2, RotateCcw } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -14,16 +14,9 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Textarea } from "@/components/ui/textarea"
-import { useStudents } from "@/lib/hooks/useStudents"
+import { StudentPicker } from "@/components/shared/StudentPicker"
 import { useAbsentEvaluations, useCreateRetakeAuthorization } from "@/lib/hooks/useRetakes"
 import { RetakeAuthorizationCreateSchema } from "@/lib/contracts/school-life"
 import { formatSchoolDate } from "@/components/shared/school-life/school-life-ui"
@@ -40,29 +33,23 @@ function today(): string {
  * une épreuve qu'il a passée, autant ne pas la lui proposer.
  */
 export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const [studentId, setStudentId] = useState("")
+  const [student, setStudent] = useState<Student | null>(null)
   const [periodStart, setPeriodStart] = useState("")
   const [periodEnd, setPeriodEnd] = useState(today)
   const [reason, setReason] = useState("")
   const [selected, setSelected] = useState<number[]>([])
   const [errors, setErrors] = useState<Record<string, string>>({})
 
-  const { data: studentsData, isLoading: loadingStudents } = useStudents({ size: 100 })
-  const students: Student[] = useMemo(() => studentsData?.items ?? [], [studentsData])
   const { mutate: create, isPending } = useCreateRetakeAuthorization()
 
-  const selectedStudent = useMemo(
-    () => students.find((student) => String(student.id) === studentId),
-    [students, studentId],
-  )
-  const classId = selectedStudent?.current_enrollment?.class_id
+  const classId = student?.current_enrollment?.class_id
 
   const {
     data: evaluations,
     isLoading: loadingEvaluations,
     isError: evaluationsFailed,
   } = useAbsentEvaluations({
-    studentId: studentId ? Number(studentId) : undefined,
+    studentId: student?.id,
     classId,
     periodStart: periodStart || undefined,
     periodEnd: periodEnd || undefined,
@@ -70,7 +57,7 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
 
   useEffect(() => {
     if (open) {
-      setStudentId("")
+      setStudent(null)
       setPeriodStart("")
       setPeriodEnd(today())
       setReason("")
@@ -83,7 +70,7 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
   // cochées qui ne s'affichent plus enverrait des évaluations invisibles.
   useEffect(() => {
     setSelected([])
-  }, [studentId, periodStart, periodEnd])
+  }, [student, periodStart, periodEnd])
 
   function toggle(evaluationId: number) {
     setSelected((prev) =>
@@ -95,7 +82,7 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
 
   function handleSubmit() {
     const parsed = RetakeAuthorizationCreateSchema.safeParse({
-      student_id: studentId ? Number(studentId) : 0,
+      student_id: student?.id ?? 0,
       period_start: periodStart,
       period_end: periodEnd,
       reason,
@@ -114,7 +101,7 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
     create(parsed.data, { onSuccess: () => onClose() })
   }
 
-  const periodChosen = Boolean(studentId && periodStart && periodEnd)
+  const periodChosen = Boolean(student && periodStart && periodEnd)
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
@@ -133,23 +120,14 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
         <div className="max-h-[60vh] space-y-4 overflow-y-auto py-2 pr-1">
           <div className="space-y-1.5">
             <Label htmlFor="retake-student">Élève</Label>
-            <Select value={studentId} onValueChange={setStudentId}>
-              <SelectTrigger id="retake-student" className="h-11 sm:h-10">
-                <SelectValue placeholder={loadingStudents ? "Chargement…" : "Choisir un élève"} />
-              </SelectTrigger>
-              <SelectContent>
-                {students.map((student) => (
-                  <SelectItem key={student.id} value={String(student.id)}>
-                    {student.last_name} {student.first_name}
-                    {student.current_enrollment?.class_name
-                      ? ` · ${student.current_enrollment.class_name}`
-                      : ""}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <StudentPicker
+              inputId="retake-student"
+              selected={student}
+              onSelect={setStudent}
+              onClear={() => setStudent(null)}
+            />
             {errors.student_id && <p className="text-sm text-destructive">{errors.student_id}</p>}
-            {studentId && !classId && (
+            {student && !classId && (
               <p className="text-sm text-destructive">
                 Cet élève n&apos;a pas d&apos;inscription pour l&apos;année courante : aucune
                 évaluation ne peut être rouverte.

--- a/components/admin/summons/SummonsCreateModal.tsx
+++ b/components/admin/summons/SummonsCreateModal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 import { Loader2, Megaphone } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -21,7 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
-import { useStudents } from "@/lib/hooks/useStudents"
+import { StudentPicker } from "@/components/shared/StudentPicker"
 import { useStudentParents } from "@/lib/hooks/useParents"
 import { useCreateSummons } from "@/lib/hooks/useSummons"
 import { ParentSummonsCreateSchema } from "@/lib/contracts/school-life"
@@ -40,7 +40,7 @@ function today(): string {
  * guichet, parce qu'un tuteur n'a pas toujours de fiche.
  */
 export function SummonsCreateModal({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const [studentId, setStudentId] = useState("")
+  const [student, setStudent] = useState<Student | null>(null)
   const [parentChoice, setParentChoice] = useState(OTHER_PARENT)
   const [parentName, setParentName] = useState("")
   const [summonsDate, setSummonsDate] = useState(today)
@@ -49,16 +49,12 @@ export function SummonsCreateModal({ open, onClose }: { open: boolean; onClose: 
   const [reason, setReason] = useState("")
   const [errors, setErrors] = useState<Record<string, string>>({})
 
-  const { data: studentsData, isLoading: loadingStudents } = useStudents({ size: 100 })
-  const students: Student[] = useMemo(() => studentsData?.items ?? [], [studentsData])
-  const { data: parents, isLoading: loadingParents } = useStudentParents(
-    studentId ? Number(studentId) : undefined,
-  )
+  const { data: parents, isLoading: loadingParents } = useStudentParents(student?.id)
   const { mutate: create, isPending } = useCreateSummons()
 
   useEffect(() => {
     if (open) {
-      setStudentId("")
+      setStudent(null)
       setParentChoice(OTHER_PARENT)
       setParentName("")
       setSummonsDate(today())
@@ -76,14 +72,9 @@ export function SummonsCreateModal({ open, onClose }: { open: boolean; onClose: 
     else setParentChoice(OTHER_PARENT)
   }, [parents])
 
-  const selectedStudent = useMemo(
-    () => students.find((student) => String(student.id) === studentId),
-    [students, studentId],
-  )
-
   function handleSubmit() {
     const payload = {
-      student_id: studentId ? Number(studentId) : 0,
+      student_id: student?.id ?? 0,
       parent_id: parentChoice === OTHER_PARENT ? null : Number(parentChoice),
       parent_name: parentChoice === OTHER_PARENT ? parentName : undefined,
       summons_date: summonsDate,
@@ -123,34 +114,18 @@ export function SummonsCreateModal({ open, onClose }: { open: boolean; onClose: 
         <div className="max-h-[60vh] space-y-4 overflow-y-auto py-2 pr-1">
           <div className="space-y-1.5">
             <Label htmlFor="summons-student">Élève</Label>
-            <Select value={studentId} onValueChange={setStudentId}>
-              <SelectTrigger id="summons-student" className="h-11 sm:h-10">
-                <SelectValue
-                  placeholder={loadingStudents ? "Chargement…" : "Choisir un élève"}
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {students.map((student) => (
-                  <SelectItem key={student.id} value={String(student.id)}>
-                    {student.last_name} {student.first_name}
-                    {student.current_enrollment?.class_name
-                      ? ` · ${student.current_enrollment.class_name}`
-                      : ""}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {!loadingStudents && students.length === 0 && (
-              <p className="text-xs text-muted-foreground">
-                Aucun élève enregistré. Créez d&apos;abord une fiche élève.
-              </p>
-            )}
+            <StudentPicker
+              inputId="summons-student"
+              selected={student}
+              onSelect={setStudent}
+              onClear={() => setStudent(null)}
+            />
             {errors.student_id && <p className="text-sm text-destructive">{errors.student_id}</p>}
           </div>
 
           <div className="space-y-1.5">
             <Label htmlFor="summons-parent">Tuteur convoqué</Label>
-            <Select value={parentChoice} onValueChange={setParentChoice} disabled={!studentId}>
+            <Select value={parentChoice} onValueChange={setParentChoice} disabled={!student}>
               <SelectTrigger id="summons-parent" className="h-11 sm:h-10">
                 <SelectValue placeholder={loadingParents ? "Chargement…" : "Choisir le tuteur"} />
               </SelectTrigger>
@@ -163,10 +138,9 @@ export function SummonsCreateModal({ open, onClose }: { open: boolean; onClose: 
                 <SelectItem value={OTHER_PARENT}>Autre personne (saisir le nom)</SelectItem>
               </SelectContent>
             </Select>
-            {studentId && !loadingParents && (parents ?? []).length === 0 && (
+            {student && !loadingParents && (parents ?? []).length === 0 && (
               <p className="text-xs text-muted-foreground">
-                Aucun parent lié à {selectedStudent?.first_name ?? "cet élève"} : saisissez le nom
-                du tuteur ci-dessous.
+                Aucun parent lié à {student.first_name} : saisissez le nom du tuteur ci-dessous.
               </p>
             )}
           </div>

--- a/components/admin/summons/SummonsOutcomeModal.tsx
+++ b/components/admin/summons/SummonsOutcomeModal.tsx
@@ -22,9 +22,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import { useRecordSummonsOutcome } from "@/lib/hooks/useSummons"
 import { SUMMONS_OUTCOME_OPTIONS } from "@/lib/contracts/school-life"
-import type { ParentSummons } from "@/lib/contracts/school-life"
-
-type Outcome = "pending" | "attended" | "missed"
+import type { ParentSummons, SummonsOutcome } from "@/lib/contracts/school-life"
 
 /** Consigne au registre si le tuteur s'est présenté, et ce qui s'est dit. */
 export function SummonsOutcomeModal({
@@ -34,13 +32,13 @@ export function SummonsOutcomeModal({
   summons: ParentSummons | null
   onClose: () => void
 }) {
-  const [outcome, setOutcome] = useState<Outcome>("attended")
+  const [outcome, setOutcome] = useState<SummonsOutcome>("attended")
   const [notes, setNotes] = useState("")
   const { mutate: record, isPending } = useRecordSummonsOutcome()
 
   useEffect(() => {
     if (summons) {
-      setOutcome(summons.outcome === "pending" ? "attended" : (summons.outcome as Outcome))
+      setOutcome(summons.outcome === "pending" ? "attended" : summons.outcome)
       setNotes(summons.outcome_notes ?? "")
     }
   }, [summons])
@@ -68,7 +66,7 @@ export function SummonsOutcomeModal({
         <div className="space-y-4 py-2">
           <div className="space-y-1.5">
             <Label htmlFor="summons-outcome">Le tuteur s&apos;est-il présenté ?</Label>
-            <Select value={outcome} onValueChange={(value) => setOutcome(value as Outcome)}>
+            <Select value={outcome} onValueChange={(value) => setOutcome(value as SummonsOutcome)}>
               <SelectTrigger id="summons-outcome" className="h-11 sm:h-10">
                 <SelectValue />
               </SelectTrigger>

--- a/components/admin/summons/SummonsRegisterList.tsx
+++ b/components/admin/summons/SummonsRegisterList.tsx
@@ -16,6 +16,10 @@ import {
   formatSchoolDate,
   formatSchoolTime,
 } from "@/components/shared/school-life/school-life-ui"
+import {
+  SUMMONS_OUTCOME_TOO_EARLY,
+  canRecordSummonsOutcome,
+} from "@/lib/utils/summons-schedule"
 import type { ParentSummons } from "@/lib/contracts/school-life"
 
 interface SummonsRegisterListProps {
@@ -36,18 +40,30 @@ function RowActions({
   onDownload: (summons: ParentSummons) => void
   downloading: boolean
 }) {
+  // Le rendez-vous n'a pas encore eu lieu : le backend refuse la consignation.
+  // Le registre étant trié du plus récent au plus ancien, ces lignes ouvrent
+  // l'écran ; mieux vaut un bouton éteint qui s'explique qu'un refus au clic.
+  const canRecord = canRecordSummonsOutcome(summons.summons_date)
+
   return (
     <div className="flex flex-wrap gap-2">
-      <Button
-        size="sm"
-        variant="outline"
-        className="h-11 gap-1.5 sm:h-9"
-        onClick={() => onRecordOutcome(summons)}
-        aria-label={`Consigner la suite donnée pour ${summons.student_name}`}
-      >
-        <ClipboardCheck className="h-4 w-4" aria-hidden="true" />
-        Suite donnée
-      </Button>
+      <span title={canRecord ? undefined : SUMMONS_OUTCOME_TOO_EARLY}>
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-11 gap-1.5 sm:h-9"
+          onClick={() => onRecordOutcome(summons)}
+          disabled={!canRecord}
+          aria-label={
+            canRecord
+              ? `Consigner la suite donnée pour ${summons.student_name}`
+              : `Suite donnée indisponible pour ${summons.student_name} : ${SUMMONS_OUTCOME_TOO_EARLY}`
+          }
+        >
+          <ClipboardCheck className="h-4 w-4" aria-hidden="true" />
+          Suite donnée
+        </Button>
+      </span>
       <Button
         size="sm"
         variant="outline"
@@ -63,6 +79,11 @@ function RowActions({
         )}
         PDF
       </Button>
+      {!canRecord && (
+        // L'infobulle ne s'ouvre pas au doigt : sur téléphone, la raison doit
+        // rester lisible sans survol.
+        <p className="w-full text-xs text-muted-foreground">{SUMMONS_OUTCOME_TOO_EARLY}</p>
+      )}
     </div>
   )
 }

--- a/components/shared/StudentPicker.tsx
+++ b/components/shared/StudentPicker.tsx
@@ -1,0 +1,176 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Loader2, Search, User } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useStudents } from "@/lib/hooks/useStudents"
+import { useDebounce } from "@/lib/hooks/useDebounce"
+import { cn } from "@/lib/utils"
+import type { Student } from "@/lib/contracts/student"
+
+/** En dessous, la recherche renverrait la moitié de l'établissement. */
+const MIN_SEARCH_LENGTH = 2
+
+interface StudentPickerProps {
+  onSelect: (student: Student) => void
+  /**
+   * Élève déjà retenu. Fourni, la recherche laisse la place à un rappel de
+   * l'élève choisi, avec un bouton pour en changer.
+   */
+  selected?: Student | null
+  onClear?: () => void
+  inputId?: string
+  autoFocus?: boolean
+  placeholder?: string
+  className?: string
+}
+
+function studentInitials(student: Student): string {
+  return `${student.first_name[0] ?? ""}${student.last_name[0] ?? ""}`.toUpperCase()
+}
+
+function studentSubtitle(student: Student): string {
+  const parts: string[] = [
+    student.enrollment_number ? `Matricule : ${student.enrollment_number}` : "Pas de matricule",
+  ]
+  if (student.current_enrollment?.class_name) parts.push(student.current_enrollment.class_name)
+  else if (student.genre) parts.push(student.genre === "M" ? "Garçon" : "Fille")
+  return parts.join(" · ")
+}
+
+function StudentIdentity({ student }: { student: Student }) {
+  return (
+    <>
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary">
+        {studentInitials(student)}
+      </span>
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block truncate font-medium">
+          {student.last_name} {student.first_name}
+        </span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {studentSubtitle(student)}
+        </span>
+      </span>
+    </>
+  )
+}
+
+/**
+ * Choix d'un élève par la recherche, jamais par une liste déroulante.
+ *
+ * Un collège de six cents élèves ne tient pas dans une page d'API : la liste
+ * déroulante n'en montrait que les cent premiers, sans champ de recherche, à
+ * faire défiler sur un téléphone d'entrée de gamme. Ici on tape deux lettres,
+ * le nom ou le matricule, et on tape sur une carte.
+ */
+export function StudentPicker({
+  onSelect,
+  selected = null,
+  onClear,
+  inputId,
+  autoFocus = false,
+  placeholder = "Rechercher un élève (nom, prénom, matricule)…",
+  className,
+}: StudentPickerProps) {
+  const [search, setSearch] = useState("")
+  const debouncedSearch = useDebounce(search, 300)
+
+  const { data, isLoading } = useStudents(
+    debouncedSearch.length >= MIN_SEARCH_LENGTH ? { search: debouncedSearch } : {},
+  )
+  const students = useMemo(() => data?.items ?? [], [data])
+  const searching = debouncedSearch.length >= MIN_SEARCH_LENGTH
+
+  if (selected) {
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-3 rounded-lg border bg-muted/30 p-3",
+          className,
+        )}
+      >
+        <StudentIdentity student={selected} />
+        {onClear && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setSearch("")
+              onClear()
+            }}
+            className="h-11 shrink-0 sm:h-9"
+          >
+            Changer
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div className="relative">
+        <Search
+          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <Input
+          id={inputId}
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={placeholder}
+          className="h-11 pl-10 sm:h-10"
+          autoFocus={autoFocus}
+        />
+      </div>
+
+      {search.length > 0 && search.length < MIN_SEARCH_LENGTH && (
+        <p className="py-4 text-center text-sm text-muted-foreground">
+          Saisissez au moins {MIN_SEARCH_LENGTH} caractères pour rechercher
+        </p>
+      )}
+
+      {isLoading && searching && (
+        <div className="flex items-center justify-center py-8">
+          <Loader2
+            className="h-5 w-5 animate-spin text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span className="sr-only">Recherche en cours</span>
+        </div>
+      )}
+
+      {!isLoading && searching && students.length === 0 && (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Aucun élève trouvé pour «&nbsp;{debouncedSearch}&nbsp;»
+        </p>
+      )}
+
+      {!isLoading && !searching && students.length === 0 && (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Aucun élève enregistré. Créez d&apos;abord une fiche élève.
+        </p>
+      )}
+
+      {students.length > 0 && (
+        <div className="max-h-[40vh] space-y-2 overflow-y-auto">
+          {students.map((student) => (
+            <button
+              key={student.id}
+              type="button"
+              onClick={() => onSelect(student)}
+              className="flex min-h-11 w-full items-center gap-3 rounded-lg border bg-card p-3 text-sm transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            >
+              <StudentIdentity student={student} />
+              <User className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/teacher/grades/DicteeMode.tsx
+++ b/components/teacher/grades/DicteeMode.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner"
 import { useGrades, useUpdateGrades, useEvaluations } from "@/lib/hooks/useGrades"
 import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
 import { parseSpokenGrade, detectCommand } from "@/lib/utils/voice-grade-parser"
+import { dicteeEntryFromServer } from "@/lib/utils/grade-reconciliation"
 import { Button } from "@/components/ui/button"
 import {
   AlertDialog,
@@ -69,11 +70,8 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
     if (grades) {
       const map = new Map<number, EntryValue>()
       grades.forEach((g) => {
-        if (g.status === "absent") {
-          map.set(g.student_id, null) // zéro d'office déjà enregistré
-        } else if (g.value !== null) {
-          map.set(g.student_id, Number(g.value))
-        }
+        const initial = dicteeEntryFromServer(g)
+        if (initial !== undefined) map.set(g.student_id, initial)
       })
       setEntries(map)
     }
@@ -213,15 +211,13 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
   }, [])
 
   // ─── Quitter avec garde sur dirty ──────────────────────────────────────
+  // La référence est exactement ce que l'amorçage a mis dans `entries` : un
+  // absent vaut `null` à l'écran alors que le serveur renvoie le zéro d'office.
+  // Comparer à la valeur brute rendait le garde vrai en permanence dès qu'un
+  // seul élève était absent, et un garde qui crie à vide ne protège plus rien.
   const hasDirty = useMemo(() => {
     if (!grades) return false
-    for (const g of grades) {
-      const local = entries.get(g.student_id)
-      const server =
-        g.value !== null ? Number(g.value) : g.status === "entered" ? null : undefined
-      if (local !== server) return true
-    }
-    return false
+    return grades.some((g) => entries.get(g.student_id) !== dicteeEntryFromServer(g))
   }, [grades, entries])
 
   const performExit = useCallback(() => {

--- a/components/teacher/grades/GradeEntryGrid.tsx
+++ b/components/teacher/grades/GradeEntryGrid.tsx
@@ -8,8 +8,22 @@ import { useGrades, useUpdateGrades, useEvaluations } from "@/lib/hooks/useGrade
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { parseGradeInput, computeAverage } from "@/lib/utils/grade-parser"
+import {
+  absenceWouldOverwriteGrade,
+  canLiftAbsence,
+  gradeStatesEqual,
+  normalizeGradeState,
+  reconcileGradeSave,
+  toGradePayloadEntry,
+  type GradeEntryState,
+} from "@/lib/utils/grade-reconciliation"
 import { GradeEntryHero } from "./entry/GradeEntryHero"
 import { GradeRow, type CellStatus } from "./entry/GradeRow"
+import {
+  AbsenceGuardDialog,
+  ABSENCE_LIFT_RULE,
+  type AbsenceGuard,
+} from "./entry/AbsenceGuardDialog"
 
 interface GradeEntryGridProps {
   evaluationId: number
@@ -21,6 +35,12 @@ interface GradeEntryGridProps {
    * enseignant, on tombe sur la route enseignant.
    */
   dicteeHref?: string
+  /**
+   * Écran des autorisations de reprise, quand le portail y donne accès. Sert à
+   * renvoyer l'administration au bon endroit quand elle bute sur un zéro
+   * d'office. L'enseignant n'a pas ce droit : il reçoit l'explication seule.
+   */
+  retakesHref?: string
 }
 
 /** Délai debounce après la dernière modif avant envoi BE. */
@@ -28,13 +48,12 @@ const SAVE_DEBOUNCE_MS = 1500
 /** Délai après lequel un cellStatus « saved » repasse en « idle » (visuel). */
 const SAVED_INDICATOR_MS = 2500
 
-type GradeSnapshotEntry = {
-  student_id: number
-  value: number | null
-  absent: boolean
-}
-
-export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntryGridProps) {
+export function GradeEntryGrid({
+  evaluationId,
+  classId,
+  dicteeHref,
+  retakesHref,
+}: GradeEntryGridProps) {
   const { data: grades, isLoading, error } = useGrades(evaluationId)
   const { data: evals } = useEvaluations(classId ?? 0)
   const evaluation = useMemo(
@@ -47,15 +66,23 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
   const [cellStatus, setCellStatus] = useState<Map<number, CellStatus>>(new Map())
   const [lastSaved, setLastSaved] = useState<Date | null>(null)
   const [absentStudents, setAbsentStudents] = useState<Set<number>>(new Set())
+  const [absenceGuard, setAbsenceGuard] = useState<{
+    studentId: number
+    guard: AbsenceGuard
+  } | null>(null)
   const dirtyStudentsRef = useRef<Set<number>>(new Set())
   const localGradesRef = useRef<Map<number, number | null>>(new Map())
   const absentStudentsRef = useRef<Set<number>>(new Set())
+  // Statut réellement enregistré côté serveur, par élève. C'est lui qui décide
+  // si la case « Abs. » peut encore être décochée.
+  const serverStatusRef = useRef<Map<number, string>>(new Map())
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const saveInFlightRef = useRef(false)
 
   // ─── Sync depuis serveur ───────────────────────────────────────────────
   useEffect(() => {
     if (grades) {
+      serverStatusRef.current = new Map(grades.map((g) => [g.student_id, g.status]))
       setLocalGrades((prev) => {
         const map = new Map(prev)
         grades.forEach((g) => {
@@ -81,12 +108,15 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
     }
   }, [grades])
 
-  // Ce qui partira réellement au serveur pour cet élève. Sert à construire le
-  // lot ET à vérifier ensuite que rien n'a bougé pendant l'envoi : si les deux
-  // lectures divergent, la ligne resterait « à sauvegarder » indéfiniment.
-  const pendingValueFor = useCallback((studentId: number): number | null => {
-    if (absentStudentsRef.current.has(studentId)) return null
-    return localGradesRef.current.get(studentId) ?? null
+  // Ce qui partira réellement au serveur pour cet élève : la note ET le zéro
+  // d'office, jamais l'un sans l'autre. Sert à construire le lot ET à vérifier
+  // ensuite que rien n'a bougé pendant l'envoi. Comparer la seule valeur
+  // laisserait passer pour « enregistré » un décochage que le backend a refusé.
+  const pendingStateFor = useCallback((studentId: number): GradeEntryState => {
+    return normalizeGradeState({
+      value: localGradesRef.current.get(studentId) ?? null,
+      absent: absentStudentsRef.current.has(studentId),
+    })
   }, [])
 
   // ─── Save logic ────────────────────────────────────────────────────────
@@ -98,14 +128,12 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
     if (dirtyStudentsRef.current.size === 0 || !grades) return
     if (saveInFlightRef.current) return
 
-    const payload: GradeSnapshotEntry[] = Array.from(dirtyStudentsRef.current).map((studentId) => ({
-      student_id: studentId,
-      // Absent : le backend force le zéro d'office, la valeur saisie ne compte
-      // plus. On n'envoie donc pas une note et un « absent » contradictoires.
-      value: pendingValueFor(studentId),
-      absent: absentStudentsRef.current.has(studentId),
-    }))
-    const snapshotByStudent = new Map(payload.map((entry) => [entry.student_id, entry.value]))
+    const payload = Array.from(dirtyStudentsRef.current).map((studentId) =>
+      toGradePayloadEntry(studentId, pendingStateFor(studentId)),
+    )
+    const sentByStudent = new Map<number, GradeEntryState>(
+      payload.map((entry) => [entry.student_id, { value: entry.value, absent: entry.absent }]),
+    )
 
     setCellStatus((prev) => {
       const next = new Map(prev)
@@ -116,16 +144,46 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
     saveInFlightRef.current = true
 
     try {
-      await updateMutation.mutateAsync({ grades: payload })
+      const updated = await updateMutation.mutateAsync({ grades: payload })
+      const statusByStudent = new Map(updated.map((g) => [g.student_id, g.status]))
+      // Ce que le serveur vient d'écrire fait foi tout de suite : la case
+      // « Abs. » doit se verrouiller sans attendre le prochain rafraîchissement.
+      serverStatusRef.current = statusByStudent
       const confirmedStudentIds: number[] = []
+      const refusedStudentIds: number[] = []
+      const outcomes = new Map<number, CellStatus>()
 
-      snapshotByStudent.forEach((sentValue, studentId) => {
-        const currentValue = pendingValueFor(studentId)
-        if (Object.is(currentValue, sentValue)) {
+      sentByStudent.forEach((sent, studentId) => {
+        const outcome = reconcileGradeSave({
+          sent,
+          current: pendingStateFor(studentId),
+          serverStatus: statusByStudent.get(studentId),
+        })
+        if (outcome === "saved") {
           dirtyStudentsRef.current.delete(studentId)
           confirmedStudentIds.push(studentId)
+          outcomes.set(studentId, "saved")
+        } else if (outcome === "refused") {
+          // Le backend a gardé le zéro d'office. Renvoyer la même chose
+          // échouerait à l'identique : on sort la ligne de la file d'attente,
+          // on la marque en erreur et on dit pourquoi. Rien n'est vert.
+          dirtyStudentsRef.current.delete(studentId)
+          refusedStudentIds.push(studentId)
+          outcomes.set(studentId, "error")
+        } else {
+          outcomes.set(studentId, "dirty")
         }
       })
+
+      if (refusedStudentIds.length > 0) {
+        // La case doit redire ce qui est réellement enregistré, sinon l'écran
+        // laisse croire que le zéro d'office a été levé.
+        const restored = new Set(absentStudentsRef.current)
+        refusedStudentIds.forEach((id) => restored.add(id))
+        absentStudentsRef.current = restored
+        setAbsentStudents(restored)
+        toast.error("Zéro d'office conservé", { description: ABSENCE_LIFT_RULE })
+      }
 
       if (confirmedStudentIds.length > 0) {
         setLastSaved(new Date())
@@ -133,10 +191,7 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
 
       setCellStatus((prev) => {
         const next = new Map(prev)
-        snapshotByStudent.forEach((sentValue, studentId) => {
-          const currentValue = pendingValueFor(studentId)
-          next.set(studentId, Object.is(currentValue, sentValue) ? "saved" : "dirty")
-        })
+        outcomes.forEach((status, studentId) => next.set(studentId, status))
         return next
       })
 
@@ -152,9 +207,11 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
     } catch {
       setCellStatus((prev) => {
         const next = new Map(prev)
-        payload.forEach((entry) => {
-          const currentValue = pendingValueFor(entry.student_id)
-          next.set(entry.student_id, Object.is(currentValue, entry.value) ? "error" : "dirty")
+        sentByStudent.forEach((sent, studentId) => {
+          // Ligne inchangée depuis l'envoi : c'est bien celle qui a échoué.
+          // Retouchée entre-temps : elle repart au prochain envoi.
+          const stillTheSame = gradeStatesEqual(sent, pendingStateFor(studentId))
+          next.set(studentId, stillTheSame ? "error" : "dirty")
         })
         return next
       })
@@ -168,7 +225,7 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
         }, SAVE_DEBOUNCE_MS)
       }
     }
-  }, [grades, updateMutation, pendingValueFor])
+  }, [grades, updateMutation, pendingStateFor])
 
   const scheduleSave = useCallback(() => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
@@ -193,20 +250,7 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
     return () => window.removeEventListener("beforeunload", handler)
   }, [])
 
-  const handleGradeChange = useCallback(
-    (studentId: number, rawValue: string) => {
-      const result = parseGradeInput(rawValue)
-      const nextGrades = new Map(localGradesRef.current).set(studentId, result.value)
-      localGradesRef.current = nextGrades
-      setLocalGrades(nextGrades)
-      dirtyStudentsRef.current.add(studentId)
-      setCellStatus((prev) => new Map(prev).set(studentId, "dirty"))
-      scheduleSave()
-    },
-    [scheduleSave],
-  )
-
-  const handleAbsentChange = useCallback(
+  const applyAbsent = useCallback(
     (studentId: number, next: boolean) => {
       const updated = new Set(absentStudentsRef.current)
       if (next) updated.add(studentId)
@@ -218,6 +262,59 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
       scheduleSave()
     },
     [scheduleSave],
+  )
+
+  const setGradeValue = useCallback(
+    (studentId: number, value: number | null) => {
+      const nextGrades = new Map(localGradesRef.current).set(studentId, value)
+      localGradesRef.current = nextGrades
+      setLocalGrades(nextGrades)
+      dirtyStudentsRef.current.add(studentId)
+      setCellStatus((prev) => new Map(prev).set(studentId, "dirty"))
+      scheduleSave()
+    },
+    [scheduleSave],
+  )
+
+  const handleGradeChange = useCallback(
+    (studentId: number, rawValue: string) => {
+      const result = parseGradeInput(rawValue)
+      if (result.absent) {
+        // Taper « absent » dans la case vaut la case cochée et vaut le mot dit
+        // à voix haute en dictée : les trois façons de l'exprimer doivent
+        // enregistrer la même chose. Pas de confirmation ici, l'enseignant
+        // écrit littéralement par-dessus la note qu'il remplace.
+        applyAbsent(studentId, true)
+        return
+      }
+      setGradeValue(studentId, result.value)
+    },
+    [applyAbsent, setGradeValue],
+  )
+
+  const handleAbsentChange = useCallback(
+    (studentId: number, studentName: string, next: boolean) => {
+      if (!next && !canLiftAbsence(serverStatusRef.current.get(studentId))) {
+        // Le zéro d'office est déjà enregistré : le backend refusera, et de
+        // deux façons également silencieuses. Autant nommer la règle ici.
+        setAbsenceGuard({ studentId, guard: { kind: "lift-blocked", studentName } })
+        return
+      }
+      const localValue = localGradesRef.current.get(studentId) ?? null
+      const wouldOverwrite = absenceWouldOverwriteGrade({
+        value: localValue,
+        absent: absentStudentsRef.current.has(studentId),
+      })
+      if (next && wouldOverwrite && localValue !== null) {
+        setAbsenceGuard({
+          studentId,
+          guard: { kind: "overwrite", studentName, value: localValue },
+        })
+        return
+      }
+      applyAbsent(studentId, next)
+    },
+    [applyAbsent],
   )
 
   // ─── Rendering ─────────────────────────────────────────────────────────
@@ -296,7 +393,8 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
       <p className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
         Cochez « Abs. » pour un élève absent le jour de l&apos;épreuve : la note vaut zéro et
         compte dans la moyenne. Une case laissée vide veut seulement dire « pas encore corrigé ».
-        Pour lever un zéro d&apos;office, l&apos;administration délivre une autorisation de reprise.
+        {" "}
+        {ABSENCE_LIFT_RULE}
       </p>
 
       {/* ─── Grade entries — 1 colonne mobile, 2 colonnes desktop ─────── */}
@@ -308,19 +406,22 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
             const liveValue = localGrades.has(grade.student_id)
               ? localGrades.get(grade.student_id) ?? null
               : serverValue
+            const studentName = grade.student_name ?? `Élève #${grade.student_id}`
             const isLeftColumn = index % 2 === 0
             return (
               <GradeRow
                 key={grade.student_id}
                 index={index}
-                studentName={grade.student_name ?? `Élève #${grade.student_id}`}
+                studentName={studentName}
                 initialValue={serverValue}
                 value={liveValue}
                 status={cellStatus.get(grade.student_id) ?? "idle"}
                 originalStatus={grade.status}
                 onChange={(rawValue) => handleGradeChange(grade.student_id, rawValue)}
                 absent={absentStudents.has(grade.student_id)}
-                onAbsentChange={(next) => handleAbsentChange(grade.student_id, next)}
+                onAbsentChange={(next) =>
+                  handleAbsentChange(grade.student_id, studentName, next)
+                }
                 className={cn(
                   "border-b border-border/60",
                   isLeftColumn && "lg:border-r",
@@ -330,6 +431,16 @@ export function GradeEntryGrid({ evaluationId, classId, dicteeHref }: GradeEntry
           })}
         </div>
       </div>
+
+      <AbsenceGuardDialog
+        guard={absenceGuard?.guard ?? null}
+        retakesHref={retakesHref}
+        onCancel={() => setAbsenceGuard(null)}
+        onConfirm={() => {
+          if (absenceGuard) applyAbsent(absenceGuard.studentId, true)
+          setAbsenceGuard(null)
+        }}
+      />
     </div>
   )
 }

--- a/components/teacher/grades/entry/AbsenceGuardDialog.tsx
+++ b/components/teacher/grades/entry/AbsenceGuardDialog.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import Link from "next/link"
+import type { Route } from "next"
+import { RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+/**
+ * Les deux gestes autour de la case « Abs. » qui ne se rattrapent pas.
+ *
+ * `lift-blocked` : décocher un zéro d'office déjà enregistré. La règle métier
+ * veut que seule une autorisation de reprise le lève. Autant le dire au moment
+ * du geste plutôt que de laisser le backend refuser en silence.
+ *
+ * `overwrite` : cocher « Abs. » sur un élève déjà noté. La note est remplacée
+ * par un zéro et rien ne permet de la retrouver ensuite.
+ */
+export type AbsenceGuard =
+  | { kind: "lift-blocked"; studentName: string }
+  | { kind: "overwrite"; studentName: string; value: number }
+
+/**
+ * La règle, dite d'une seule façon. Le bandeau de la feuille de saisie, cette
+ * boîte de dialogue et le message affiché quand le backend refuse la levée
+ * lisent tous cette phrase : trois formulations différentes pour une même
+ * règle, ce serait trois occasions de la contredire.
+ */
+export const ABSENCE_LIFT_RULE =
+  "Pour lever un zéro d'office, l'administration délivre une autorisation de reprise."
+
+interface AbsenceGuardDialogProps {
+  guard: AbsenceGuard | null
+  /** Écran des autorisations de reprise, quand le portail y donne accès. */
+  retakesHref?: string
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+function formatGrade(value: number): string {
+  return String(value).replace(".", ",")
+}
+
+export function AbsenceGuardDialog({
+  guard,
+  retakesHref,
+  onCancel,
+  onConfirm,
+}: AbsenceGuardDialogProps) {
+  const isBlocked = guard?.kind === "lift-blocked"
+
+  return (
+    <AlertDialog open={guard !== null} onOpenChange={(next) => !next && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {isBlocked
+              ? "Ce zéro d'office ne se lève pas ici"
+              : "Remplacer la note par un zéro d'office ?"}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {guard === null ? null : guard.kind === "lift-blocked" ? (
+              <>
+                {guard.studentName} est enregistré absent à cette épreuve. Le zéro compte
+                dans la moyenne tant que l&apos;administration n&apos;a pas délivré une
+                autorisation de reprise. Une fois le billet délivré, la case se libère et
+                vous saisissez la note de rattrapage.
+              </>
+            ) : (
+              <>
+                {guard.studentName} a déjà {formatGrade(guard.value)}/20 sur cette épreuve.
+                La cocher absente remplace cette note par un zéro d&apos;office, et la note
+                d&apos;origine ne sera plus consultable nulle part.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          {isBlocked ? (
+            <>
+              {retakesHref && (
+                <Button variant="outline" asChild className="h-11 gap-2 sm:h-10">
+                  <Link href={retakesHref as Route}>
+                    <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                    Voir les autorisations de reprise
+                  </Link>
+                </Button>
+              )}
+              <AlertDialogAction onClick={onCancel} className="h-11 sm:h-10">
+                J&apos;ai compris
+              </AlertDialogAction>
+            </>
+          ) : (
+            <>
+              <AlertDialogCancel onClick={onCancel} className="h-11 sm:h-10">
+                Garder la note
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={onConfirm}
+                className="h-11 bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:h-10"
+              >
+                Remplacer par un zéro
+              </AlertDialogAction>
+            </>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/lib/contracts/school-life.ts
+++ b/lib/contracts/school-life.ts
@@ -8,7 +8,12 @@ import { z } from "zod"
 // Convocation de parent
 // ---------------------------------------------------------------------------
 
-export const SUMMONS_OUTCOME_OPTIONS = [
+// Miroir de app.models.school_life.SummonsOutcome. L'énumération est connue :
+// la typer ici évite aux écrans de recaster une réponse réseau à la main.
+export const SummonsOutcomeSchema = z.enum(["pending", "attended", "missed"])
+export type SummonsOutcome = z.infer<typeof SummonsOutcomeSchema>
+
+export const SUMMONS_OUTCOME_OPTIONS: readonly { value: SummonsOutcome; label: string }[] = [
   { value: "pending", label: "Non renseignée" },
   { value: "attended", label: "Tuteur présent" },
   { value: "missed", label: "Tuteur absent" },
@@ -38,7 +43,7 @@ export const ParentSummonsSchema = z.object({
   summons_time: z.string(),
   reason: z.string(),
   reference: z.string().nullish(),
-  outcome: z.string(),
+  outcome: SummonsOutcomeSchema,
   outcome_label: z.string(),
   outcome_notes: z.string().nullish(),
   outcome_recorded_at: z.string().nullish(),
@@ -84,7 +89,7 @@ export const ParentSummonsCreateSchema = z
   })
 
 export const SummonsOutcomeUpdateSchema = z.object({
-  outcome: z.enum(["pending", "attended", "missed"], {
+  outcome: z.enum(SummonsOutcomeSchema.options, {
     required_error: "La suite donnée est requise",
   }),
   notes: z.string().max(2000, "La note est trop longue").optional(),

--- a/lib/utils/grade-reconciliation.test.ts
+++ b/lib/utils/grade-reconciliation.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest"
+import {
+  absenceWouldOverwriteGrade,
+  canLiftAbsence,
+  dicteeEntryFromServer,
+  gradeStatesEqual,
+  isAbsenceLiftRefused,
+  normalizeGradeState,
+  reconcileGradeSave,
+  toGradePayloadEntry,
+} from "./grade-reconciliation"
+
+describe("normalizeGradeState", () => {
+  it("efface la note d'un élève absent : le zéro d'office est écrit par le backend", () => {
+    expect(normalizeGradeState({ value: 12, absent: true })).toEqual({ value: null, absent: true })
+  })
+
+  it("laisse intacte la note d'un élève présent", () => {
+    expect(normalizeGradeState({ value: 12, absent: false })).toEqual({ value: 12, absent: false })
+  })
+})
+
+describe("gradeStatesEqual", () => {
+  it("distingue deux états qui ne diffèrent que par le drapeau absent", () => {
+    // Le bug d'origine : les deux valeurs valent null, mais l'un est un zéro
+    // d'office et l'autre une case vide. Les confondre marquait « enregistré »
+    // une ligne que le backend venait de refuser.
+    expect(gradeStatesEqual({ value: null, absent: true }, { value: null, absent: false })).toBe(
+      false,
+    )
+  })
+
+  it("distingue un absent d'un zéro saisi à la main", () => {
+    expect(gradeStatesEqual({ value: 0, absent: true }, { value: 0, absent: false })).toBe(false)
+  })
+
+  it("reconnaît deux absents malgré une note résiduelle à l'écran", () => {
+    expect(gradeStatesEqual({ value: 0, absent: true }, { value: null, absent: true })).toBe(true)
+  })
+
+  it("compare les notes des élèves présents", () => {
+    expect(gradeStatesEqual({ value: 14, absent: false }, { value: 14, absent: false })).toBe(true)
+    expect(gradeStatesEqual({ value: 14, absent: false }, { value: 15, absent: false })).toBe(false)
+    expect(gradeStatesEqual({ value: null, absent: false }, { value: 0, absent: false })).toBe(false)
+  })
+})
+
+describe("toGradePayloadEntry", () => {
+  it("n'envoie jamais une note et un absent contradictoires", () => {
+    expect(toGradePayloadEntry(7, { value: 12, absent: true })).toEqual({
+      student_id: 7,
+      value: null,
+      absent: true,
+    })
+  })
+
+  it("envoie la note d'un élève présent", () => {
+    expect(toGradePayloadEntry(7, { value: 12.5, absent: false })).toEqual({
+      student_id: 7,
+      value: 12.5,
+      absent: false,
+    })
+  })
+
+  it("envoie une case vide comme « pas encore corrigé »", () => {
+    expect(toGradePayloadEntry(7, { value: null, absent: false })).toEqual({
+      student_id: 7,
+      value: null,
+      absent: false,
+    })
+  })
+})
+
+describe("canLiftAbsence", () => {
+  it("interdit de décocher un zéro d'office déjà enregistré", () => {
+    expect(canLiftAbsence("absent")).toBe(false)
+  })
+
+  it("autorise le décochage tant que le serveur n'a rien enregistré", () => {
+    expect(canLiftAbsence("pending")).toBe(true)
+    expect(canLiftAbsence("entered")).toBe(true)
+    expect(canLiftAbsence("retake_allowed")).toBe(true)
+    expect(canLiftAbsence(undefined)).toBe(true)
+    expect(canLiftAbsence(null)).toBe(true)
+  })
+})
+
+describe("isAbsenceLiftRefused", () => {
+  it("voit le refus quand le serveur garde « absent » malgré un décochage", () => {
+    expect(isAbsenceLiftRefused({ value: null, absent: false }, "absent")).toBe(true)
+    expect(isAbsenceLiftRefused({ value: 0, absent: false }, "absent")).toBe(true)
+  })
+
+  it("ne crie pas au refus quand on a bien demandé l'absence", () => {
+    expect(isAbsenceLiftRefused({ value: null, absent: true }, "absent")).toBe(false)
+  })
+
+  it("ne crie pas au refus sur une note ordinaire", () => {
+    expect(isAbsenceLiftRefused({ value: 14, absent: false }, "entered")).toBe(false)
+  })
+})
+
+describe("absenceWouldOverwriteGrade", () => {
+  it("signale qu'une note déjà saisie va être remplacée par un zéro", () => {
+    expect(absenceWouldOverwriteGrade({ value: 15, absent: false })).toBe(true)
+    expect(absenceWouldOverwriteGrade({ value: 0, absent: false })).toBe(true)
+  })
+
+  it("ne signale rien sur une case vide ou déjà cochée", () => {
+    expect(absenceWouldOverwriteGrade({ value: null, absent: false })).toBe(false)
+    expect(absenceWouldOverwriteGrade({ value: 15, absent: true })).toBe(false)
+  })
+})
+
+describe("reconcileGradeSave", () => {
+  it("chemin 1 : décocher un absent renvoie un 0/20 « saisi », ce n'est pas un succès", () => {
+    // L'élève était absent côté serveur, la valeur chargée valait donc 0.
+    // L'enseignant décoche, le lot part avec {value: 0, absent: false}.
+    expect(
+      reconcileGradeSave({
+        sent: { value: 0, absent: false },
+        current: { value: 0, absent: false },
+        serverStatus: "absent",
+      }),
+    ).toBe("refused")
+  })
+
+  it("chemin 2 : décocher puis vider la case ne doit pas passer pour enregistré", () => {
+    // Le backend garde « absent » et met la valeur à NULL. L'ancien code
+    // comparait null à null et affichait du vert.
+    expect(
+      reconcileGradeSave({
+        sent: { value: null, absent: false },
+        current: { value: null, absent: false },
+        serverStatus: "absent",
+      }),
+    ).toBe("refused")
+  })
+
+  it("confirme une absence réellement demandée", () => {
+    expect(
+      reconcileGradeSave({
+        sent: { value: null, absent: true },
+        current: { value: 0, absent: true },
+        serverStatus: "absent",
+      }),
+    ).toBe("saved")
+  })
+
+  it("confirme une note ordinaire", () => {
+    expect(
+      reconcileGradeSave({
+        sent: { value: 13.5, absent: false },
+        current: { value: 13.5, absent: false },
+        serverStatus: "entered",
+      }),
+    ).toBe("saved")
+  })
+
+  it("garde la ligne en attente si l'enseignant la retouche pendant l'envoi", () => {
+    expect(
+      reconcileGradeSave({
+        sent: { value: 13.5, absent: false },
+        current: { value: 14, absent: false },
+        serverStatus: "entered",
+      }),
+    ).toBe("dirty")
+  })
+
+  it("garde la ligne en attente si la case « Abs. » est cochée pendant l'envoi", () => {
+    expect(
+      reconcileGradeSave({
+        sent: { value: 13.5, absent: false },
+        current: { value: 13.5, absent: true },
+        serverStatus: "entered",
+      }),
+    ).toBe("dirty")
+  })
+
+  it("ne confond pas une case vidée avec un zéro d'office levé", () => {
+    expect(
+      reconcileGradeSave({
+        sent: { value: null, absent: false },
+        current: { value: null, absent: false },
+        serverStatus: "pending",
+      }),
+    ).toBe("saved")
+  })
+})
+
+describe("dicteeEntryFromServer", () => {
+  it("amorce un absent à null même si le serveur renvoie le zéro d'office", () => {
+    expect(dicteeEntryFromServer({ value: 0, status: "absent" })).toBeNull()
+  })
+
+  it("amorce une note saisie à sa valeur", () => {
+    expect(dicteeEntryFromServer({ value: 15, status: "entered" })).toBe(15)
+  })
+
+  it("laisse « pas encore saisi » indéfini", () => {
+    expect(dicteeEntryFromServer({ value: null, status: "pending" })).toBeUndefined()
+    expect(dicteeEntryFromServer({ value: null, status: "retake_allowed" })).toBeUndefined()
+  })
+
+  it("sert de référence au garde de sortie : un absent intact n'est pas une modification", () => {
+    // Le garde comparait la valeur serveur (0) à l'amorçage (null) et voyait
+    // une modification permanente dès qu'un seul élève était absent.
+    const grade = { value: 0, status: "absent" }
+    const entries = new Map<number, number | null | undefined>([[1, dicteeEntryFromServer(grade)]])
+    expect(entries.get(1)).toBe(dicteeEntryFromServer(grade))
+  })
+})

--- a/lib/utils/grade-reconciliation.ts
+++ b/lib/utils/grade-reconciliation.ts
@@ -1,0 +1,120 @@
+/**
+ * Réconciliation d'une feuille de notes après envoi au serveur.
+ *
+ * Une ligne de saisie n'est pas une note : c'est un couple « note, absent ».
+ * Les deux voyagent ensemble au serveur, donc les deux doivent servir à
+ * décider si la ligne est enregistrée ou toujours en attente. Comparer la
+ * seule valeur numérique fait passer pour « enregistré » un décochage que le
+ * backend a refusé, et l'écran recoche alors la case tout seul.
+ *
+ * Ces fonctions sont pures et sans React : c'est ici que vivait le bug, c'est
+ * ici qu'il est testé.
+ */
+
+/** Statut renvoyé par le backend pour un zéro d'office. */
+export const ABSENT_SERVER_STATUS = "absent"
+
+/** État d'une ligne de saisie : la note et le zéro d'office vont ensemble. */
+export interface GradeEntryState {
+  value: number | null
+  absent: boolean
+}
+
+/** Ce qu'une ligne devient après un envoi. */
+export type GradeSaveOutcome = "saved" | "dirty" | "refused"
+
+/**
+ * Un élève absent n'emporte pas de note : le backend inscrit lui-même le zéro
+ * d'office. Envoyer une valeur et un « absent » contradictoires laisserait le
+ * serveur arbitrer, et l'écran ne saurait pas ce qu'il a réellement écrit.
+ */
+export function normalizeGradeState(state: GradeEntryState): GradeEntryState {
+  return state.absent ? { value: null, absent: true } : state
+}
+
+/** Deux états de saisie décrivent-ils la même chose ? */
+export function gradeStatesEqual(a: GradeEntryState, b: GradeEntryState): boolean {
+  const left = normalizeGradeState(a)
+  const right = normalizeGradeState(b)
+  return left.absent === right.absent && Object.is(left.value, right.value)
+}
+
+/** La ligne telle qu'elle part dans le lot envoyé au backend. */
+export function toGradePayloadEntry(
+  studentId: number,
+  state: GradeEntryState,
+): { student_id: number; value: number | null; absent: boolean } {
+  const normalized = normalizeGradeState(state)
+  return {
+    student_id: studentId,
+    value: normalized.value,
+    absent: normalized.absent,
+  }
+}
+
+/**
+ * Un zéro d'office ne se lève pas depuis la feuille de notes : c'est
+ * l'administration qui délivre une autorisation de reprise. Tant que le
+ * serveur porte le statut « absent », décocher la case ne peut qu'échouer, et
+ * échouer de deux façons également silencieuses : soit la note repart à un
+ * 0/20 « saisi » qui compte dans la moyenne sans que personne ne l'ait décidé,
+ * soit le backend garde le statut et vide la valeur, et le zéro disparaît du
+ * bulletin.
+ */
+export function canLiftAbsence(serverStatus: string | null | undefined): boolean {
+  return serverStatus !== ABSENT_SERVER_STATUS
+}
+
+/**
+ * Le serveur a-t-il refusé la levée du zéro d'office ? On a envoyé
+ * `absent: false`, il répond toujours « absent » : c'est un refus, pas un
+ * succès, même si la valeur renvoyée ressemble à ce qu'on attendait.
+ */
+export function isAbsenceLiftRefused(
+  sent: GradeEntryState,
+  serverStatus: string | null | undefined,
+): boolean {
+  return !normalizeGradeState(sent).absent && serverStatus === ABSENT_SERVER_STATUS
+}
+
+/** Cocher « Abs. » sur une ligne déjà notée remplace cette note par un zéro. */
+export function absenceWouldOverwriteGrade(state: GradeEntryState): boolean {
+  return !state.absent && state.value !== null
+}
+
+/**
+ * Verdict d'une ligne après retour du serveur.
+ *
+ * - `refused` : le backend a gardé le zéro d'office. La ligne n'est pas
+ *   enregistrée, et la renvoyer telle quelle échouerait à l'identique.
+ * - `saved` : ce qui est à l'écran est exactement ce qui est parti.
+ * - `dirty` : l'enseignant a retouché la ligne pendant l'envoi, il faut
+ *   repartir avec la nouvelle valeur.
+ */
+export function reconcileGradeSave(args: {
+  sent: GradeEntryState
+  current: GradeEntryState
+  serverStatus: string | null | undefined
+}): GradeSaveOutcome {
+  const { sent, current, serverStatus } = args
+  if (isAbsenceLiftRefused(sent, serverStatus)) return "refused"
+  return gradeStatesEqual(sent, current) ? "saved" : "dirty"
+}
+
+/**
+ * Valeur d'amorçage du mode dictée pour une note déjà au serveur.
+ *
+ * `undefined` = pas encore saisi, `null` = absent, `number` = note /20. Le
+ * garde de sortie « modifications non enregistrées » compare l'état courant à
+ * cette même fonction : les deux lectures doivent venir d'un seul endroit,
+ * sinon le garde crie à vide dès qu'un élève est absent, et un garde qui crie
+ * à vide est un garde qu'on apprend à cliquer sans lire.
+ */
+export function dicteeEntryFromServer(grade: {
+  value: number | null
+  status: string
+}): number | null | undefined {
+  if (grade.status === ABSENT_SERVER_STATUS) return null
+  if (grade.value !== null) return Number(grade.value)
+  return undefined
+}

--- a/lib/utils/summons-schedule.test.ts
+++ b/lib/utils/summons-schedule.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { canRecordSummonsOutcome, todayIso } from "./summons-schedule"
+
+describe("todayIso", () => {
+  it("formate en AAAA-MM-JJ avec les zéros de tête", () => {
+    expect(todayIso(new Date(2026, 0, 5))).toBe("2026-01-05")
+    expect(todayIso(new Date(2026, 11, 31))).toBe("2026-12-31")
+  })
+})
+
+describe("canRecordSummonsOutcome", () => {
+  const today = "2026-08-21"
+
+  it("refuse un rendez-vous à venir : le backend le rejette de toute façon", () => {
+    expect(canRecordSummonsOutcome("2026-08-22", today)).toBe(false)
+    expect(canRecordSummonsOutcome("2026-09-01", today)).toBe(false)
+    expect(canRecordSummonsOutcome("2027-01-04", today)).toBe(false)
+  })
+
+  it("autorise dès le jour même", () => {
+    expect(canRecordSummonsOutcome("2026-08-21", today)).toBe(true)
+  })
+
+  it("autorise un rendez-vous passé", () => {
+    expect(canRecordSummonsOutcome("2026-08-20", today)).toBe(true)
+    expect(canRecordSummonsOutcome("2025-12-31", today)).toBe(true)
+  })
+
+  it("tolère un horodatage complet renvoyé par le backend", () => {
+    expect(canRecordSummonsOutcome("2026-08-21T00:00:00", today)).toBe(true)
+    expect(canRecordSummonsOutcome("2026-08-22T00:00:00", today)).toBe(false)
+  })
+
+  it("ne bloque pas une date manquante : ce n'est pas au registre d'inventer", () => {
+    expect(canRecordSummonsOutcome("", today)).toBe(true)
+  })
+})

--- a/lib/utils/summons-schedule.ts
+++ b/lib/utils/summons-schedule.ts
@@ -1,0 +1,35 @@
+/**
+ * Règles de calendrier des convocations de parent.
+ *
+ * Le backend refuse de consigner la suite donnée avant le jour du rendez-vous
+ * (`summons_date > date.today()`). Le registre étant trié du plus récent au
+ * plus ancien, les rendez-vous à venir sont les premières lignes de l'écran :
+ * y laisser un bouton actif, c'est promettre un geste que le serveur rejette
+ * systématiquement.
+ */
+
+/** Date du jour au format « AAAA-MM-JJ », dans le fuseau du navigateur. */
+export function todayIso(now: Date = new Date()): string {
+  const month = String(now.getMonth() + 1).padStart(2, "0")
+  const day = String(now.getDate()).padStart(2, "0")
+  return `${now.getFullYear()}-${month}-${day}`
+}
+
+/**
+ * La suite donnée peut-elle être consignée ?
+ *
+ * Oui à partir du jour du rendez-vous. Les deux dates sont comparées au format
+ * « AAAA-MM-JJ », qui se trie comme du texte : pas de conversion en Date, donc
+ * pas de décalage de fuseau qui ferait basculer la veille au lendemain.
+ */
+export function canRecordSummonsOutcome(
+  summonsDate: string,
+  today: string = todayIso(),
+): boolean {
+  if (!summonsDate) return true
+  return summonsDate.slice(0, 10) <= today
+}
+
+/** Pourquoi le bouton est désactivé, dit à l'éducateur. */
+export const SUMMONS_OUTCOME_TOO_EARLY =
+  "La suite se consigne à partir du jour du rendez-vous."


### PR DESCRIPTION
Deux blocages de la revue qualité, tous deux sur des données qu'on ne rattrape pas.

## Blocage 1 — la case « Abs. » corrompait la note par deux chemins

Le drapeau `absent` n'entrait dans aucune des trois comparaisons de réconciliation après envoi : elles ne regardaient que la valeur numérique, et `pendingValueFor` rendait `null` dès que la case était cochée. Deux conséquences.

**Chemin 1.** L'élève est absent côté serveur, donc `value = 0`. L'enseignant décoche, le lot part avec `{value: 0, absent: false}`, le backend écrit `status = ENTERED, value = 0`. L'élève repart avec un **0/20 « note saisie »** qui compte dans la moyenne et que l'écran des reprises ne verra jamais, puisqu'il ne retient que `status === "absent"`.

**Chemin 2.** L'enseignant décoche puis vide la case. La règle `STICKY_GRADE_STATUSES` du backend **conserve** `status = ABSENT` en mettant `value = NULL`. L'écran comparait `null` à `null`, affichait du vert, puis recochait la case tout seul. En base, la ligne reste `ABSENT / NULL`, état que le calcul des moyennes ignore : **le zéro d'office disparaît du bulletin** sans que personne ne l'ait décidé.

### Le choix fait pour le décochage

**Les deux, avec une hiérarchie claire.** L'interdiction est la règle, le refus détecté est le filet.

1. **Interdire le décochage quand le statut enregistré est `absent`** (chemin principal). C'est la règle métier réelle : seule une autorisation de reprise lève un zéro d'office. Une boîte de dialogue la nomme au moment du geste, et propose « Voir les autorisations de reprise » côté admin, qui a ce droit. L'enseignant reçoit l'explication seule, sans lien mort vers un écran interdit. Tant que la sauvegarde n'a pas eu lieu, le statut serveur vaut encore `pending` : l'enseignant peut donc défaire sa propre erreur immédiatement. Un `retake_allowed` reste décochable, c'est justement ce que le billet a ouvert.

2. **Traiter le refus comme un refus** (filet, pour la course avec un admin qui marque l'absence en parallèle). Si la réponse revient avec `status === "absent"` alors qu'on a envoyé `absent: false`, la ligne passe en erreur, la case reprend la vérité du serveur, et la phrase du bandeau du bas est répétée en message d'échec. Elle sort de la file d'attente : la renvoyer telle quelle échouerait à l'identique, et une ligne « en attente » qu'on ne peut pas sauver relance le débounce en boucle. Rien n'est vert.

Le refus est délibérément un second rideau et non la réponse principale : un échec réseau explique un geste que l'écran aurait dû empêcher avant de le tenter.

### Le reste du même fichier

- **Cocher « Abs. » sur un élève déjà noté** demande confirmation, avec la note nommée. La note locale n'est pas effacée : décocher avant sauvegarde la restitue.
- **`handleGradeChange` jetait le drapeau `absent`** que `parseGradeInput` renvoyait déjà : taper « absent » dans la case ne faisait rien alors que le dire à voix haute fonctionnait. Les trois façons de l'exprimer enregistrent désormais la même chose. Pas de confirmation sur ce chemin : l'enseignant écrit littéralement par-dessus la note qu'il remplace.
- **`DicteeMode`, garde de sortie.** Il lisait `g.value !== null ? Number(g.value) : …` alors que l'amorçage met `null` pour un absent, dont la valeur serveur est `0` : `hasDirty` était vrai en permanence dès qu'un seul élève était absent. Les deux lectures viennent maintenant de la même fonction, `dicteeEntryFromServer`.

La logique est sortie dans `lib/utils/grade-reconciliation.ts`, pure et sans React, avec **27 tests** qui rejouent nommément les deux chemins. C'est là que le bug vivait.

## Blocage 2 — un collège de 600 élèves ne pouvait en convoquer que 100

`SummonsCreateModal` et `RetakeCreateModal` faisaient `useStudents({ size: 100 })` dans un `<Select>` nu. Le backend plafonne à 100 : c'était la page 1 et rien d'autre, sans recherche, à faire défiler sur un téléphone d'entrée de gamme.

`StepSearchStudent` du tunnel de paiement est extrait en `components/shared/StudentPicker.tsx` et sert aux trois écrans. Le tunnel garde exactement son comportement : recherche debouncée à 300 ms, requête à partir de deux caractères, états vide, chargement et aucun résultat. Les deux modales ajoutent un rappel de l'élève retenu avec un bouton « Changer ».

Deux corrections au passage dans le composant partagé : les cartes de résultat deviennent des `<button>` (elles étaient des `div` cliquables, hors de portée du clavier), et le français est accentué.

## Corrections courtes du même périmètre

- `ParentSummonsSchema.outcome` était typé `z.string()` alors que l'énumération est déclarée vingt lignes plus bas. Typé en `z.enum`, le `summons.outcome as Outcome` de `SummonsOutcomeModal` disparaît, ainsi que le cast sur une réponse réseau que la règle du projet interdit.
- `SummonsRegisterList` proposait « Suite donnée » sur les rendez-vous futurs, que le backend refuse (`summons_date > date.today()`). Le registre étant trié par date décroissante, c'étaient les premières lignes de l'écran. Le bouton est désactivé, avec infobulle et raison visible : l'infobulle ne s'ouvre pas au doigt, la phrase reste donc lisible sur téléphone.

## Signalé, pas fait

En mode dictée, prononcer une note pour un élève encore au statut `absent` lève le zéro d'office côté backend, là où la feuille de saisie le refuse désormais. Après un billet de reprise le statut vaut `retake_allowed` et le geste est légitime, donc l'écart ne concerne que le cas non autorisé. Hors périmètre demandé, à traiter séparément.

## Vérification

- `pnpm exec tsc --noEmit --incremental false` : 0 erreur
- `pnpm exec eslint` sur les 15 fichiers touchés : 0 erreur, 0 avertissement
- `pnpm exec vitest run` : 10 fichiers, 77 tests au vert, dont 33 nouveaux

Aucun build n'a été lancé : le disque de la machine est saturé.
