### PR TITLE
fix(auth): carry the real name into the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- L'application saluait chacun par le début de son adresse e-mail : le caissier Ibrahim Tanoh lisait « Bonjour, Cashier3 » alors que l'écran juste en dessous affichait son vrai nom. Le prénom et le nom sont désormais repris de la connexion *(admin, personnel, enseignant, parent, élève)*
+- Le bandeau affichait le rôle technique, « Staff », au lieu d'un libellé français *(admin, personnel)*
 - Le parent n'avait aucun moyen d'atteindre les bulletins de son enfant : la page existait, aucun lien n'y menait. Un bouton « Bulletins » figure désormais sur la carte de chaque enfant *(parent)*
 - Le bouton « PDF » du bulletin fonctionne enfin dans les portails élève et parent : il appelait la page réservée à l'administration et répondait « accès refusé » à une famille qui voyait pourtant le bulletin à l'écran *(élève, parent)*
 - La liste « Mes bulletins » de l'élève ne s'affichait pas du tout : l'écran attendait une réponse d'une autre forme que celle envoyée par le serveur *(élève)*

--- a/auth.ts
+++ b/auth.ts
@@ -50,6 +50,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             id: String(data.user.id),
             email: data.user.email,
             role: data.user.role,
+            // Le backend les renvoie depuis toujours ; les jeter forçait les
+            // écrans à afficher le début de l'adresse e-mail.
+            firstName: data.user.first_name,
+            lastName: data.user.last_name,
             accessToken: data.access_token,
             refreshToken: data.refreshToken ?? undefined,
             mustChangePassword: data.user.must_change_password,
@@ -67,6 +71,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         token.id = user.id
         token.email = user.email!
         token.role = user.role
+        token.firstName = user.firstName
+        token.lastName = user.lastName
         token.accessToken = user.accessToken
         token.refreshToken = user.refreshToken
         token.mustChangePassword = user.mustChangePassword
@@ -140,6 +146,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       session.user.id = token.id
       session.user.email = token.email
       session.user.role = token.role
+      session.user.firstName = token.firstName
+      session.user.lastName = token.lastName
       session.user.mustChangePassword = token.mustChangePassword
       return session
     },

--- a/components/admin/dashboard/DashboardHero.tsx
+++ b/components/admin/dashboard/DashboardHero.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react"
 import { GraduationCap, Wallet, CalendarDays, AlertTriangle } from "lucide-react"
 import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
 import { useDashboardStats } from "@/lib/hooks/useDashboard"
+import { greetingName } from "@/lib/utils/session-identity"
 
 export function DashboardHero() {
   const { data: session } = useSession()
@@ -15,8 +16,11 @@ export function DashboardHero() {
     month: "long",
     year: "numeric",
   })
