### PR TITLE
fix(enrollments): give the assignment field the form context it reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Le formulaire de nouvelle inscription plantait en arrivant à l'étape de la classe, sur un message technique, et il fallait tout recommencer *(secrétariat, admin)*
+- Les compteurs en tête de page ne suivaient plus après une création ou une suppression : l'écran des classes affichait six lignes sous une carte qui en annonçait cinq *(admin)*
 - L'éducateur et le secrétariat peuvent enfin délivrer un billet d'annulation de zéro : l'écran cherchait les évaluations manquées dans le cahier de notes de la classe, qu'ils n'ont pas le droit de lire, et répondait « Réessayez dans un instant » à une erreur de droits qui ne se résolvait jamais *(éducateur, secrétariat)*
 - Les quatre compteurs du registre des convocations décrivent l'année consultée et non le filtre en cours : cliquer « Tuteur absent » affichait « Convocations 8, Tuteur venu 0, Tuteur absent 8 » *(éducateur)*
 - Quand la liste des évaluations manquées ne peut pas être lue, le formulaire affiche enfin la raison au lieu d'inviter à réessayer *(éducateur, secrétariat)*

--- a/components/forms/EnrollmentForm.tsx
+++ b/components/forms/EnrollmentForm.tsx
@@ -23,6 +23,7 @@ import type { Class } from "@/lib/contracts/class"
 import { useCreateWithStudent, useReEnroll, useFeeVariants } from "@/lib/hooks/useEnrollments"
 import { useStudents } from "@/lib/hooks/useStudents"
 import { useClasses } from "@/lib/hooks/useClasses"
+import { Form } from "@/components/ui/form"
 import { AssignmentStatusField } from "@/components/forms/AssignmentStatusField"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -394,21 +395,25 @@ export function EnrollmentForm({ onSuccess, preselectedStudentId }: EnrollmentFo
           {/* L'affectation decide du tarif : elle se saisit ici, avec la
               classe, et non apres coup sur une inscription deja creee. */}
           {enrollmentType === "new" ? (
-            <AssignmentStatusField
-              control={newForm.control}
-              statusName="assignment_status"
-              decisionName="assignment_decision_number"
-              status={newForm.watch("assignment_status")}
-              onDecisionCleared={() => newForm.setValue("assignment_decision_number", null)}
-            />
+            <Form {...newForm}>
+              <AssignmentStatusField
+                control={newForm.control}
+                statusName="assignment_status"
+                decisionName="assignment_decision_number"
+                status={newForm.watch("assignment_status")}
+                onDecisionCleared={() => newForm.setValue("assignment_decision_number", null)}
+              />
+            </Form>
           ) : (
-            <AssignmentStatusField
-              control={reForm.control}
-              statusName="assignment_status"
-              decisionName="assignment_decision_number"
-              status={reForm.watch("assignment_status")}
-              onDecisionCleared={() => reForm.setValue("assignment_decision_number", null)}
-            />
+            <Form {...reForm}>
+              <AssignmentStatusField
+                control={reForm.control}
+                statusName="assignment_status"
+                decisionName="assignment_decision_number"
+                status={reForm.watch("assignment_status")}
+                onDecisionCleared={() => reForm.setValue("assignment_decision_number", null)}
+              />
+            </Form>
           )}
         </div>
       )}

--- a/lib/hooks/createCrudHooks.ts
+++ b/lib/hooks/createCrudHooks.ts
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import type { CrudApi } from "@/lib/api/createCrudApi"
 import type { PaginatedResponse } from "@/lib/contracts"
+import { dashboardKeys } from "./useDashboard"
 
 interface CrudLabels {
   created: string
@@ -78,6 +79,9 @@ export function createCrudHooks<
       },
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: keys.all })
+        // Les compteurs en tête de page viennent du résumé, pas de la liste :
+        // sans cela, l'écran affiche six lignes sous une carte qui annonce cinq.
+        queryClient.invalidateQueries({ queryKey: dashboardKeys.summary })
       },
     })
   }
@@ -123,6 +127,7 @@ export function createCrudHooks<
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: keys.all })
         queryClient.invalidateQueries({ queryKey: keys.detail(id) })
+        queryClient.invalidateQueries({ queryKey: dashboardKeys.summary })
       },
     })
   }
@@ -160,6 +165,9 @@ export function createCrudHooks<
       },
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: keys.all })
+        // Les compteurs en tête de page viennent du résumé, pas de la liste :
+        // sans cela, l'écran affiche six lignes sous une carte qui annonce cinq.
+        queryClient.invalidateQueries({ queryKey: dashboardKeys.summary })
       },
     })
   }


### PR DESCRIPTION
Deux défauts signalés en démonstration, dont un qui interrompt une inscription en cours de saisie.

## L'étape 2 du formulaire d'inscription plantait

Message à l'écran : `Cannot destructure property 'getFieldState' of ... as it is null`, puis un bouton « Réessayer » qui ne réessaye rien.

`FormField` se contente d'un `control` explicite, mais `FormItem`, `FormLabel` et `FormMessage` lisent le contexte par `useFormContext()`. L'étape 2 rendait le champ d'affectation avec sa liaison mais **sans fournisseur au-dessus** : le contexte valait `null` et l'étape entière mourait.

Le défaut vient de la saisie affecté / non affecté ajoutée aujourd'hui. Le modal de modification, lui, était correct — il enveloppe déjà son contenu.

## Les compteurs ne suivaient pas les mutations

Créer une classe affichait six lignes dans la liste sous une carte qui annonçait toujours cinq, sur le même écran. Les compteurs viennent du résumé du tableau de bord, jamais de la liste, et seule la liste était invalidée.

Corrigé dans la fabrique CRUD partagée plutôt qu'écran par écran : la création, la modification et la suppression périment désormais le résumé. Toutes les entités qui alimentent une carte en profitent d'un coup.

## Vérification

- `tsc --noEmit --incremental false` : 0 erreur
- `eslint` sur les fichiers touchés : 0 erreur
- Recherche des autres champs de formulaire rendus hors contexte : les deux candidats restants sont des composants enfants, toujours appelés sous un fournisseur
