### PR TITLE
fix(retakes): read missed evaluations from the school-life endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Les écrans « Convocations de parent » et « Autorisations de reprise » ouvrent sur l'année scolaire en cours et se lisent par pages de vingt : ils affichaient jusqu'ici tout l'historique de l'établissement, qui n'est jamais purgé *(éducateur, secrétariat)*
+- Formulaire du billet d'annulation de zéro : les évaluations manquées ne se cherchent plus à chaque caractère tapé dans les dates, mais une fois la saisie posée *(éducateur, secrétariat)*
 - Fiche Personnel : le rôle d'accès propose désormais six métiers (secrétariat, caissier, éducateur, comptable, directeur des études, directeur), chacun accompagné d'une phrase qui dit ce que la personne pourra faire. « Personnel administratif » devient « Secrétariat » *(admin, directeur)*.
 - Wizard Nouvelle inscription : le modal ne se ferme plus si on appuie hors du cadre (la saisie n'est plus perdue). L'étape élève et la sélection de classe sont lisibles sur téléphone, avec des boutons assez grands. La liste des classes montre les places encore disponibles, pas seulement le maximum *(admin)*.
 - Publication Windows : le frontend standalone est désormais compilé hors production par la CI puis livré comme artefact versionné.
@@ -53,6 +55,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- L'éducateur et le secrétariat peuvent enfin délivrer un billet d'annulation de zéro : l'écran cherchait les évaluations manquées dans le cahier de notes de la classe, qu'ils n'ont pas le droit de lire, et répondait « Réessayez dans un instant » à une erreur de droits qui ne se résolvait jamais *(éducateur, secrétariat)*
+- Les quatre compteurs du registre des convocations décrivent l'année consultée et non le filtre en cours : cliquer « Tuteur absent » affichait « Convocations 8, Tuteur venu 0, Tuteur absent 8 » *(éducateur)*
+- Quand la liste des évaluations manquées ne peut pas être lue, le formulaire affiche enfin la raison au lieu d'inviter à réessayer *(éducateur, secrétariat)*
 - La grille des frais n'affichait que les vingt premiers montants et donnait le reste pour inexistant : des niveaux apparaissaient avec moins de frais qu'ils n'en portent, le total par élève était faux, et recréer un montant manquant se soldait par « doublon possible ». Tous les montants sont désormais chargés *(admin, comptable)*
 - Le motif d'une suppression définitive n'apparaît plus dans l'adresse de la requête, donc plus dans les journaux du serveur ni chez les intermédiaires. « Élève exclu pour vol » n'a rien à y faire *(admin)*
 

--- a/components/admin/retakes/RetakeCreateModal.tsx
+++ b/components/admin/retakes/RetakeCreateModal.tsx
@@ -23,8 +23,9 @@ import {
 } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Textarea } from "@/components/ui/textarea"
+import { useDebounce } from "@/lib/hooks/useDebounce"
 import { useStudents } from "@/lib/hooks/useStudents"
-import { useAbsentEvaluations, useCreateRetakeAuthorization } from "@/lib/hooks/useRetakes"
+import { useCreateRetakeAuthorization, useMissedEvaluations } from "@/lib/hooks/useRetakes"
 import { RetakeAuthorizationCreateSchema } from "@/lib/contracts/school-life"
 import { formatSchoolDate } from "@/components/shared/school-life/school-life-ui"
 import type { Student } from "@/lib/contracts/student"
@@ -55,17 +56,22 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
     () => students.find((student) => String(student.id) === studentId),
     [students, studentId],
   )
