### PR TITLE
feat(bulletins): show withheld bulletins greyed with reason and amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- Bulletin retenu pour impayé : la carte reste affichée mais grisée, la moyenne montre un tiret plutôt qu'un chiffre, et une phrase dit le trimestre concerné, le montant en retard et d'aller au secrétariat. Le bouton de téléchargement disparaît au lieu d'échouer au clic *(élève, parent)*
+- Un lien « Consulter les notes publiées » figure sur chaque bulletin retenu : les notes restent accessibles, et la famille voit que ce n'est pas une panne *(élève, parent)*
 - Les écrans « Convocations de parent » et « Autorisations de reprise » ouvrent sur l'année scolaire en cours et se lisent par pages de vingt : ils affichaient jusqu'ici tout l'historique de l'établissement, qui n'est jamais purgé *(éducateur, secrétariat)*
 - Formulaire du billet d'annulation de zéro : les évaluations manquées ne se cherchent plus à chaque caractère tapé dans les dates, mais une fois la saisie posée *(éducateur, secrétariat)*
 - Le choix de l’élève se fait par recherche, dans les convocations, les autorisations de reprise et les versements : on tape deux lettres, nom ou matricule, au lieu de faire défiler une liste tronquée aux cent premiers *(admin, secrétariat, caissier)*.

--- a/components/parent/ParentChildBulletinsClient.tsx
+++ b/components/parent/ParentChildBulletinsClient.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useCallback } from "react"
+import type { Route } from "next"
 import { ArrowLeft, FileText, Award, Download, Loader2 } from "lucide-react"
 import Link from "next/link"
 import { toast } from "sonner"
@@ -10,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { DataError } from "@/components/shared/DataError"
 import { PdfPreviewButton } from "@/components/shared/PdfPreviewButton"
+import { BulletinWithheldNotice } from "@/components/shared/documents/BulletinWithheldNotice"
 import { useParentChildBulletins } from "@/lib/hooks/useParentPortal"
 import { parentPortalApi } from "@/lib/api/parent-portal"
 import { downloadBlob } from "@/lib/utils"
@@ -74,9 +76,13 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
               <CardHeader className="pb-2">
                 <div className="flex items-center justify-between">
                   <CardTitle className="text-base">Trimestre {bulletin.trimester}</CardTitle>
-                  <Badge variant={bulletin.is_published ? "default" : "secondary"}>
-                    {bulletin.is_published ? "Publié" : "Brouillon"}
-                  </Badge>
+                  {bulletin.is_withheld ? (
+                    <Badge variant="secondary">Retenu</Badge>
+                  ) : (
+                    <Badge variant={bulletin.is_published ? "default" : "secondary"}>
+                      {bulletin.is_published ? "Publié" : "Brouillon"}
+                    </Badge>
+                  )}
                 </div>
                 <p className="text-xs text-muted-foreground">
                   {bulletin.class_name} — {bulletin.academic_year_name}
@@ -103,7 +109,16 @@ export function ParentChildBulletinsClient({ childId }: ParentChildBulletinsClie
                     <span className="text-sm font-medium">{bulletin.mention}</span>
                   </div>
                 )}
