### PR TITLE
fix(parent): link the child card to the bulletins page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Le parent n'avait aucun moyen d'atteindre les bulletins de son enfant : la page existait, aucun lien n'y menait. Un bouton « Bulletins » figure désormais sur la carte de chaque enfant *(parent)*
 - Le bouton « PDF » du bulletin fonctionne enfin dans les portails élève et parent : il appelait la page réservée à l'administration et répondait « accès refusé » à une famille qui voyait pourtant le bulletin à l'écran *(élève, parent)*
 - La liste « Mes bulletins » de l'élève ne s'affichait pas du tout : l'écran attendait une réponse d'une autre forme que celle envoyée par le serveur *(élève)*
 - Le formulaire de nouvelle inscription plantait en arrivant à l'étape de la classe, sur un message technique, et il fallait tout recommencer *(secrétariat, admin)*

--- a/components/parent/ParentChildrenClient.tsx
+++ b/components/parent/ParentChildrenClient.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import type { Route } from "next"
-import { Users, GraduationCap, Wallet, AlertCircle, FileText, Calendar, Clock, UserCheck } from "lucide-react"
+import { Users, GraduationCap, Wallet, AlertCircle, FileText, FileBadge, Calendar, Clock, UserCheck } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -172,14 +172,21 @@ function ChildDetailCard({ child }: { child: ParentChild }) {
           </div>
         </div>
 
-        {/* Actions : 4 liens — Notes / Frais / EDT / Documents. Disabled si
-            pas inscrit (sauf Documents qui ont leur propre fallback côté
-            ParentChildDocumentsClient). */}
-        <div className="grid grid-cols-4 gap-2">
+        {/* Actions : 5 liens — Notes / Bulletins / Frais / EDT / Documents.
+            Disabled si pas inscrit (sauf Documents qui ont leur propre fallback
+            côté ParentChildDocumentsClient). Cinq colonnes tiennent sur 320 px
+            avec des libellés courts ; au-delà il faudrait passer en deux rangs. */}
+        <div className="grid grid-cols-5 gap-1.5">
           <ChildActionLink
             href={`/parent/children/${child.id}/grades` as Route}
             icon={GraduationCap}
             label="Notes"
+            disabled={!isEnrolled}
+          />
+          <ChildActionLink
+            href={`/parent/children/${child.id}/bulletins` as Route}
+            icon={FileBadge}
+            label="Bulletins"
             disabled={!isEnrolled}
           />
           <ChildActionLink


### PR DESCRIPTION
La page `/parent/children/{id}/bulletins` existait, avec son client, son état de chargement et son état d'erreur. Rien n'y menait : ni la navigation du portail, ni la carte de l'enfant, qui n'offrait que Notes, Frais, EDT et Documents.

Un parent ne pouvait donc pas atteindre les bulletins de son enfant, alors même que le téléchargement vient d'être livré et que la retenue pour impayé y est appliquée.

Un cinquième bouton « Bulletins » sur la carte enfant, désactivé comme ses voisins quand l'enfant n'est pas inscrit. La grille passe de quatre à cinq colonnes avec un espacement resserré : les cinq libellés tiennent sur un écran de 320 px, ce que j'ai noté dans le code pour la prochaine personne qui voudra en ajouter un sixième.

## Vérification

- `tsc --noEmit --incremental false` : 0 erreur
- `eslint` sur le fichier touché : 0 erreur
