### PR TITLE
fix(payments): show a dash where the cashier is not served the figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Le bandeau de la page des versements annonce à la caissière ce qu'elle a encaissé, et non plus les chiffres de toute l'école *(caissier)*
 - Le portail se construisait avec une mémoire plafonnée pour un serveur qui n'existe plus, ce qui faisait échouer des mises en ligne au hasard *(devops)*
 - L'application saluait chacun par le début de son adresse e-mail : le caissier Ibrahim Tanoh lisait « Bonjour, Cashier3 » alors que l'écran juste en dessous affichait son vrai nom. Le prénom et le nom sont désormais repris de la connexion *(admin, personnel, enseignant, parent, élève)*
 - Le bandeau affichait le rôle technique, « Staff », au lieu d'un libellé français *(admin, personnel)*

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -205,15 +205,22 @@ export function PaymentsPageClient() {
     setSearch("")
   }
 
+  // Le serveur ne sert pas le recouvrement a qui ne lit que sa propre caisse.
+  // Son absence est donc le signal, et il n'y en a pas d'autre a inventer.
+  const cloisonne = summary?.total_expected === null
+
   const heroKpis: HeroKpi[] | undefined = summary
     ? [
         {
           label: "Attendu",
-          value: `${summary.total_expected.toLocaleString("fr-FR")} F`,
+          // Une caissiere ne lit pas le recouvrement de l'etablissement : le
+          // tiret dit « pas de votre ressort », la ou un 0 F dirait « rien
+          // n'est du ».
+          value: cloisonne ? "—" : `${summary.total_expected!.toLocaleString("fr-FR")} F`,
           icon: Banknote,
         },
         {
-          label: "Collecté",
+          label: cloisonne ? "Encaissé par vous" : "Collecté",
           value: `${summary.total_paid.toLocaleString("fr-FR")} F`,
           icon: Wallet,
           hint: `${summary.payment_count} paiement(s)`,
@@ -225,7 +232,7 @@ export function PaymentsPageClient() {
         },
         {
           label: "Taux de recouvrement",
-          value: `${summary.completion_rate.toFixed(1)}%`,
+          value: cloisonne ? "—" : `${summary.completion_rate!.toFixed(1)}%`,
           icon: TrendingUp,
           hint:
             summary.total_cancelled > 0

--- a/lib/contracts/payment.ts
+++ b/lib/contracts/payment.ts
@@ -109,12 +109,15 @@ export const AllocationPreviewSchema = z.object({
 })
 
 export const FinancialSummarySchema = z.object({
-  total_expected: z.number(),
+  // Vides pour une caissiere : le recouvrement est un chiffre d'ecole, il ne
+  // se restreint pas a une personne. Vides et non a zero, parce qu'un zero se
+  // lirait « rien n'est du ».
+  total_expected: z.number().nullable(),
   total_paid: z.number(),
   total_pending: z.number(),
   total_cancelled: z.number(),
   payment_count: z.number(),
-  completion_rate: z.number(),
+  completion_rate: z.number().nullable(),
 })
 
 /** Un compte ayant déjà encaissé — options du filtre « Encaissé par ». */


### PR DESCRIPTION
Accompagne [klassci-college-backend#290](https://github.com/African-DC/klassci-college-backend/pull/290), qui cesse de servir le recouvrement de l'école à qui ne lit que sa propre caisse.

## Ce qui change à l'écran

| Case du bandeau | Comptable, directeur | Caissière |
|---|---|---|
| Attendu | 8 000 000 F | **—** |
| Collecté | 4 500 000 F | **« Encaissé par vous »** · son total à elle |
| En attente | inchangé | ses versements |
| Taux de recouvrement | 56,3 % | **—** |

Un tiret dit « pas de votre ressort ». Un « 0 F » dirait « rien n'est dû », ce qui serait faux. C'est la règle déjà appliquée à un élève non inscrit (`not-enrolled-empty-state.md`).

## Comment l'écran sait qu'il est cloisonné

Il ne le devine pas et n'invente rien côté client : le serveur ne sert pas le recouvrement dans ce cas, et **cette absence est le signal**.

```ts
const cloisonne = summary?.total_expected === null
```

Une constante, relue deux fois.

## Contrat

`total_expected` et `completion_rate` deviennent nullables dans `FinancialSummarySchema`. Ce sont les deux seuls endroits du portail qui lisent ces champs — vérifié plutôt que supposé : les portails parent et élève ont leurs propres schémas et ne sont pas touchés.

Le typage est vérifié par l'intégration continue : le disque de la machine de développement est saturé, et un build qui manque d'espace tronque les fichiers qu'il est en train d'écrire.
