### PR TITLE
feat(fees): pick percentage or fixed amount per instalment line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Chaque tranche de paiement se saisit au choix en pourcentage ou en montant fixe, dans la même grille : « Inscription 37 000 FCFA à la rentrée », puis 35 / 35 / 30 % du reste *(admin, comptable)*
+- Simulation en direct sous la grille : on choisit un niveau et la situation de l'élève, affecté ou non, et l'on voit les francs que recevra chaque famille avant d'enregistrer *(admin, comptable)*
 - Rapport de fin de trimestre de la DEEP téléchargeable depuis Rapports : on choisit l'année et le trimestre, on obtient le canevas officiel des vingt-sept tableaux, avec aperçu avant impression *(admin, directeur)*
 - Bouton « Demande de dossier scolaire » sur la fiche élève : le courrier réclamant le dossier à l'établissement d'origine se télécharge en un clic, scellé pour être vérifiable *(admin)*.
 - Billet d'entrée depuis l'écran des présences : sur une absence non régularisée, l'éducateur saisit la date de reprise et le motif, l'absence passe en excusée dans le cahier d'appel et le billet s'imprime *(admin)*.

--- a/components/admin/installments/EnrollmentScheduleCard.tsx
+++ b/components/admin/installments/EnrollmentScheduleCard.tsx
@@ -105,6 +105,17 @@ export function EnrollmentScheduleCard({ enrollmentId }: { enrollmentId: number 
           ))}
         </ul>
 
