### PR TITLE
fix(reports): open on the current year, not the first of the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- Les bulletins et les statistiques DREN s'ouvraient sur une année sans données au lieu de l'année en cours *(admin)*
 - Le bandeau de la page des versements annonce à la caissière ce qu'elle a encaissé, et non plus les chiffres de toute l'école *(caissier)*
 - Le portail se construisait avec une mémoire plafonnée pour un serveur qui n'existe plus, ce qui faisait échouer des mises en ligne au hasard *(devops)*
 - L'application saluait chacun par le début de son adresse e-mail : le caissier Ibrahim Tanoh lisait « Bonjour, Cashier3 » alors que l'écran juste en dessous affichait son vrai nom. Le prénom et le nom sont désormais repris de la connexion *(admin, personnel, enseignant, parent, élève)*

--- a/components/admin/reports/ReportsPageClient.tsx
+++ b/components/admin/reports/ReportsPageClient.tsx
@@ -15,7 +15,7 @@ import { BulletinList } from "./BulletinList"
 import { BulletinGenerateButton } from "./BulletinGenerateButton"
 import { ReportsNav } from "./ReportsNav"
 import { useClasses } from "@/lib/hooks/useClasses"
-import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { useCurrentAcademicYearId } from "@/lib/hooks/useCurrentAcademicYear"
 import type { BulletinListParams } from "@/lib/contracts/bulletin"
 
 export function ReportsPageClient() {
@@ -27,10 +27,11 @@ export function ReportsPageClient() {
 
   const { data: classesData, isLoading: classesLoading } = useClasses()
   const classes = classesData?.items
-  const { data: academicYearsData, isLoading: yearsLoading } = useAcademicYears()
-  const academicYears = academicYearsData?.items
-
-  const activeYearId = academicYearId ?? academicYears?.[0]?.id
+  const {
+    academicYearId: activeYearId,
+    years: academicYears,
+    isLoading: yearsLoading,
+  } = useCurrentAcademicYearId(academicYearId)
 
   const params: BulletinListParams = {
     ...(classId && { class_id: classId }),

--- a/components/admin/reports/deep/DeepReportPageClient.tsx
+++ b/components/admin/reports/deep/DeepReportPageClient.tsx
@@ -32,8 +32,7 @@ export function DeepReportPageClient() {
   const [previewing, setPreviewing] = useState(false)
 
   // L'année en cours d'abord : c'est celle qu'on dépose neuf fois sur dix.
-  const activeYearId =
-    academicYearId ?? academicYears?.find((y) => y.is_current)?.id ?? academicYears?.[0]?.id
+  const { academicYearId: activeYearId } = useCurrentAcademicYearId(academicYearId)
   const activeYear = academicYears?.find((y) => y.id === activeYearId)
 
   const handleDownload = useCallback(async () => {

--- a/components/admin/reports/dren/DrenPageClient.tsx
+++ b/components/admin/reports/dren/DrenPageClient.tsx
@@ -27,15 +27,14 @@ import { LevelStatsTable } from "./LevelStatsTable"
 import { PageHero, heroAccentBtn, heroGlassBtn } from "@/components/shared/PageHero"
 import { ReportsNav } from "../ReportsNav"
 import { useDrenStats } from "@/lib/hooks/useDrenStats"
-import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { useCurrentAcademicYearId } from "@/lib/hooks/useCurrentAcademicYear"
 import { drenApi } from "@/lib/api/dren"
 import { openPdfPreview } from "@/lib/pdf/preview"
 
 export function DrenPageClient() {
-  const { data: academicYearsData } = useAcademicYears()
-  const academicYears = academicYearsData?.items
   const [academicYearId, setAcademicYearId] = useState<number | undefined>(undefined)
-  const activeYearId = academicYearId ?? academicYears?.[0]?.id
+  const { academicYearId: activeYearId, years: academicYears } =
+    useCurrentAcademicYearId(academicYearId)
   const { data: stats, isLoading, isError } = useDrenStats(activeYearId)
   const [downloading, setDownloading] = useState<"excel" | "pdf" | null>(null)
   const [previewingPdf, setPreviewingPdf] = useState(false)

--- a/lib/hooks/useCurrentAcademicYear.ts
+++ b/lib/hooks/useCurrentAcademicYear.ts
@@ -1,0 +1,23 @@
+import { useAcademicYears } from "./useAcademicYears"
+
+/**
+ * L'annee sur laquelle un ecran doit s'ouvrir.
+ *
+ * L'annee courante est celle que l'etablissement a marquee comme telle, pas la
+ * premiere de la liste. Les deux different des qu'une annee suivante est creee
+ * pour preparer les inscriptions : l'ecran s'ouvrait alors sur une annee sans
+ * donnees, sous un en-tete qui en annoncait une autre, et on croyait l'ecran
+ * casse. Le repli sur la premiere ne sert qu'a un etablissement qui n'a rien
+ * marque du tout.
+ *
+ * `override` est le choix explicite de l'utilisateur : il gagne toujours.
+ */
+export function useCurrentAcademicYearId(override?: number) {
+  const { data, isLoading } = useAcademicYears()
+  const years = data?.items
+  return {
+    academicYearId: override ?? years?.find((y) => y.is_current)?.id ?? years?.[0]?.id,
+    years,
+    isLoading,
+  }
+}


### PR DESCRIPTION
Constaté en capture sur la démonstration : l'écran des bulletins s'ouvre sur **2026-2027** alors que l'en-tête de l'application affiche **2025-2026**, où vivent les 2 148 bulletins. On tombe sur un écran vide sans comprendre pourquoi.

## La cause

Trois écrans prenaient la **première** année de la liste :

    const activeYearId = academicYearId ?? academicYears?.[0]?.id

La liste n'est pas triée par pertinence. Tant qu'une école n'a qu'une année, le défaut ne se voit pas. Dès qu'elle crée l'année suivante pour préparer les inscriptions, l'écran s'ouvre dessus : vide.

## Le correctif

L'année courante est celle que l'établissement a **marquée** comme telle. Le rapport de fin de trimestre faisait déjà ce choix ; les deux autres écrans ne l'avaient pas. Plutôt que de recopier l'expression une troisième fois, elle vit maintenant dans un seul crochet que les trois utilisent, avec le repli sur la première année pour un établissement qui n'a rien marqué.

Le choix explicite de l'utilisateur gagne toujours.

Closes #352