-                {bulletin.is_published && (
+                {bulletin.is_withheld && (
+                  <BulletinWithheldNotice
+                    reason={bulletin.withheld_reason ?? null}
+                    gradesHref={`/parent/children/${childId}/grades` as Route}
+                  />
+                )}
+                {/* Aucun bouton quand le bulletin est retenu : un
+                    téléchargement qui échoue en 402 vaut moins qu'un bouton
+                    absent et expliqué. */}
+                {bulletin.is_published && !bulletin.is_withheld && (
                   <div className="flex flex-col gap-2 sm:flex-row">
                     <PdfPreviewButton
                       fetchBlob={() => parentPortalApi.downloadChildBulletinPdf(childId, bulletin.id)}

--- a/components/shared/documents/BulletinWithheldNotice.tsx
+++ b/components/shared/documents/BulletinWithheldNotice.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import Link from "next/link"
+import { Lock } from "lucide-react"
+import type { Route } from "next"
+
+interface BulletinWithheldNoticeProps {
+  /** Phrase composée par le serveur : trimestre, montant en retard, marche à suivre. */
+  reason: string | null
+  /** Vers le relevé des notes, qui reste consultable. */
+  gradesHref: Route
+}
+
+/**
+ * Ce que voit une famille dont le bulletin est retenu pour impayé.
+ *
+ * Deux choses à dire, et une seule est évidente. La première est le motif :
+ * sans lui, un bulletin grisé se lit comme une panne. La seconde est que les
+ * notes, elles, restent accessibles — c'est le lien ci-dessous. Une famille
+ * qui voit son bulletin barré et rien d'autre suppose que tout est bloqué, et
+ * appelle le secrétariat.
+ *
+ * Le ton reste factuel. La famille en retard n'a pas besoin d'un message
+ * accusateur en plus.
+ */
+export function BulletinWithheldNotice({ reason, gradesHref }: BulletinWithheldNoticeProps) {
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/50 dark:bg-amber-950/30"
+    >
+      <div className="flex items-start gap-2.5">
+        <Lock
+          aria-hidden="true"
+          className="mt-0.5 h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300"
+        />
+        <div className="min-w-0 space-y-2">
+          <p className="text-xs leading-relaxed text-amber-900 dark:text-amber-100">
+            {reason ?? "Bulletin indisponible : des échéances restent à régler. Rapprochez-vous du secrétariat."}
+          </p>
+          <Link
+            href={gradesHref}
+            className="inline-flex h-11 items-center text-xs font-semibold text-amber-900 underline underline-offset-4 hover:text-amber-950 dark:text-amber-100 dark:hover:text-amber-50"
+          >
+            Consulter les notes publiées
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/student/StudentBulletinsClient.tsx
+++ b/components/student/StudentBulletinsClient.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useCallback } from "react"
+import type { Route } from "next"
 import { Download, FileText, Loader2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -9,6 +10,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { toast } from "sonner"
 import { downloadBlob } from "@/lib/utils"
 import { PdfPreviewButton } from "@/components/shared/PdfPreviewButton"
+import { BulletinWithheldNotice } from "@/components/shared/documents/BulletinWithheldNotice"
 import { useStudentBulletins } from "@/lib/hooks/useStudentPortal"
 import { studentPortalApi } from "@/lib/api/student-portal"
 import { DataError } from "@/components/shared/DataError"
@@ -67,63 +69,95 @@ function BulletinCard({ bulletin }: { bulletin: StudentBulletin }) {
   }, [bulletin.id, bulletin.trimester, bulletin.academic_year])
 
   const isPublished = bulletin.status === "publie"
+  const isWithheld = bulletin.is_withheld
 
   return (
     <Card className="border-0 shadow-sm ring-1 ring-border">
-      <CardContent className="flex items-center justify-between gap-3 p-4">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-            <FileText aria-hidden="true" className="h-5 w-5 text-primary" />
-          </div>
-          <div className="min-w-0">
-            <p className="truncate text-sm font-semibold">{bulletin.trimester}</p>
-            <p className="text-xs text-muted-foreground">{bulletin.academic_year}</p>
-            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5">
-              {bulletin.general_average !== null && (
-                <span className={`text-xs font-medium tabular-nums ${bulletin.general_average >= 10 ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}`}>
-                  Moy. {bulletin.general_average.toFixed(2)}/20
-                </span>
-              )}
-              {bulletin.rank !== null && (
-                <span className="text-xs text-muted-foreground tabular-nums">
-                  Rang {bulletin.rank}
-                  {bulletin.total_students !== null && `/${bulletin.total_students}`}
-                </span>
-              )}
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <div
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${isWithheld ? "bg-muted" : "bg-primary/10"}`}
+            >
+              <FileText
+                aria-hidden="true"
+                className={`h-5 w-5 ${isWithheld ? "text-muted-foreground" : "text-primary"}`}
+              />
             </div>
+            <div className="min-w-0">
+              <p
+                className={`truncate text-sm font-semibold ${isWithheld ? "text-muted-foreground" : ""}`}
+              >
+                {bulletin.trimester}
+              </p>
+              <p className="text-xs text-muted-foreground">{bulletin.academic_year}</p>
+              <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                {isWithheld ? (
+                  // Un tiret, pas un zéro : la moyenne n'est pas connue, elle
+                  // n'est pas nulle.
+                  <span className="text-xs text-muted-foreground tabular-nums">Moy. —</span>
+                ) : (
+                  <>
+                    {bulletin.general_average !== null && (
+                      <span className={`text-xs font-medium tabular-nums ${bulletin.general_average >= 10 ? "text-emerald-600 dark:text-emerald-400" : "text-destructive"}`}>
+                        Moy. {bulletin.general_average.toFixed(2)}/20
+                      </span>
+                    )}
+                    {bulletin.rank !== null && (
+                      <span className="text-xs text-muted-foreground tabular-nums">
+                        Rang {bulletin.rank}
+                        {bulletin.total_students !== null && `/${bulletin.total_students}`}
+                      </span>
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            {!isPublished && (
+              <Badge variant="secondary" className="text-[10px]">Brouillon</Badge>
+            )}
+            {isWithheld && (
+              <Badge variant="secondary" className="text-[10px]">Retenu</Badge>
+            )}
+            {/* Aucun bouton quand le bulletin est retenu : un téléchargement
+                qui échoue en 402 vaut moins qu'un bouton absent et expliqué. */}
+            {isPublished && !isWithheld && (
+              <>
+                <PdfPreviewButton
+                  fetchBlob={() => studentPortalApi.downloadBulletin(bulletin.id)}
+                  label={`le bulletin ${bulletin.trimester}`}
+                  size="sm"
+                  className="h-11 sm:h-9"
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleDownload}
+                  disabled={isDownloading}
+                  aria-label={`Télécharger le bulletin ${bulletin.trimester} en PDF`}
+                  className="h-11 sm:h-9"
+                >
+                  {isDownloading ? (
+                    <Loader2 aria-hidden="true" className="mr-1 h-4 w-4 animate-spin sm:h-3 sm:w-3" />
+                  ) : (
+                    <Download aria-hidden="true" className="mr-1 h-4 w-4 sm:h-3 sm:w-3" />
+                  )}
+                  PDF
+                </Button>
+              </>
+            )}
           </div>
         </div>
 
-        <div className="flex shrink-0 items-center gap-2">
-          {!isPublished && (
-            <Badge variant="secondary" className="text-[10px]">Brouillon</Badge>
-          )}
-          {isPublished && (
-            <>
-              <PdfPreviewButton
-                fetchBlob={() => studentPortalApi.downloadBulletin(bulletin.id)}
-                label={`le bulletin ${bulletin.trimester}`}
-                size="sm"
-                className="h-11 sm:h-9"
-              />
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleDownload}
-                disabled={isDownloading}
-                aria-label={`Télécharger le bulletin ${bulletin.trimester} en PDF`}
-                className="h-11 sm:h-9"
-              >
-                {isDownloading ? (
-                  <Loader2 aria-hidden="true" className="mr-1 h-4 w-4 animate-spin sm:h-3 sm:w-3" />
-                ) : (
-                  <Download aria-hidden="true" className="mr-1 h-4 w-4 sm:h-3 sm:w-3" />
-                )}
-                PDF
-              </Button>
-            </>
-          )}
-        </div>
+        {isWithheld && (
+          <BulletinWithheldNotice
+            reason={bulletin.withheld_reason}
+            gradesHref={"/student/grades" as Route}
+          />
+        )}
       </CardContent>
     </Card>
   )

--- a/lib/api/bulletin-withheld.test.ts
+++ b/lib/api/bulletin-withheld.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Le client HTTP lit la session NextAuth pour poser l'entête d'autorisation.
+// Ici on teste la lecture du contrat, pas l'auth.
+vi.mock("next-auth/react", () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+  signOut: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { parentPortalApi } from "./parent-portal"
+import { studentPortalApi } from "./student-portal"
+
+const REASON =
+  "Bulletin du 1er trimestre indisponible : 45 000 FCFA en retard sur l'échéancier. " +
+  "Rapprochez-vous du secrétariat."
+
+/** `GET /student/bulletins` pour une famille à jour de son échéancier. */
+const STUDENT_RELEASED = {
+  items: [
+    {
+      id: 5,
+      trimester: 1,
+      average: "14.30",
+      rank: 4,
+      mention: "B",
+      class_name: "6ème A",
+      academic_year_name: "2025-2026",
+      file_url: "/media/bulletins/5.pdf",
+      generated_at: "2026-08-09T16:32:59",
+      is_withheld: false,
+      withheld_reason: null,
+      withheld_amount: null,
+    },
+  ],
+  total: 1,
+}
+
+/** La même liste, famille en retard : le bulletin est annoncé, pas divulgué. */
+const STUDENT_WITHHELD = {
+  items: [
+    {
+      id: 5,
+      trimester: 1,
+      average: null,
+      rank: null,
+      mention: null,
+      class_name: "6ème A",
+      academic_year_name: "2025-2026",
+      file_url: null,
+      generated_at: "2026-08-09T16:32:59",
+      is_withheld: true,
+      withheld_reason: REASON,
+      withheld_amount: 45000,
+    },
+  ],
+  total: 1,
+}
+
+const PARENT_WITHHELD = {
+  student_id: 2,
+  bulletins: [
+    {
+      id: 5,
+      trimester: 1,
+      average: null,
+      rank: null,
+      mention: null,
+      class_name: "6ème A",
+      academic_year_name: "2025-2026",
+      is_published: true,
+      generated_at: "2026-08-09T16:32:59",
+      is_withheld: true,
+      withheld_reason: REASON,
+      withheld_amount: 45000,
+    },
+  ],
+}
+
+function respondWithJson(payload: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+  vi.spyOn(console, "error").mockImplementation(() => undefined)
+})
+
+describe("le portail élève lit la retenue pour impayé", () => {
+  it("une famille à jour voit le contenu du bulletin", async () => {
+    respondWithJson(STUDENT_RELEASED)
+
+    const [bulletin] = await studentPortalApi.getBulletins()
+
+    expect(bulletin.is_withheld).toBe(false)
+    expect(bulletin.general_average).toBe(14.3)
+    expect(bulletin.rank).toBe(4)
+    expect(bulletin.withheld_reason).toBeNull()
+  })
+
+  it("une famille en retard voit le bulletin annoncé, vidé de son contenu", async () => {
+    respondWithJson(STUDENT_WITHHELD)
+
+    const bulletins = await studentPortalApi.getBulletins()
+
+    expect(bulletins).toHaveLength(1)
+    const [bulletin] = bulletins
+    // Ce qui identifie le bulletin reste lisible : la liste ne se vide pas.
+    expect(bulletin.trimester).toBe("Trimestre 1")
+    expect(bulletin.academic_year).toBe("2025-2026")
+    // Ce qu'il dit de l'élève est absent, et vaut null, jamais zéro.
+    expect(bulletin.general_average).toBeNull()
+    expect(bulletin.rank).toBeNull()
+  })
+
+  it("la retenue porte le motif et le montant dû", async () => {
+    respondWithJson(STUDENT_WITHHELD)
+
+    const [bulletin] = await studentPortalApi.getBulletins()
+
+    expect(bulletin.is_withheld).toBe(true)
+    expect(bulletin.withheld_amount).toBe(45000)
+    expect(bulletin.withheld_reason).toBe(REASON)
+  })
+
+  it("un serveur qui ne pose pas encore les champs ne casse pas la liste", async () => {
+    // Le front peut être déployé avant le serveur : l'absence des trois
+    // champs se lit « rien n'est retenu », pas « la page est en erreur ».
+    respondWithJson({
+      items: [
+        {
+          id: 5,
+          trimester: 1,
+          average: "12.00",
+          rank: 2,
+          mention: "AB",
+          class_name: "6ème A",
+          academic_year_name: "2025-2026",
+          file_url: null,
+          generated_at: null,
+        },
+      ],
+      total: 1,
+    })
+
+    const [bulletin] = await studentPortalApi.getBulletins()
+
+    expect(bulletin.is_withheld).toBe(false)
+    expect(bulletin.withheld_reason).toBeNull()
+    expect(bulletin.general_average).toBe(12)
+  })
+})
+
+describe("le portail parent lit la même retenue", () => {
+  it("le parent d'une famille en retard voit le bulletin annoncé, vidé", async () => {
+    respondWithJson(PARENT_WITHHELD)
+
+    const response = await parentPortalApi.getChildBulletins(2)
+
+    expect(response.bulletins).toHaveLength(1)
+    const [bulletin] = response.bulletins
+    expect(bulletin.trimester).toBe(1)
+    expect(bulletin.class_name).toBe("6ème A")
+    expect(bulletin.average).toBeNull()
+    expect(bulletin.rank).toBeNull()
+    expect(bulletin.mention).toBeNull()
+    expect(bulletin.is_withheld).toBe(true)
+    expect(bulletin.withheld_amount).toBe(45000)
+    expect(bulletin.withheld_reason).toBe(REASON)
+  })
+})

--- a/lib/api/student-portal.ts
+++ b/lib/api/student-portal.ts
@@ -31,6 +31,12 @@ const StudentBulletinRawSchema = z.object({
   academic_year_name: z.string(),
   file_url: z.string().nullable(),
   generated_at: z.string().nullable(),
+  // Retenue pour impayé. Facultatifs plutôt que requis : le front peut être
+  // déployé avant le serveur qui les pose, et une liste de bulletins ne doit
+  // pas tomber entière parce que trois champs manquent.
+  is_withheld: z.boolean().optional(),
+  withheld_reason: z.string().nullable().optional(),
+  withheld_amount: z.coerce.number().nullable().optional(),
 })
 const StudentBulletinsRawSchema = z.object({
   items: z.array(StudentBulletinRawSchema),
@@ -167,6 +173,9 @@ export const studentPortalApi = {
       // L'endpoint ne rend que les bulletins publiés.
       status: "publie" as const,
       published_at: b.generated_at,
+      is_withheld: b.is_withheld ?? false,
+      withheld_reason: b.withheld_reason ?? null,
+      withheld_amount: b.withheld_amount ?? null,
     }))
   },
 

--- a/lib/contracts/parent-portal.ts
+++ b/lib/contracts/parent-portal.ts
@@ -85,6 +85,12 @@ export const ParentChildBulletinSchema = z.object({
   academic_year_name: z.string(),
   is_published: z.boolean(),
   generated_at: z.string().nullable(),
+  // Retenue pour impayé : le bulletin existe et reste annoncé, mais moyenne,
+  // rang et mention reviennent vides. Facultatifs plutôt que requis, le front
+  // pouvant être déployé avant le serveur qui les pose.
+  is_withheld: z.boolean().optional(),
+  withheld_reason: z.string().nullable().optional(),
+  withheld_amount: z.coerce.number().nullable().optional(),
 })
 
 export const ParentChildBulletinsResponseSchema = z.object({

--- a/lib/contracts/student-portal.ts
+++ b/lib/contracts/student-portal.ts
@@ -82,6 +82,9 @@ export const StudentFeesResponseSchema = z.object({
 // Bulletins publiés
 // `total_students` reste facultatif : la liste du portail élève ne porte pas
 // l'effectif de la classe, et l'affichage se contente alors du rang seul.
+// `is_withheld` marque un bulletin retenu pour impayé : il existe, il est
+// publié, mais son contenu revient vide du serveur. `withheld_reason` porte
+// la phrase à afficher, montant compris.
 export const StudentBulletinSchema = z.object({
   id: z.number(),
   trimester: z.string(),
@@ -91,6 +94,9 @@ export const StudentBulletinSchema = z.object({
   total_students: z.number().nullable(),
   status: z.enum(["brouillon", "publie"]),
   published_at: z.string().nullish(),
+  is_withheld: z.boolean(),
+  withheld_reason: z.string().nullable(),
+  withheld_amount: z.coerce.number().nullable(),
 })
 
 export type StudentNextCourse = z.infer<typeof StudentNextCourseSchema>


### PR DESCRIPTION
## Contexte

Dépend de **African-DC/klassci-college-backend#277**, à merger d'abord.

Le serveur retient désormais le **contenu** d'un bulletin, et plus seulement son PDF, quand la famille est en retard sur son échéancier. Moyenne, rang et mention reviennent à `null`, et trois champs disent la retenue : `is_withheld`, `withheld_reason`, `withheld_amount`. Cette PR les lit et les affiche, dans les deux portails.

## Ce que voit une famille retenue

La carte du bulletin **reste affichée**, grisée, avec un badge « Retenu ». Une liste vide ferait croire qu'aucun bulletin n'a été édité, et enverrait la famille téléphoner au secrétariat.

- La moyenne montre **un tiret**, pas un zéro : un zéro se lirait « il a eu zéro de moyenne ».
- Un encart amber `role="alert"` porte la phrase composée par le serveur :

  > Bulletin du 1er trimestre indisponible : 45 000 FCFA en retard sur l'échéancier. Rapprochez-vous du secrétariat.

- **Le bouton de téléchargement disparaît**, aperçu compris, au lieu d'être présent et de casser en 402 au clic.
- Un lien **« Consulter les notes publiées »** figure sur chaque bulletin retenu, cible `h-11`. Les notes restent accessibles depuis le même écran : la famille voit que ce n'est pas une panne. Les deux portails ont leur relevé de notes sur une route distincte, d'où le lien plutôt qu'un bloc inline.

Nouveau composant partagé `components/shared/documents/BulletinWithheldNotice.tsx`, réutilisé par les deux portails.

## Contrats

Les trois champs sont lus en **facultatif** (`.optional()`, jamais `.default()`), et coalescés à la lecture. Le front peut être déployé avant le serveur qui les pose, et une liste de bulletins ne doit pas tomber entière parce que trois champs manquent. Tout passe par `apiFetch<unknown>` + `safeValidate`, sans cast.

## Tests

`lib/api/bulletin-withheld.test.ts`, 5 tests sur les vrais clients API, avec des charges utiles qui reproduisent la réponse serveur, `Decimal` sérialisé en chaîne compris :

- famille à jour : contenu lisible ;
- famille en retard, portail élève : bulletin annoncé, contenu à `null` ;
- le motif et le montant sont transportés jusqu'à l'UI ;
- une réponse sans les trois champs se lit « rien n'est retenu », pas « erreur » ;
- famille en retard, portail parent : même retenue.

`vitest run` : **106 passed** (14 fichiers). `tsc --noEmit --incremental false` : 0 erreur. `next lint` : 0 erreur (les avertissements restants préexistent et ne concernent pas ces fichiers).

Aucun build lancé, conformément à la contrainte disque.

## Repéré au passage, non traité

La route des bulletins du portail parent n'a **aucun point d'entrée** dans l'interface : ni la navigation parent ni la carte enfant n'y mènent. Hors périmètre de cette PR, mais à ouvrir en ticket.