-  const rawName = session?.user?.email?.split("@")[0] ?? "Administrateur"
-  const firstName = rawName.split(/[._]/)[0].replace(/^\w/, (c) => c.toUpperCase())
+  // Le prénom réel quand la session le porte ; sinon le début de l'adresse
+  // e-mail, mis en forme, pour les sessions ouvertes avant qu'il n'y transite.
+  const firstName = greetingName(session?.user)
+    .split(/[._]/)[0]
+    .replace(/^\w/, (c) => c.toUpperCase())
   const dash = (v: number | undefined) => (isLoading ? "—" : (v ?? 0))
 
   const kpis: HeroKpi[] = [

--- a/components/admin/dashboard/StaffHero.tsx
+++ b/components/admin/dashboard/StaffHero.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react"
 import { ClipboardCheck, GraduationCap, UserPlus, Wallet } from "lucide-react"
 import { PageHero, type HeroKpi } from "@/components/shared/PageHero"
 import { useDashboardStats } from "@/lib/hooks/useDashboard"
+import { greetingName } from "@/lib/utils/session-identity"
 
 /** Hero du tableau de bord du personnel — KPIs orientés secrétariat. */
 export function StaffHero() {
@@ -16,8 +17,11 @@ export function StaffHero() {
     month: "long",
     year: "numeric",
   })
-  const rawName = session?.user?.email?.split("@")[0] ?? "Personnel"
-  const firstName = rawName.split(/[._]/)[0].replace(/^\w/, (c) => c.toUpperCase())
+  // Le prénom réel quand la session le porte ; sinon le début de l'adresse
+  // e-mail, mis en forme, pour les sessions ouvertes avant qu'il n'y transite.
+  const firstName = greetingName(session?.user)
+    .split(/[._]/)[0]
+    .replace(/^\w/, (c) => c.toUpperCase())
   const dash = (v: number | undefined) => (isLoading ? "—" : (v ?? 0))
 
   const kpis: HeroKpi[] = [

--- a/components/admin/dashboard/WelcomeHeader.tsx
+++ b/components/admin/dashboard/WelcomeHeader.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react"
 import { CalendarDays } from "lucide-react"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import { greetingName } from "@/lib/utils/session-identity"
 
 export function WelcomeHeader() {
   const { data: session, status } = useSession()
@@ -19,8 +20,11 @@ export function WelcomeHeader() {
     return <WelcomeHeaderSkeleton />
   }
 
-  const rawName = session?.user?.email?.split("@")[0] ?? "Administrateur"
-  const firstName = rawName.split(/[._]/)[0].replace(/^\w/, (c) => c.toUpperCase())
+  // Le prénom réel quand la session le porte ; sinon le début de l'adresse
+  // e-mail, mis en forme, pour les sessions ouvertes avant qu'il n'y transite.
+  const firstName = greetingName(session?.user)
+    .split(/[._]/)[0]
+    .replace(/^\w/, (c) => c.toUpperCase())
 
   return (
     <div className="space-y-4">

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -19,6 +19,7 @@ import {
 import { NotificationBell } from "@/components/shared/NotificationBell"
 import { AcademicYearBadge } from "@/components/shared/AcademicYearBadge"
 import { logout } from "@/lib/utils/logout"
+import { displayName, roleLabel } from "@/lib/utils/session-identity"
 
 interface NavbarProps {
   onMenuClick: () => void
@@ -27,10 +28,8 @@ interface NavbarProps {
 export function Navbar({ onMenuClick }: NavbarProps) {
   const { data: session } = useSession()
   const { theme, setTheme } = useTheme()
-  const initials = session?.user?.email
-    ?.split("@")[0]
-    .slice(0, 2)
-    .toUpperCase() ?? "AD"
+  const nom = displayName(session?.user)
+  const initials = nom.slice(0, 2).toUpperCase()
 
   const role = session?.user?.role
   const profilePortal =
@@ -82,8 +81,8 @@ export function Navbar({ onMenuClick }: NavbarProps) {
                 </AvatarFallback>
               </Avatar>
               <div className="hidden md:block text-left">
-                <p className="text-sm font-medium leading-none">{session?.user?.email?.split("@")[0] ?? "Admin"}</p>
-                <p className="text-xs text-muted-foreground capitalize">{session?.user?.role ?? "admin"}</p>
+                <p className="text-sm font-medium leading-none">{nom}</p>
+                <p className="text-xs text-muted-foreground">{roleLabel(session?.user?.role)}</p>
               </div>
               <ChevronDown className="hidden md:block h-4 w-4 text-muted-foreground" />
             </button>

--- a/lib/utils/session-identity.test.ts
+++ b/lib/utils/session-identity.test.ts
@@ -1,0 +1,64 @@
+/**
+ * La coquille d'administration accueillait le caissier Ibrahim Tanoh par
+ * « Bonjour, Cashier3 », et l'étiquetait « Staff », pendant que l'écran juste
+ * en dessous affichait son vrai nom. La session ne transportait pas les noms
+ * que le backend renvoie pourtant à la connexion.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { displayName, greetingName, roleLabel } from "./session-identity"
+
+describe("displayName", () => {
+  it("rend le nom complet quand la session le porte", () => {
+    expect(
+      displayName({ email: "cashier3@demo.klassci.ci", firstName: "Ibrahim", lastName: "Tanoh" }),
+    ).toBe("Ibrahim Tanoh")
+  })
+
+  it("retombe sur le début de l'adresse pour une session ouverte avant le correctif", () => {
+    // Ces sessions restent valables plusieurs jours : sans ce repli, l'écran
+    // afficherait « undefined » jusqu'à la prochaine connexion.
+    expect(displayName({ email: "cashier3@demo.klassci.ci" })).toBe("cashier3")
+  })
+
+  it("se contente du prénom quand le nom manque", () => {
+    expect(displayName({ email: "a@b.ci", firstName: "Ibrahim" })).toBe("Ibrahim")
+  })
+
+  it("ne rend jamais une chaîne vide", () => {
+    expect(displayName(undefined)).toBe("Utilisateur")
+    expect(displayName({ email: "" })).toBe("Utilisateur")
+  })
+})
+
+describe("greetingName", () => {
+  it("rend le prénom seul, pas le nom complet", () => {
+    expect(greetingName({ email: "a@b.ci", firstName: "Ibrahim", lastName: "Tanoh" })).toBe(
+      "Ibrahim",
+    )
+  })
+
+  it("retombe sur le début de l'adresse sans prénom", () => {
+    expect(greetingName({ email: "cashier3@demo.klassci.ci" })).toBe("cashier3")
+  })
+})
+
+describe("roleLabel", () => {
+  it("traduit le rôle de portail en français", () => {
+    expect(roleLabel("admin")).toBe("Administrateur")
+    expect(roleLabel("teacher")).toBe("Enseignant")
+    expect(roleLabel("parent")).toBe("Parent")
+  })
+
+  it("dit « Personnel » pour staff, sans inventer un métier", () => {
+    // `/auth/me` rend le rôle de portail : `staff` couvre indifféremment le
+    // caissier, l'éducateur, le comptable, le secrétariat et le directeur des
+    // études. Afficher « Caissier » serait une précision que la session n'a pas.
+    expect(roleLabel("staff")).toBe("Personnel")
+  })
+
+  it("ne rend rien plutôt qu'un mot faux quand le rôle manque", () => {
+    expect(roleLabel(undefined)).toBe("")
+  })
+})

--- a/lib/utils/session-identity.ts
+++ b/lib/utils/session-identity.ts
@@ -1,0 +1,57 @@
+import type { UserRole } from "@/types/next-auth"
+
+/** Ce que la session porte pour identifier la personne connectée. */
+interface SessionUser {
+  email?: string | null
+  firstName?: string | null
+  lastName?: string | null
+}
+
+/**
+ * Le nom à afficher pour la personne connectée.
+ *
+ * Le repli sur le début de l'adresse e-mail est délibéré : une session créée
+ * avant que les noms ne transitent n'en porte pas, et elle reste valable
+ * plusieurs jours. Sans ce repli, l'écran afficherait « undefined » jusqu'à
+ * la prochaine connexion.
+ */
+export function displayName(user: SessionUser | undefined | null): string {
+  const complet = [user?.firstName, user?.lastName].filter(Boolean).join(" ").trim()
+  if (complet) return complet
+  return emailLocalPart(user?.email) || "Utilisateur"
+}
+
+/** Le prénom seul, pour une salutation. */
+export function greetingName(user: SessionUser | undefined | null): string {
+  const prenom = user?.firstName?.trim()
+  if (prenom) return prenom
+  return emailLocalPart(user?.email) || "Utilisateur"
+}
+
+function emailLocalPart(email: string | null | undefined): string {
+  return (email ?? "").split("@")[0] ?? ""
+}
+
+/**
+ * Le rôle en français, tel qu'on peut honnêtement le nommer.
+ *
+ * `/auth/me` ne rend que le rôle de portail : `staff` couvre indifféremment
+ * le caissier, l'éducateur, le comptable, le secrétariat et le directeur des
+ * études. Afficher « Caissier » serait donc inventer une précision que la
+ * session ne porte pas — d'où « Personnel », qui est vrai pour tous.
+ */
+const LIBELLES: Record<UserRole, string> = {
+  admin: "Administrateur",
+  director: "Direction",
+  staff: "Personnel",
+  accountant: "Comptable",
+  teacher: "Enseignant",
+  student: "Élève",
+  parent: "Parent",
+  super_admin: "Super-administrateur",
+}
+
+export function roleLabel(role: UserRole | undefined | null): string {
+  if (!role) return ""
+  return LIBELLES[role] ?? "Personnel"
+}

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -17,6 +17,14 @@ declare module "next-auth" {
     email: string
     role: UserRole
     accessToken: string
+    /**
+     * Prénom et nom réels, renvoyés par `/auth/login`. Sans eux, les écrans
+     * retombaient sur le début de l'adresse e-mail : le caissier Ibrahim
+     * Tanoh était accueilli par « Bonjour, Cashier3 ». Facultatifs, car une
+     * session créée avant leur introduction n'en porte pas.
+     */
+    firstName?: string
+    lastName?: string
     /** Mot de passe temporaire à changer à la 1re connexion. */
     mustChangePassword?: boolean
     /**
@@ -33,6 +41,8 @@ declare module "next-auth" {
       id: string
       email: string
       role: UserRole
+      firstName?: string
+      lastName?: string
       mustChangePassword?: boolean
     }
     accessToken: string
@@ -46,6 +56,8 @@ declare module "next-auth/jwt" {
     email: string
     role: UserRole
     accessToken: string
+    firstName?: string
+    lastName?: string
     mustChangePassword?: boolean
     /** Refresh token BE — server-side only, jamais propagé à la session client. */
     refreshToken?: string


### PR DESCRIPTION
Le caissier Ibrahim Tanoh était accueilli par « **Bonjour, Cashier3** » et étiqueté « **Staff** », pendant que l'écran « Ma caisse » juste en dessous affichait correctement « Ibrahim Tanoh » — parce que lui lit l'API.

## La cause

`authorize()` ne renvoyait que `id`, `email`, `role` et les jetons. Il jetait `first_name` et `last_name`, que `POST /auth/login` envoie pourtant depuis toujours. Les quatre endroits qui affichent une identité retombaient donc sur le début de l'adresse e-mail.

Les noms traversent maintenant `authorize`, les rappels `jwt` et `session`, et les trois déclarations de type.

## Le repli sur l'adresse est conservé, délibérément

Une session ouverte avant ce changement ne porte pas les noms, et elle reste valable plusieurs jours. Sans repli, ces personnes liraient « undefined » jusqu'à leur prochaine connexion. Le comportement d'avant devient donc le filet, pas la règle.

Un helper partagé porte cette logique — `displayName`, `greetingName`, `roleLabel` — plutôt que quatre copies du même repli dans quatre composants.

## Le rôle affiché

`/auth/me` ne rend que le rôle de **portail** : `staff` couvre indifféremment le caissier, l'éducateur, le comptable, le secrétariat et le directeur des études. Le bandeau affiche donc « **Personnel** », qui est vrai pour tous, plutôt qu'un métier précis que la session ne porte pas. Écrire « Caissier » aurait été inventer une information absente.

## Vérification

- `pnpm exec tsc --noEmit --incremental false` : 0 erreur
- `pnpm exec eslint` sur les fichiers touchés : 0 erreur
- `pnpm exec vitest run` : 123 tests, dont 9 nouveaux sur le helper — nom complet, repli sur l'adresse, prénom seul, session absente, et le libellé « Personnel » qui n'invente pas de métier

Aucun build lancé, le disque de la machine est saturé.
