### PR TITLE
fix(grades): follow the paginated evaluations and bulletins envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Changed
 
+- L'écran des évaluations et celui des bulletins s'ouvrent en une fraction de seconde : ils réclamaient toute l'année scolaire au serveur pour n'afficher qu'une vingtaine de lignes, et mettaient plus de quatre secondes à répondre *(admin, directeur des études, enseignant)*
+- Le pied de la liste des bulletins annonce le nombre de la classe entière et les flèches de page fonctionnent enfin : elles affichaient « Page 1/1 » quel que soit l'effectif *(admin)*
+- Le bandeau « publiez-les » de la liste des bulletins compte les brouillons de toute la classe, plus seulement ceux de la page visible *(admin, directeur des études)*
 - Bulletin retenu pour impayé : la carte reste affichée mais grisée, la moyenne montre un tiret plutôt qu'un chiffre, et une phrase dit le trimestre concerné, le montant en retard et d'aller au secrétariat. Le bouton de téléchargement disparaît au lieu d'échouer au clic *(élève, parent)*
 - Un lien « Consulter les notes publiées » figure sur chaque bulletin retenu : les notes restent accessibles, et la famille voit que ce n'est pas une panne *(élève, parent)*
 - Les écrans « Convocations de parent » et « Autorisations de reprise » ouvrent sur l'année scolaire en cours et se lisent par pages de vingt : ils affichaient jusqu'ici tout l'historique de l'établissement, qui n'est jamais purgé *(éducateur, secrétariat)*

