### PR TITLE
fix(build): stop capping the build heap for a server that is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Le portail se construisait avec une mémoire plafonnée pour un serveur qui n'existe plus, ce qui faisait échouer des mises en ligne au hasard *(devops)*
 - L'application saluait chacun par le début de son adresse e-mail : le caissier Ibrahim Tanoh lisait « Bonjour, Cashier3 » alors que l'écran juste en dessous affichait son vrai nom. Le prénom et le nom sont désormais repris de la connexion *(admin, personnel, enseignant, parent, élève)*
 - Le bandeau affichait le rôle technique, « Staff », au lieu d'un libellé français *(admin, personnel)*
 - Le parent n'avait aucun moyen d'atteindre les bulletins de son enfant : la page existait, aucun lien n'y menait. Un bouton « Bulletins » figure désormais sur la carte de chaque enfant *(parent)*

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "NODE_OPTIONS='--max-old-space-size=1536' next build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",


### PR DESCRIPTION
Le `Build Check` du portail échoue par intermittence sur un dépassement de tas, puis passe à la relance **sans le moindre changement de code**. Ce n'est pas de la malchance.

## Ce qui se passe

```json
"build": "NODE_OPTIONS='--max-old-space-size=1536' next build"
```

Le script **repose** `NODE_OPTIONS` juste avant `next build`, ce qui **écrase** la valeur que l'environnement vient d'exporter. Or les deux hôtes qui construisent demandent quatre fois plus :

| Où | Ce qui est demandé | Ce qui s'applique |
|---|---|---|
| `Dockerfile:10` (production Contabo) | `ENV NODE_OPTIONS=--max-old-space-size=4096` | **1536** |
| `deploy/server/frontend-build.ps1:4` (démo Windows) | `$env:NODE_OPTIONS = '--max-old-space-size=4096'` | **1536** |

Personne ne construit avec la mémoire qu'il croit avoir.

## D'où vient ce plafond

Il était dimensionné pour l'**EC2 de 2 Go**, où un build non bridé saturait la machine et coupait le login. Cette machine n'existe plus. La production tourne sur un Contabo de 24 Go et la démo sur un Windows de 12 Go, mais le plafond leur a survécu en silence.

## Le correctif

Retirer la valeur en ligne, et laisser l'hôte décider. C'est déjà ce que le Dockerfile et le script de la démo avaient l'intention de faire.

Rien à régler ailleurs : les deux hôtes posent déjà leur valeur, et la CI la pose pour les tests de bout en bout.