+        {(data.unscheduled_amount ?? 0) > 0 && (
+          <p
+            role="note"
+            className="rounded-lg border border-border/60 bg-muted/40 p-3 text-sm text-muted-foreground"
+          >
+            {formatFcfa(data.unscheduled_amount ?? 0)} des frais de cet élève ne sont couverts par
+            aucune tranche. Cette part n&apos;a donc pas de date limite et ne compte pas dans le
+            retard. Complétez la grille de l&apos;année pour l&apos;échelonner.
+          </p>
+        )}
+
         {data.next_due_date && data.next_due_amount !== null && (
           <p className="border-t pt-3 text-sm text-muted-foreground">
             Prochaine échéance : {formatFcfa(data.next_due_amount ?? 0)} avant le{" "}

--- a/components/admin/installments/InstallmentGridEditor.tsx
+++ b/components/admin/installments/InstallmentGridEditor.tsx
@@ -1,25 +1,39 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { AlertTriangle, CalendarClock, Plus, Save, Trash2 } from "lucide-react"
+import { AlertTriangle, CalendarClock, Info, Plus, Save, Trash2 } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
+  fixedTotal,
+  hasPercentageLine,
   isGridComplete,
   percentageTotal,
   type FeeInstallment,
   type InstallmentDraft,
+  type InstallmentKind,
 } from "@/lib/contracts/installment"
 import { useInstallmentGrid, useReplaceInstallmentGrid } from "@/lib/hooks/useInstallments"
+import { formatFcfa } from "@/lib/utils/money"
+import { InstallmentGridPreview } from "./InstallmentGridPreview"
 
 function toDraft(row: FeeInstallment): InstallmentDraft {
   return {
     name: row.name,
     position: row.position,
-    percentage: row.percentage,
+    kind: row.kind,
+    percentage: row.percentage ?? null,
+    amount: row.amount ?? null,
     due_date: row.due_date,
   }
 }
@@ -27,18 +41,36 @@ function toDraft(row: FeeInstallment): InstallmentDraft {
 /** Grille proposée à une école qui n'a rien configuré : trois tranches usuelles. */
 function defaultDrafts(): InstallmentDraft[] {
   return [
-    { name: "Tranche 1", position: 1, percentage: 40, due_date: "" },
-    { name: "Tranche 2", position: 2, percentage: 30, due_date: "" },
-    { name: "Tranche 3", position: 3, percentage: 30, due_date: "" },
+    { name: "Tranche 1", position: 1, kind: "percentage", percentage: 40, amount: null, due_date: "" },
+    { name: "Tranche 2", position: 2, kind: "percentage", percentage: 30, amount: null, due_date: "" },
+    { name: "Tranche 3", position: 3, kind: "percentage", percentage: 30, amount: null, due_date: "" },
   ]
+}
+
+/** Ce que l'API attend : l'écriture non retenue part vide, jamais à zéro. */
+function toPayload(draft: InstallmentDraft) {
+  return {
+    name: draft.name,
+    position: draft.position,
+    kind: draft.kind,
+    percentage: draft.kind === "percentage" ? draft.percentage : null,
+    amount: draft.kind === "fixed" ? draft.amount : null,
+    due_date: draft.due_date,
+  }
+}
+
+function isLineFilled(draft: InstallmentDraft): boolean {
+  const valeur = draft.kind === "fixed" ? draft.amount : draft.percentage
+  return draft.name.trim() !== "" && draft.due_date !== "" && (valeur ?? 0) > 0
 }
 
 /**
  * Éditeur de la grille de tranches d'une année scolaire.
  *
- * La grille se saisit d'un bloc et se remplace d'un bloc : la somme doit faire
- * 100 %, donc une grille n'est valide que prise entièrement. Éditer une
- * tranche isolément la laisserait forcément invalide entre deux appels.
+ * Chaque ligne s'exprime au choix en pourcentage ou en montant ferme. La
+ * grille se saisit d'un bloc et se remplace d'un bloc : les pourcentages
+ * doivent faire 100 % du reste, une grille n'est donc valide que prise
+ * entièrement.
  */
 export function InstallmentGridEditor({ academicYearId }: { academicYearId: number | undefined }) {
   const { data, isLoading } = useInstallmentGrid(academicYearId)
@@ -51,19 +83,33 @@ export function InstallmentGridEditor({ academicYearId }: { academicYearId: numb
   }, [data])
 
   const total = percentageTotal(drafts)
+  const francs = fixedTotal(drafts)
+  const avecPourcentage = hasPercentageLine(drafts)
   const complete = isGridComplete(drafts)
-  const allDated = drafts.every((d) => d.due_date !== "")
-  const allNamed = drafts.every((d) => d.name.trim() !== "")
-  const canSave = complete && allDated && allNamed && !isPending
+  const toutesRemplies = drafts.every(isLineFilled)
+  const canSave = complete && toutesRemplies && !isPending
 
   function update(index: number, patch: Partial<InstallmentDraft>) {
     setDrafts((prev) => prev.map((d, i) => (i === index ? { ...d, ...patch } : d)))
   }
 
+  function changeKind(index: number, kind: InstallmentKind) {
+    // L'écriture abandonnée est vidée : garder un pourcentage résiduel sous une
+    // tranche en francs laisserait deux vérités dans la même ligne.
+    update(index, { kind, percentage: null, amount: null })
+  }
+
   function addLine() {
     setDrafts((prev) => [
       ...prev,
-      { name: `Tranche ${prev.length + 1}`, position: prev.length + 1, percentage: 0, due_date: "" },
+      {
+        name: `Tranche ${prev.length + 1}`,
+        position: prev.length + 1,
+        kind: "percentage",
+        percentage: null,
+        amount: null,
+        due_date: "",
+      },
     ])
   }
 
@@ -98,8 +144,30 @@ export function InstallmentGridEditor({ academicYearId }: { academicYearId: numb
           <div className="min-w-0">
             <h2 className="text-sm font-semibold">Tranches de paiement</h2>
             <p className="text-xs text-muted-foreground">
-              Chaque tranche est une part du total des frais obligatoires. Le montant attendu
-              s&apos;adapte donc au niveau de chaque élève, sans ressaisie.
+              Chaque tranche s&apos;exprime au choix en montant fixe ou en pourcentage. Posez en
+              francs ce que vous connaissez déjà, l&apos;inscription par exemple, et laissez les
+              pourcentages suivre le niveau de chaque élève.
+            </p>
+          </div>
+        </div>
+
+        <div
+          role="note"
+          className="flex items-start gap-3 rounded-lg border border-border/60 bg-muted/40 p-3"
+        >
+          <Info aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="space-y-1 text-xs text-muted-foreground">
+            <p>
+              <span className="font-medium text-foreground">
+                Les montants fixes se prélèvent en premier ;
+              </span>{" "}
+              les pourcentages se partagent ensuite ce qui reste. Un pourcentage porte donc sur le
+              solde après montants fixes, jamais sur le total.
+            </p>
+            <p>
+              L&apos;assiette est le <span className="font-medium">total des frais obligatoires</span>{" "}
+              de l&apos;élève. En sont exclus les frais optionnels souscrits à part, cantine,
+              transport ou autres, ainsi que les frais dont l&apos;élève a été exonéré.
             </p>
           </div>
         </div>
@@ -108,7 +176,7 @@ export function InstallmentGridEditor({ academicYearId }: { academicYearId: numb
           {drafts.map((draft, index) => (
             <div
               key={index}
-              className="grid gap-2 rounded-lg border border-border/60 bg-muted/40 p-3 sm:grid-cols-[1fr_7rem_11rem_auto] sm:items-end"
+              className="grid gap-2 rounded-lg border border-border/60 bg-muted/40 p-3 sm:grid-cols-[1fr_9rem_9rem_11rem_auto] sm:items-end"
             >
               <div className="space-y-1.5">
                 <Label htmlFor={`name-${index}`} className="text-xs">
@@ -123,22 +191,67 @@ export function InstallmentGridEditor({ academicYearId }: { academicYearId: numb
                 />
               </div>
               <div className="space-y-1.5">
-                <Label htmlFor={`pct-${index}`} className="text-xs">
-                  Part (%)
+                <Label htmlFor={`kind-${index}`} className="text-xs">
+                  Exprimée en
                 </Label>
-                <Input
-                  id={`pct-${index}`}
-                  type="number"
-                  inputMode="decimal"
-                  min={0}
-                  max={100}
-                  step="0.01"
-                  className="h-11 tabular-nums"
-                  value={draft.percentage}
-                  onChange={(e) => update(index, { percentage: Number(e.target.value) })}
+                <Select
+                  value={draft.kind}
+                  onValueChange={(v) => changeKind(index, v as InstallmentKind)}
                   disabled={isPending}
-                />
+                >
+                  <SelectTrigger id={`kind-${index}`} className="h-11">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="percentage">Pourcentage</SelectItem>
+                    <SelectItem value="fixed">Montant fixe</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
+              {draft.kind === "percentage" ? (
+                <div className="space-y-1.5">
+                  <Label htmlFor={`pct-${index}`} className="text-xs">
+                    Part du reste (%)
+                  </Label>
+                  <Input
+                    id={`pct-${index}`}
+                    type="number"
+                    inputMode="decimal"
+                    min={0}
+                    max={100}
+                    step="0.01"
+                    className="h-11 tabular-nums"
+                    value={draft.percentage ?? ""}
+                    onChange={(e) =>
+                      update(index, {
+                        percentage: e.target.value === "" ? null : Number(e.target.value),
+                      })
+                    }
+                    disabled={isPending}
+                  />
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  <Label htmlFor={`amount-${index}`} className="text-xs">
+                    Montant (FCFA)
+                  </Label>
+                  <Input
+                    id={`amount-${index}`}
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    step="1"
+                    className="h-11 tabular-nums"
+                    value={draft.amount ?? ""}
+                    onChange={(e) =>
+                      update(index, {
+                        amount: e.target.value === "" ? null : Number(e.target.value),
+                      })
+                    }
+                    disabled={isPending}
+                  />
+                </div>
+              )}
               <div className="space-y-1.5">
                 <Label htmlFor={`due-${index}`} className="text-xs">
                   À payer avant le
@@ -178,22 +291,36 @@ export function InstallmentGridEditor({ academicYearId }: { academicYearId: numb
             Ajouter une tranche
           </Button>
 
-          <div className="text-sm">
-            <span className="text-muted-foreground">Total : </span>
-            <span className={complete ? "font-semibold text-emerald-600" : "font-semibold text-amber-600"}>
-              {total} %
-            </span>
+          <div className="space-y-0.5 text-right text-sm">
+            {avecPourcentage && (
+              <div>
+                <span className="text-muted-foreground">Pourcentages : </span>
+                <span
+                  className={
+                    complete ? "font-semibold text-emerald-600" : "font-semibold text-amber-600"
+                  }
+                >
+                  {total} %
+                </span>
+              </div>
+            )}
+            {francs > 0 && (
+              <div>
+                <span className="text-muted-foreground">Montants fixes : </span>
+                <span className="font-semibold tabular-nums">{formatFcfa(francs)}</span>
+              </div>
+            )}
           </div>
         </div>
 
-        {!complete && (
+        {avecPourcentage && !complete && (
           <div
             role="alert"
             className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3"
           >
             <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
             <p className="text-sm">
-              Les tranches totalisent {total} % au lieu de 100 %.{" "}
+              Les tranches en pourcentage totalisent {total} % au lieu de 100 %.{" "}
               {total < 100
                 ? "Une part des frais resterait sans échéance."
                 : "La grille réclamerait plus que le montant dû."}
@@ -201,18 +328,26 @@ export function InstallmentGridEditor({ academicYearId }: { academicYearId: numb
           </div>
         )}
 
-        {complete && (!allDated || !allNamed) && (
+        {!avecPourcentage && drafts.length > 0 && (
           <p className="text-sm text-muted-foreground">
-            {!allDated
-              ? "Chaque tranche a besoin d'une date limite."
-              : "Chaque tranche a besoin d'un nom."}
+            Cette grille ne contient que des montants fixes. Aucune somme n&apos;est imposée, car
+            le total des frais change d&apos;un niveau à l&apos;autre. Vérifiez la simulation
+            ci-dessous : ce qu&apos;elle ne couvre pas restera sans date d&apos;échéance.
           </p>
         )}
+
+        {complete && !toutesRemplies && (
+          <p className="text-sm text-muted-foreground">
+            Chaque tranche a besoin d&apos;un nom, d&apos;une valeur et d&apos;une date limite.
+          </p>
+        )}
+
+        <InstallmentGridPreview academicYearId={academicYearId} drafts={drafts} />
 
         <Button
           type="button"
           className="h-11 w-full gap-2"
-          onClick={() => mutate(drafts)}
+          onClick={() => mutate(drafts.map(toPayload))}
           disabled={!canSave}
         >
           <Save aria-hidden="true" className="h-4 w-4" />

--- a/components/admin/installments/InstallmentGridPreview.tsx
+++ b/components/admin/installments/InstallmentGridPreview.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Calculator } from "lucide-react"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { simulateGrid, type InstallmentDraft } from "@/lib/contracts/installment"
+import { useFeeCategories, useFeeVariants } from "@/lib/hooks/useFees"
+import { useLevels } from "@/lib/hooks/useLevels"
+import { formatFcfa } from "@/lib/utils/money"
+
+type Scope = "non_affecte" | "affecte"
+
+const SCOPE_LABELS: Record<Scope, string> = {
+  non_affecte: "Non affecté",
+  affecte: "Affecté",
+}
+
+interface PreviewVariant {
+  fee_category_id: number
+  level_id: number
+  series_id?: number | null
+  amount: number
+  assignment_scope?: string | null
+}
+
+/**
+ * Le tarif retenu pour une catégorie, du plus précis au plus général.
+ *
+ * Un tarif réservé aux affectés ou aux non affectés l'emporte sur un tarif
+ * valable pour tout le monde, exactement comme à l'inscription : sinon la
+ * simulation annoncerait le plein tarif à un élève subventionné. À portée
+ * égale, le tarif sans série passe devant, puisque c'est celui du tronc
+ * commun — un niveau de lycée qui n'aurait que des tarifs par série en
+ * montre alors un, plutôt que rien.
+ */
+function specificity(variant: PreviewVariant): number {
+  return (variant.assignment_scope ? 2 : 0) + (variant.series_id == null ? 1 : 0)
+}
+
+/** Assiette d'un élève d'un niveau donné : la somme de ses frais obligatoires. */
+function mandatoryTotalForLevel(
+  variants: PreviewVariant[],
+  mandatoryCategoryIds: Set<number>,
+  levelId: number,
+  scope: Scope,
+): number {
+  const retenu = new Map<number, PreviewVariant>()
+
+  for (const variant of variants) {
+    if (variant.level_id !== levelId) continue
+    if (!mandatoryCategoryIds.has(variant.fee_category_id)) continue
+    if (variant.assignment_scope && variant.assignment_scope !== scope) continue
+
+    const actuel = retenu.get(variant.fee_category_id)
+    if (!actuel || specificity(variant) > specificity(actuel)) {
+      retenu.set(variant.fee_category_id, variant)
+    }
+  }
+
+  return [...retenu.values()].reduce((total, variant) => total + variant.amount, 0)
+}
+
+/**
+ * Simulation de la grille sur un niveau représentatif.
+ *
+ * Une directrice ne valide pas des pourcentages, elle valide des francs :
+ * elle doit voir ses 37 000 puis ses 30 800 avant d'enregistrer, sur le
+ * niveau et la situation d'affectation qu'elle a en tête.
+ */
+export function InstallmentGridPreview({
+  academicYearId,
+  drafts,
+}: {
+  academicYearId: number | undefined
+  drafts: InstallmentDraft[]
+}) {
+  const { data: levelsData } = useLevels({ size: 100 })
+  const { data: categories } = useFeeCategories()
+  const { data: variants } = useFeeVariants(academicYearId)
+
+  const levels = useMemo(
+    () => [...(levelsData?.items ?? [])].sort((a, b) => a.order - b.order),
+    [levelsData],
+  )
+  const [levelId, setLevelId] = useState<number | undefined>(undefined)
+  const [scope, setScope] = useState<Scope>("non_affecte")
+
+  const niveauChoisi = levelId ?? levels[0]?.id
+  const mandatoryIds = useMemo(
+    () => new Set((categories ?? []).filter((c) => c.is_mandatory).map((c) => c.id)),
+    [categories],
+  )
+
+  const total = useMemo(() => {
+    if (!niveauChoisi) return 0
+    return mandatoryTotalForLevel(variants ?? [], mandatoryIds, niveauChoisi, scope)
+  }, [variants, mandatoryIds, niveauChoisi, scope])
+
+  const montants = useMemo(() => simulateGrid(total, drafts), [total, drafts])
+
+  return (
+    <div className="space-y-3 rounded-lg border border-border/60 bg-muted/30 p-4">
+      <div className="flex items-center gap-2.5">
+        <Calculator aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold">Ce que donnera cette grille</h3>
+          <p className="text-xs text-muted-foreground">
+            Simulation sur un niveau, avant enregistrement. Chaque élève verra le calcul refait
+            sur ses propres frais.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="preview-level" className="text-xs">
+            Niveau
+          </Label>
+          <Select
+            value={niveauChoisi ? String(niveauChoisi) : undefined}
+            onValueChange={(v) => setLevelId(Number(v))}
+          >
+            <SelectTrigger id="preview-level" className="h-11">
+              <SelectValue placeholder="Choisir un niveau" />
+            </SelectTrigger>
+            <SelectContent>
+              {levels.map((level) => (
+                <SelectItem key={level.id} value={String(level.id)}>
+                  {level.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="preview-scope" className="text-xs">
+            Situation de l&apos;élève
+          </Label>
+          <Select value={scope} onValueChange={(v) => setScope(v as Scope)}>
+            <SelectTrigger id="preview-scope" className="h-11">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="non_affecte">{SCOPE_LABELS.non_affecte}</SelectItem>
+              <SelectItem value="affecte">{SCOPE_LABELS.affecte}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {total === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Aucun frais obligatoire n&apos;est encore défini pour ce niveau et cette situation. La
+          simulation apparaîtra dès que les tarifs seront saisis.
+        </p>
+      ) : (
+        <>
+          <dl className="space-y-1.5">
+            {drafts.map((draft, index) => (
+              <div
+                key={index}
+                className="flex items-baseline justify-between gap-3 border-b border-border/50 pb-1.5 text-sm last:border-0"
+              >
+                <dt className="min-w-0 truncate">
+                  {draft.name.trim() || `Tranche ${index + 1}`}
+                  <span className="ml-1.5 text-xs text-muted-foreground">
+                    {draft.kind === "fixed"
+                      ? "montant fixe"
+                      : `${draft.percentage ?? 0} % du reste`}
+                  </span>
+                </dt>
+                <dd className="shrink-0 font-semibold tabular-nums">
+                  {formatFcfa(montants[index] ?? 0)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+          <div className="flex items-baseline justify-between gap-3 text-sm">
+            <span className="text-muted-foreground">
+              Frais obligatoires de ce niveau ({SCOPE_LABELS[scope].toLowerCase()})
+            </span>
+            <span className="font-semibold tabular-nums">{formatFcfa(total)}</span>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/components/admin/installments/InstallmentsPageClient.tsx
+++ b/components/admin/installments/InstallmentsPageClient.tsx
@@ -14,7 +14,8 @@ import {
 import { useState } from "react"
 import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
 import { useInstallmentGrid } from "@/lib/hooks/useInstallments"
-import { percentageTotal } from "@/lib/contracts/installment"
+import { fixedTotal, hasPercentageLine, percentageTotal } from "@/lib/contracts/installment"
+import { formatFcfa } from "@/lib/utils/money"
 import { InstallmentGridEditor } from "./InstallmentGridEditor"
 
 /**
@@ -32,10 +33,27 @@ export function InstallmentsPageClient() {
   const yearId = selectedId ?? currentYear?.id
   const { data: grid } = useInstallmentGrid(yearId)
 
-  const total = grid ? percentageTotal(grid) : 0
+  const lignes = grid ?? []
+  const total = percentageTotal(lignes)
+  const francs = fixedTotal(lignes)
+  const avecPourcentage = hasPercentageLine(lignes)
+
+  // Une grille faite uniquement de montants fixes n'a pas de « couverture » en
+  // pourcentage : annoncer 0 % la ferait passer pour incomplète alors qu'elle
+  // est valide. On montre alors la somme en francs, qui est l'information.
   const kpis: HeroKpi[] = [
-    { label: "Tranches", value: grid?.length ?? 0, icon: CalendarClock },
-    { label: "Couverture", value: `${total} %`, hint: total === 100 ? "Grille complète" : "À compléter" },
+    { label: "Tranches", value: lignes.length, icon: CalendarClock },
+    avecPourcentage
+      ? {
+          label: "Pourcentages",
+          value: `${total} %`,
+          hint: total === 100 ? "Grille complète" : "À compléter",
+        }
+      : {
+          label: "Montants fixes",
+          value: formatFcfa(francs),
+          hint: lignes.length > 0 ? "Grille en francs" : "Aucune tranche",
+        },
   ]
 
   return (

--- a/lib/contracts/installment.test.ts
+++ b/lib/contracts/installment.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import {
+  fixedTotal,
+  hasPercentageLine,
+  isGridComplete,
+  percentageTotal,
+  simulateGrid,
+  type InstallmentDraft,
+} from "./installment"
+
+/**
+ * La simulation affichée avant enregistrement doit donner exactement ce que le
+ * serveur calculera. Si les deux divergent, une directrice valide des chiffres
+ * que les familles ne recevront jamais — et c'est précisément ce genre d'écart
+ * qui a fait retenir des certificats pour des impayés inventés.
+ */
+
+function ligne(patch: Partial<InstallmentDraft>): InstallmentDraft {
+  return {
+    name: "Tranche",
+    position: 1,
+    kind: "percentage",
+    percentage: null,
+    amount: null,
+    due_date: "2026-11-30",
+    ...patch,
+  }
+}
+
+const pct = (percentage: number) => ligne({ kind: "percentage", percentage })
+const fixe = (amount: number) => ligne({ kind: "fixed", amount })
+
+describe("simulateGrid", () => {
+  it("reproduit le cas de la brochure au franc près", () => {
+    // 6e non affectée : inscription 37 000 + scolarité 70 000 + tenue 18 000.
+    const montants = simulateGrid(125000, [fixe(37000), pct(35), pct(35), pct(30)])
+    expect(montants).toEqual([37000, 30800, 30800, 26400])
+    expect(montants.reduce((a, b) => a + b, 0)).toBe(125000)
+  })
+
+  it("fait porter le pourcentage sur le reste, pas sur le total", () => {
+    const montants = simulateGrid(125000, [fixe(37000), pct(35), pct(35), pct(30)])
+    expect(montants[1]).not.toBe(43750)
+  })
+
+  it("laisse une grille en pourcentages produire exactement ce qu'elle produisait", () => {
+    expect(simulateGrid(125000, [pct(35), pct(35), pct(30)])).toEqual([43750, 43750, 37500])
+    expect(simulateGrid(200000, [pct(40), pct(30), pct(30)])).toEqual([80000, 60000, 60000])
+  })
+
+  it("fait absorber l'arrondi par la dernière tranche en pourcentage", () => {
+    const montants = simulateGrid(100001, [fixe(1), pct(33.33), pct(33.33), pct(33.34)])
+    expect(montants.reduce((a, b) => a + b, 0)).toBe(100001)
+  })
+
+  it("ne réclame jamais plus qu'un élève ne doit", () => {
+    // Grille bâtie pour un non affecté, appliquée à un élève subventionné.
+    expect(simulateGrid(60000, [fixe(37000), fixe(44000), fixe(44000)])).toEqual([37000, 23000, 0])
+  })
+
+  it("ne fait rien payer à un élève entièrement exonéré", () => {
+    expect(simulateGrid(0, [fixe(37000), pct(100)])).toEqual([0, 0])
+  })
+
+  it("ne produit aucune échéance sans tranche", () => {
+    expect(simulateGrid(125000, [])).toEqual([])
+  })
+})
+
+describe("validité d'une grille", () => {
+  it("exige 100 % dès qu'une tranche est en pourcentage", () => {
+    expect(isGridComplete([fixe(37000), pct(35), pct(35), pct(30)])).toBe(true)
+    expect(isGridComplete([fixe(37000), pct(35), pct(35)])).toBe(false)
+  })
+
+  it("accepte une grille faite uniquement de montants fixes", () => {
+    expect(isGridComplete([fixe(37000), fixe(44000)])).toBe(true)
+    expect(hasPercentageLine([fixe(37000), fixe(44000)])).toBe(false)
+  })
+
+  it("refuse une grille vide", () => {
+    expect(isGridComplete([])).toBe(false)
+  })
+
+  it("ne compte que les pourcentages dans le total en pourcentage", () => {
+    expect(percentageTotal([fixe(37000), pct(35), pct(65)])).toBe(100)
+    expect(fixedTotal([fixe(37000), pct(35), fixe(44000)])).toBe(81000)
+  })
+})

--- a/lib/contracts/installment.ts
+++ b/lib/contracts/installment.ts
@@ -4,16 +4,25 @@ import { z } from "zod"
  * Une tranche découpe le **total des frais obligatoires** dans le temps.
  *
  * Ce n'est pas une catégorie de frais : le trimestre est un moment de
- * paiement, pas une nature de frais. La grille de l'établissement est en
- * pourcentages pour suivre automatiquement le total de chaque élève ; un
- * accord négocié avec une famille est en montants fermes.
+ * paiement, pas une nature de frais. Chaque ligne de la grille s'exprime au
+ * choix en pourcentage ou en montant ferme, et les deux se mélangent : l'école
+ * pose en francs ce qu'elle connaît déjà — l'inscription, annoncée telle
+ * quelle dans sa brochure — et laisse les pourcentages absorber la scolarité,
+ * qui change d'un niveau à l'autre. Un accord négocié avec une famille, lui,
+ * est toujours en montants fermes.
  */
+export const InstallmentKindSchema = z.enum(["percentage", "fixed"])
+
 export const FeeInstallmentSchema = z.object({
   id: z.number(),
   academic_year_id: z.number(),
   name: z.string(),
   position: z.number(),
-  percentage: z.number(),
+  kind: InstallmentKindSchema,
+  /** Renseigné pour les tranches en pourcentage seulement. */
+  percentage: z.number().nullish(),
+  /** Renseigné pour les tranches en montant ferme seulement. */
+  amount: z.number().nullish(),
   due_date: z.string(),
 })
 
@@ -36,9 +45,12 @@ export const EnrollmentScheduleSchema = z.object({
   is_late: z.boolean(),
   next_due_date: z.string().nullish(),
   next_due_amount: z.number().nullish(),
+  /** Part des frais qu'aucune tranche ne planifie. Absente sur un ancien serveur. */
+  unscheduled_amount: z.number().nullish(),
   lines: z.array(ScheduleLineSchema),
 })
 
+export type InstallmentKind = z.infer<typeof InstallmentKindSchema>
 export type FeeInstallment = z.infer<typeof FeeInstallmentSchema>
 export type ScheduleLine = z.infer<typeof ScheduleLineSchema>
 export type EnrollmentSchedule = z.infer<typeof EnrollmentScheduleSchema>
@@ -46,22 +58,92 @@ export type EnrollmentSchedule = z.infer<typeof EnrollmentScheduleSchema>
 export interface InstallmentDraft {
   name: string
   position: number
-  percentage: number
+  kind: InstallmentKind
+  /** Rempli quand `kind` vaut `percentage`, laissé vide sinon. */
+  percentage: number | null
+  /** Rempli quand `kind` vaut `fixed`, laissé vide sinon. */
+  amount: number | null
   due_date: string
 }
 
 /** Total des pourcentages saisis, arrondi au centième pour éviter les 99.99999. */
-export function percentageTotal(drafts: InstallmentDraft[]): number {
-  return Math.round(drafts.reduce((sum, d) => sum + (d.percentage || 0), 0) * 100) / 100
+export function percentageTotal(
+  lines: { kind: InstallmentKind; percentage?: number | null }[],
+): number {
+  const somme = lines
+    .filter((l) => l.kind === "percentage")
+    .reduce((total, l) => total + (l.percentage || 0), 0)
+  return Math.round(somme * 100) / 100
+}
+
+/** Somme des tranches exprimées en francs. */
+export function fixedTotal(lines: { kind: InstallmentKind; amount?: number | null }[]): number {
+  return lines.filter((l) => l.kind === "fixed").reduce((total, l) => total + (l.amount || 0), 0)
+}
+
+export function hasPercentageLine(lines: { kind: InstallmentKind }[]): boolean {
+  return lines.some((l) => l.kind === "percentage")
 }
 
 /**
- * Une grille n'est valide que complète : une somme inférieure laisserait une
- * part des frais sans échéance, une somme supérieure réclamerait plus que le
- * montant dû.
+ * Une grille est valide si ses pourcentages, quand il y en a, couvrent
+ * exactement l'assiette restante : une somme inférieure laisserait une part
+ * des frais sans échéance, une somme supérieure réclamerait plus que le dû.
+ *
+ * Une grille faite uniquement de montants fermes est légitime et n'est
+ * contrainte par aucune somme : le total obligatoire change d'un niveau à
+ * l'autre, l'imposer ici reviendrait à bloquer une école sur un chiffre
+ * inventé. L'écran annonce la somme et la simule à la place.
  */
-export function isGridComplete(drafts: InstallmentDraft[]): boolean {
-  return drafts.length > 0 && percentageTotal(drafts) === 100
+export function isGridComplete(lines: { kind: InstallmentKind; percentage?: number | null }[]): boolean {
+  if (lines.length === 0) return false
+  if (!hasPercentageLine(lines)) return true
+  return percentageTotal(lines) === 100
+}
+
+/**
+ * Chiffre une grille sur une assiette donnée, dans l'ordre des échéances.
+ *
+ * Miroir exact de `resolve_grid_amounts` côté serveur, pour que la simulation
+ * affichée avant enregistrement soit celle que les familles recevront : les
+ * montants fermes se prélèvent d'abord sur le total, les pourcentages se
+ * répartissent sur ce qui reste, et la dernière tranche en pourcentage absorbe
+ * l'arrondi pour qu'aucun franc ne se perde.
+ *
+ * Un montant ferme est borné par ce qui reste : une grille bâtie pour un non
+ * affecté ne présente pas à un affecté subventionné une dette qu'il n'a pas.
+ */
+export function simulateGrid(
+  total: number,
+  lines: { kind: InstallmentKind; percentage?: number | null; amount?: number | null }[],
+): number[] {
+  if (lines.length === 0) return []
+
+  let reste = Math.max(total, 0)
+  const montants: (number | null)[] = lines.map(() => null)
+
+  lines.forEach((ligne, index) => {
+    if (ligne.kind !== "fixed") return
+    const preleve = Math.min(Math.max(ligne.amount || 0, 0), reste)
+    montants[index] = preleve
+    reste -= preleve
+  })
+
+  const indexesPourcentage = lines
+    .map((ligne, index) => (ligne.kind === "percentage" ? index : -1))
+    .filter((index) => index >= 0)
+
+  let distribue = 0
+  indexesPourcentage.forEach((index, rang) => {
+    const dernier = rang === indexesPourcentage.length - 1
+    const part = dernier
+      ? reste - distribue
+      : Math.round((reste * (lines[index].percentage || 0)) / 100)
+    montants[index] = part
+    distribue += part
+  })
+
+  return montants.map((montant) => montant ?? 0)
 }
 
 const SOURCE_LABELS: Record<string, string> = {


### PR DESCRIPTION
Dépend de **klassci-college-backend#273**, à fusionner en premier.

## Ce que l'écran laissait croire

L'éditeur de tranches ne connaissait que les pourcentages, et son sous-titre disait « chaque tranche est une part du total des frais obligatoires ». Une directrice ne pouvait donc pas saisir ce que sa brochure annonce — « Inscription 37 000 F, payable en totalité à l'inscription » — et rien ne lui disait ce que l'assiette contenait ou excluait.

## Ce que fait cette PR

**Une écriture par ligne, au choix.** Un sélecteur « Exprimée en » sur chaque tranche fait basculer entre « Pourcentage » et « Montant fixe », et le champ suivant change avec lui. Les deux se mélangent dans la même grille. Changer d'écriture vide l'autre valeur, pour qu'une ligne ne porte jamais deux vérités.

**L'écran dit sur quoi portent les pourcentages.** Un encadré permanent au-dessus de la grille :

> **Les montants fixes se prélèvent en premier ;** les pourcentages se partagent ensuite ce qui reste. Un pourcentage porte donc sur le solde après montants fixes, jamais sur le total.
>
> L'assiette est le **total des frais obligatoires** de l'élève. En sont exclus les frais optionnels souscrits à part, cantine, transport ou autres, ainsi que les frais dont l'élève a été exonéré.

**Une simulation en direct sous la grille.** On choisit un niveau et la situation de l'élève, affecté ou non, et l'on voit ligne par ligne les francs que recevront les familles, avant d'enregistrer. Sur le cas de la brochure — 6e non affectée, 125 000 F de frais obligatoires, grille « Inscription 37 000 F » puis 35 / 35 / 30 % — elle affiche 37 000, 30 800, 30 800 et 26 400.

C'est ce panneau qui rend visible la principale limite du montant fixe : il vaut le même francs pour tous les élèves de l'année. Le tarif retenu par la simulation suit la même règle qu'à l'inscription, un tarif réservé aux affectés ou aux non affectés l'emportant sur un tarif universel, si bien que basculer le sélecteur montre immédiatement ce qu'un élève subventionné recevrait.

**L'échéancier d'un élève annonce ce qui n'est pas planifié.** Une grille en francs qui ne couvre pas tout le dû laissait un écart muet entre la somme des échéances et le total. Un encadré le nomme désormais, en précisant que cette part n'a pas de date limite et ne compte pas dans le retard.

## Validation côté écran

Le bouton d'enregistrement reste bloqué tant que les pourcentages, **s'il y en a**, ne totalisent pas 100 %. Une grille faite uniquement de montants fixes est acceptée : l'écran explique alors qu'aucune somme n'est imposée, puisque le total change d'un niveau à l'autre, et renvoie vers la simulation. Le compteur du bandeau suit : il affiche les pourcentages quand il y en a, la somme en francs sinon — annoncer « 0 % » sur une grille en francs la ferait passer pour incomplète alors qu'elle est valide.

## Rétrocompatibilité

`simulateGrid` est le miroir exact de `resolve_grid_amounts` côté serveur, arrondi absorbé par la dernière tranche compris. Une grille entièrement en pourcentages produit les mêmes montants qu'avant, et c'est testé des deux côtés avec les mêmes chiffres.

## Tests

`lib/contracts/installment.test.ts`, 11 tests sur les fonctions réelles : le cas de la brochure au franc près, la non-régression d'une grille en pourcentages, l'absorption de l'arrondi, le plafonnement sur un élève subventionné, l'élève exonéré, et les règles de validité de la grille.

## Vérifications

- `pnpm exec tsc --noEmit --incremental false` : **0 erreur**
- `pnpm lint` (le script du projet, `next lint`) : **0 erreur, 0 avertissement** sur les fichiers touchés
- `pnpm exec vitest run` : **55 tests passés, 9 fichiers**

Aucun build Next n'a été lancé : le disque de la machine de développement est saturé et un build à court d'espace tronque les fichiers en écriture.

## Points de revue

- Les cibles tactiles restent en `h-11`, les nouveaux sélecteurs compris.
- La simulation calcule côté client à partir des tarifs et des catégories déjà chargés ; aucun nouveau point d'entrée serveur.
- `unscheduled_amount` est lu en `nullish` : un portail servi par un serveur qui n'a pas encore la PR backend n'affiche simplement pas l'encadré, au lieu d'échouer à valider tout l'échéancier.
