### PR TITLE
fix(reports): le bulletin se télécharge depuis les portails élève et parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Le bouton « PDF » du bulletin fonctionne enfin dans les portails élève et parent : il appelait la page réservée à l'administration et répondait « accès refusé » à une famille qui voyait pourtant le bulletin à l'écran *(élève, parent)*
+- La liste « Mes bulletins » de l'élève ne s'affichait pas du tout : l'écran attendait une réponse d'une autre forme que celle envoyée par le serveur *(élève)*
 - L'éducateur et le secrétariat peuvent enfin délivrer un billet d'annulation de zéro : l'écran cherchait les évaluations manquées dans le cahier de notes de la classe, qu'ils n'ont pas le droit de lire, et répondait « Réessayez dans un instant » à une erreur de droits qui ne se résolvait jamais *(éducateur, secrétariat)*
 - Les quatre compteurs du registre des convocations décrivent l'année consultée et non le filtre en cours : cliquer « Tuteur absent » affichait « Convocations 8, Tuteur venu 0, Tuteur absent 8 » *(éducateur)*
 - Quand la liste des évaluations manquées ne peut pas être lue, le formulaire affiche enfin la raison au lieu d'inviter à réessayer *(éducateur, secrétariat)*

--- a/components/parent/ParentChildBulletinsClient.tsx
+++ b/components/parent/ParentChildBulletinsClient.tsx
@@ -25,7 +25,7 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
   const handleDownload = useCallback(async (bulletinId: number) => {
     setDownloadingId(bulletinId)
     try {
-      const blob = await parentPortalApi.downloadChildBulletinPdf(bulletinId)
+      const blob = await parentPortalApi.downloadChildBulletinPdf(childId, bulletinId)
       downloadBlob(blob, `bulletin-${bulletinId}.pdf`)
     } catch (err) {
       toast.error("Erreur lors du téléchargement", {
@@ -34,7 +34,7 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
     } finally {
       setDownloadingId(null)
     }
-  }, [])
+  }, [childId])
 
   if (error) {
     return <DataError message="Impossible de charger les bulletins." onRetry={refetch} />
@@ -106,7 +106,7 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
                 {bulletin.is_published && (
                   <div className="flex flex-col gap-2 sm:flex-row">
                     <PdfPreviewButton
-                      fetchBlob={() => parentPortalApi.downloadChildBulletinPdf(bulletin.id)}
+                      fetchBlob={() => parentPortalApi.downloadChildBulletinPdf(childId, bulletin.id)}
                       label={`le bulletin du trimestre ${bulletin.trimester}`}
                       className="h-11 w-full sm:h-9 sm:flex-1"
                     />

--- a/components/student/StudentBulletinsClient.tsx
+++ b/components/student/StudentBulletinsClient.tsx
@@ -86,7 +86,8 @@ function BulletinCard({ bulletin }: { bulletin: StudentBulletin }) {
               )}
               {bulletin.rank !== null && (
                 <span className="text-xs text-muted-foreground tabular-nums">
-                  Rang {bulletin.rank}/{bulletin.total_students}
+                  Rang {bulletin.rank}
+                  {bulletin.total_students !== null && `/${bulletin.total_students}`}
                 </span>
               )}
             </div>

--- a/lib/api/bulletin-download.test.ts
+++ b/lib/api/bulletin-download.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Le client HTTP lit la session NextAuth pour poser l'entête d'autorisation.
+// Ici on teste l'adresse appelée et le contrat de réponse, pas l'auth.
+vi.mock("next-auth/react", () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+  signOut: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { parentPortalApi } from "./parent-portal"
+import { studentPortalApi } from "./student-portal"
+
+/** Réponse BE réelle de `GET /student/bulletins` (enveloppe items/total). */
+const STUDENT_BULLETINS = {
+  items: [
+    {
+      id: 5,
+      trimester: 1,
+      average: "14.30",
+      rank: 4,
+      mention: "B",
+      class_name: "6ème A",
+      academic_year_name: "2025-2026",
+      file_url: null,
+      generated_at: "2026-08-09T16:32:59",
+    },
+  ],
+  total: 1,
+}
+
+function respondWithJson(payload: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+function respondWithPdf() {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response("%PDF-1.7", {
+      status: 200,
+      headers: { "Content-Type": "application/pdf" },
+    }),
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+function calledPath(fetchMock: ReturnType<typeof vi.fn>): string {
+  return new URL(String(fetchMock.mock.calls[0][0]), "http://api.test").pathname
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+  vi.spyOn(console, "error").mockImplementation(() => undefined)
+})
+
+describe("téléchargement d'un bulletin depuis un portail", () => {
+  it("l'élève passe par le portail élève, jamais par la route d'administration", async () => {
+    const fetchMock = respondWithPdf()
+
+    const blob = await studentPortalApi.downloadBulletin(5)
+
+    expect(calledPath(fetchMock)).toBe("/student/bulletins/5/pdf")
+    expect(calledPath(fetchMock)).not.toContain("/reports/")
+    expect(blob.type).toBe("application/pdf")
+  })
+
+  it("le parent porte l'identifiant de son enfant dans l'adresse", async () => {
+    const fetchMock = respondWithPdf()
+
+    const blob = await parentPortalApi.downloadChildBulletinPdf(42, 5)
+
+    expect(calledPath(fetchMock)).toBe("/parent/children/42/bulletins/5/pdf")
+    expect(calledPath(fetchMock)).not.toContain("/reports/")
+    expect(blob.type).toBe("application/pdf")
+  })
+
+  it("remonte le message du serveur quand le bulletin est refusé", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "Bulletin with id 9 not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    )
+
+    await expect(studentPortalApi.downloadBulletin(9)).rejects.toThrow(
+      "Bulletin with id 9 not found",
+    )
+  })
+})
+
+describe("studentPortalApi.getBulletins", () => {
+  it("normalise l'enveloppe du serveur vers le contrat de l'écran", async () => {
+    respondWithJson(STUDENT_BULLETINS)
+
+    const bulletins = await studentPortalApi.getBulletins()
+
+    expect(bulletins).toHaveLength(1)
+    expect(bulletins[0]).toMatchObject({
+      id: 5,
+      trimester: "Trimestre 1",
+      academic_year: "2025-2026",
+      general_average: 14.3,
+      rank: 4,
+      total_students: null,
+      status: "publie",
+    })
+  })
+
+  it("rend une liste vide quand l'élève n'a aucun bulletin publié", async () => {
+    respondWithJson({ items: [], total: 0 })
+
+    await expect(studentPortalApi.getBulletins()).resolves.toEqual([])
+  })
+})

--- a/lib/api/parent-portal.ts
+++ b/lib/api/parent-portal.ts
@@ -99,9 +99,17 @@ export const parentPortalApi = {
     return safeValidate(ParentChildBulletinsResponseSchema, unwrapResponse(res), `GET /parent/children/${childId}/bulletins`)
   },
 
-  // Télécharger un bulletin en PDF
-  downloadChildBulletinPdf: async (bulletinId: number): Promise<Blob> => {
-    return apiFetchBlob(`/reports/bulletins/${bulletinId}/pdf`)
+  /**
+   * Télécharger le bulletin d'un enfant en PDF.
+   *
+   * Passe par le portail parent, pas par `/reports/bulletins/{id}/pdf` :
+   * cette route-là est gardée par `reports:read`, un droit qui ouvre les
+   * bulletins de toute l'école et qu'un parent n'a pas. Le téléchargement
+   * répondait donc 403 alors que le bulletin s'affichait bien. Ici, la garde
+   * est le lien de filiation, d'où l'identifiant de l'enfant dans l'adresse.
+   */
+  downloadChildBulletinPdf: async (childId: number, bulletinId: number): Promise<Blob> => {
+    return apiFetchBlob(`/parent/children/${childId}/bulletins/${bulletinId}/pdf`)
   },
 
   // Emploi du temps d'un enfant

--- a/lib/api/student-portal.ts
+++ b/lib/api/student-portal.ts
@@ -3,7 +3,6 @@ import { apiFetch, apiFetchBlob, safeValidate } from "./client"
 import {
   StudentDashboardSchema,
   StudentGradesResponseSchema,
-  StudentBulletinSchema,
   StudentAttendanceResponseSchema,
   type StudentDashboard,
   type StudentGradesResponse,
@@ -17,7 +16,26 @@ import {
 } from "@/lib/contracts/timetable"
 
 const TimetableSlotArraySchema = z.array(TimetableSlotSchema)
-const StudentBulletinArraySchema = z.array(StudentBulletinSchema)
+
+// Le BE /student/bulletins renvoie {items:[{id, trimester:number, average,
+// rank, mention, class_name, academic_year_name, file_url, generated_at}],
+// total}. On valide cette forme réelle avant de la normaliser vers le
+// contrat consommé par l'UI.
+const StudentBulletinRawSchema = z.object({
+  id: z.number(),
+  trimester: z.number(),
+  average: z.coerce.number().nullable(),
+  rank: z.number().nullable(),
+  mention: z.string().nullable(),
+  class_name: z.string(),
+  academic_year_name: z.string(),
+  file_url: z.string().nullable(),
+  generated_at: z.string().nullable(),
+})
+const StudentBulletinsRawSchema = z.object({
+  items: z.array(StudentBulletinRawSchema),
+  total: z.number(),
+})
 
 // Le BE /student/fees renvoie {total_due, total_paid, balance, fees:[{id,
 // fee_category_name, amount, status: paid|partial|pending, payments}]}. On
@@ -133,14 +151,32 @@ export const studentPortalApi = {
     }
   },
 
-  // Bulletins publiés
+  // Bulletins publiés — normalise l'enveloppe BE vers le contrat UI.
   getBulletins: async (): Promise<StudentBulletin[]> => {
     const res = await apiFetch<unknown>("/student/bulletins")
-    const arr = Array.isArray(res) ? res : unwrapResponse<StudentBulletin[]>(res)
-    return safeValidate(StudentBulletinArraySchema, arr, "GET /student/bulletins")
+    const raw = safeValidate(StudentBulletinsRawSchema, res, "GET /student/bulletins")
+    return raw.items.map((b) => ({
+      id: b.id,
+      trimester: `Trimestre ${b.trimester}`,
+      academic_year: b.academic_year_name,
+      general_average: b.average,
+      rank: b.rank,
+      // L'effectif de la classe n'est pas porté par cette réponse : le rang
+      // s'affiche seul plutôt que suivi d'un dénominateur inventé.
+      total_students: null,
+      // L'endpoint ne rend que les bulletins publiés.
+      status: "publie" as const,
+      published_at: b.generated_at,
+    }))
   },
 
-  // Télécharger un bulletin en PDF (via apiFetchBlob centralisé)
+  /**
+   * Télécharger son bulletin en PDF.
+   *
+   * Route du portail, pas `/reports/bulletins/{id}/pdf` : cette dernière est
+   * gardée par `reports:read`, un droit qui ouvre les bulletins de toute
+   * l'école et qu'un élève n'a pas. Ici la garde est l'appartenance.
+   */
   downloadBulletin: async (bulletinId: number): Promise<Blob> => {
     return apiFetchBlob(`/student/bulletins/${bulletinId}/pdf`)
   },

--- a/lib/contracts/student-portal.ts
+++ b/lib/contracts/student-portal.ts
@@ -80,13 +80,15 @@ export const StudentFeesResponseSchema = z.object({
 })
 
 // Bulletins publiés
+// `total_students` reste facultatif : la liste du portail élève ne porte pas
+// l'effectif de la classe, et l'affichage se contente alors du rang seul.
 export const StudentBulletinSchema = z.object({
   id: z.number(),
   trimester: z.string(),
   academic_year: z.string(),
   general_average: z.coerce.number().nullable(),
   rank: z.number().nullable(),
-  total_students: z.number(),
+  total_students: z.number().nullable(),
   status: z.enum(["brouillon", "publie"]),
   published_at: z.string().nullish(),
 })


### PR DESCRIPTION
Suite de **African-DC/klassci-college-backend#275**, qui ouvre les deux routes
appelées ici. À merger après elle.

## Le défaut

Un élève voit son bulletin dans son portail et le bouton « PDF » répond
« accès refusé ». Même chose côté parent.

`lib/api/parent-portal.ts` appelait `/reports/bulletins/{id}/pdf`, la route
d'administration. Elle est gardée par `reports:read`, un droit que ni l'élève ni
le parent ne possède, et ne doit pas posséder : il ouvre les bulletins de toute
l'école.

## Ce que fait cette PR

- **Parent** : `downloadChildBulletinPdf` prend désormais l'identifiant de
  l'enfant et appelle `/parent/children/{childId}/bulletins/{bulletinId}/pdf`.
  Plus aucun appel à `/reports/*` depuis `parent-portal.ts`.
- **Élève** : `downloadBulletin` visait déjà `/student/bulletins/{id}/pdf` —
  une adresse qui n'existait pas encore côté serveur, d'où un 404 silencieux.
  La PR backend la crée ; le commentaire explique ici pourquoi ce n'est pas la
  route d'administration.
- `lib/api/bulletins.ts` garde la sienne : l'administration a bien
  `reports:read`, et son bouton « PDF » n'est pas en cause.

## Un second défaut trouvé en chemin

La liste « Mes bulletins » de l'élève ne s'affichait **pas du tout** : elle
attendait un tableau JSON là où le serveur envoie `{items, total}`. La
validation échouait à chaque chargement et l'écran tombait sur « Impossible de
charger les bulletins ». Le bouton de téléchargement n'apparaissait donc jamais,
ce qui rendait le correctif ci-dessus invisible.

`getBulletins` valide maintenant la forme réelle du serveur puis la normalise
vers le contrat de l'écran, comme le fait déjà `getFees` juste au-dessus. Trois
champs différaient au-delà de l'enveloppe : `trimester` est un entier côté
serveur, `academic_year_name` s'appelait `academic_year`, et `total_students`
n'est pas porté par cette réponse.

Ce dernier passe donc à `number | null` dans le contrat, et le rang s'affiche
seul — « Rang 4 » au lieu de « Rang 4/undefined » — plutôt que suivi d'un
dénominateur inventé.

## Comment tester

Portail élève, `Mes bulletins` : la liste s'affiche, « Aperçu » et « PDF »
ouvrent le document. Portail parent, un enfant → `Bulletins` : idem.

## Vérifications

```
tsc --noEmit --incremental false   0 erreur
eslint lib components app          0 erreur (38 avertissements préexistants)
vitest run                         101 tests, 13 fichiers, tous au vert
```

Les 2 erreurs eslint restantes sur le dépôt entier viennent de `next-env.d.ts`
(généré) et `tailwind.config.ts` : préexistantes, non touchées ici.

`lib/api/bulletin-download.test.ts` couvre les adresses réellement appelées
(aucune ne contient `/reports/`), la remontée du message du serveur sur un
refus, et la normalisation de la liste, liste vide comprise.
