### PR TITLE
feat(payments): print the daily cash book from the daily point and show each till's methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Bouton « Bordereau du jour » sur le point journalier : le comptable édite la pièce comptable de la journée depuis l'écran où il la consulte, au lieu d'aller la chercher dans l'aperçu des paramètres *(comptable)*
+- Chaque caisse du point journalier montre sa ventilation par moyen de paiement, espèces, mobile money, virement et chèque : rapprocher un dépôt bancaire d'une caisse ne demande plus d'ouvrir le détail des versements *(comptable, directeur)*
 - Bandeau « Ma caisse » qui signale les journées clôturées d'office pendant la nuit et permet de les régulariser en saisissant ce qui avait été compté *(caissier)*
 - Une journée non comptée affiche « Écart inconnu » et non un écart nul : le comptable voit la différence entre une caisse qui tombe juste et une caisse que personne n'a ouverte *(caissier, comptable)*
 - Chaque tranche de paiement se saisit au choix en pourcentage ou en montant fixe, dans la même grille : « Inscription 37 000 FCFA à la rentrée », puis 35 / 35 / 30 % du reste *(admin, comptable)*

--- a/components/admin/cash/DailyCashPointClient.tsx
+++ b/components/admin/cash/DailyCashPointClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Banknote, ClipboardCheck, Lock, Scale, Wallet } from "lucide-react"
+import { Banknote, ClipboardCheck, FileText, Lock, Scale, Wallet } from "lucide-react"
 import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -10,7 +10,9 @@ import { Label } from "@/components/ui/label"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useDailyCashPoint } from "@/lib/hooks/useCashSessions"
 import { hasBeenCounted, isLocked } from "@/lib/contracts/cash-session"