-  const classId = selectedStudent?.current_enrollment?.class_id
+  const enrolled = Boolean(selectedStudent?.current_enrollment)
+
+  // Un champ date se saisit caractère par caractère : sans ce délai, chaque
+  // frappe relançait la recherche des absences, année comprise.
+  const searchedStart = useDebounce(periodStart, 400)
+  const searchedEnd = useDebounce(periodEnd, 400)
 
   const {
     data: evaluations,
     isLoading: loadingEvaluations,
     isError: evaluationsFailed,
-  } = useAbsentEvaluations({
+    error: evaluationsError,
+  } = useMissedEvaluations({
     studentId: studentId ? Number(studentId) : undefined,
-    classId,
-    periodStart: periodStart || undefined,
-    periodEnd: periodEnd || undefined,
+    periodStart: searchedStart || undefined,
+    periodEnd: searchedEnd || undefined,
   })
 
   useEffect(() => {
@@ -83,7 +89,7 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
   // cochées qui ne s'affichent plus enverrait des évaluations invisibles.
   useEffect(() => {
     setSelected([])
-  }, [studentId, periodStart, periodEnd])
+  }, [studentId, searchedStart, searchedEnd])
 
   function toggle(evaluationId: number) {
     setSelected((prev) =>
@@ -114,7 +120,7 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
     create(parsed.data, { onSuccess: () => onClose() })
   }
 
-  const periodChosen = Boolean(studentId && periodStart && periodEnd)
+  const periodChosen = Boolean(studentId && searchedStart && searchedEnd)
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
@@ -149,7 +155,7 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
               </SelectContent>
             </Select>
             {errors.student_id && <p className="text-sm text-destructive">{errors.student_id}</p>}
-            {studentId && !classId && (
+            {studentId && !enrolled && (
               <p className="text-sm text-destructive">
                 Cet élève n&apos;a pas d&apos;inscription pour l&apos;année courante : aucune
                 évaluation ne peut être rouverte.
@@ -200,8 +206,9 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
               </div>
             ) : evaluationsFailed ? (
               <p className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-xs text-destructive">
-                Les évaluations de la classe n&apos;ont pas pu être lues. Réessayez dans un
-                instant.
+                Les évaluations manquées n&apos;ont pas pu être lues.{" "}
+                {(evaluationsError as Error | null)?.message ??
+                  "Réessayez, et prévenez l'administration si cela persiste."}
               </p>
             ) : (evaluations ?? []).length === 0 ? (
               <p className="rounded-lg border border-dashed p-4 text-xs text-muted-foreground">
@@ -212,14 +219,14 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
               <div className="space-y-2">
                 {(evaluations ?? []).map((evaluation) => (
                   <label
-                    key={evaluation.id}
-                    htmlFor={`retake-eval-${evaluation.id}`}
+                    key={evaluation.evaluation_id}
+                    htmlFor={`retake-eval-${evaluation.evaluation_id}`}
                     className="flex min-h-11 cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/60"
                   >
                     <Checkbox
-                      id={`retake-eval-${evaluation.id}`}
-                      checked={selected.includes(evaluation.id)}
-                      onCheckedChange={() => toggle(evaluation.id)}
+                      id={`retake-eval-${evaluation.evaluation_id}`}
+                      checked={selected.includes(evaluation.evaluation_id)}
+                      onCheckedChange={() => toggle(evaluation.evaluation_id)}
                       className="mt-0.5"
                     />
                     <span className="min-w-0 flex-1">
@@ -227,7 +234,8 @@ export function RetakeCreateModal({ open, onClose }: { open: boolean; onClose: (
                         {evaluation.title}
                       </span>
                       <span className="block text-xs text-muted-foreground">
-                        {evaluation.subject_name} · {formatSchoolDate(evaluation.date)} ·
+                        {evaluation.subject_name ?? "Matière non renseignée"} ·{" "}
+                        {formatSchoolDate(evaluation.date)} ·
                         coefficient {evaluation.coefficient} · T{evaluation.trimester}
                       </span>
                     </span>

--- a/components/admin/retakes/RetakesPageClient.tsx
+++ b/components/admin/retakes/RetakesPageClient.tsx
@@ -8,10 +8,12 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { cn } from "@/lib/utils"
 import { usePermissions } from "@/lib/hooks/usePermissions"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import {
   useDownloadRetakeAuthorization,
   useRetakeAuthorizations,
 } from "@/lib/hooks/useRetakes"
+import { RegisterPagination } from "@/components/shared/school-life/RegisterPagination"
 import { RetakeCreateModal } from "./RetakeCreateModal"
 import { RetakesList } from "./RetakesList"
 import type { RetakeAuthorization } from "@/lib/contracts/school-life"
@@ -23,28 +25,48 @@ const TRIMESTER_FILTERS = [
   { key: 3, label: "T3" },
 ]
 
+const PAGE_SIZE = 20
+
 export function RetakesPageClient() {
   const [trimester, setTrimester] = useState(0)
+  const [page, setPage] = useState(1)
   const [createOpen, setCreateOpen] = useState(false)
   const [downloadingId, setDownloadingId] = useState<number | null>(null)
 
   const { has, isLoading: loadingPermissions } = usePermissions()
   const canManage = has("documents:zero-cancellation")
 
+  // Le registre n'est jamais purgé : sans borne sur l'année courante, l'écran
+  // ouvrait sur toute l'histoire de l'établissement pour n'en montrer que le
+  // haut.
+  const { data: yearsData } = useAcademicYears()
+  const years = yearsData?.items ?? []
+  const currentYearId = (years.find((year) => year.is_current) ?? years[0])?.id
+
   const { data, isLoading, error, refetch } = useRetakeAuthorizations(
-    trimester ? { trimester } : {},
-    canManage,
+    {
+      ...(currentYearId ? { academic_year_id: currentYearId } : {}),
+      ...(trimester ? { trimester } : {}),
+      page,
+      size: PAGE_SIZE,
+    },
+    canManage && Boolean(currentYearId),
   )
   const { mutate: download } = useDownloadRetakeAuthorization()
 
-  const items = data ?? []
-  const reopened = items.reduce((total, item) => total + item.evaluations.length, 0)
+  const items = data?.items ?? []
+  const total = data?.total ?? 0
+
+  function changeTrimester(next: number) {
+    setTrimester(next)
+    setPage(1)
+  }
 
   const kpis: HeroKpi[] = [
-    { label: "Billets délivrés", value: isLoading ? "—" : items.length, icon: FileCheck2 },
+    { label: "Billets délivrés", value: isLoading ? "—" : total, icon: FileCheck2 },
     {
       label: "Évaluations rouvertes",
-      value: isLoading ? "—" : reopened,
+      value: isLoading ? "—" : (data?.reopened_evaluations ?? 0),
       icon: ClipboardList,
     },
   ]
@@ -75,7 +97,7 @@ export function RetakesPageClient() {
       <PageHero
         icon={RotateCcw}
         title="Autorisations de reprise"
-        subtitle="Les évaluations manquées rouvertes, et pour quel motif"
+        subtitle="Les évaluations rouvertes cette année, et pour quel motif"
         kpis={kpis}
         actions={
           <button type="button" className={heroAccentBtn} onClick={() => setCreateOpen(true)}>
@@ -90,7 +112,7 @@ export function RetakesPageClient() {
           <button
             key={filter.key}
             type="button"
-            onClick={() => setTrimester(filter.key)}
+            onClick={() => changeTrimester(filter.key)}
             aria-pressed={trimester === filter.key}
             className={cn(
               "h-11 shrink-0 rounded-full border px-4 text-sm font-medium transition-colors sm:h-9",
@@ -127,11 +149,20 @@ export function RetakesPageClient() {
           </CardContent>
         </Card>
       ) : (
-        <RetakesList
-          items={items}
-          onDownload={handleDownload}
-          downloadingId={downloadingId}
-        />
+        <div className="space-y-4">
+          <RetakesList
+            items={items}
+            onDownload={handleDownload}
+            downloadingId={downloadingId}
+          />
+          <RegisterPagination
+            total={total}
+            page={data?.page ?? page}
+            size={data?.size ?? PAGE_SIZE}
+            onPageChange={setPage}
+            noun="billet"
+          />
+        </div>
       )}
 
       <RetakeCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />

--- a/components/admin/summons/SummonsPageClient.tsx
+++ b/components/admin/summons/SummonsPageClient.tsx
@@ -8,7 +8,9 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { cn } from "@/lib/utils"
 import { usePermissions } from "@/lib/hooks/usePermissions"
+import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { useDownloadSummons, useSummonsRegister } from "@/lib/hooks/useSummons"
+import { RegisterPagination } from "@/components/shared/school-life/RegisterPagination"
 import { SummonsCreateModal } from "./SummonsCreateModal"
 import { SummonsOutcomeModal } from "./SummonsOutcomeModal"
 import { SummonsRegisterList } from "./SummonsRegisterList"
@@ -28,9 +30,12 @@ const TRIMESTER_FILTERS = [
   { key: 3, label: "T3" },
 ]
 
+const PAGE_SIZE = 20
+
 export function SummonsPageClient() {
   const [outcome, setOutcome] = useState("")
   const [trimester, setTrimester] = useState(0)
+  const [page, setPage] = useState(1)
   const [createOpen, setCreateOpen] = useState(false)
   const [outcomeTarget, setOutcomeTarget] = useState<ParentSummons | null>(null)
   const [downloadingId, setDownloadingId] = useState<number | null>(null)
@@ -38,15 +43,38 @@ export function SummonsPageClient() {
   const { has, isLoading: loadingPermissions } = usePermissions()
   const canManage = has("documents:parent-summons")
 
+  // Un bureau qui convoque cinq tuteurs par jour écrit neuf cents lignes par
+  // an, et le registre n'est jamais purgé : on ouvre sur l'année courante, par
+  // pages.
+  const { data: yearsData } = useAcademicYears()
+  const years = yearsData?.items ?? []
+  const currentYearId = (years.find((year) => year.is_current) ?? years[0])?.id
+
   const filters = {
+    ...(currentYearId ? { academic_year_id: currentYearId } : {}),
     ...(outcome ? { outcome } : {}),
     ...(trimester ? { trimester } : {}),
+    page,
+    size: PAGE_SIZE,
   }
-  const { data, isLoading, error, refetch } = useSummonsRegister(filters, canManage)
+  const { data, isLoading, error, refetch } = useSummonsRegister(
+    filters,
+    canManage && Boolean(currentYearId),
+  )
   const { mutate: download } = useDownloadSummons()
 
   const items = data?.items ?? []
   const summary = data?.summary
+
+  function changeOutcome(next: string) {
+    setOutcome(next)
+    setPage(1)
+  }
+
+  function changeTrimester(next: number) {
+    setTrimester(next)
+    setPage(1)
+  }
 
   const kpis: HeroKpi[] = [
     { label: "Convocations", value: summary?.total ?? "—", icon: Users },
@@ -81,7 +109,7 @@ export function SummonsPageClient() {
       <PageHero
         icon={Megaphone}
         title="Convocations de parent"
-        subtitle="Qui a été convoqué, quand, et qui est venu"
+        subtitle="Le registre de l'année en cours : qui a été convoqué, et qui est venu"
         kpis={kpis}
         actions={
           <button
@@ -101,7 +129,7 @@ export function SummonsPageClient() {
             <button
               key={filter.key || "all"}
               type="button"
-              onClick={() => setOutcome(filter.key)}
+              onClick={() => changeOutcome(filter.key)}
               aria-pressed={outcome === filter.key}
               className={cn(
                 "h-11 shrink-0 rounded-full border px-4 text-sm font-medium transition-colors sm:h-9",
@@ -120,7 +148,7 @@ export function SummonsPageClient() {
             <button
               key={filter.key}
               type="button"
-              onClick={() => setTrimester(filter.key)}
+              onClick={() => changeTrimester(filter.key)}
               aria-pressed={trimester === filter.key}
               className={cn(
                 "h-11 shrink-0 rounded-full border px-4 text-sm font-medium transition-colors sm:h-9",
@@ -159,12 +187,21 @@ export function SummonsPageClient() {
           </CardContent>
         </Card>
       ) : (
-        <SummonsRegisterList
-          items={items}
-          onRecordOutcome={setOutcomeTarget}
-          onDownload={handleDownload}
-          downloadingId={downloadingId}
-        />
+        <div className="space-y-4">
+          <SummonsRegisterList
+            items={items}
+            onRecordOutcome={setOutcomeTarget}
+            onDownload={handleDownload}
+            downloadingId={downloadingId}
+          />
+          <RegisterPagination
+            total={data?.total ?? 0}
+            page={data?.page ?? page}
+            size={data?.size ?? PAGE_SIZE}
+            onPageChange={setPage}
+            noun="convocation"
+          />
+        </div>
       )}
 
       <SummonsCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />

--- a/components/shared/school-life/RegisterPagination.tsx
+++ b/components/shared/school-life/RegisterPagination.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface RegisterPaginationProps {
+  total: number
+  page: number
+  size: number
+  onPageChange: (page: number) => void
+  /** « convocation » / « billet » — accordé au singulier, pluriel ajouté ici. */
+  noun: string
+}
+
+/**
+ * Pied de registre : combien de lignes en tout, et de quoi changer de page.
+ *
+ * Les deux registres de vie scolaire s'empilent d'une année sur l'autre et ne
+ * sont jamais purgés. Ils sont donc servis par pages, et le total répond à la
+ * question que la page seule ne peut pas trancher : combien y en a-t-il.
+ */
+export function RegisterPagination({
+  total,
+  page,
+  size,
+  onPageChange,
+  noun,
+}: RegisterPaginationProps) {
+  const lastPage = size > 0 ? Math.max(1, Math.ceil(total / size)) : 1
+  if (total <= size) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {total} {noun}
+        {total > 1 ? "s" : ""}
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+      <span>
+        {total} {noun}
+        {total > 1 ? "s" : ""} au total
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-11 gap-1.5 sm:h-9"
+          disabled={page <= 1}
+          onClick={() => onPageChange(page - 1)}
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+          Précédente
+        </Button>
+        <span aria-live="polite">
+          Page {page} sur {lastPage}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-11 gap-1.5 sm:h-9"
+          disabled={page >= lastPage}
+          onClick={() => onPageChange(page + 1)}
+        >
+          Suivante
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/lib/api/retakes.test.ts
+++ b/lib/api/retakes.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Le client HTTP lit la session NextAuth pour poser l'entête d'autorisation.
+// Ici on teste l'adresse appelée et le contrat de réponse, pas l'auth.
+vi.mock("next-auth/react", () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+  signOut: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { retakesApi } from "./retakes"
+
+const TARGET = {
+  evaluation_id: 7,
+  title: "Devoir de mathématiques",
+  subject_name: "Mathématiques",
+  date: "2026-05-18",
+  coefficient: 2,
+  trimester: 1,
+}
+
+const AUTHORIZATION = {
+  id: 4,
+  student_id: 42,
+  student_name: "Traoré Aminata",
+  enrollment_number: "M-2026-004",
+  class_name: "6ème B",
+  academic_year_id: 3,
+  academic_year_name: "2025-2026",
+  trimester: 1,
+  period_start: "2026-05-15",
+  period_end: "2026-05-22",
+  reason: "Hospitalisation justifiée",
+  reference: "BAZ-2026-M-2026-004-4",
+  issued_by_user_id: 7,
+  issued_by_name: "Yao Sophie",
+  evaluations: [TARGET],
+  created_at: "2026-05-23T09:00:00",
+}
+
+function respondWith(payload: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+function calledPath(fetchMock: ReturnType<typeof vi.fn>): string {
+  return new URL(String(fetchMock.mock.calls[0][0]), "http://api.test").pathname + new URL(String(fetchMock.mock.calls[0][0]), "http://api.test").search
+}
+
+describe("retakesApi.missedEvaluations", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("asks the school-life endpoint, not the class grade book", async () => {
+    const fetchMock = respondWith([TARGET])
+
+    await expect(retakesApi.missedEvaluations(42, "2026-05-15", "2026-05-22")).resolves.toEqual([
+      TARGET,
+    ])
+
+    // Un seul appel, sur le point d'entrée gardé par le droit du billet.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(calledPath(fetchMock)).toBe(
+      "/school-life/students/42/missed-evaluations?from=2026-05-15&to=2026-05-22",
+    )
+  })
+
+  it("accepts a target whose subject is not filled in", async () => {
+    respondWith([{ ...TARGET, subject_name: null }])
+    const targets = await retakesApi.missedEvaluations(42, "2026-05-15", "2026-05-22")
+    expect(targets[0].subject_name).toBeNull()
+  })
+
+  it("refuses a payload that does not match the contract", async () => {
+    respondWith([{ ...TARGET, coefficient: "deux" }])
+    await expect(
+      retakesApi.missedEvaluations(42, "2026-05-15", "2026-05-22"),
+    ).rejects.toThrow(/Réponse inattendue/)
+  })
+})
+
+describe("retakesApi.list", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("reads the page envelope and the register-wide counts", async () => {
+    respondWith({
+      items: [AUTHORIZATION],
+      total: 412,
+      reopened_evaluations: 907,
+      page: 2,
+      size: 20,
+    })
+
+    const page = await retakesApi.list({ academic_year_id: 3, page: 2, size: 20 })
+
+    expect(page.items).toHaveLength(1)
+    // Les deux chiffres décrivent l'année consultée, pas les vingt lignes rendues.
+    expect(page.total).toBe(412)
+    expect(page.reopened_evaluations).toBe(907)
+  })
+
+  it("carries the year and the page in the query string", async () => {
+    const fetchMock = respondWith({
+      items: [],
+      total: 0,
+      reopened_evaluations: 0,
+      page: 1,
+      size: 20,
+    })
+
+    await retakesApi.list({ academic_year_id: 3, trimester: 2, page: 1, size: 20 })
+
+    expect(calledPath(fetchMock)).toBe(
+      "/school-life/retake-authorizations?academic_year_id=3&trimester=2&page=1&size=20",
+    )
+  })
+
+  it("refuses a bare array, the shape served before pagination", async () => {
+    respondWith([AUTHORIZATION])
+    await expect(retakesApi.list()).rejects.toThrow(/Réponse inattendue/)
+  })
+})

--- a/lib/api/retakes.ts
+++ b/lib/api/retakes.ts
@@ -1,17 +1,23 @@
 import { z } from "zod"
 import { apiFetch, apiFetchBlob, safeValidate } from "./client"
 import {
+  RetakeAuthorizationListSchema,
   RetakeAuthorizationSchema,
+  RetakeTargetSchema,
   type RetakeAuthorization,
   type RetakeAuthorizationCreate,
+  type RetakeAuthorizationList,
+  type RetakeTarget,
 } from "@/lib/contracts/school-life"
 
-const RetakeAuthorizationArraySchema = z.array(RetakeAuthorizationSchema)
+const RetakeTargetArraySchema = z.array(RetakeTargetSchema)
 
 export interface RetakeListFilters {
   academic_year_id?: number
   trimester?: number
   student_id?: number
+  page?: number
+  size?: number
 }
 
 function toQuery(filters: RetakeListFilters): string {
@@ -25,10 +31,27 @@ function toQuery(filters: RetakeListFilters): string {
 
 /** Billets d'annulation de zéro : autorisation de rattrapage et son document. */
 export const retakesApi = {
-  list: async (filters: RetakeListFilters = {}): Promise<RetakeAuthorization[]> => {
+  list: async (filters: RetakeListFilters = {}): Promise<RetakeAuthorizationList> => {
     const path = `/school-life/retake-authorizations${toQuery(filters)}`
     const json = await apiFetch<unknown>(path)
-    return safeValidate(RetakeAuthorizationArraySchema, json, `GET ${path}`)
+    return safeValidate(RetakeAuthorizationListSchema, json, `GET ${path}`)
+  },
+
+  /**
+   * Évaluations que l'élève a manquées sur la période, donc les seules que le
+   * billet peut rouvrir. Le croisement est fait par le serveur : le refaire
+   * ici supposait de lire le cahier de notes de la classe, un droit que le
+   * bureau de la vie scolaire n'a pas.
+   */
+  missedEvaluations: async (
+    studentId: number,
+    periodStart: string,
+    periodEnd: string,
+  ): Promise<RetakeTarget[]> => {
+    const query = new URLSearchParams({ from: periodStart, to: periodEnd })
+    const path = `/school-life/students/${studentId}/missed-evaluations?${query.toString()}`
+    const json = await apiFetch<unknown>(path)
+    return safeValidate(RetakeTargetArraySchema, json, `GET ${path}`)
   },
 
   create: async (data: RetakeAuthorizationCreate): Promise<RetakeAuthorization> => {

--- a/lib/api/summons.ts
+++ b/lib/api/summons.ts
@@ -13,6 +13,8 @@ export interface SummonsRegisterFilters {
   trimester?: number
   student_id?: number
   outcome?: string
+  page?: number
+  size?: number
 }
 
 function toQuery(filters: SummonsRegisterFilters): string {

--- a/lib/contracts/school-life.ts
+++ b/lib/contracts/school-life.ts
@@ -54,9 +54,15 @@ export const SummonsRegisterSummarySchema = z.object({
   pending: z.number(),
 })
 
+// `summary` décrit tout le registre consulté (année, trimestre, élève), jamais
+// la page rendue ni la suite filtrée : les quatre compteurs sont un tableau de
+// bord d'établissement, pas un écho du filtre en cours.
 export const ParentSummonsRegisterSchema = z.object({
   items: z.array(ParentSummonsSchema),
   summary: SummonsRegisterSummarySchema,
+  total: z.number(),
+  page: z.number(),
+  size: z.number(),
 })
 
 // Le backend exige un tuteur : sa fiche quand elle existe, sinon le nom dicté
@@ -122,6 +128,17 @@ export const RetakeAuthorizationSchema = z.object({
   created_at: z.string(),
 })
 
+// `total` et `reopened_evaluations` portent sur toute la période consultée, pas
+// sur la page rendue : les compter à l'écran les ferait varier avec la
+// pagination.
+export const RetakeAuthorizationListSchema = z.object({
+  items: z.array(RetakeAuthorizationSchema),
+  total: z.number(),
+  reopened_evaluations: z.number(),
+  page: z.number(),
+  size: z.number(),
+})
+
 export const RetakeAuthorizationCreateSchema = z
   .object({
     student_id: z.number({ required_error: "L'élève est requis" }).positive("L'élève est requis"),
@@ -160,5 +177,6 @@ export type ParentSummonsCreate = z.infer<typeof ParentSummonsCreateSchema>
 export type SummonsOutcomeUpdate = z.infer<typeof SummonsOutcomeUpdateSchema>
 export type RetakeTarget = z.infer<typeof RetakeTargetSchema>
 export type RetakeAuthorization = z.infer<typeof RetakeAuthorizationSchema>
+export type RetakeAuthorizationList = z.infer<typeof RetakeAuthorizationListSchema>
 export type RetakeAuthorizationCreate = z.infer<typeof RetakeAuthorizationCreateSchema>
 export type EntrySlipRequest = z.infer<typeof EntrySlipRequestSchema>

--- a/lib/hooks/useRetakes.ts
+++ b/lib/hooks/useRetakes.ts
@@ -3,11 +3,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { retakesApi, type RetakeListFilters } from "@/lib/api/retakes"
-import { gradesApi } from "@/lib/api/grades"
 import { gradeKeys } from "./useGrades"
 import { fileSafeName } from "@/components/admin/classes/detail/class-downloads"
 import { downloadBlob } from "@/lib/utils"
-import type { Evaluation } from "@/lib/contracts/grade"
 import type {
   RetakeAuthorization,
   RetakeAuthorizationCreate,
@@ -16,8 +14,8 @@ import type {
 export const retakeKeys = {
   all: ["school-life", "retakes"] as const,
   list: (filters: RetakeListFilters) => ["school-life", "retakes", "list", filters] as const,
-  absentEvaluations: (studentId: number, classId: number, from: string, to: string) =>
-    ["school-life", "retakes", "absent-evaluations", studentId, classId, from, to] as const,
+  missedEvaluations: (studentId: number, from: string, to: string) =>
+    ["school-life", "retakes", "missed-evaluations", studentId, from, to] as const,
 }
 
 export function useRetakeAuthorizations(filters: RetakeListFilters = {}, enabled = true) {
@@ -29,56 +27,35 @@ export function useRetakeAuthorizations(filters: RetakeListFilters = {}, enabled
   })
 }
 
-interface AbsentEvaluationsParams {
-  studentId?: number
-  classId?: number
-  periodStart?: string
-  periodEnd?: string
-}
-
 /**
- * Évaluations de la classe tombées dans la période et marquées « absent »
- * pour cet élève : ce sont les seules que le backend accepte de rouvrir.
+ * Évaluations que l'élève a manquées sur la période : les seules que le
+ * backend accepte de rouvrir.
  *
- * Le backend n'expose pas ce croisement, on le fait donc ici : une requête
- * pour les évaluations de la classe, puis une par évaluation de la période
- * pour lire les notes. La période restreint le lot avant les appels, sinon on
- * interrogerait toute l'année scolaire pour rien.
+ * Le croisement est fait par le serveur, sur un point d'entrée gardé par le
+ * droit du billet. Le reconstituer ici obligeait à lire le cahier de notes de
+ * la classe, que ni l'éducateur ni le secrétariat n'ont le droit de consulter.
  */
-export function useAbsentEvaluations({
+export function useMissedEvaluations({
   studentId,
-  classId,
   periodStart,
   periodEnd,
-}: AbsentEvaluationsParams) {
-  const enabled = Boolean(studentId && classId && periodStart && periodEnd)
+}: {
+  studentId?: number
+  periodStart?: string
+  periodEnd?: string
+}) {
+  const enabled = Boolean(studentId && periodStart && periodEnd && periodEnd >= periodStart)
 
   return useQuery({
-    queryKey: retakeKeys.absentEvaluations(
-      studentId ?? 0,
-      classId ?? 0,
-      periodStart ?? "",
-      periodEnd ?? "",
-    ),
+    queryKey: retakeKeys.missedEvaluations(studentId ?? 0, periodStart ?? "", periodEnd ?? ""),
     enabled,
     staleTime: 1000 * 30,
-    queryFn: async (): Promise<Evaluation[]> => {
-      const evaluations = await gradesApi.listEvaluations(classId as number)
-      const inPeriod = evaluations.filter(
-        (evaluation) =>
-          evaluation.date >= (periodStart as string) && evaluation.date <= (periodEnd as string),
-      )
-      const missed = await Promise.all(
-        inPeriod.map(async (evaluation) => {
-          const grades = await gradesApi.getGrades(evaluation.id)
-          const grade = grades.find((g) => g.student_id === studentId)
-          return grade?.status === "absent" ? evaluation : null
-        }),
-      )
-      return missed
-        .filter((evaluation): evaluation is Evaluation => evaluation !== null)
-        .sort((a, b) => a.date.localeCompare(b.date))
-    },
+    queryFn: () =>
+      retakesApi.missedEvaluations(
+        studentId as number,
+        periodStart as string,
+        periodEnd as string,
+      ),
   })
 }
 

--- a/lib/navigation/adminNav.test.ts
+++ b/lib/navigation/adminNav.test.ts
@@ -8,6 +8,35 @@ const accountant = [
   "reports:read",
 ]
 
+// Le bureau de la vie scolaire : c'est lui qui délivre convocations et billets
+// d'annulation de zéro. Le directeur des études, lui, signe la demande de
+// dossier scolaire — pas ces deux actes.
+const educator = [
+  "enrollments:read",
+  "admin:students:read",
+  "admin:classes:read",
+  "attendance:read",
+  "reports:read",
+  "documents:entry-slip",
+  "documents:parent-summons",
+  "documents:zero-cancellation",
+  "leave:request",
+]
+
+const studiesDirector = [
+  "admin:classes:read",
+  "admin:students:read",
+  "admin:teachers:read",
+  "enrollments:read",
+  "timetable:read",
+  "grades:read",
+  "attendance:read",
+  "reports:read",
+  "performance:read",
+  "documents:school-file-request",
+  "leave:approve",
+]
+
 const staff = [
   "enrollments:read",
   "enrollments:create",
@@ -48,6 +77,22 @@ describe("filterAdminNavigation", () => {
     expect(labels(accountant)).not.toContain("Personnel")
     expect(labels(accountant)).not.toContain("Enseignants")
     expect(labels(accountant)).not.toContain("Notes")
+  })
+
+  it("gives the school-life acts to the educator", () => {
+    const seen = labels(educator)
+    expect(seen).toContain("Convocations")
+    expect(seen).toContain("Autorisations de reprise")
+  })
+
+  it("hides the school-life acts from the directeur des etudes", () => {
+    // Il lit le cahier de notes et pilote le pédagogique, mais il ne tient pas
+    // le registre de la vie scolaire : ces deux entrées ne sont pas les
+    // siennes, malgré ce qu'un commentaire du menu a longtemps prétendu.
+    const seen = labels(studiesDirector)
+    expect(seen).toContain("Notes")
+    expect(seen).not.toContain("Convocations")
+    expect(seen).not.toContain("Autorisations de reprise")
   })
 
   it("shows secretariat enrollment and student pages but not staff admin", () => {

--- a/lib/navigation/adminNav.ts
+++ b/lib/navigation/adminNav.ts
@@ -56,8 +56,10 @@ export const ADMIN_NAVIGATION: AdminNavSection[] = [
       { label: "Emploi du temps", href: "/admin/timetable", iconName: "CalendarDays", anyOf: ["timetable:read"] },
       { label: "Notes", href: "/admin/grades", iconName: "ClipboardList", anyOf: ["grades:read"] },
       { label: "Présences", href: "/admin/attendance", iconName: "UserCheck", anyOf: ["attendance:read"] },
-      // Actes de vie scolaire : chacun n'apparaît qu'au métier qui le délivre
-      // (éducateur pour les convocations, directeur des études pour les reprises).
+      // Actes de vie scolaire : les deux entrées vont ensemble, portées par le
+      // bureau de la vie scolaire, éducateur et secrétariat. Le directeur des
+      // études ne les a pas : il signe la demande de dossier scolaire, l'acte
+      // qui correspond avec l'établissement d'origine.
       { label: "Convocations", href: "/admin/summons" as Route, iconName: "Megaphone", anyOf: ["documents:parent-summons"] },
       { label: "Autorisations de reprise", href: "/admin/retakes" as Route, iconName: "RotateCcw", anyOf: ["documents:zero-cancellation"] },
       { label: "Bulletins", href: "/admin/reports", iconName: "FileText", anyOf: ["reports:read", "bulletins:generate"] },


### PR DESCRIPTION
> Dépend de la PR backend **African-DC/klassci-college-backend#270**, à merger d'abord.

## Le blocage

`RetakeCreateModal` appelait `useAbsentEvaluations`, qui croisait
`gradesApi.listEvaluations` et `gradesApi.getGrades`. Les deux exigent `grades:read`.

| rôle | `documents:zero-cancellation` | `grades:read` |
|---|---|---|
| éducateur | oui | **non** |
| secrétariat | oui | **non** |
| directeur des études | **non** | oui |

L'éducateur ouvrait l'écran, choisissait un élève et une période, et la première
requête partait en 403. L'écran affichait alors « Réessayez dans un instant » : un
message d'attente pour une erreur de droits qui ne se résoudra jamais. Seuls
l'administrateur et le directeur, qui portent tous les droits, faisaient fonctionner
le flux — d'où une recette verte sur une fonctionnalité inutilisable.

## Le remède

Le formulaire appelle `GET /school-life/students/{id}/missed-evaluations?from=&to=`,
gardé par `documents:zero-cancellation`.

`useAbsentEvaluations` disparaît, et avec lui la dépendance de cet écran
d'administration à `gradesApi`.

**Ce que la suppression retire :** le hook et son croisement occupaient 53 lignes
(`interface AbsentEvaluationsParams` + doc + corps), remplacés par 31 lignes qui ne font
qu'appeler le serveur. Sur le fichier entier, 44 lignes supprimées pour 21 ajoutées,
soit `lib/hooks/useRetakes.ts` qui passe de 116 à 93 lignes — et deux imports en moins,
`gradesApi` et le type `Evaluation`.

Cela règle quatre choses :

1. **La permission** — l'écran demande ce qu'il a le droit de demander.
2. **Un N+1** — un `Promise.all` d'un appel par évaluation de la période, soit trente
   à quarante appels parallèles pour un trimestre, devient une requête.
3. **L'historique complet de la classe** — `listEvaluations` ne passait pas
   `academic_year_id` et la table `Class` est universelle : la réponse contenait toutes
   les évaluations jamais créées pour cette classe, toutes années confondues et sans
   pagination. La fenêtre de dates borne désormais la requête en base.
4. **Le rejeu à chaque frappe** — la suppression du N+1 le divise par quarante mais ne
   l'élimine pas : les deux champs de date sont donc **débouncés à 400 ms**, et la
   recherche part sur une saisie posée. Les cases cochées se vident sur la valeur
   débouncée, jamais sur une frappe intermédiaire.

L'écran d'erreur affiche maintenant la raison remontée par le serveur au lieu d'inviter
à réessayer.

## Défaut 2 — les registres chargeaient tout

`SummonsPageClient` et `RetakesPageClient` n'envoyaient jamais `academic_year_id`, alors
que le champ existait des deux côtés. Les deux écrans ouvrent désormais sur l'année en
cours et lisent par pages de vingt, via un pied de registre partagé
(`components/shared/school-life/RegisterPagination.tsx`, cibles tactiles `h-11`).

Cela borne aussi le DOM : `SummonsRegisterList` rend deux arbres par ligne, un tableau
et une carte. À neuf cents convocations, cela faisait mille huit cents sous-arbres et
trois mille six cents boutons sur un téléphone d'entrée de gamme ; c'est maintenant
quarante et quatre-vingts.

Changer un filtre ramène à la page 1 — sans quoi on reste sur une page 12 qui n'existe
plus dans le nouveau périmètre.

## Défaut 3 — les compteurs

Corrigé côté serveur (voir la PR jumelle) : les quatre compteurs viennent d'un
`COUNT ... GROUP BY` sur le périmètre consulté, sans le filtre de suite donnée. Le
frontend les affiche tels quels et le sous-titre du hero dit désormais ce qu'ils
décrivent : « Le registre de l'année en cours ».

La pagination créait le même piège sur l'écran des reprises : « Évaluations rouvertes »
serait devenu le compte des vingt lignes affichées. Le chiffre vient donc lui aussi d'un
agrégat serveur (`reopened_evaluations`), et non plus d'un `reduce` sur les items.

## Droits du directeur des études — décision

Le commentaire de `lib/navigation/adminNav.ts` ligne 59 désignait le directeur des
études comme titulaire des reprises. **C'est le commentaire qui était faux.**

`permissions.py` est explicite et cohérent :

- `_SCHOOL_LIFE_ACTS` (billet d'entrée, convocation, annulation de zéro) va à `staff` et
  `educator`, commenté « le cœur du bureau de la vie scolaire » ;
- `studies_director` reçoit `documents:school-file-request` seul, commenté « il signe la
  demande de dossier scolaire : c'est lui qui correspond avec l'établissement d'origine » ;
- la migration `20260820_0057_school_life_documents.py` sème exactement la même
  répartition, et un test existant vérifie déjà que catalogue et migration ne divergent pas.

Le partage est donc voulu et documenté deux fois. **Aucune migration alembic**, seul le
commentaire est corrigé — et deux tests le tiennent désormais en place : l'éducateur voit
les deux entrées, le directeur des études ne les voit pas alors qu'il voit « Notes ».

Le commentaire était doublement faux au passage : il donnait aussi les convocations au
seul éducateur, alors que le secrétariat les délivre également.

## Tests

- `lib/api/retakes.test.ts` — l'adresse appelée est bien celle de la vie scolaire et non
  le cahier de notes, en un seul appel ; une matière non renseignée passe ; un contrat
  cassé est refusé ; l'enveloppe paginée est lue, et le tableau nu servi avant cette PR
  est rejeté.
- `lib/navigation/adminNav.test.ts` — le partage des actes de vie scolaire entre
  éducateur et directeur des études.

```
pnpm exec tsc --noEmit --incremental false    0 erreur
pnpm lint                                     0 erreur (warnings préexistants seuls)
pnpm exec vitest run                          52 tests, 9 fichiers, tous verts
```

Aucun build frontend n'a été lancé.