--- a/components/admin/grades/GradesSupervisor.tsx
+++ b/components/admin/grades/GradesSupervisor.tsx
@@ -63,7 +63,14 @@ export function GradesSupervisor() {
   const { has } = usePermissions()
   const canCreate = has("grades:write")
 
-  const { data: evaluations, isLoading, error } = useEvaluations(classId ?? 0)
+  const { data: page, isLoading, error } = useEvaluations(classId ?? 0)
+  // Une classe compte quelques dizaines d'évaluations par année : la page
+  // demandée les couvre. `total` vient de l'enveloppe et dit le compte de
+  // l'école ; s'il dépasse ce qui est chargé, l'écran le dit au lieu de
+  // laisser des compteurs faux passer pour la vérité.
+  const evaluations = page?.items
+  const schoolTotal = page?.total ?? 0
+  const isTruncated = schoolTotal > (evaluations?.length ?? 0)
 
   const noClass = classId === null
 
@@ -296,6 +303,17 @@ export function GradesSupervisor() {
               Choisissez d&apos;abord une classe pour filtrer les matières et afficher les
               évaluations.
             </p>
+          )}
+
+          {!noClass && isTruncated && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50/60 px-3 py-2 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600" />
+              <p>
+                Cette classe compte <strong>{schoolTotal}</strong> évaluations. Les{" "}
+                {evaluations?.length ?? 0} plus récentes sont affichées, et les compteurs
+                ci-dessus ne portent que sur celles-là.
+              </p>
+            </div>
           )}
 
           {!noClass && !canCreate && (

--- a/components/admin/reports/BulletinList.tsx
+++ b/components/admin/reports/BulletinList.tsx
@@ -60,6 +60,15 @@ interface BulletinListProps {
 
 export function BulletinList({ params, onPageChange }: BulletinListProps) {
   const { data, isLoading, isError } = useBulletins(params)
+  // Le bandeau « publiez-les » doit parler de la classe entière, pas de la
+  // page affichée : une seule ligne suffit, c'est le `total` de l'enveloppe
+  // qui répond.
+  const { data: draftsProbe } = useBulletins({
+    ...params,
+    is_published: false,
+    page: 1,
+    size: 1,
+  })
   const { mutate: publish, isPending: isPublishing } = usePublishBulletins()
   const [previewId, setPreviewId] = useState<number | null>(null)
   const [downloadingId, setDownloadingId] = useState<number | null>(null)
@@ -80,10 +89,11 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
   }, [])
 
   const bulletins = useMemo(() => data?.items ?? [], [data])
-  const hasDrafts = useMemo(
-    () => bulletins.some((b) => !b.is_published),
-    [bulletins],
-  )
+  const hasDrafts = (draftsProbe?.total ?? 0) > 0
+  // `total` vient de l'enveloppe : il compte les bulletins de la classe et
+  // du trimestre choisis, pas les lignes de la page affichée.
+  const schoolTotal = data?.total ?? 0
+  const isPaged = schoolTotal > bulletins.length
 
   const handleDownloadAll = useCallback(async () => {
     if (bulletins.length === 0) return
@@ -171,7 +181,9 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
           ) : (
             <>
               <DownloadCloud className="mr-2 h-3 w-3" />
-              Télécharger tout
+              {/* Le bouton ne télécharge que ce qui est chargé : le dire
+                  plutôt que promettre « tout » sur une liste paginée. */}
+              {isPaged ? "Télécharger cette page" : "Télécharger tout"}
             </>
           )}
         </Button>
@@ -287,7 +299,7 @@ export function BulletinList({ params, onPageChange }: BulletinListProps) {
       </div>
 
       <div className="flex items-center justify-between text-xs text-muted-foreground">
-        <span>{data?.total ?? 0} bulletin(s)</span>
+        <span>{schoolTotal} bulletin(s)</span>
         <div className="flex items-center gap-2">
           <Button
             size="icon"

--- a/components/admin/teachers/tabs/TeacherEvaluationsTab.tsx
+++ b/components/admin/teachers/tabs/TeacherEvaluationsTab.tsx
@@ -26,7 +26,12 @@ interface TeacherEvaluationsTabProps {
 }
 
 export function TeacherEvaluationsTab({ teacherId }: TeacherEvaluationsTabProps) {
-  const { data: evaluations, isLoading } = useTeacherEvaluations(teacherId)
+  const { data: page, isLoading } = useTeacherEvaluations(teacherId)
+  const evaluations = page?.items
+  // `total` vient de l'enveloppe : c'est le compte de l'enseignant, pas
+  // celui de la page rendue.
+  const schoolTotal = page?.total ?? 0
+  const isTruncated = schoolTotal > (evaluations?.length ?? 0)
 
   if (isLoading) {
     return (
@@ -112,6 +117,11 @@ export function TeacherEvaluationsTab({ teacherId }: TeacherEvaluationsTabProps)
             })}
           </TableBody>
         </Table>
+        <p className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
+          {isTruncated
+            ? `${evaluations.length} des ${schoolTotal} évaluations de cet enseignant, les plus récentes d'abord.`
+            : `${schoolTotal} évaluation${schoolTotal > 1 ? "s" : ""}.`}
+        </p>
       </CardContent>
     </Card>
   )

--- a/components/teacher/grades/DicteeMode.tsx
+++ b/components/teacher/grades/DicteeMode.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import type { Route } from "next"
 import { Loader2, X } from "lucide-react"
 import { toast } from "sonner"
-import { useGrades, useUpdateGrades, useEvaluations } from "@/lib/hooks/useGrades"
+import { useGrades, useUpdateGrades, useEvaluation } from "@/lib/hooks/useGrades"
 import { useSpeechRecognition } from "@/lib/hooks/useSpeechRecognition"
 import { parseSpokenGrade, detectCommand } from "@/lib/utils/voice-grade-parser"
 import { dicteeEntryFromServer } from "@/lib/utils/grade-reconciliation"
@@ -50,11 +50,7 @@ export function DicteeMode({ evaluationId, classId, returnHref }: DicteeModeProp
   const router = useRouter()
   const backHref = returnHref ?? `/teacher/grades/${classId}/${evaluationId}`
   const { data: grades, isLoading } = useGrades(evaluationId)
-  const { data: evals } = useEvaluations(classId)
-  const evaluation = useMemo(
-    () => evals?.find((e) => e.id === evaluationId),
-    [evals, evaluationId],
-  )
+  const { data: evaluation } = useEvaluation(evaluationId)
 
   const updateMutation = useUpdateGrades(evaluationId)
 

--- a/components/teacher/grades/GradeEntryGrid.tsx
+++ b/components/teacher/grades/GradeEntryGrid.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import { Save, Loader2, CheckCircle2 } from "lucide-react"
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
-import { useGrades, useUpdateGrades, useEvaluations } from "@/lib/hooks/useGrades"
+import { useGrades, useUpdateGrades, useEvaluation } from "@/lib/hooks/useGrades"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { parseGradeInput, computeAverage } from "@/lib/utils/grade-parser"
@@ -55,11 +55,7 @@ export function GradeEntryGrid({
   retakesHref,
 }: GradeEntryGridProps) {
   const { data: grades, isLoading, error } = useGrades(evaluationId)
-  const { data: evals } = useEvaluations(classId ?? 0)
-  const evaluation = useMemo(
-    () => evals?.find((e) => e.id === evaluationId),
-    [evals, evaluationId],
-  )
+  const { data: evaluation } = useEvaluation(evaluationId)
 
   const updateMutation = useUpdateGrades(evaluationId)
   const [localGrades, setLocalGrades] = useState<Map<number, number | null>>(new Map())

--- a/lib/api/bulletins.ts
+++ b/lib/api/bulletins.ts
@@ -8,9 +8,16 @@ import {
 } from "@/lib/contracts/bulletin"
 
 const BulletinArraySchema = z.array(BulletinSchema)
+/**
+ * Enveloppe paginée. `total` porte le compte de l'école pour les filtres
+ * demandés : le pied de liste et le pagineur le lisent ici, jamais en
+ * comptant `items`, qui ne décrit que la page rendue.
+ */
 const BulletinListResponseSchema = z.object({
   items: BulletinArraySchema,
   total: z.number(),
+  page: z.number(),
+  size: z.number(),
 })
 
 export interface BulletinListResult {
@@ -19,6 +26,12 @@ export interface BulletinListResult {
   page: number
   size: number
 }
+
+/**
+ * Une classe compte au plus une quarantaine d'élèves : ce format tient un
+ * niveau entier sur une page, tout en restant sous le plafond du backend.
+ */
+export const BULLETINS_PAGE_SIZE = 50
 
 export interface BulletinGenerateResult {
   message: string
@@ -34,19 +47,14 @@ export interface BulletinPublishResult {
 export const bulletinsApi = {
   list: async (params: BulletinListParams = {}): Promise<BulletinListResult> => {
     const query = new URLSearchParams(
-      Object.entries(params)
+      Object.entries({ size: BULLETINS_PAGE_SIZE, ...params })
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => [k, String(v)]),
     ).toString()
     const json = await apiFetch<unknown>(
       `/reports/bulletins${query ? `?${query}` : ""}`,
     )
-    const validated = safeValidate(BulletinListResponseSchema, json, "GET /reports/bulletins")
-    return {
-      ...validated,
-      page: 1,
-      size: validated.items.length || 1,
-    }
+    return safeValidate(BulletinListResponseSchema, json, "GET /reports/bulletins")
   },
 
   getById: async (id: number): Promise<Bulletin> => {

--- a/lib/api/grades.ts
+++ b/lib/api/grades.ts
@@ -2,58 +2,90 @@ import { z } from "zod"
 import { apiFetch, safeValidate } from "./client"
 import {
   EvaluationSchema,
+  EvaluationListResponseSchema,
   GradeSchema,
   type Evaluation,
+  type EvaluationListResponse,
   type Grade,
   type EvaluationCreate,
   type GradeBatchUpdate,
 } from "@/lib/contracts/grade"
 
-export type { Evaluation, Grade, EvaluationCreate, GradeBatchUpdate }
+export type { Evaluation, EvaluationListResponse, Grade, EvaluationCreate, GradeBatchUpdate }
 
-const EvaluationArraySchema = z.array(EvaluationSchema)
 const GradeArraySchema = z.array(GradeSchema)
 
+/**
+ * Plafond de page du backend. Une classe compte quelques dizaines
+ * d'évaluations par année : une seule page les couvre en pratique, et
+ * `total` dit toujours la vérité quand ce n'est pas le cas.
+ */
+export const EVALUATIONS_MAX_PAGE_SIZE = 100
+
+export interface EvaluationListQuery {
+  page?: number
+  size?: number
+}
+
+function buildQuery(params: Record<string, string | number | undefined>): string {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) search.set(key, String(value))
+  }
+  return search.toString()
+}
+
 export const gradesApi = {
-  listEvaluations: async (classId: number): Promise<Evaluation[]> => {
-    const json = await apiFetch<{ data?: Evaluation[] } | Evaluation[]>(
-      `/evaluations?class_id=${classId}`,
-    )
-    const arr = Array.isArray(json) ? json : json.data ?? []
-    return safeValidate(EvaluationArraySchema, arr, `/evaluations?class_id=${classId}`)
+  listEvaluations: async (
+    classId: number,
+    query: EvaluationListQuery = {},
+  ): Promise<EvaluationListResponse> => {
+    const qs = buildQuery({
+      class_id: classId,
+      page: query.page ?? 1,
+      size: query.size ?? EVALUATIONS_MAX_PAGE_SIZE,
+    })
+    const json = await apiFetch<unknown>(`/evaluations?${qs}`)
+    return safeValidate(EvaluationListResponseSchema, json, `/evaluations?${qs}`)
   },
 
-  listByTeacher: async (teacherId: number): Promise<Evaluation[]> => {
-    const json = await apiFetch<{ data?: Evaluation[] } | Evaluation[]>(
-      `/evaluations?teacher_id=${teacherId}`,
-    )
-    const arr = Array.isArray(json) ? json : json.data ?? []
-    return safeValidate(EvaluationArraySchema, arr, `/evaluations?teacher_id=${teacherId}`)
+  listByTeacher: async (
+    teacherId: number,
+    query: EvaluationListQuery = {},
+  ): Promise<EvaluationListResponse> => {
+    const qs = buildQuery({
+      teacher_id: teacherId,
+      page: query.page ?? 1,
+      size: query.size ?? EVALUATIONS_MAX_PAGE_SIZE,
+    })
+    const json = await apiFetch<unknown>(`/evaluations?${qs}`)
+    return safeValidate(EvaluationListResponseSchema, json, `/evaluations?${qs}`)
+  },
+
+  /** Une évaluation seule — la liste de la classe n'a pas à être chargée pour ça. */
+  getEvaluation: async (evaluationId: number): Promise<Evaluation> => {
+    const json = await apiFetch<unknown>(`/evaluations/${evaluationId}`)
+    return safeValidate(EvaluationSchema, json, `/evaluations/${evaluationId}`)
   },
 
   getGrades: async (evaluationId: number): Promise<Grade[]> => {
-    const json = await apiFetch<Grade[]>(
-      `/grades?evaluation_id=${evaluationId}`,
-    )
-    const arr = Array.isArray(json) ? json : []
-    return safeValidate(GradeArraySchema, arr, `/grades?evaluation_id=${evaluationId}`)
+    const json = await apiFetch<unknown>(`/grades?evaluation_id=${evaluationId}`)
+    return safeValidate(GradeArraySchema, json, `/grades?evaluation_id=${evaluationId}`)
   },
 
   createEvaluation: async (data: EvaluationCreate): Promise<Evaluation> => {
-    const json = await apiFetch<{ data?: Evaluation } | Evaluation>(
-      `/evaluations`,
-      { method: "POST", body: JSON.stringify(data) },
-    )
-    const evaluation = (json as { data?: Evaluation }).data ?? (json as Evaluation)
-    return safeValidate(EvaluationSchema, evaluation, "POST /evaluations")
+    const json = await apiFetch<unknown>(`/evaluations`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(EvaluationSchema, json, "POST /evaluations")
   },
 
   updateGrades: async (evaluationId: number, data: GradeBatchUpdate): Promise<Grade[]> => {
-    const json = await apiFetch<Grade[]>(
-      `/grades/${evaluationId}`,
-      { method: "PATCH", body: JSON.stringify(data) },
-    )
-    const arr = Array.isArray(json) ? json : []
-    return safeValidate(GradeArraySchema, arr, `PATCH /grades/${evaluationId}`)
+    const json = await apiFetch<unknown>(`/grades/${evaluationId}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    })
+    return safeValidate(GradeArraySchema, json, `PATCH /grades/${evaluationId}`)
   },
 }

--- a/lib/api/paginated-lists.test.ts
+++ b/lib/api/paginated-lists.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Le client HTTP lit la session NextAuth pour poser l'entête d'autorisation.
+// Ici on teste l'adresse appelée et le contrat de réponse, pas l'auth.
+vi.mock("next-auth/react", () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+  signOut: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { gradesApi } from "./grades"
+import { bulletinsApi } from "./bulletins"
+
+const EVALUATION = {
+  id: 1,
+  title: "Devoir de mathématiques",
+  type: "devoir",
+  date: "2026-05-18",
+  coefficient: 2,
+  subject_id: 20,
+  subject_name: "Mathématiques",
+  class_id: 10,
+  class_name: "6ème A",
+  teacher_id: 30,
+  teacher_name: "Aïssatou Diallo",
+  academic_year_id: 3,
+  trimester: 1,
+  total_students: 35,
+  graded_students: 12,
+  created_at: "2026-05-18T09:00:00",
+}
+
+const BULLETIN = {
+  id: 1,
+  student_id: 42,
+  student_name: "Traoré Aminata",
+  student_photo_url: null,
+  student_enrollment_number: "M-2026-004",
+  class_id: 10,
+  class_name: "6ème A",
+  academic_year_id: 3,
+  trimester: 1,
+  average: "12.50",
+  rank: 7,
+  total_students: 34,
+  mention: "AB",
+  file_url: null,
+  generated_at: null,
+  is_published: true,
+  teacher_comment: null,
+  council_decision: null,
+  subject_averages: [
+    { subject_id: 20, subject_name: "Mathématiques", average: "12.50", coefficient: 4 },
+  ],
+  created_at: "2026-05-18T09:00:00",
+  updated_at: "2026-05-18T09:00:00",
+}
+
+function respondWith(payload: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+function calledUrl(fetchMock: ReturnType<typeof vi.fn>): URL {
+  return new URL(String(fetchMock.mock.calls[0][0]), "http://api.test")
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+  vi.spyOn(console, "error").mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("gradesApi.listEvaluations", () => {
+  it("demande une page bornée au lieu de toute l'année", async () => {
+    const fetchMock = respondWith({ items: [EVALUATION], total: 772, page: 1, size: 100 })
+
+    await gradesApi.listEvaluations(10)
+
+    const url = calledUrl(fetchMock)
+    expect(url.pathname).toBe("/evaluations")
+    expect(url.searchParams.get("class_id")).toBe("10")
+    expect(url.searchParams.get("page")).toBe("1")
+    expect(Number(url.searchParams.get("size"))).toBeLessThanOrEqual(100)
+  })
+
+  it("rend le total de l'école et non celui de la page", async () => {
+    respondWith({ items: [EVALUATION], total: 772, page: 1, size: 100 })
+
+    const page = await gradesApi.listEvaluations(10)
+
+    // Le piège : compter `items` donnerait 1 et l'écran afficherait
+    // « 1 évaluation » pour une école qui en compte 772.
+    expect(page.total).toBe(772)
+    expect(page.items).toHaveLength(1)
+  })
+
+  it("conserve les deux compteurs de l'évaluation", async () => {
+    respondWith({ items: [EVALUATION], total: 1, page: 1, size: 100 })
+
+    const page = await gradesApi.listEvaluations(10)
+
+    expect(page.items[0].total_students).toBe(35)
+    expect(page.items[0].graded_students).toBe(12)
+  })
+
+  it("refuse une réponse sans enveloppe plutôt que de deviner", async () => {
+    respondWith([EVALUATION])
+
+    await expect(gradesApi.listEvaluations(10)).rejects.toThrow()
+  })
+})
+
+describe("gradesApi.getEvaluation", () => {
+  it("lit une évaluation seule, sans charger la liste de la classe", async () => {
+    const fetchMock = respondWith(EVALUATION)
+
+    const evaluation = await gradesApi.getEvaluation(1)
+
+    expect(calledUrl(fetchMock).pathname).toBe("/evaluations/1")
+    expect(evaluation.title).toBe("Devoir de mathématiques")
+    expect(evaluation.graded_students).toBe(12)
+  })
+})
+
+describe("bulletinsApi.list", () => {
+  it("demande une page bornée", async () => {
+    const fetchMock = respondWith({ items: [BULLETIN], total: 2148, page: 1, size: 50 })
+
+    await bulletinsApi.list({ class_id: 10, trimester: 1 })
+
+    const url = calledUrl(fetchMock)
+    expect(url.pathname).toBe("/reports/bulletins")
+    expect(url.searchParams.get("class_id")).toBe("10")
+    expect(Number(url.searchParams.get("size"))).toBeLessThanOrEqual(100)
+  })
+
+  it("rend la pagination du serveur et non une pagination inventée", async () => {
+    respondWith({ items: [BULLETIN], total: 2148, page: 3, size: 50 })
+
+    const result = await bulletinsApi.list({ page: 3 })
+
+    // Avant, le client posait `page: 1` et `size: items.length`, ce qui
+    // faisait toujours « Page 1/1 » quel que soit le nombre de bulletins.
+    expect(result.total).toBe(2148)
+    expect(result.page).toBe(3)
+    expect(result.size).toBe(50)
+    expect(Math.ceil(result.total / result.size)).toBe(43)
+  })
+
+  it("laisse l'appelant choisir sa taille de page", async () => {
+    const fetchMock = respondWith({ items: [], total: 0, page: 1, size: 1 })
+
+    await bulletinsApi.list({ class_id: 10, trimester: 1, is_published: false, size: 1 })
+
+    expect(calledUrl(fetchMock).searchParams.get("size")).toBe("1")
+  })
+})

--- a/lib/contracts/grade.ts
+++ b/lib/contracts/grade.ts
@@ -23,6 +23,18 @@ export const EvaluationSchema = z.object({
   created_at: z.string(),
 })
 
+/**
+ * Enveloppe paginee de `/evaluations`. `total` porte le compte de l'ecole
+ * pour les filtres demandes : un compteur d'ecran le lit ici, jamais en
+ * comptant `items`, qui ne decrit que la page rendue.
+ */
+export const EvaluationListResponseSchema = z.object({
+  items: z.array(EvaluationSchema),
+  total: z.number(),
+  page: z.number(),
+  size: z.number(),
+})
+
 export const GradeSchema = z.object({
   student_id: z.number(),
   student_name: z.string(),
@@ -65,6 +77,7 @@ export const GradeBatchUpdateSchema = z.object({
 
 export type EvaluationType = z.infer<typeof EvaluationTypeSchema>
 export type Evaluation = z.infer<typeof EvaluationSchema>
+export type EvaluationListResponse = z.infer<typeof EvaluationListResponseSchema>
 export type Grade = z.infer<typeof GradeSchema>
 export type EvaluationCreate = z.infer<typeof EvaluationCreateSchema>
 export type GradeBatchUpdate = z.infer<typeof GradeBatchUpdateSchema>

--- a/lib/hooks/useGrades.ts
+++ b/lib/hooks/useGrades.ts
@@ -2,9 +2,10 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { gradesApi } from "@/lib/api/grades"
+import { gradesApi, type EvaluationListQuery } from "@/lib/api/grades"
 import type {
   Evaluation,
+  EvaluationListResponse,
   Grade,
   EvaluationCreate,
   GradeBatchUpdate,
@@ -12,25 +13,44 @@ import type {
 
 export const gradeKeys = {
   all: ["grades"] as const,
-  evaluations: (classId: number) => ["grades", "evaluations", classId] as const,
-  teacherEvaluations: (teacherId: number) => ["grades", "teacher-evaluations", teacherId] as const,
+  /** Racine des listes d'une classe : sert aux invalidations, toutes pages confondues. */
+  evaluationsRoot: (classId: number) => ["grades", "evaluations", classId] as const,
+  evaluations: (classId: number, query: EvaluationListQuery = {}) =>
+    ["grades", "evaluations", classId, query] as const,
+  teacherEvaluations: (teacherId: number, query: EvaluationListQuery = {}) =>
+    ["grades", "teacher-evaluations", teacherId, query] as const,
+  evaluation: (evaluationId: number) => ["grades", "evaluation", evaluationId] as const,
   grades: (evaluationId: number) => ["grades", "entries", evaluationId] as const,
 }
 
-export function useEvaluations(classId: number) {
+export function useEvaluations(classId: number, query: EvaluationListQuery = {}) {
   return useQuery({
-    queryKey: gradeKeys.evaluations(classId),
-    queryFn: () => gradesApi.listEvaluations(classId),
+    queryKey: gradeKeys.evaluations(classId, query),
+    queryFn: () => gradesApi.listEvaluations(classId, query),
     enabled: !!classId,
     staleTime: 1000 * 60 * 5,
   })
 }
 
-export function useTeacherEvaluations(teacherId: number) {
+export function useTeacherEvaluations(teacherId: number, query: EvaluationListQuery = {}) {
   return useQuery({
-    queryKey: gradeKeys.teacherEvaluations(teacherId),
-    queryFn: () => gradesApi.listByTeacher(teacherId),
+    queryKey: gradeKeys.teacherEvaluations(teacherId, query),
+    queryFn: () => gradesApi.listByTeacher(teacherId, query),
     enabled: !!teacherId,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+/**
+ * L'évaluation en cours de saisie, lue seule. Les écrans de notes
+ * parcouraient la liste de la classe pour y retrouver cette ligne, ce
+ * qu'une liste paginée ne garantit plus.
+ */
+export function useEvaluation(evaluationId: number | undefined) {
+  return useQuery({
+    queryKey: gradeKeys.evaluation(evaluationId ?? 0),
+    queryFn: () => gradesApi.getEvaluation(evaluationId as number),
+    enabled: !!evaluationId,
     staleTime: 1000 * 60 * 5,
   })
 }
@@ -49,8 +69,9 @@ export function useCreateEvaluation() {
   return useMutation({
     mutationFn: (data: EvaluationCreate) => gradesApi.createEvaluation(data),
     onMutate: async (newEval) => {
-      await queryClient.cancelQueries({ queryKey: gradeKeys.evaluations(newEval.class_id) })
-      const prev = queryClient.getQueryData<Evaluation[]>(gradeKeys.evaluations(newEval.class_id))
+      const root = { queryKey: gradeKeys.evaluationsRoot(newEval.class_id) }
+      await queryClient.cancelQueries(root)
+      const snapshot = queryClient.getQueriesData<EvaluationListResponse>(root)
       const optimistic: Evaluation = {
         id: -Date.now(),
         title: newEval.title,
@@ -69,22 +90,25 @@ export function useCreateEvaluation() {
         graded_students: 0,
         created_at: new Date().toISOString(),
       }
-      if (prev) {
-        queryClient.setQueryData(gradeKeys.evaluations(newEval.class_id), [...prev, optimistic])
-      }
-      return { prev, classId: newEval.class_id }
+      // La liste est triée par date décroissante : la nouvelle évaluation
+      // se place en tête. `total` suit, sinon le compteur d'écran mentirait
+      // d'une unité jusqu'au prochain rafraîchissement.
+      queryClient.setQueriesData<EvaluationListResponse>(root, (prev) =>
+        prev ? { ...prev, items: [optimistic, ...prev.items], total: prev.total + 1 } : prev,
+      )
+      return { snapshot }
     },
-    onError: (_err, _vars, context) => {
-      if (context?.prev) {
-        queryClient.setQueryData(gradeKeys.evaluations(context.classId), context.prev)
+    onError: (err, _vars, context) => {
+      for (const [key, data] of context?.snapshot ?? []) {
+        queryClient.setQueryData(key, data)
       }
-      toast.error("Erreur", { description: _err.message })
+      toast.error("Erreur", { description: err.message })
     },
     onSuccess: (data) => {
       toast.success("Evaluation creee", { description: data.title })
     },
     onSettled: (_data, _err, vars) => {
-      queryClient.invalidateQueries({ queryKey: gradeKeys.evaluations(vars.class_id) })
+      queryClient.invalidateQueries({ queryKey: gradeKeys.evaluationsRoot(vars.class_id) })
     },
   })
 }
@@ -122,6 +146,9 @@ export function useUpdateGrades(evaluationId: number) {
     },
     onSuccess: (data) => {
       queryClient.setQueryData(gradeKeys.grades(evaluationId), data)
+      // Le « 12 / 35 » de l'évaluation change à chaque enregistrement et
+      // vient maintenant du serveur : la fiche doit être redemandée.
+      queryClient.invalidateQueries({ queryKey: gradeKeys.evaluation(evaluationId) })
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: gradeKeys.grades(evaluationId) })


### PR DESCRIPTION
Accompagne la PR backend `African-DC/klassci-college-backend#284`, qui pagine
`GET /evaluations` et `GET /reports/bulletins`. Les deux renvoient désormais
`{items, total, page, size}` ; sans cette PR, les écrans concernés cassent.

## Les appelants adaptés

| Fichier | Ce qui changeait |
|---|---|
| `lib/api/grades.ts` | `listEvaluations` / `listByTeacher` recevaient une liste nue |
| `lib/contracts/grade.ts` | schéma Zod de l'enveloppe |
| `lib/hooks/useGrades.ts` | clés de cache, insertion optimiste, nouveau `useEvaluation` |
| `components/admin/grades/GradesSupervisor.tsx` | KPIs et badges d'onglets calculés sur les éléments reçus |
| `components/admin/teachers/tabs/TeacherEvaluationsTab.tsx` | tableau des évaluations d'un enseignant |
| `components/teacher/grades/GradeEntryGrid.tsx` | cherchait son évaluation dans la liste de la classe |
| `components/teacher/grades/DicteeMode.tsx` | idem, mode dictée |
| `lib/api/bulletins.ts` | fabriquait `page: 1, size: items.length` |
| `components/admin/reports/BulletinList.tsx` | pied de liste, pagineur, bandeau de publication |

Les portails élève et parent passent par `/student/bulletins` et
`/children/{id}/bulletins`, et la liste d'évaluations du portail enseignant par
`/teacher/evaluations` : trois routes distinctes, non touchées par la PR
backend, donc laissées telles quelles. Vérifié dans le backend plutôt que
supposé d'après les noms de hooks, dont deux s'appellent `useTeacherEvaluations`
sans viser la même route.

## Le piège des compteurs

Deux écrans faisaient un `reduce` ou un `.some()` sur les éléments reçus.
Paginés, ils auraient annoncé le compte de la page visible pour celui de
l'école, sans rien signaler.

- **Supervision des évaluations** : les KPIs et les badges d'onglets restent
  calculés sur ce qui est chargé, mais l'écran compare maintenant ce nombre au
  `total` de l'enveloppe et affiche un bandeau explicite quand les deux
  divergent (« Cette classe compte 132 évaluations. Les 100 plus récentes sont
  affichées, et les compteurs ci-dessus ne portent que sur celles-là »). Une
  classe en compte quelques dizaines par année : le cas ne se produit pas sur
  des données réelles, mais il ne peut plus produire un chiffre faux en
  silence.
- **Liste des bulletins** : le pied de liste lit `total`. Le bandeau
  « publiez-les » interrogeait les lignes affichées ; il demande maintenant au
  serveur combien de brouillons porte la classe et le trimestre, par une sonde
  d'une seule ligne dont la réponse est le `total` de l'enveloppe.
- **« Télécharger tout »** ne télécharge que ce qui est chargé : le libellé
  devient « Télécharger cette page » dès que la liste en compte plusieurs.

## Un bug de pagination corrigé au passage

`bulletinsApi.list` jetait l'enveloppe du serveur et la reconstruisait en
`page: 1, size: items.length`. `Math.ceil(total / size)` valait donc toujours 1 :
les flèches précédent/suivant de `BulletinList` étaient désactivées en
permanence et le pied affichait « Page 1/1 » quel que soit l'effectif, alors
que `ReportsPageClient` envoyait bien un `page`. La pagination existait à
l'écran sans jamais fonctionner.

## Une évaluation ne se cherche plus dans une liste

`GradeEntryGrid` et `DicteeMode` chargeaient toutes les évaluations de la classe
puis faisaient `.find(e => e.id === evaluationId)`. Contre une liste paginée,
cela rend `undefined` sans erreur dès que la ligne se trouve sur une autre page :
l'écran de saisie perdrait son titre, sa matière et son trimestre. Les deux
lisent maintenant `GET /evaluations/{id}`, ajouté côté backend dans la même
livraison — ce qui supprime au passage un chargement de liste entière à chaque
ouverture d'une feuille de notes.

## Validation

Aucun build lancé, conformément à la contrainte disque.

- `pnpm install --frozen-lockfile` : OK
- `pnpm exec tsc --noEmit --incremental false` : 0 erreur
- `pnpm exec eslint app components lib types` : 0 erreur (38 avertissements préexistants)
- `pnpm exec vitest run` : 16 fichiers, 122 tests, tous verts

`lib/api/paginated-lists.test.ts` couvre le contrat : la requête reste sous le
plafond du serveur, le `total` est celui de l'école et non celui de la page, les
deux compteurs par évaluation traversent la validation, une liste nue est
rejetée au lieu d'être devinée, et le pagineur des bulletins rend la page du
serveur au lieu d'une page inventée.