-import { CashStatusBadge, VarianceBadge, formatFcfa } from "./cash-ui"
+import { cashSessionsApi } from "@/lib/api/cash-sessions"
+import { openPdfPreview } from "@/lib/pdf/preview"
+import { CashStatusBadge, MethodBreakdown, VarianceBadge, formatFcfa } from "./cash-ui"
 
 function todayIso(): string {
   const now = new Date()
@@ -27,7 +29,20 @@ function todayIso(): string {
  */
 export function DailyCashPointClient() {
   const [businessDate, setBusinessDate] = useState(todayIso())
+  const [printing, setPrinting] = useState(false)
   const { data, isLoading, isError, error, refetch } = useDailyCashPoint(businessDate)
+
+  // Le point journalier se termine par une pièce qu'on archive. Le bordereau
+  // consolidé existait déjà côté serveur, mais aucun écran ne l'offrait : il
+  // n'était atteignable que depuis l'aperçu des paramètres PDF.
+  async function handlePrint() {
+    setPrinting(true)
+    try {
+      await openPdfPreview(() => cashSessionsApi.dailyCashBook(businessDate))
+    } finally {
+      setPrinting(false)
+    }
+  }
 
   const kpis: HeroKpi[] = [
     { label: "Total encaissé", value: formatFcfa(data?.total_collected ?? 0), icon: Wallet },
@@ -54,6 +69,17 @@ export function DailyCashPointClient() {
         title="Point journalier"
         subtitle="Toutes les caisses de la journée, clôturées ou non"
         kpis={kpis}
+        actions={
+          <button
+            type="button"
+            onClick={handlePrint}
+            disabled={printing || isLoading}
+            className="inline-flex h-11 items-center gap-2 rounded-md bg-accent px-4 text-sm font-semibold text-accent-foreground ring-1 ring-white/40 transition-colors hover:bg-accent/90 disabled:opacity-60"
+          >
+            <FileText aria-hidden="true" className="h-4 w-4" />
+            {printing ? "Génération…" : "Bordereau du jour"}
+          </button>
+        }
       />
 
       <Card className="rounded-xl border shadow-sm">
@@ -132,6 +158,16 @@ export function DailyCashPointClient() {
                     </p>
                   </div>
                 </div>
+
+                {/* Ventilation par moyen : le comptable rapproche un dépôt
+                    bancaire d'une caisse précise, et « 20 000 F en espèces »
+                    ne suffit pas à savoir ce qui est arrivé par Wave ou par
+                    virement. La donnée était déjà chargée, jamais affichée. */}
+                {session.by_method.length > 0 && (
+                  <div className="mt-3 border-t pt-3">
+                    <MethodBreakdown methods={session.by_method} />
+                  </div>
+                )}
 
                 {!hasBeenCounted(session) && (
                   <p className="mt-3 flex items-center gap-2 border-t pt-3 text-xs text-muted-foreground">

--- a/lib/api/cash-sessions.ts
+++ b/lib/api/cash-sessions.ts
@@ -7,7 +7,7 @@ import {
   type CashSessionList,
   type CashSessionRegularize,
 } from "@/lib/contracts/cash-session"
-import { apiFetch, safeValidate } from "./client"
+import { apiFetch, apiFetchBlob, safeValidate } from "./client"
 
 const CashSessionArraySchema = z.array(CashSessionSchema)
 
@@ -58,4 +58,14 @@ export const cashSessionsApi = {
     const json = await apiFetch<unknown>(`/cash-sessions${dateQuery(businessDate)}`)
     return safeValidate(CashSessionListSchema, json, "GET /cash-sessions")
   },
+
+  /**
+   * Bordereau journalier en PDF — la pièce que le comptable archive.
+   *
+   * Le serveur décide de la portée à partir des droits de l'appelant :
+   * consolidé pour qui détient `payments:read:all`, sa seule caisse pour un
+   * caissier. Rien à passer d'ici, et donc rien à falsifier depuis le client.
+   */
+  dailyCashBook: (businessDate: string): Promise<Blob> =>
+    apiFetchBlob(`/payments/daily-cash-book?date=${encodeURIComponent(businessDate)}`),
 }

--- a/lib/api/daily-cash-book.test.ts
+++ b/lib/api/daily-cash-book.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Le client HTTP lit la session NextAuth pour poser l'entête d'autorisation.
+// Ici on teste l'adresse appelée et le contrat de réponse, pas l'auth.
+vi.mock("next-auth/react", () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+  signOut: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { cashSessionsApi } from "./cash-sessions"
+
+function respondWithPdf() {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response("%PDF-1.7", {
+      status: 200,
+      headers: { "Content-Type": "application/pdf" },
+    }),
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+function calledUrl(fetchMock: ReturnType<typeof vi.fn>): URL {
+  return new URL(String(fetchMock.mock.calls[0][0]), "http://api.test")
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+  vi.spyOn(console, "error").mockImplementation(() => undefined)
+})
+
+describe("bordereau journalier", () => {
+  it("demande la journée affichée à l'écran, pas la date du serveur", async () => {
+    const fetchMock = respondWithPdf()
+
+    const blob = await cashSessionsApi.dailyCashBook("2026-08-20")
+
+    const url = calledUrl(fetchMock)
+    expect(url.pathname).toBe("/payments/daily-cash-book")
+    expect(url.searchParams.get("date")).toBe("2026-08-20")
+    expect(blob.type).toBe("application/pdf")
+  })
+
+  it("ne porte aucun paramètre de portée : le serveur la déduit des droits", async () => {
+    const fetchMock = respondWithPdf()
+
+    await cashSessionsApi.dailyCashBook("2026-08-21")
+
+    const params = [...calledUrl(fetchMock).searchParams.keys()]
+    expect(params).toEqual(["date"])
+  })
+})


### PR DESCRIPTION
## Contexte

Vérification de bout en bout de la chaîne de la caisse sur le serveur de démonstration, avec les comptes des rôles métier. Testé au navigateur avec `accountant6@demo.klassci.ci` (Vamara Beugré, comptable) et `cashier3@demo.klassci.ci` (Ibrahim Tanoh, caissier).

Le point journalier du comptable rend bien la liste des caisses. Deux morceaux de son travail manquaient à l'écran.

## Ce que corrige cette PR

### La ventilation par moyen de paiement était chargée, jamais affichée

L'écran montrait, par caisse :

> Ibrahim Tanoh · Clôturée · Manquant 500 FCFA
> 3 versements · 25 000 FCFA en espèces
> TOTAL ENCAISSÉ 70 000 FCFA

Les 45 000 FCFA restants existent — mobile money et virement — mais rien ne dit comment ils sont arrivés. `session.by_method` était pourtant déjà dans la réponse, validé par le schéma Zod, et le composant `MethodBreakdown` existait déjà : il n'était utilisé que sur « Ma caisse ».

Chaque carte du point journalier porte maintenant sa ventilation. Rapprocher un dépôt bancaire d'une caisse ne demande plus d'ouvrir le détail des versements.

### Le bordereau du jour n'avait de bouton nulle part

`GET /payments/daily-cash-book` existe et renvoie le document consolidé pour qui détient `payments:read:all`. Le seul endroit du produit qui l'appelait était l'**aperçu des paramètres PDF** — un écran de configuration de la charte graphique, pas un écran de caisse. Le comptable n'avait aucun chemin depuis son point journalier vers la pièce qu'il archive.

Un bouton « Bordereau du jour » dans le hero, sur la journée affichée à l'écran, via le helper `openPdfPreview` déjà utilisé ailleurs.

La portée du document reste décidée par le serveur à partir des droits de l'appelant : le client ne passe que la date, il n'a aucun paramètre de portée à falsifier. Un test le verrouille.

## Ce que je n'ai pas corrigé ici

L'identité affichée dans la coquille admin vient du début de l'adresse e-mail, et le rôle affiché est la chaîne brute : connecté en caissier, l'écran dit **« Bonjour, Cashier3 »** et **« cashier3 / Staff »**, pendant que « Ma caisse » juste en dessous affiche correctement « Ibrahim Tanoh ». La cause est que `auth.ts` ne transporte pas `first_name` / `last_name`, alors que le backend les renvoie au login. Cela touche la forme de la session et les quatre endroits qui affichent une identité, sur tous les portails — c'est une PR à part, signalée au propriétaire.

## Validation

```
tsc --noEmit --incremental false → 0 erreur
eslint .                         → 0 erreur (2 warnings pré-existants dans lib/api/enrollments.ts)
vitest run                       → 16 fichiers, 116 tests passés
```

Aucun build frontend lancé (contrainte machine : disque saturé).

Vérifié au navigateur sur la démonstration avec le compte comptable, pas avec l'administrateur.
