### PR TITLE
feat(cash): surface auto-closed cash days and let the cashier regularize them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Bandeau « Ma caisse » qui signale les journées clôturées d'office pendant la nuit et permet de les régulariser en saisissant ce qui avait été compté *(caissier)*
+- Une journée non comptée affiche « Écart inconnu » et non un écart nul : le comptable voit la différence entre une caisse qui tombe juste et une caisse que personne n'a ouverte *(caissier, comptable)*
 - Chaque tranche de paiement se saisit au choix en pourcentage ou en montant fixe, dans la même grille : « Inscription 37 000 FCFA à la rentrée », puis 35 / 35 / 30 % du reste *(admin, comptable)*
 - Simulation en direct sous la grille : on choisit un niveau et la situation de l'élève, affecté ou non, et l'on voit les francs que recevra chaque famille avant d'enregistrer *(admin, comptable)*
 - Rapport de fin de trimestre de la DEEP téléchargeable depuis Rapports : on choisit l'année et le trimestre, on obtient le canevas officiel des vingt-sept tableaux, avec aperçu avant impression *(admin, directeur)*

--- a/components/admin/cash/DailyCashPointClient.tsx
+++ b/components/admin/cash/DailyCashPointClient.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useDailyCashPoint } from "@/lib/hooks/useCashSessions"
+import { hasBeenCounted, isLocked } from "@/lib/contracts/cash-session"
 import { CashStatusBadge, VarianceBadge, formatFcfa } from "./cash-ui"
 
 function todayIso(): string {
@@ -32,7 +33,18 @@ export function DailyCashPointClient() {
     { label: "Total encaissé", value: formatFcfa(data?.total_collected ?? 0), icon: Wallet },
     { label: "Dont espèces", value: formatFcfa(data?.cash_collected ?? 0), icon: Banknote },
     { label: "Caisses ouvertes", value: data?.open_count ?? 0, icon: ClipboardCheck },
-    { label: "Écart cumulé", value: formatFcfa(data?.total_variance ?? 0), icon: Scale },
+    {
+      // L'écart cumulé ne couvre QUE les caisses réellement comptées. Le
+      // compteur des clôtures d'office est ce qui empêche de le lire comme
+      // un solde complet.
+      label: "Écart cumulé",
+      value: formatFcfa(data?.total_variance ?? 0),
+      icon: Scale,
+      hint:
+        (data?.auto_closed_count ?? 0) > 0
+          ? `${data?.auto_closed_count} caisse${(data?.auto_closed_count ?? 0) > 1 ? "s" : ""} clôturée${(data?.auto_closed_count ?? 0) > 1 ? "s" : ""} d'office, écart inconnu`
+          : undefined,
+    },
   ]
 
   return (
@@ -101,7 +113,7 @@ export function DailyCashPointClient() {
                     <div className="flex flex-wrap items-center gap-2">
                       <p className="font-medium">{session.cashier_name}</p>
                       <CashStatusBadge status={session.status} />
-                      {session.status === "closed" && <VarianceBadge variance={session.variance} />}
+                      {hasBeenCounted(session) && <VarianceBadge variance={session.variance} />}
                     </div>
                     <p className="mt-1 text-sm text-muted-foreground">
                       {session.payments_count} versement{session.payments_count > 1 ? "s" : ""} ·{" "}
@@ -121,11 +133,12 @@ export function DailyCashPointClient() {
                   </div>
                 </div>
 
-                {session.status !== "closed" && (
+                {!hasBeenCounted(session) && (
                   <p className="mt-3 flex items-center gap-2 border-t pt-3 text-xs text-muted-foreground">
                     <Lock aria-hidden="true" className="h-3.5 w-3.5" />
-                    Journée non clôturée : le montant compté et l&apos;écart ne sont pas encore
-                    connus.
+                    {isLocked(session)
+                      ? "Clôturée d'office à minuit : le tiroir n'a pas été compté, l'écart reste inconnu tant que le caissier n'a pas régularisé."
+                      : "Journée non clôturée : le montant compté et l'écart ne sont pas encore connus."}
                   </p>
                 )}
               </CardContent>

--- a/components/admin/cash/MyCashSessionClient.tsx
+++ b/components/admin/cash/MyCashSessionClient.tsx
@@ -7,9 +7,16 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useMyCashSession } from "@/lib/hooks/useCashSessions"
-import { isClosed } from "@/lib/contracts/cash-session"
-import { CashStatusBadge, MethodBreakdown, VarianceBadge, formatFcfa } from "./cash-ui"
+import { hasBeenCounted, isAutoClosed, isLocked } from "@/lib/contracts/cash-session"
+import {
+  CashStatusBadge,
+  MethodBreakdown,
+  VarianceBadge,
+  formatBusinessDate,
+  formatFcfa,
+} from "./cash-ui"
 import { CloseCashDialog } from "./CloseCashDialog"
+import { RegularizeCashBanner } from "./RegularizeCashBanner"
 
 /**
  * « Ma caisse » — la journée du caissier connecté.
@@ -32,21 +39,32 @@ export function MyCashSessionClient() {
   }
 
   if (isError || !session) {
+    // Le bandeau reste rendu : les journées à régulariser sont indépendantes
+    // de la journée en cours, et c'est justement l'action que le caissier
+    // doit pouvoir mener même si sa caisse du jour ne charge pas.
     return (
-      <Card className="rounded-xl border shadow-sm">
-        <CardContent className="space-y-3 p-10 text-center">
-          <p className="text-sm text-muted-foreground">
-            {error instanceof Error ? error.message : "Impossible de charger votre caisse."}
-          </p>
-          <Button variant="outline" className="h-11" onClick={() => refetch()}>
-            Réessayer
-          </Button>
-        </CardContent>
-      </Card>
+      <div className="space-y-6">
+        <RegularizeCashBanner />
+        <Card className="rounded-xl border shadow-sm">
+          <CardContent className="space-y-3 p-10 text-center">
+            <p className="text-sm text-muted-foreground">
+              {error instanceof Error ? error.message : "Impossible de charger votre caisse."}
+            </p>
+            <Button variant="outline" className="h-11" onClick={() => refetch()}>
+              Réessayer
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
     )
   }
 
-  const closed = isClosed(session)
+  // Une journée clôturée d'office est verrouillée comme une journée signée :
+  // ne plus proposer de la clôturer. Elle se régularise, et cela se fait
+  // depuis le bandeau, qui porte la journée concernée.
+  const locked = isLocked(session)
+  const counted = hasBeenCounted(session)
+  const autoClosed = isAutoClosed(session)
 
   const kpis: HeroKpi[] = [
     { label: "Encaissé aujourd'hui", value: formatFcfa(session.total_collected), icon: Wallet },
@@ -54,20 +72,22 @@ export function MyCashSessionClient() {
     { label: "Versements", value: session.payments_count, icon: Receipt },
     {
       label: "État",
-      value: closed ? "Clôturée" : "Ouverte",
-      icon: closed ? Lock : CheckCircle2,
+      value: autoClosed ? "Clôturée d'office" : locked ? "Clôturée" : "Ouverte",
+      icon: locked ? Lock : CheckCircle2,
     },
   ]
 
   return (
     <div className="space-y-6">
+      <RegularizeCashBanner />
+
       <PageHero
         icon={Wallet}
         title="Ma caisse"
-        subtitle={`${session.cashier_name} · journée du ${session.business_date}`}
+        subtitle={`${session.cashier_name} · journée du ${formatBusinessDate(session.business_date)}`}
         kpis={kpis}
         actions={
-          !closed ? (
+          !locked ? (
             <button
               type="button"
               onClick={() => setCloseOpen(true)}
@@ -95,7 +115,36 @@ export function MyCashSessionClient() {
           <CardContent className="space-y-4 p-5">
             <h2 className="border-b pb-3 text-sm font-semibold">Clôture</h2>
 
-            {closed ? (
+            {autoClosed ? (
+              <div className="space-y-3 text-sm">
+                <p className="text-muted-foreground">
+                  Cette journée a été clôturée d&apos;office à minuit : elle n&apos;avait pas été
+                  clôturée en fin de service. Le tiroir n&apos;ayant pas été compté,
+                  l&apos;écart est inconnu.
+                </p>
+                <dl className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Espèces attendues</dt>
+                    <dd className="font-medium tabular-nums">
+                      {formatFcfa(session.expected_amount ?? 0)}
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-muted-foreground">Espèces comptées</dt>
+                    <dd className="text-muted-foreground">Non comptées</dd>
+                  </div>
+                  <div className="flex items-center justify-between border-t pt-3">
+                    <dt className="text-muted-foreground">Écart</dt>
+                    <dd>
+                      <VarianceBadge variance={session.variance} />
+                    </dd>
+                  </div>
+                </dl>
+                <p className="text-xs text-muted-foreground">
+                  Régularisez-la depuis le bandeau en haut de cet écran.
+                </p>
+              </div>
+            ) : counted ? (
               <dl className="space-y-3 text-sm">
                 <div className="flex items-center justify-between">
                   <dt className="text-muted-foreground">Espèces attendues</dt>
@@ -115,6 +164,12 @@ export function MyCashSessionClient() {
                     <VarianceBadge variance={session.variance} />
                   </dd>
                 </div>
+                {session.regularized_at && (
+                  <p className="text-xs text-muted-foreground">
+                    Journée clôturée d&apos;office puis régularisée : le comptage a été saisi
+                    après coup, sur le théorique arrêté à la clôture.
+                  </p>
+                )}
                 {session.notes && (
                   <div className="rounded-lg border border-border/60 bg-muted/40 p-3">
                     <dt className="text-xs uppercase tracking-wide text-muted-foreground">Note</dt>

--- a/components/admin/cash/RegularizeCashBanner.tsx
+++ b/components/admin/cash/RegularizeCashBanner.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useState } from "react"
+import { AlertTriangle, ClipboardCheck } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useCashSessionsToRegularize } from "@/lib/hooks/useCashSessions"
+import type { CashSession } from "@/lib/contracts/cash-session"
+import { RegularizeCashDialog } from "./RegularizeCashDialog"
+import { formatBusinessDate, formatFcfa } from "./cash-ui"
+
+/**
+ * Ce que le caissier doit voir en arrivant le matin : les journées que le
+ * système a clôturées d'office pendant la nuit, et le bouton pour les
+ * régulariser.
+ *
+ * Un bandeau et non une pastille : la caisse est arrêtée sur un écart inconnu,
+ * et tant que personne n'a saisi son comptage, la comptabilité travaille sur
+ * un trou. Il faut le dire, dire pourquoi, et dire quoi faire.
+ *
+ * Rend `null` dans le cas normal — la plupart des caissiers clôturent leur
+ * journée, et un bandeau « tout va bien » permanent finit par ne plus être lu.
+ */
+export function RegularizeCashBanner() {
+  const [selected, setSelected] = useState<CashSession | null>(null)
+  const { data, isLoading, isError } = useCashSessionsToRegularize()
+
+  if (isLoading) {
+    return <Skeleton className="h-24 rounded-xl" />
+  }
+
+  // Un échec de ce seul appel ne doit pas masquer l'écran caisse : l'erreur
+  // de chargement de la journée en cours, elle, est déjà rendue en dessous.
+  if (isError || !data || data.length === 0) {
+    return null
+  }
+
+  const plural = data.length > 1
+
+  return (
+    <>
+      <section
+        role="alert"
+        aria-labelledby="regularize-banner-title"
+        className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 sm:p-5"
+      >
+        <div className="flex items-start gap-3">
+          <AlertTriangle
+            aria-hidden="true"
+            className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-500"
+          />
+          <div className="min-w-0 flex-1">
+            <h2 id="regularize-banner-title" className="text-sm font-semibold">
+              {plural
+                ? `${data.length} journées de caisse clôturées d'office`
+                : "Une journée de caisse clôturée d'office"}
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {plural ? "Ces journées n'ont pas été clôturées" : "Cette journée n'a pas été clôturée"}{" "}
+              en fin de service : le système {plural ? "les" : "l'"}a arrêtée
+              {plural ? "s" : ""} à minuit sans compter le tiroir. L&apos;écart reste inconnu tant
+              que vous n&apos;avez pas saisi ce que vous aviez compté.
+            </p>
+
+            <ul className="mt-4 space-y-2">
+              {data.map((session) => (
+                <li
+                  key={session.business_date}
+                  className="flex flex-col gap-3 rounded-lg border border-border/60 bg-background p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">
+                      Journée du {formatBusinessDate(session.business_date)}
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {session.payments_count} versement{session.payments_count > 1 ? "s" : ""} ·{" "}
+                      {formatFcfa(session.expected_amount ?? 0)} attendus en espèces · écart inconnu
+                    </p>
+                  </div>
+                  <Button
+                    className="h-11 w-full shrink-0 gap-2 sm:w-auto"
+                    onClick={() => setSelected(session)}
+                  >
+                    <ClipboardCheck aria-hidden="true" className="h-4 w-4" />
+                    Régulariser
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <RegularizeCashDialog session={selected} onClose={() => setSelected(null)} />
+    </>
+  )
+}

--- a/components/admin/cash/RegularizeCashDialog.tsx
+++ b/components/admin/cash/RegularizeCashDialog.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { AlertTriangle, ClipboardCheck } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { useRegularizeCashSession } from "@/lib/hooks/useCashSessions"
+import type { CashSession } from "@/lib/contracts/cash-session"
+import { formatFcfa, formatBusinessDate } from "./cash-ui"
+
+interface RegularizeCashDialogProps {
+  /** La journée à régulariser, ou `null` quand la boîte est fermée. */
+  session: CashSession | null
+  onClose: () => void
+}
+
+/**
+ * Régularisation d'une journée clôturée d'office.
+ *
+ * Le théorique affiché est celui qui a été FIGÉ la nuit de la clôture, pas un
+ * théorique recalculé : c'est contre lui que se mesurera l'écart, et le
+ * caissier doit voir le même chiffre que celui qui servira au calcul.
+ *
+ * Le champ « compté » n'est jamais pré-rempli avec le théorique, sinon le
+ * caissier validerait sans compter et l'écart ne voudrait plus rien dire.
+ */
+export function RegularizeCashDialog({ session, onClose }: RegularizeCashDialogProps) {
+  const [counted, setCounted] = useState("")
+  const [notes, setNotes] = useState("")
+  const businessDate = session?.business_date ?? ""
+  const { mutate, isPending } = useRegularizeCashSession(businessDate)
+
+  // Passer d'une journée à l'autre sans vider les champs ferait saisir le
+  // comptage du lundi sur la journée du mardi.
+  useEffect(() => {
+    setCounted("")
+    setNotes("")
+  }, [businessDate])
+
+  const expectedCash = session?.expected_amount ?? 0
+  const countedValue = counted.trim() === "" ? null : Number(counted)
+  const isValid = countedValue !== null && Number.isFinite(countedValue) && countedValue >= 0
+  const variance = isValid ? countedValue - expectedCash : null
+
+  function handleSubmit() {
+    if (!isValid || !session) return
+    mutate(
+      { counted_amount: countedValue, notes: notes.trim() || undefined },
+      { onSuccess: () => onClose() },
+    )
+  }
+
+  return (
+    <Dialog open={session !== null} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-w-lg" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>
+            Régulariser la journée du {session ? formatBusinessDate(session.business_date) : ""}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Cette journée a été clôturée d&apos;office à minuit, sans comptage. Saisissez ce que
+            vous aviez compté dans le tiroir ce jour-là : l&apos;écart sera calculé sur le
+            théorique arrêté à ce moment.
+          </p>
+
+          <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Espèces attendues ce jour-là
+            </p>
+            <p className="mt-1 text-2xl font-bold tabular-nums">{formatFcfa(expectedCash)}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Montant arrêté à la clôture d&apos;office. Il ne bouge plus.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="regularize-counted">Espèces comptées *</Label>
+            <Input
+              id="regularize-counted"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={1}
+              className="h-11 text-lg tabular-nums"
+              placeholder="Ce que vous aviez compté ce jour-là"
+              value={counted}
+              onChange={(e) => setCounted(e.target.value)}
+              disabled={isPending}
+            />
+          </div>
+
+          {variance !== null && variance !== 0 && (
+            <div
+              role="alert"
+              className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3"
+            >
+              <AlertTriangle aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+              <div className="min-w-0 text-sm">
+                <p className="font-medium">
+                  {variance < 0 ? "Manquant" : "Excédent"} de {formatFcfa(Math.abs(variance))}
+                </p>
+                <p className="mt-0.5 text-muted-foreground">
+                  Expliquez l&apos;écart dans la note ci-dessous. La régularisation reste possible.
+                </p>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="regularize-notes">
+              Note {variance ? "(recommandée)" : "(facultative)"}
+            </Label>
+            <Textarea
+              id="regularize-notes"
+              placeholder="Pourquoi la journée n'a pas été clôturée, explication d'un écart..."
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              disabled={isPending}
+              rows={3}
+            />
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            La régularisation est tracée : elle indique qui a saisi le comptage et quand.
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" className="h-11" onClick={onClose} disabled={isPending}>
+            Annuler
+          </Button>
+          <Button className="h-11 gap-2" onClick={handleSubmit} disabled={!isValid || isPending}>
+            <ClipboardCheck aria-hidden="true" className="h-4 w-4" />
+            {isPending ? "Enregistrement..." : "Enregistrer le comptage"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/cash/cash-ui.tsx
+++ b/components/admin/cash/cash-ui.tsx
@@ -1,10 +1,21 @@
 "use client"
 
 import { Badge } from "@/components/ui/badge"
-import type { CashMethodTotal } from "@/lib/contracts/cash-session"
+import { CASH_STATUS, type CashMethodTotal } from "@/lib/contracts/cash-session"
 import { formatFcfa } from "@/lib/utils/money"
 
 export { formatFcfa }
+
+/**
+ * « 2026-08-20 » devient « 20/08/2026 ». Découpage manuel plutôt que `new
+ * Date(iso)` : ce dernier interprète une date nue comme minuit UTC et affiche
+ * la veille dans les fuseaux négatifs.
+ */
+export function formatBusinessDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split("-")
+  if (!year || !month || !day) return isoDate
+  return `${day}/${month}/${year}`
+}
 
 /**
  * L'écart de caisse est l'information que le comptable cherche en premier.
@@ -13,7 +24,9 @@ export { formatFcfa }
  */
 export function VarianceBadge({ variance }: { variance: number | null | undefined }) {
   if (variance === null || variance === undefined) {
-    return <span className="text-sm text-muted-foreground">—</span>
+    // Écart inconnu, faute de comptage. Le tiret dit « on ne sait pas » ;
+    // afficher « Juste » ou « 0 » affirmerait que le tiroir tombait juste.
+    return <span className="text-sm text-muted-foreground">Inconnu</span>
   }
   if (variance === 0) {
     return <Badge className="bg-emerald-600 text-white hover:bg-emerald-600/90">Juste</Badge>
@@ -30,8 +43,16 @@ export function VarianceBadge({ variance }: { variance: number | null | undefine
 }
 
 export function CashStatusBadge({ status }: { status: string }) {
-  if (status === "closed") {
+  if (status === CASH_STATUS.CLOSED) {
     return <Badge variant="secondary">Clôturée</Badge>
+  }
+  if (status === CASH_STATUS.AUTO_CLOSED) {
+    // Ambre et non gris : la journée est arrêtée, mais il reste un geste à
+    // faire. La confondre visuellement avec une clôture normale la ferait
+    // oublier.
+    return (
+      <Badge className="bg-amber-500 text-white hover:bg-amber-500/90">Clôturée d&apos;office</Badge>
+    )
   }
   return <Badge className="bg-primary text-primary-foreground hover:bg-primary/90">Ouverte</Badge>
 }

--- a/lib/api/cash-sessions.ts
+++ b/lib/api/cash-sessions.ts
@@ -1,11 +1,15 @@
+import { z } from "zod"
 import {
   CashSessionListSchema,
   CashSessionSchema,
   type CashSession,
   type CashSessionClose,
   type CashSessionList,
+  type CashSessionRegularize,
 } from "@/lib/contracts/cash-session"
 import { apiFetch, safeValidate } from "./client"
+
+const CashSessionArraySchema = z.array(CashSessionSchema)
 
 /** Journée demandée, ou aujourd'hui si non précisée. */
 function dateQuery(businessDate?: string): string {
@@ -26,6 +30,27 @@ export const cashSessionsApi = {
       body: JSON.stringify(data),
     })
     return safeValidate(CashSessionSchema, json, "POST /cash-sessions/me/close")
+  },
+
+  /** Mes journées clôturées d'office qui attendent encore un comptage. */
+  toRegularize: async (): Promise<CashSession[]> => {
+    const json = await apiFetch<unknown>("/cash-sessions/me/to-regularize")
+    return safeValidate(CashSessionArraySchema, json, "GET /cash-sessions/me/to-regularize")
+  },
+
+  /**
+   * Régularisation : saisit après coup ce qui a été compté. La date est
+   * obligatoire, c'est forcément une journée passée.
+   */
+  regularize: async (
+    businessDate: string,
+    data: CashSessionRegularize,
+  ): Promise<CashSession> => {
+    const json = await apiFetch<unknown>(
+      `/cash-sessions/me/regularize?date=${encodeURIComponent(businessDate)}`,
+      { method: "POST", body: JSON.stringify(data) },
+    )
+    return safeValidate(CashSessionSchema, json, "POST /cash-sessions/me/regularize")
   },
 
   /** Point journalier : toutes les caisses d'une date (comptable). */

--- a/lib/contracts/cash-session.test.ts
+++ b/lib/contracts/cash-session.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest"
+import {
+  CASH_STATUS,
+  CashSessionListSchema,
+  CashSessionSchema,
+  hasBeenCounted,
+  isAutoClosed,
+  isLocked,
+} from "./cash-session"
+
+/**
+ * Une journée de caisse a trois états, et les confondre a un coût réel :
+ * afficher « écart 0 » sur une caisse que personne n'a comptée dit au
+ * comptable que le tiroir tombe juste.
+ */
+
+const baseSession = {
+  id: 1,
+  cashier_user_id: 7,
+  cashier_name: "Sophie Yao",
+  business_date: "2026-08-20",
+  status: CASH_STATUS.OPEN,
+  opened_at: "2026-08-20T08:00:00",
+  payments_count: 3,
+  total_collected: 150000,
+  cash_collected: 120000,
+  by_method: [{ method: "cash", label: "Espèces", count: 3, total: 120000 }],
+}
+
+describe("états d'une journée de caisse", () => {
+  it("verrouille une journée clôturée d'office comme une journée signée", () => {
+    // Son théorique est figé : y encaisser ou y annuler le rendrait faux.
+    expect(isLocked({ status: CASH_STATUS.AUTO_CLOSED })).toBe(true)
+    expect(isLocked({ status: CASH_STATUS.CLOSED })).toBe(true)
+    expect(isLocked({ status: CASH_STATUS.OPEN })).toBe(false)
+  })
+
+  it("ne considère comptée qu'une journée dont le caissier a ouvert le tiroir", () => {
+    expect(hasBeenCounted({ status: CASH_STATUS.CLOSED })).toBe(true)
+    expect(hasBeenCounted({ status: CASH_STATUS.AUTO_CLOSED })).toBe(false)
+    expect(hasBeenCounted({ status: CASH_STATUS.OPEN })).toBe(false)
+  })
+
+  it("distingue la clôture d'office de la clôture normale", () => {
+    expect(isAutoClosed({ status: CASH_STATUS.AUTO_CLOSED })).toBe(true)
+    expect(isAutoClosed({ status: CASH_STATUS.CLOSED })).toBe(false)
+  })
+})
+
+describe("contrat d'une journée clôturée d'office", () => {
+  it("accepte un montant compté et un écart absents", () => {
+    const parsed = CashSessionSchema.parse({
+      ...baseSession,
+      status: CASH_STATUS.AUTO_CLOSED,
+      closed_at: "2026-08-21T00:10:00",
+      expected_amount: 120000,
+      counted_amount: null,
+      variance: null,
+      regularized_at: null,
+    })
+
+    expect(parsed.expected_amount).toBe(120000)
+    // Absents, et surtout pas ramenés à zéro par le contrat.
+    expect(parsed.counted_amount).toBeNull()
+    expect(parsed.variance).toBeNull()
+    expect(hasBeenCounted(parsed)).toBe(false)
+  })
+
+  it("garde la trace d'une régularisation après coup", () => {
+    const parsed = CashSessionSchema.parse({
+      ...baseSession,
+      status: CASH_STATUS.CLOSED,
+      closed_at: "2026-08-21T00:10:00",
+      expected_amount: 120000,
+      counted_amount: 118500,
+      variance: -1500,
+      regularized_at: "2026-08-21T09:12:00",
+    })
+
+    expect(parsed.variance).toBe(-1500)
+    expect(parsed.regularized_at).toBe("2026-08-21T09:12:00")
+    expect(hasBeenCounted(parsed)).toBe(true)
+  })
+
+  it("rejette un écart envoyé en chaîne, comme le ferait un Decimal Pydantic", () => {
+    const result = CashSessionSchema.safeParse({
+      ...baseSession,
+      status: CASH_STATUS.CLOSED,
+      variance: "-1500",
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("point journalier", () => {
+  it("compte à part les caisses clôturées d'office", () => {
+    const parsed = CashSessionListSchema.parse({
+      items: [],
+      business_date: "2026-08-20",
+      total_collected: 0,
+      cash_collected: 0,
+      total_variance: 0,
+      open_count: 0,
+      closed_count: 2,
+      auto_closed_count: 1,
+    })
+    expect(parsed.auto_closed_count).toBe(1)
+  })
+
+  it("reste lisible face à un backend qui n'envoie pas encore ce compteur", () => {
+    const parsed = CashSessionListSchema.parse({
+      items: [],
+      business_date: "2026-08-20",
+      total_collected: 0,
+      cash_collected: 0,
+      total_variance: 0,
+      open_count: 1,
+      closed_count: 0,
+    })
+    // Absent plutôt que défaut Zod : un `.default()` ferait diverger les types
+    // d'entrée et de sortie du schéma, et `safeValidate` ne compilerait plus.
+    expect(parsed.auto_closed_count).toBeUndefined()
+  })
+})

--- a/lib/contracts/cash-session.ts
+++ b/lib/contracts/cash-session.ts
@@ -24,9 +24,12 @@ export const CashSessionSchema = z.object({
   status: z.string(),
   opened_at: z.string(),
   closed_at: z.string().nullish(),
+  // Nuls sur une journee clôturée d'office : le tiroir n'a pas été compté et
+  // l'écart est INCONNU. Surtout pas zéro, qui dirait « la caisse tombe juste ».
   counted_amount: z.number().nullish(),
   expected_amount: z.number().nullish(),
   variance: z.number().nullish(),
+  regularized_at: z.string().nullish(),
   notes: z.string().nullish(),
   payments_count: z.number(),
   total_collected: z.number(),
@@ -42,6 +45,22 @@ export const CashSessionListSchema = z.object({
   total_variance: z.number(),
   open_count: z.number(),
   closed_count: z.number(),
+  // Clôturées d'office : ni encore en service, ni arrêtées par quelqu'un.
+  // Leur écart n'entre pas dans `total_variance`, qui ne se lit donc pas
+  // comme un solde complet.
+  //
+  // `.optional()` et non `.default(0)` : un défaut Zod fait diverger le type
+  // d'entrée du type de sortie, et `safeValidate` rend alors un objet que
+  // TypeScript refuse d'assigner au type inféré. Les appelants écrivent
+  // `?? 0`, ce qui dit aussi honnêtement « pas encore renseigné ».
+  auto_closed_count: z.number().optional(),
+})
+
+export const CashSessionRegularizeSchema = z.object({
+  counted_amount: z
+    .number({ invalid_type_error: "Saisissez le montant compté" })
+    .min(0, "Le montant ne peut pas être négatif"),
+  notes: z.string().max(1000, "1000 caractères maximum").optional(),
 })
 
 export const CashSessionCloseSchema = z.object({
@@ -55,8 +74,37 @@ export type CashMethodTotal = z.infer<typeof CashMethodTotalSchema>
 export type CashSession = z.infer<typeof CashSessionSchema>
 export type CashSessionList = z.infer<typeof CashSessionListSchema>
 export type CashSessionClose = z.infer<typeof CashSessionCloseSchema>
+export type CashSessionRegularize = z.infer<typeof CashSessionRegularizeSchema>
 
-/** `true` quand la journée est verrouillée : plus d'encaissement ni d'annulation. */
-export function isClosed(session: Pick<CashSession, "status">): boolean {
-  return session.status === "closed"
+/** Les trois états d'une journée de caisse, tels que le backend les nomme. */
+export const CASH_STATUS = {
+  OPEN: "open",
+  /** Clôturée par son caissier, qui a compté son tiroir. */
+  CLOSED: "closed",
+  /** Clôturée d'office à minuit, sans comptage. Écart inconnu. */
+  AUTO_CLOSED: "auto_closed",
+} as const
+
+/**
+ * `true` quand la journée est verrouillée : plus d'encaissement ni d'annulation.
+ *
+ * Une journée clôturée d'office l'est tout autant qu'une journée signée — son
+ * théorique est figé. Ne pas remplacer par `status === "closed"` : l'écran
+ * proposerait de clôturer une journée déjà verrouillée.
+ */
+export function isLocked(session: Pick<CashSession, "status">): boolean {
+  return session.status !== CASH_STATUS.OPEN
+}
+
+/** `true` quand personne n'a compté le tiroir : l'écart est inconnu, pas nul. */
+export function isAutoClosed(session: Pick<CashSession, "status">): boolean {
+  return session.status === CASH_STATUS.AUTO_CLOSED
+}
+
+/**
+ * `true` quand la journée porte un comptage réel, donc un écart qui veut dire
+ * quelque chose. C'est la seule condition sous laquelle afficher un écart.
+ */
+export function hasBeenCounted(session: Pick<CashSession, "status">): boolean {
+  return session.status === CASH_STATUS.CLOSED
 }

--- a/lib/hooks/useCashSessions.ts
+++ b/lib/hooks/useCashSessions.ts
@@ -3,12 +3,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { cashSessionsApi } from "@/lib/api/cash-sessions"
-import type { CashSessionClose } from "@/lib/contracts/cash-session"
+import type { CashSessionClose, CashSessionRegularize } from "@/lib/contracts/cash-session"
 
 export const cashSessionKeys = {
   all: ["cash-sessions"] as const,
   mine: (businessDate?: string) => ["cash-sessions", "me", businessDate ?? "today"] as const,
   dailyPoint: (businessDate?: string) => ["cash-sessions", "point", businessDate ?? "today"] as const,
+  toRegularize: () => ["cash-sessions", "to-regularize"] as const,
 }
 
 /** Ma caisse du jour. Rafraîchie souvent : le total bouge à chaque encaissement. */
@@ -47,6 +48,44 @@ export function useCloseMyCashSession(businessDate?: string) {
     },
     onError: (err) => {
       toast.error("Clôture impossible", { description: err.message })
+    },
+  })
+}
+
+/**
+ * Ce que le caissier doit régulariser. Interrogé à chaque montage de l'écran
+ * caisse : c'est la première chose qu'il doit voir en arrivant le matin.
+ * Une liste vide est la réponse normale, pas une erreur.
+ */
+export function useCashSessionsToRegularize() {
+  return useQuery({
+    queryKey: cashSessionKeys.toRegularize(),
+    queryFn: () => cashSessionsApi.toRegularize(),
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useRegularizeCashSession(businessDate: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: CashSessionRegularize) =>
+      cashSessionsApi.regularize(businessDate, data),
+    onSuccess: (session) => {
+      queryClient.invalidateQueries({ queryKey: cashSessionKeys.all })
+      const variance = session.variance ?? 0
+      if (variance === 0) {
+        toast.success("Journée régularisée", { description: "La caisse tombe juste." })
+        return
+      }
+      // L'écart n'est pas une erreur : c'est justement ce qu'on cherchait à
+      // connaître. Il doit être vu et expliqué, pas masqué.
+      const label = variance < 0 ? "Manquant" : "Excédent"
+      const amount = Math.abs(variance).toLocaleString("fr-FR")
+      toast.warning("Journée régularisée", { description: `${label} de ${amount} FCFA.` })
+    },
+    onError: (err) => {
+      toast.error("Régularisation impossible", { description: err.message })
     },
   })
 }


### PR DESCRIPTION
Accompagne la PR backend **African-DC/klassci-college-backend#276**, qui clôture d'office à minuit les journées de caisse restées ouvertes. À merger après elle : les deux endpoints consommés ici n'existent pas avant.

## Ce que le caissier voit maintenant

Un bandeau en haut de « Ma caisse », pas une pastille. La caisse a été arrêtée sur un écart inconnu, et tant que personne n'a saisi son comptage, la comptabilité travaille sur un trou. Le bandeau dit ce qui s'est passé, pourquoi, et quoi faire :

> **2 journées de caisse clôturées d'office**
> Ces journées n'ont pas été clôturées en fin de service : le système les a arrêtées à minuit sans compter le tiroir. L'écart reste inconnu tant que vous n'avez pas saisi ce que vous aviez compté.
>
> Journée du 19/08/2026 — 4 versements · 95 000 FCFA attendus en espèces · écart inconnu → **[Régulariser]**

Le bouton ouvre une boîte qui affiche le théorique **figé la nuit de la clôture** — le même chiffre que celui qui servira au calcul — et demande le montant compté. Jamais pré-rempli avec le théorique : le caissier validerait sans compter, et l'écart ne voudrait plus rien dire. L'écart s'affiche en direct avant validation, et une note explicative est proposée dès qu'il n'est pas nul.

Le bandeau rend `null` dans le cas normal. Un bandeau « tout va bien » permanent finit par ne plus être lu.

Il reste rendu même quand la journée en cours échoue à charger : les journées à régulariser en sont indépendantes, et c'est justement l'action que le caissier doit pouvoir mener dans ce cas.

## Zéro n'est pas « inconnu »

C'est tout l'objet de la PR côté écran. Trois endroits mentaient si on ne les touchait pas :

| Endroit | Avant | Maintenant |
|---|---|---|
| Badge d'écart | tiret muet quand `variance` est nul | **« Inconnu »**, explicite |
| Fiche « Ma caisse » | branche `closed` unique | trois états : ouverte / clôturée d'office / comptée. La clôture d'office affiche « Espèces comptées : Non comptées » et « Écart : Inconnu » |
| Point journalier | `Écart cumulé` seul | même chiffre, plus la mention « 2 caisses clôturées d'office, écart inconnu » sous le KPI |

Le badge de statut passe en ambre pour une clôture d'office, pas en gris comme une clôture normale : la journée est arrêtée, mais il reste un geste à faire. La confondre visuellement avec une clôture signée la ferait oublier.

Une journée régularisée affiche en plus, sous son écart, qu'elle a été clôturée d'office puis comptée après coup.

## Le statut n'est plus comparé à la main

`isClosed(session)` testait `status === "closed"`. Avec un troisième statut, ce test devient faux à deux endroits opposés : il proposerait de clôturer une journée déjà verrouillée, et il afficherait un écart sur une caisse non comptée.

Il est remplacé par trois prédicats nommés dans le contrat, qui disent chacun ce qu'ils décident :

- `isLocked` — plus d'encaissement ni d'annulation. Vrai aussi pour une clôture d'office.
- `hasBeenCounted` — la seule condition sous laquelle afficher un écart.
- `isAutoClosed` — pour le libellé et le ton.

Tous les sites d'appel des deux écrans ont été convertis ; plus aucune comparaison de chaîne littérale sur `status` dans les composants caisse.

## Détail de contrat

`auto_closed_count` est déclaré `.optional()` et non `.default(0)`. Un défaut Zod fait diverger le type d'entrée du type de sortie, et `safeValidate` rend alors un objet que TypeScript refuse d'assigner au type inféré — l'erreur est survenue pendant l'écriture de cette PR. Les appelants écrivent `?? 0`, ce qui dit d'ailleurs plus honnêtement « pas encore renseigné » qu'un zéro fabriqué.

`formatBusinessDate` découpe la chaîne au lieu de passer par `new Date(iso)` : ce dernier interprète une date nue comme minuit UTC et affiche la veille dans les fuseaux négatifs — sur un écran qui parle précisément de journées de caisse, se tromper d'un jour est exactement le bug à ne pas faire. Il est appliqué aussi au sous-titre de « Ma caisse », qui affichait jusqu'ici la date ISO brute.

Les deux nouveaux appels passent par `apiFetch<unknown>` + `safeValidate`, sans cast.

## Persona et design

Cibles tactiles `h-11` sur le bouton « Régulariser » et les actions de la boîte. Le bandeau passe en colonne sous `sm` : le libellé de la journée au-dessus, le bouton pleine largeur en dessous. Ambre sémantique (alerte à traiter), pas un second accent décoratif. `role="alert"` avec `aria-labelledby` sur le bandeau, textes français accentués sans tiret long.

Les champs de la boîte se vident quand on passe d'une journée à l'autre : sans cela, on saisirait le comptage du lundi sur la journée du mardi.

## Validation

- `pnpm exec tsc --noEmit --incremental false` → **0 erreur**
- `pnpm exec eslint` sur les fichiers touchés → **0 erreur, 0 avertissement**
- `pnpm exec vitest run` → **13 fichiers, 104 tests, tous verts** (dont 8 nouveaux)
- `pnpm install --frozen-lockfile` → OK, lockfile inchangé

Aucun `next build` lancé : disque saturé sur la machine, un build à court d'espace tronque les fichiers en écriture. Les routes touchées sont préexistantes (`/admin/cash`, `/admin/cash-point`), aucune route neuve n'est ajoutée, donc pas de `as Route` à poser.

Les huit tests portent sur les trois prédicats de statut et sur le contrat : une journée clôturée d'office garde `counted_amount` et `variance` **absents** plutôt que ramenés à zéro, une journée régularisée garde sa trace, et un écart envoyé en chaîne — ce que ferait un `Decimal` Pydantic — est rejeté.
