### PR TITLE
feat(timetable): show teacher availability while placing a slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- La grille de disponibilités d'un enseignant affichait toute sa semaine en rouge « indisponible » alors qu'il n'avait rien déclaré : une semaine vierge ne ferme plus rien *(admin, directeur des études, enseignant)*
 - Le bandeau de la page des versements annonce à la caissière ce qu'elle a encaissé, et non plus les chiffres de toute l'école *(caissier)*
 - Le portail se construisait avec une mémoire plafonnée pour un serveur qui n'existe plus, ce qui faisait échouer des mises en ligne au hasard *(devops)*
 - L'application saluait chacun par le début de son adresse e-mail : le caissier Ibrahim Tanoh lisait « Bonjour, Cashier3 » alors que l'écran juste en dessous affichait son vrai nom. Le prénom et le nom sont désormais repris de la connexion *(admin, personnel, enseignant, parent, élève)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- L'enseignant déclare ses indisponibilités depuis « Mon emploi du temps », sur la même grille que celle de sa fiche côté administration *(enseignant)*
+- Le formulaire de créneau affiche la semaine de l'enseignant choisi, cours dans les autres classes et plages fermées, et prévient avant d'enregistrer quand l'horaire visé ne passe pas *(directeur des études, secrétariat, admin)*
 - Onglet « Moyens de paiement » dans Paramètres : pour chaque profil qui encaisse, on coche les moyens qu'il a le droit de saisir. Retirer les espèces au comptable prend deux clics, et l'écran prévient qu'autoriser les espèces engage une journée de caisse à ouvrir et à compter *(admin, directeur)*
 - Wave, MTN MoMo, Orange Money et Moov Money se choisissent séparément au guichet, au lieu d'un « Mobile Money » unique qui obligeait le comptable à démêler ses relevés *(caissier, comptable, secrétariat)*
 - Colonne « Encaissé par » sur l'écran des versements, dans le tableau comme sur les cartes du téléphone, et filtre par caisse pour la comptabilité qui veut contrôler un guichet *(comptable, directeur, caissier)*

--- a/app/(teacher)/teacher/availabilities/error.tsx
+++ b/app/(teacher)/teacher/availabilities/error.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export default function TimetableError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-20">
+      <AlertTriangle className="h-8 w-8 text-destructive" />
+      <p className="text-sm text-muted-foreground">{error.message || "Impossible de charger l'emploi du temps."}</p>
+      <Button onClick={reset} variant="outline" size="sm">Réessayer</Button>
+    </div>
+  )
+}

--- a/app/(teacher)/teacher/availabilities/loading.tsx
+++ b/app/(teacher)/teacher/availabilities/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function TimetableLoading() {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-4 w-56" />
+      </div>
+      <Skeleton className="h-[500px] rounded-lg" />
+    </div>
+  )
+}

--- a/app/(teacher)/teacher/availabilities/page.tsx
+++ b/app/(teacher)/teacher/availabilities/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation"
+import { auth } from "@/auth"
+import { MyAvailabilityClient } from "@/components/teacher/MyAvailabilityClient"
+
+export const metadata = { title: "Mes disponibilités | KLASSCI" }
+
+export default async function TeacherAvailabilitiesPage() {
+  const session = await auth()
+  if (!session?.user?.id) {
+    redirect("/login")
+  }
+  // Le backend resout l'enseignant depuis le jeton : aucune correspondance
+  // user_id / teacher_profile.id n'est a faire ici.
+  return <MyAvailabilityClient />
+}

--- a/components/admin/teachers/TeacherDetailClient.tsx
+++ b/components/admin/teachers/TeacherDetailClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import {
   Archive,
   BookOpen,
@@ -60,11 +60,14 @@ interface TeacherDetailClientProps {
 
 export function TeacherDetailClient({ teacherId }: TeacherDetailClientProps) {
   const router = useRouter()
+  // Le formulaire de creneau renvoie ici avec ?tab=disponibilites quand
+  // l'enseignant choisi bloque : autant arriver sur le bon onglet.
+  const searchParams = useSearchParams()
 
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [photoPreview, setPhotoPreview] = useState(false)
-  const [activeTab, setActiveTab] = useState("overview")
+  const [activeTab, setActiveTab] = useState(searchParams.get("tab") ?? "overview")
   const [photoLoaded, setPhotoLoaded] = useState(false)
 
   const { data: teacher, isLoading, isError, refetch } = useTeacher(teacherId)

--- a/components/admin/teachers/availability/AvailabilityGrid.tsx
+++ b/components/admin/teachers/availability/AvailabilityGrid.tsx
@@ -8,6 +8,7 @@ import {
   HOURS,
   STATE_LABELS,
   STATE_STYLES,
+  UNDECLARED_STYLE,
   cellKey,
 } from "./availability-helpers"
 
@@ -15,6 +16,8 @@ interface AvailabilityGridProps {
   getDisplayState: (day: DayOfWeek, start: string, end: string) => CellState
   isPendingCell: (day: DayOfWeek, start: string, end: string) => boolean
   interactive: boolean
+  /** Faux : rien n'est declare, une case vide ne ferme rien. */
+  hasDeclarations: boolean
   onToggle: (day: DayOfWeek, start: string, end: string) => void
 }
 
@@ -22,6 +25,7 @@ export function AvailabilityGrid({
   getDisplayState,
   isPendingCell,
   interactive,
+  hasDeclarations,
   onToggle,
 }: AvailabilityGridProps) {
   return (
@@ -37,9 +41,10 @@ export function AvailabilityGrid({
                 {DAYS.map((d) => (
                   <th
                     key={d.key}
-                    className="p-2 text-center font-medium text-muted-foreground min-w-[80px]"
+                    className="p-2 text-center font-medium text-muted-foreground min-w-[52px] sm:min-w-[80px]"
                   >
-                    {d.label}
+                    <span className="sm:hidden">{d.court}</span>
+                    <span className="hidden sm:inline">{d.label}</span>
                   </th>
                 ))}
               </tr>
@@ -53,6 +58,16 @@ export function AvailabilityGrid({
                   {DAYS.map((day) => {
                     const state = getDisplayState(day.key, hour.start, hour.end)
                     const isPending = isPendingCell(day.key, hour.start, hour.end)
+                    const style =
+                      state === "unavailable" && !hasDeclarations
+                        ? UNDECLARED_STYLE
+                        : STATE_STYLES[state]
+                    const lu =
+                      state === "unavailable"
+                        ? hasDeclarations
+                          ? "hors des plages declarees"
+                          : "non declare"
+                        : state
                     return (
                       <td
                         key={cellKey(day.key, hour.start, hour.end)}
@@ -63,13 +78,13 @@ export function AvailabilityGrid({
                           disabled={!interactive}
                           onClick={() => onToggle(day.key, hour.start, hour.end)}
                           className={`
-                            w-full h-9 rounded-md text-[10px] font-medium transition-colors
+                            w-full h-11 sm:h-9 rounded-md text-[10px] font-medium transition-colors
                             focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
                             ${interactive ? "hover:opacity-80 cursor-pointer" : "cursor-default"}
-                            ${STATE_STYLES[state]}
+                            ${style}
                             ${isPending ? "ring-2 ring-dashed ring-amber-500/70" : ""}
                           `}
-                          aria-label={`${day.label} ${hour.start}-${hour.end}: ${state}${
+                          aria-label={`${day.label} ${hour.start}-${hour.end} : ${lu}${
                             isPending ? " (modification en attente)" : ""
                           }`}
                         >

--- a/components/admin/teachers/availability/AvailabilityToolbar.tsx
+++ b/components/admin/teachers/availability/AvailabilityToolbar.tsx
@@ -110,7 +110,13 @@ export function AvailabilityToolbar({
 }
 
 
-export function AvailabilityLegend({ pendingCount }: { pendingCount: number }) {
+export function AvailabilityLegend({
+  pendingCount,
+  hasDeclarations,
+}: {
+  pendingCount: number
+  hasDeclarations: boolean
+}) {
   return (
     <div className="flex flex-wrap items-center gap-5 text-xs text-muted-foreground">
       <div className="flex items-center gap-1.5">
@@ -122,8 +128,17 @@ export function AvailabilityLegend({ pendingCount }: { pendingCount: number }) {
         <span>Créneaux préférés</span>
       </div>
       <div className="flex items-center gap-1.5">
-        <div className="h-3 w-5 rounded-sm bg-rose-500/15 ring-1 ring-rose-300/40" />
-        <span>Indisponible</span>
+        {hasDeclarations ? (
+          <>
+            <div className="h-3 w-5 rounded-sm bg-rose-500/15 ring-1 ring-rose-300/40" />
+            <span>Hors des plages déclarées</span>
+          </>
+        ) : (
+          <>
+            <div className="h-3 w-5 rounded-sm bg-muted/50 ring-1 ring-inset ring-border/60" />
+            <span>Non déclaré — aucune contrainte</span>
+          </>
+        )}
       </div>
       {pendingCount > 0 && (
         <div className="flex items-center gap-1.5">

--- a/components/admin/teachers/availability/availability-helpers.ts
+++ b/components/admin/teachers/availability/availability-helpers.ts
@@ -7,13 +7,13 @@
 
 import type { DayOfWeek, TeacherAvailability } from "@/lib/contracts/timetable"
 
-export const DAYS: { key: DayOfWeek; label: string }[] = [
-  { key: "monday", label: "Lundi" },
-  { key: "tuesday", label: "Mardi" },
-  { key: "wednesday", label: "Mercredi" },
-  { key: "thursday", label: "Jeudi" },
-  { key: "friday", label: "Vendredi" },
-  { key: "saturday", label: "Samedi" },
+export const DAYS: { key: DayOfWeek; label: string; court: string }[] = [
+  { key: "monday", label: "Lundi", court: "Lun" },
+  { key: "tuesday", label: "Mardi", court: "Mar" },
+  { key: "wednesday", label: "Mercredi", court: "Mer" },
+  { key: "thursday", label: "Jeudi", court: "Jeu" },
+  { key: "friday", label: "Vendredi", court: "Ven" },
+  { key: "saturday", label: "Samedi", court: "Sam" },
 ]
 
 // 07:00 a 18:00 (11 creneaux)
@@ -47,6 +47,17 @@ export const STATE_LABELS: Record<CellState, string> = {
   available: "Dispo",
   preferred: "Préféré",
 }
+
+/**
+ * Une case vide ne veut pas dire la meme chose selon la semaine.
+ *
+ * Tant que l'enseignant n'a rien declare, il est disponible partout : peindre
+ * la semaine entiere en rouge « indisponible » etait un mensonge, et il
+ * contredisait le bandeau juste au-dessus. Des qu'une plage est declaree, la
+ * regle passe en liste blanche — cote backend comme pour la generation
+ * automatique — et le reste est bel et bien ferme.
+ */
+export const UNDECLARED_STYLE = "bg-muted/50 ring-1 ring-inset ring-border/60"
 
 export interface SavedCell {
   id: number

--- a/components/admin/teachers/availability/use-availability-surface.ts
+++ b/components/admin/teachers/availability/use-availability-surface.ts
@@ -1,0 +1,71 @@
+"use client"
+
+/**
+ * D'où viennent les disponibilités affichées par la grille, et où vont les
+ * modifications.
+ *
+ * La même grille sert deux personnes : l'administration qui saisit pour un
+ * enseignant donné, et l'enseignant qui gère les siennes depuis son portail.
+ * Les gestes sont identiques, seules les routes changent — et côté portail le
+ * backend résout l'enseignant depuis le jeton, si bien que le front n'a aucun
+ * identifiant à transmettre. Une seule grille, deux surfaces.
+ */
+
+import { useCallback, useMemo } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { timetableApi } from "@/lib/api/timetable"
+import { timetableKeys, useMyAvailabilities, useTeacherAvailabilities } from "@/lib/hooks/useTimetable"
+import type {
+  TeacherAvailability,
+  TeacherAvailabilityCreate,
+  TeacherAvailabilityUpdate,
+} from "@/lib/contracts/timetable"
+
+export interface AvailabilitySurface {
+  availabilities: TeacherAvailability[] | undefined
+  isLoading: boolean
+  create: (data: TeacherAvailabilityCreate) => Promise<unknown>
+  update: (id: number, data: TeacherAvailabilityUpdate) => Promise<unknown>
+  remove: (id: number) => Promise<unknown>
+  invalidate: () => Promise<void>
+}
+
+/** `teacherId` absent = l'enseignant connecté gère ses propres plages. */
+export function useAvailabilitySurface(teacherId?: number): AvailabilitySurface {
+  const queryClient = useQueryClient()
+  const soi = teacherId === undefined
+
+  const duProf = useTeacherAvailabilities(soi ? 0 : teacherId)
+  const lesMiennes = useMyAvailabilities()
+  const source = soi ? lesMiennes : duProf
+
+  const invalidate = useCallback(async () => {
+    if (soi) {
+      await queryClient.invalidateQueries({ queryKey: timetableKeys.myAvailabilities() })
+      await queryClient.invalidateQueries({ queryKey: timetableKeys.myWeek() })
+      return
+    }
+    await queryClient.invalidateQueries({ queryKey: timetableKeys.availabilities(teacherId) })
+    await queryClient.invalidateQueries({ queryKey: timetableKeys.teacherWeek(teacherId) })
+    await queryClient.invalidateQueries({ queryKey: ["teachers", teacherId, "full"] })
+  }, [queryClient, soi, teacherId])
+
+  return useMemo(
+    () => ({
+      availabilities: source.data,
+      isLoading: source.isLoading,
+      create: (data) =>
+        soi
+          ? timetableApi.declareMyAvailability(data)
+          : timetableApi.createAvailability(teacherId as number, data),
+      update: (id, data) =>
+        soi
+          ? timetableApi.updateMyAvailability(id, data)
+          : timetableApi.updateAvailability(id, data),
+      remove: (id) =>
+        soi ? timetableApi.deleteMyAvailability(id) : timetableApi.deleteAvailability(id),
+      invalidate,
+    }),
+    [source.data, source.isLoading, soi, teacherId, invalidate],
+  )
+}

--- a/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
+++ b/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
@@ -173,6 +173,9 @@ export function TeacherAvailabilityTab({ teacherId, intro }: TeacherAvailability
     (v) => v.state === "preferred",
   ).length
   const maxSlots = DAYS.length * HOURS.length
+  // Rien de declare : la semaine ne contraint rien, et la grille ne doit pas
+  // afficher le contraire (cf. UNDECLARED_STYLE).
+  const hasDeclarations = savedMap.size > 0
 
   return (
     <div className="space-y-4">
@@ -204,10 +207,11 @@ export function TeacherAvailabilityTab({ teacherId, intro }: TeacherAvailability
         getDisplayState={getDisplayState}
         isPendingCell={isPendingCell}
         interactive={editMode && !saving}
+        hasDeclarations={hasDeclarations}
         onToggle={handleToggle}
       />
 
-      <AvailabilityLegend pendingCount={pending.size} />
+      <AvailabilityLegend pendingCount={pending.size} hasDeclarations={hasDeclarations} />
     </div>
   )
 }

--- a/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
+++ b/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
@@ -2,11 +2,9 @@
 
 import { useCallback, useMemo, useState } from "react"
 import { toast } from "sonner"
-import { useQueryClient } from "@tanstack/react-query"
 import { Info } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
-import { timetableApi } from "@/lib/api/timetable"
-import { timetableKeys, useTeacherAvailabilities } from "@/lib/hooks/useTimetable"
+import { useAvailabilitySurface } from "@/components/admin/teachers/availability/use-availability-surface"
 import type { DayOfWeek } from "@/lib/contracts/timetable"
 import {
   AvailabilityGrid,
@@ -26,12 +24,15 @@ import {
 } from "@/components/admin/teachers/availability/availability-helpers"
 
 interface TeacherAvailabilityTabProps {
-  teacherId: number
+  /** Absent : l'enseignant connecté gère ses propres plages depuis son portail. */
+  teacherId?: number
+  /** Le portail enseignant parle à la première personne. */
+  intro?: React.ReactNode
 }
 
-export function TeacherAvailabilityTab({ teacherId }: TeacherAvailabilityTabProps) {
-  const queryClient = useQueryClient()
-  const { data: availabilities, isLoading } = useTeacherAvailabilities(teacherId)
+export function TeacherAvailabilityTab({ teacherId, intro }: TeacherAvailabilityTabProps) {
+  const surface = useAvailabilitySurface(teacherId)
+  const { availabilities, isLoading } = surface
 
   const [editMode, setEditMode] = useState(false)
   const [pending, setPending] = useState<Map<string, PendingChange>>(new Map())
@@ -109,7 +110,7 @@ export function TeacherAvailabilityTab({ teacherId }: TeacherAvailabilityTabProp
       const [day, start, end] = key.split("|") as [DayOfWeek, string, string]
       if (change.kind === "create") {
         operations.push(
-          timetableApi.createAvailability(teacherId, {
+          surface.create({
             day,
             start_time: start,
             end_time: end,
@@ -118,10 +119,10 @@ export function TeacherAvailabilityTab({ teacherId }: TeacherAvailabilityTabProp
           }),
         )
       } else if (change.kind === "delete") {
-        operations.push(timetableApi.deleteAvailability(change.existingId))
+        operations.push(surface.remove(change.existingId))
       } else {
         operations.push(
-          timetableApi.updateAvailability(change.existingId, {
+          surface.update(change.existingId, {
             available: true,
             preferred: change.target === "preferred",
           }),
@@ -151,15 +152,10 @@ export function TeacherAvailabilityTab({ teacherId }: TeacherAvailabilityTabProp
       )
     }
 
-    await queryClient.invalidateQueries({
-      queryKey: timetableKeys.availabilities(teacherId),
-    })
-    await queryClient.invalidateQueries({
-      queryKey: ["teachers", teacherId, "full"],
-    })
+    await surface.invalidate()
 
     setSaving(false)
-  }, [pending, teacherId, queryClient])
+  }, [pending, surface])
 
   if (isLoading) {
     return (
@@ -180,6 +176,7 @@ export function TeacherAvailabilityTab({ teacherId }: TeacherAvailabilityTabProp
 
   return (
     <div className="space-y-4">
+{intro ?? (
       <div className="flex items-start gap-2.5 rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm">
         <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
         <p className="text-muted-foreground">
@@ -189,6 +186,7 @@ export function TeacherAvailabilityTab({ teacherId }: TeacherAvailabilityTabProp
           <span className="font-medium text-foreground">demande de congé</span>.
         </p>
       </div>
+      )}
 
       <AvailabilityToolbar
         editMode={editMode}

--- a/components/forms/TimetableSlotForm.tsx
+++ b/components/forms/TimetableSlotForm.tsx
@@ -307,6 +307,7 @@ export function TimetableSlotForm({
                 highlightDay={watchedDay}
                 highlightStart={watchedStart}
                 highlightEnd={watchedEnd}
+                editHref={`/admin/teachers/${selectedTeacherId}?tab=disponibilites`}
               />
             </div>
           ) : null}
@@ -366,6 +367,19 @@ export function TimetableSlotForm({
             />
           </div>
 
+          {empechement && !error && (
+            <div
+              role="status"
+              className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden />
+              <div className="space-y-0.5">
+                <p className="text-sm font-medium">Créneau impossible</p>
+                <p className="text-sm text-muted-foreground">{empechement.message}</p>
+              </div>
+            </div>
+          )}
+
           {/* Room select */}
           <FormField
             control={form.control}
@@ -395,19 +409,6 @@ export function TimetableSlotForm({
               </FormItem>
             )}
           />
-
-          {empechement && !error && (
-            <div
-              role="status"
-              className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3"
-            >
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden />
-              <div className="space-y-0.5">
-                <p className="text-sm font-medium">Créneau impossible</p>
-                <p className="text-sm text-muted-foreground">{empechement.message}</p>
-              </div>
-            </div>
-          )}
 
           {error && (
             <div

--- a/components/forms/TimetableSlotForm.tsx
+++ b/components/forms/TimetableSlotForm.tsx
@@ -3,18 +3,24 @@
 import { useState, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Plus } from "lucide-react"
+import { AlertTriangle, Plus } from "lucide-react"
 import { TimetableSlotCreateSchema, type TimetableSlotCreate } from "@/lib/contracts/timetable"
-import { useCreateSlot, useUpdateSlot } from "@/lib/hooks/useTimetable"
+import { useCreateSlot, useTeacherWeek, useUpdateSlot } from "@/lib/hooks/useTimetable"
 import type { TimetableSlot } from "@/lib/contracts/timetable"
-import { useSubjects, useCreateSubject } from "@/lib/hooks/useSubjects"
-import { useTeachers, useCreateTeacher } from "@/lib/hooks/useTeachers"
+import { useSubjects } from "@/lib/hooks/useSubjects"
+import { useTeachers } from "@/lib/hooks/useTeachers"
 import { useClass } from "@/lib/hooks/useClasses"
 import { useRooms } from "@/lib/hooks/useRooms"
 import { useAcademicYears } from "@/lib/hooks/useAcademicYears"
+import { TeacherWeekPanel } from "@/components/timetable/TeacherWeekPanel"
+import { trouverEmpechement } from "@/lib/timetable/week-overlap"
+import {
+  InlineCreateSubjectDialog,
+  InlineCreateTeacherDialog,
+  addHour,
+} from "@/components/forms/timetable-slot/inline-create-dialogs"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import {
   Select,
   SelectContent,
@@ -22,13 +28,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog"
 import {
   Form,
   FormControl,
@@ -136,6 +135,40 @@ export function TimetableSlotForm({
     prevSubjectRef.id = selectedSubjectId ?? 0
     form.setValue("teacher_id", selectedSubject.teacher_id)
   }
+
+  // La semaine de l'enseignant choisi, chargee des qu'il est choisi : elle
+  // sert a montrer l'empechement pendant la saisie, au lieu de le decouvrir en
+  // validant. Le backend refait la verification, celle-ci ne fait qu'avertir.
+  const selectedTeacherId = form.watch("teacher_id")
+  const watchedDay = form.watch("day")
+  const watchedStart = form.watch("start_time")
+  const watchedEnd = form.watch("end_time")
+  const { data: teacherWeek, isLoading: weekLoading } = useTeacherWeek(selectedTeacherId)
+
+  // En modification, le creneau qu'on deplace figure dans sa propre semaine :
+  // sans cela, il se signalerait lui-meme comme conflit.
+  const weekSansCeCreneau = useMemo(() => {
+    if (!teacherWeek || !slot) return teacherWeek
+    return {
+      ...teacherWeek,
+      busy: teacherWeek.busy.filter(
+        (b) =>
+          !(
+            b.kind === "course" &&
+            b.start_time === slot.start_time &&
+            b.end_time === slot.end_time &&
+            b.class_name === slot.class_name
+          ),
+      ),
+    }
+  }, [teacherWeek, slot])
+
+  const empechement = trouverEmpechement(
+    weekSansCeCreneau,
+    watchedDay,
+    watchedStart,
+    watchedEnd,
+  )
 
   const createMutation = useCreateSlot()
   const updateMutation = useUpdateSlot(slot?.id ?? 0)
@@ -266,6 +299,18 @@ export function TimetableSlotForm({
             )}
           />
 
+          {selectedTeacherId ? (
+            <div className="rounded-xl border bg-card/60 p-3 sm:p-4">
+              <TeacherWeekPanel
+                week={weekSansCeCreneau}
+                isLoading={weekLoading}
+                highlightDay={watchedDay}
+                highlightStart={watchedStart}
+                highlightEnd={watchedEnd}
+              />
+            </div>
+          ) : null}
+
           <div className="grid gap-4 sm:grid-cols-3">
             <FormField
               control={form.control}
@@ -351,9 +396,31 @@ export function TimetableSlotForm({
             )}
           />
 
+          {empechement && !error && (
+            <div
+              role="status"
+              className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden />
+              <div className="space-y-0.5">
+                <p className="text-sm font-medium">Créneau impossible</p>
+                <p className="text-sm text-muted-foreground">{empechement.message}</p>
+              </div>
+            </div>
+          )}
+
           {error && (
-            <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
-              <p className="text-sm text-destructive">{error.message}</p>
+            <div
+              role="alert"
+              className="flex items-start gap-2.5 rounded-lg border border-destructive/25 bg-destructive/5 px-4 py-3"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" aria-hidden />
+              <div className="space-y-0.5">
+                <p className="text-sm font-medium text-destructive">
+                  Enregistrement refusé
+                </p>
+                <p className="text-sm text-destructive/90">{error.message}</p>
+              </div>
             </div>
           )}
 
@@ -388,184 +455,4 @@ export function TimetableSlotForm({
       />
     </>
   )
-}
-
-// ---------------------------------------------------------------------------
-// Inline mini-dialogs
-// ---------------------------------------------------------------------------
-
-function InlineCreateSubjectDialog({
-  open,
-  onClose,
-  onCreated,
-}: {
-  open: boolean
-  onClose: () => void
-  onCreated: (id: number) => void
-}) {
-  const [name, setName] = useState("")
-  const { mutate, isPending } = useCreateSubject()
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!name.trim()) return
-    mutate(
-      {
-        name: name.trim(),
-        coefficient: 1,
-        hours_per_week: 1,
-      },
-      {
-        onSuccess: (created) => {
-          setName("")
-          onCreated(created.id)
-        },
-      },
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Créer une matière</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="subject-name">Nom de la matière *</Label>
-            <Input
-              id="subject-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Ex: Mathématiques"
-              className="h-11"
-              autoFocus
-            />
-            <p className="text-xs text-muted-foreground">
-              Crée une matière catalogue. Le coefficient et les heures seront configurés lors de l'assignation à un niveau.
-            </p>
-          </div>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={onClose}>
-              Annuler
-            </Button>
-            <Button type="submit" disabled={isPending || !name.trim()}>
-              {isPending ? "Création..." : "Créer"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-function generateAutoCredentials(first: string, last: string) {
-  const slug = `${first}.${last}`.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/\s+/g, ".")
-  const suffix = String(Math.floor(Math.random() * 900) + 100)
-  return {
-    email: `${slug}.${suffix}@klassci.local`,
-    password: `Klassci${suffix}!${first[0]?.toUpperCase() ?? "X"}`,
-  }
-}
-
-function InlineCreateTeacherDialog({
-  open,
-  onClose,
-  onCreated,
-}: {
-  open: boolean
-  onClose: () => void
-  onCreated: (id: number) => void
-}) {
-  const [firstName, setFirstName] = useState("")
-  const [lastName, setLastName] = useState("")
-  const [speciality, setSpeciality] = useState("")
-  const { mutate, isPending } = useCreateTeacher()
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!firstName.trim() || !lastName.trim()) return
-    const { email, password } = generateAutoCredentials(firstName.trim(), lastName.trim())
-    mutate(
-      {
-        first_name: firstName.trim(),
-        last_name: lastName.trim(),
-        email,
-        password,
-        speciality: speciality.trim() || undefined,
-      },
-      {
-        onSuccess: (created) => {
-          setFirstName("")
-          setLastName("")
-          setSpeciality("")
-          onCreated(created.id)
-        },
-      },
-    )
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Créer un enseignant</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="teacher-first">Prénom *</Label>
-              <Input
-                id="teacher-first"
-                value={firstName}
-                onChange={(e) => setFirstName(e.target.value)}
-                placeholder="Prénom"
-                className="h-11"
-                autoFocus
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="teacher-last">Nom *</Label>
-              <Input
-                id="teacher-last"
-                value={lastName}
-                onChange={(e) => setLastName(e.target.value)}
-                placeholder="Nom"
-                className="h-11"
-            />
-          </div>
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="teacher-spec">Spécialité</Label>
-            <Input
-              id="teacher-spec"
-              value={speciality}
-              onChange={(e) => setSpeciality(e.target.value)}
-              placeholder="Ex: Mathématiques (optionnel)"
-              className="h-11"
-            />
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Un compte sera créé automatiquement. Pour configurer les identifiants, rendez-vous sur la page de l'enseignant.
-          </p>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={onClose}>
-              Annuler
-            </Button>
-            <Button
-              type="submit"
-              disabled={isPending || !firstName.trim() || !lastName.trim()}
-            >
-              {isPending ? "Création..." : "Créer"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-function addHour(time: string): string {
-  const [h, m] = time.split(":").map(Number)
-  return `${String(h + 1).padStart(2, "0")}:${String(m).padStart(2, "0")}`
 }

--- a/components/forms/timetable-slot/inline-create-dialogs.tsx
+++ b/components/forms/timetable-slot/inline-create-dialogs.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+/**
+ * Les deux creations express du formulaire de creneau.
+ *
+ * Extrait de TimetableSlotForm.tsx, qui depassait la limite de taille avant
+ * meme d'accueillir le panneau de disponibilite : une matiere ou un
+ * enseignant qui manque se cree sans quitter la saisie, mais cela n'a rien a
+ * voir avec la pose d'un creneau.
+ */
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { useCreateSubject } from "@/lib/hooks/useSubjects"
+import { useCreateTeacher } from "@/lib/hooks/useTeachers"
+
+export function InlineCreateSubjectDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean
+  onClose: () => void
+  onCreated: (id: number) => void
+}) {
+  const [name, setName] = useState("")
+  const { mutate, isPending } = useCreateSubject()
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim()) return
+    mutate(
+      {
+        name: name.trim(),
+        coefficient: 1,
+        hours_per_week: 1,
+      },
+      {
+        onSuccess: (created) => {
+          setName("")
+          onCreated(created.id)
+        },
+      },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Créer une matière</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="subject-name">Nom de la matière *</Label>
+            <Input
+              id="subject-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Ex: Mathématiques"
+              className="h-11"
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              Crée une matière catalogue. Le coefficient et les heures seront configurés lors de l'assignation à un niveau.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Annuler
+            </Button>
+            <Button type="submit" disabled={isPending || !name.trim()}>
+              {isPending ? "Création..." : "Créer"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function generateAutoCredentials(first: string, last: string) {
+  const slug = `${first}.${last}`.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/\s+/g, ".")
+  const suffix = String(Math.floor(Math.random() * 900) + 100)
+  return {
+    email: `${slug}.${suffix}@klassci.local`,
+    password: `Klassci${suffix}!${first[0]?.toUpperCase() ?? "X"}`,
+  }
+}
+
+export function InlineCreateTeacherDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean
+  onClose: () => void
+  onCreated: (id: number) => void
+}) {
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [speciality, setSpeciality] = useState("")
+  const { mutate, isPending } = useCreateTeacher()
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!firstName.trim() || !lastName.trim()) return
+    const { email, password } = generateAutoCredentials(firstName.trim(), lastName.trim())
+    mutate(
+      {
+        first_name: firstName.trim(),
+        last_name: lastName.trim(),
+        email,
+        password,
+        speciality: speciality.trim() || undefined,
+      },
+      {
+        onSuccess: (created) => {
+          setFirstName("")
+          setLastName("")
+          setSpeciality("")
+          onCreated(created.id)
+        },
+      },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Créer un enseignant</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="teacher-first">Prénom *</Label>
+              <Input
+                id="teacher-first"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="Prénom"
+                className="h-11"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="teacher-last">Nom *</Label>
+              <Input
+                id="teacher-last"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                placeholder="Nom"
+                className="h-11"
+            />
+          </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="teacher-spec">Spécialité</Label>
+            <Input
+              id="teacher-spec"
+              value={speciality}
+              onChange={(e) => setSpeciality(e.target.value)}
+              placeholder="Ex: Mathématiques (optionnel)"
+              className="h-11"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Un compte sera créé automatiquement. Pour configurer les identifiants, rendez-vous sur la page de l'enseignant.
+          </p>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Annuler
+            </Button>
+            <Button
+              type="submit"
+              disabled={isPending || !firstName.trim() || !lastName.trim()}
+            >
+              {isPending ? "Création..." : "Créer"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function addHour(time: string): string {
+  const [h, m] = time.split(":").map(Number)
+  return `${String(h + 1).padStart(2, "0")}:${String(m).padStart(2, "0")}`
+}

--- a/components/teacher/MyAvailabilityClient.tsx
+++ b/components/teacher/MyAvailabilityClient.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+/**
+ * L'enseignant déclare lui-même quand il n'est pas là.
+ *
+ * Même grille que celle de sa fiche côté administration : ce que l'un saisit,
+ * l'autre le voit, et il n'y a qu'un seul geste à apprendre. Seule la voix
+ * change — ici on s'adresse à l'intéressé, et sa semaine réelle s'affiche
+ * au-dessus pour qu'il déclare en connaissance de ses cours.
+ */
+
+import { Info } from "lucide-react"
+import { TeacherAvailabilityTab } from "@/components/admin/teachers/tabs/TeacherAvailabilityTab"
+import { TeacherWeekPanel } from "@/components/timetable/TeacherWeekPanel"
+import { useMyWeek } from "@/lib/hooks/useTimetable"
+import { Card, CardContent } from "@/components/ui/card"
+
+export function MyAvailabilityClient() {
+  const { data: week, isLoading } = useMyWeek()
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="font-serif text-xl tracking-tight">Mes disponibilités</h1>
+        <p className="text-sm text-muted-foreground">
+          Ce que le secrétariat verra avant de vous placer un cours
+        </p>
+      </div>
+
+      <Card className="border-0 shadow-sm ring-1 ring-border">
+        <CardContent className="p-3 sm:p-4">
+          <TeacherWeekPanel
+            week={week}
+            isLoading={isLoading}
+            title="Ma semaine actuelle"
+          />
+        </CardContent>
+      </Card>
+
+      <TeacherAvailabilityTab
+        intro={
+          <div className="flex items-start gap-2.5 rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm">
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+            <p className="text-muted-foreground">
+              Ces plages valent pour{" "}
+              <span className="font-medium text-foreground">toute l&apos;année</span>, jour de
+              semaine par jour de semaine. Une fois qu&apos;une plage est déclarée, le
+              secrétariat ne peut plus vous placer de cours en dehors. Pour une absence
+              d&apos;un jour précis, faites plutôt une{" "}
+              <span className="font-medium text-foreground">demande de congé</span>.
+            </p>
+          </div>
+        }
+      />
+    </div>
+  )
+}

--- a/components/teacher/TeacherScheduleClient.tsx
+++ b/components/teacher/TeacherScheduleClient.tsx
@@ -1,13 +1,25 @@
 "use client"
 
+import Link from "next/link"
+import type { Route } from "next"
+import { CalendarCog } from "lucide-react"
 import { TeacherScheduleView } from "@/components/teacher/timetable/TeacherScheduleView"
+import { Button } from "@/components/ui/button"
 
 export function TeacherScheduleClient() {
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="font-serif text-xl tracking-tight">Mon emploi du temps</h1>
-        <p className="text-sm text-muted-foreground">Votre planning de la semaine</p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="font-serif text-xl tracking-tight">Mon emploi du temps</h1>
+          <p className="text-sm text-muted-foreground">Votre planning de la semaine</p>
+        </div>
+        <Button asChild variant="outline" className="h-11">
+          <Link href={"/teacher/availabilities" as Route}>
+            <CalendarCog className="h-4 w-4" aria-hidden />
+            Mes disponibilités
+          </Link>
+        </Button>
       </div>
       {/* No teacherId prop → fetch via /teacher/schedule (JWT-resolved) */}
       <TeacherScheduleView />

--- a/components/timetable/TeacherWeekPanel.tsx
+++ b/components/timetable/TeacherWeekPanel.tsx
@@ -11,7 +11,9 @@
  * décider.
  */
 
-import { AlertTriangle, CalendarX2, Check, Info } from "lucide-react"
+import Link from "next/link"
+import type { Route } from "next"
+import { AlertTriangle, CalendarX2, Check, Info, SquarePen } from "lucide-react"
 import type { DayOfWeek, TeacherWeek } from "@/lib/contracts/timetable"
 import { JOURS_FR, enMinutes, versJourAnglais } from "@/lib/timetable/week-overlap"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -57,6 +59,15 @@ interface TeacherWeekPanelProps {
   highlightEnd?: string
   /** Titre facultatif — le portail enseignant parle à la première personne. */
   title?: string
+  /**
+   * Affiche un lien vers la fiche de l'enseignant pour y corriger ses plages.
+   *
+   * L'administration a le droit de les saisir à sa place — chez ROSTAN c'est
+   * le directeur des études qui note ce qu'on lui a dit de vive voix. Depuis la
+   * pose d'un créneau, on ne veut pas d'un éditeur de plus dans la fenêtre :
+   * juste le chemin le plus court vers l'endroit qui existe déjà.
+   */
+  editHref?: string
 }
 
 function etatDe(week: TeacherWeek, jour: DayOfWeek, heure: number): EtatCase {
@@ -99,6 +110,7 @@ export function TeacherWeekPanel({
   highlightStart,
   highlightEnd,
   title,
+  editHref,
 }: TeacherWeekPanelProps) {
   if (isLoading) {
     return (
@@ -129,7 +141,20 @@ export function TeacherWeekPanel({
     <div className="space-y-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <p className="text-sm font-medium">{title ?? `Semaine de ${week.teacher_name}`}</p>
-        <Legende />
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <Legende />
+          {editHref && (
+            <Link
+              href={editHref as Route}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-11 items-center gap-1.5 text-xs font-medium text-primary underline-offset-4 hover:underline sm:h-auto"
+            >
+              <SquarePen className="h-3.5 w-3.5" aria-hidden />
+              Modifier ses disponibilités
+            </Link>
+          )}
+        </div>
       </div>
 
       {rienDeclare && (

--- a/components/timetable/TeacherWeekPanel.tsx
+++ b/components/timetable/TeacherWeekPanel.tsx
@@ -1,0 +1,273 @@
+"use client"
+
+/**
+ * La semaine d'un enseignant, montrée pendant qu'on lui pose un créneau.
+ *
+ * Deux tailles d'écran, deux lectures du même contenu, parce qu'aucune ne
+ * marche partout : sur un écran large, une grille jour × heure se balaie d'un
+ * regard ; sur un téléphone, elle se réduit à des cases illisibles, alors on
+ * liste les empêchements jour par jour. Le composant ne choisit pas à la
+ * place du navigateur, il rend les deux et laisse les points de rupture
+ * décider.
+ */
+
+import { AlertTriangle, CalendarX2, Check, Info } from "lucide-react"
+import type { DayOfWeek, TeacherWeek } from "@/lib/contracts/timetable"
+import { JOURS_FR, enMinutes, versJourAnglais } from "@/lib/timetable/week-overlap"
+import { Skeleton } from "@/components/ui/skeleton"
+
+const JOURS: DayOfWeek[] = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]
+
+const JOURS_COURTS: Record<DayOfWeek, string> = {
+  monday: "Lun",
+  tuesday: "Mar",
+  wednesday: "Mer",
+  thursday: "Jeu",
+  friday: "Ven",
+  saturday: "Sam",
+}
+
+/** 7 h à 18 h : l'amplitude d'une journée de collège ivoirien. */
+const HEURES = Array.from({ length: 11 }, (_, i) => 7 + i)
+
+type EtatCase = "libre" | "cours" | "ferme" | "ouvert" | "hors"
+
+const STYLES: Record<EtatCase, string> = {
+  libre: "bg-muted/40",
+  cours: "bg-sky-500/25 ring-1 ring-inset ring-sky-500/40",
+  ferme: "bg-rose-500/20 ring-1 ring-inset ring-rose-400/40",
+  ouvert: "bg-emerald-500/20 ring-1 ring-inset ring-emerald-500/30",
+  hors: "bg-muted/70",
+}
+
+const LIBELLES: Record<EtatCase, string> = {
+  libre: "libre",
+  cours: "cours",
+  ferme: "indisponible",
+  ouvert: "disponible",
+  hors: "hors des plages déclarées",
+}
+
+interface TeacherWeekPanelProps {
+  week: TeacherWeek | undefined
+  isLoading?: boolean
+  /** Jour visé par la saisie en cours, en français ou en anglais. */
+  highlightDay?: string
+  highlightStart?: string
+  highlightEnd?: string
+  /** Titre facultatif — le portail enseignant parle à la première personne. */
+  title?: string
+}
+
+function etatDe(week: TeacherWeek, jour: DayOfWeek, heure: number): EtatCase {
+  const debut = heure * 60
+  const fin = debut + 60
+  const couvre = (d: string, f: string) => {
+    const d1 = enMinutes(d)
+    const f1 = enMinutes(f)
+    return d1 !== null && f1 !== null && d1 < fin && f1 > debut
+  }
+
+  if (week.busy.some((b) => b.day === jour && b.kind === "course" && couvre(b.start_time, b.end_time)))
+    return "cours"
+  if (
+    week.busy.some((b) => b.day === jour && b.kind === "unavailable" && couvre(b.start_time, b.end_time))
+  )
+    return "ferme"
+  if (week.open.some((o) => o.day === jour && couvre(o.start_time, o.end_time))) return "ouvert"
+  return week.has_declarations ? "hors" : "libre"
+}
+
+function estVise(
+  jour: DayOfWeek,
+  heure: number,
+  jourVise: DayOfWeek | undefined,
+  debut: string | undefined,
+  fin: string | undefined,
+): boolean {
+  if (jour !== jourVise) return false
+  const d = enMinutes(debut)
+  const f = enMinutes(fin)
+  if (d === null || f === null || d >= f) return false
+  return d < (heure + 1) * 60 && f > heure * 60
+}
+
+export function TeacherWeekPanel({
+  week,
+  isLoading,
+  highlightDay,
+  highlightStart,
+  highlightEnd,
+  title,
+}: TeacherWeekPanelProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2" aria-busy="true">
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+      </div>
+    )
+  }
+
+  if (!week) return null
+
+  const jourVise = versJourAnglais(highlightDay)
+  const parJour = JOURS.map((jour) => ({
+    jour,
+    empechements: [
+      ...week.busy.filter((b) => b.day === jour),
+    ].sort((a, b) => a.start_time.localeCompare(b.start_time)),
+    ouvertures: week.open
+      .filter((o) => o.day === jour)
+      .sort((a, b) => a.start_time.localeCompare(b.start_time)),
+  }))
+
+  const rienDeclare = !week.has_declarations
+  const semaineVide = week.busy.length === 0
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm font-medium">{title ?? `Semaine de ${week.teacher_name}`}</p>
+        <Legende />
+      </div>
+
+      {rienDeclare && (
+        <p className="flex items-start gap-2 rounded-lg bg-muted/60 px-3 py-2 text-xs text-muted-foreground">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+          <span>
+            Aucune plage déclarée : l&apos;enseignant est considéré disponible à toute heure.
+            {semaineVide ? "" : " Seuls ses cours déjà posés bloquent."}
+          </span>
+        </p>
+      )}
+
+      {/* Écran large : la grille jour x heure, balayable d'un regard. */}
+      <div className="hidden overflow-x-auto sm:block">
+        <table className="w-full border-separate border-spacing-0.5 text-[10px]">
+          <caption className="sr-only">
+            Occupation de la semaine, par jour et par heure
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col" className="w-9 text-left font-medium text-muted-foreground">
+                <span className="sr-only">Heure</span>
+              </th>
+              {JOURS.map((jour) => (
+                <th
+                  key={jour}
+                  scope="col"
+                  className="pb-1 text-center text-[11px] font-medium text-muted-foreground"
+                >
+                  {JOURS_COURTS[jour]}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {HEURES.map((heure) => (
+              <tr key={heure}>
+                <th
+                  scope="row"
+                  className="pr-1 text-right align-middle font-normal tabular-nums text-muted-foreground"
+                >
+                  {String(heure).padStart(2, "0")}h
+                </th>
+                {JOURS.map((jour) => {
+                  const etat = etatDe(week, jour, heure)
+                  const vise = estVise(jour, heure, jourVise, highlightStart, highlightEnd)
+                  return (
+                    <td key={jour} className="p-0">
+                      <div
+                        className={`h-5 rounded-sm ${STYLES[etat]} ${
+                          vise ? "outline outline-2 outline-offset-1 outline-foreground/70" : ""
+                        }`}
+                        title={`${JOURS_FR[jour]} ${String(heure).padStart(2, "0")}h — ${LIBELLES[etat]}`}
+                      >
+                        <span className="sr-only">
+                          {JOURS_FR[jour]} {heure}h : {LIBELLES[etat]}
+                          {vise ? ", créneau en cours de saisie" : ""}
+                        </span>
+                      </div>
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Téléphone : la même chose en liste, lisible sans zoom. */}
+      <ul className="space-y-1.5 sm:hidden">
+        {parJour.map(({ jour, empechements, ouvertures }) => (
+          <li
+            key={jour}
+            className={`rounded-lg px-3 py-2 ${
+              jour === jourVise ? "bg-muted ring-1 ring-foreground/20" : "bg-muted/40"
+            }`}
+          >
+            <p className="text-xs font-medium capitalize">{JOURS_FR[jour]}</p>
+            {empechements.length === 0 && ouvertures.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                {week.has_declarations ? "Aucune plage ouverte" : "Rien de prévu"}
+              </p>
+            ) : (
+              <ul className="mt-1 space-y-1">
+                {empechements.map((b) => (
+                  <li
+                    key={`${b.kind}-${b.start_time}`}
+                    className="flex items-start gap-1.5 text-xs text-muted-foreground"
+                  >
+                    {b.kind === "course" ? (
+                      <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-sky-600" aria-hidden />
+                    ) : (
+                      <CalendarX2 className="mt-0.5 h-3 w-3 shrink-0 text-rose-600" aria-hidden />
+                    )}
+                    <span className="tabular-nums">
+                      {b.start_time}–{b.end_time}
+                    </span>
+                    <span>
+                      {b.label}
+                      {b.class_name ? ` · ${b.class_name}` : ""}
+                    </span>
+                  </li>
+                ))}
+                {ouvertures.map((o) => (
+                  <li
+                    key={`open-${o.start_time}`}
+                    className="flex items-start gap-1.5 text-xs text-muted-foreground"
+                  >
+                    <Check className="mt-0.5 h-3 w-3 shrink-0 text-emerald-600" aria-hidden />
+                    <span className="tabular-nums">
+                      {o.start_time}–{o.end_time}
+                    </span>
+                    <span>{o.preferred ? "Préféré" : "Disponible"}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function Legende() {
+  const entrees: { etat: EtatCase; texte: string }[] = [
+    { etat: "cours", texte: "Cours" },
+    { etat: "ferme", texte: "Indisponible" },
+    { etat: "ouvert", texte: "Disponible" },
+  ]
+  return (
+    <ul className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+      {entrees.map(({ etat, texte }) => (
+        <li key={etat} className="flex items-center gap-1">
+          <span className={`h-2.5 w-2.5 rounded-sm ${STYLES[etat]}`} aria-hidden />
+          {texte}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/lib/api/timetable.ts
+++ b/lib/api/timetable.ts
@@ -5,6 +5,7 @@ import {
   TimetableSlotSchema,
   GenerateTaskResponseSchema,
   TeacherAvailabilitySchema,
+  TeacherWeekSchema,
   type TimetableSlot,
   type TimetableSlotCreate,
   type TimetableSlotUpdate,
@@ -12,6 +13,7 @@ import {
   type TeacherAvailability,
   type TeacherAvailabilityCreate,
   type TeacherAvailabilityUpdate,
+  type TeacherWeek,
   type TimetableDiagnostic,
 } from "@/lib/contracts/timetable"
 
@@ -168,6 +170,59 @@ export const timetableApi = {
     )
     const item = (json as { data?: TeacherAvailability }).data ?? (json as TeacherAvailability)
     return safeValidate(TeacherAvailabilitySchema, item, `PATCH /teacher-availabilities/${availabilityId}`)
+  },
+
+  // La semaine occupee d'un enseignant, pour la montrer avant de choisir
+  // l'horaire plutot que de refuser apres coup.
+  teacherWeek: async (teacherId: number): Promise<TeacherWeek> => {
+    const json = await apiFetch<unknown>(`/teachers/${teacherId}/week`)
+    return safeValidate(TeacherWeekSchema, json, `/teachers/${teacherId}/week`)
+  },
+
+  // Portail enseignant : le backend resout l'enseignant depuis le jeton, le
+  // front n'a jamais a connaitre son identifiant de profil.
+  myWeek: async (): Promise<TeacherWeek> => {
+    const json = await apiFetch<unknown>(`/teacher/week`)
+    return safeValidate(TeacherWeekSchema, json, `/teacher/week`)
+  },
+
+  myAvailabilities: async (): Promise<TeacherAvailability[]> => {
+    const json = await apiFetch<TeacherAvailability[] | { data?: TeacherAvailability[] }>(
+      `/teacher/availabilities`,
+    )
+    const arr = Array.isArray(json) ? json : json.data ?? []
+    return safeValidate(TeacherAvailabilityArraySchema, arr, `/teacher/availabilities`)
+  },
+
+  declareMyAvailability: async (
+    data: TeacherAvailabilityCreate,
+  ): Promise<TeacherAvailability> => {
+    const json = await apiFetch<TeacherAvailability | { data?: TeacherAvailability }>(
+      `/teacher/availabilities`,
+      { method: "POST", body: JSON.stringify(data) },
+    )
+    const item = (json as { data?: TeacherAvailability }).data ?? (json as TeacherAvailability)
+    return safeValidate(TeacherAvailabilitySchema, item, `POST /teacher/availabilities`)
+  },
+
+  updateMyAvailability: async (
+    availabilityId: number,
+    data: TeacherAvailabilityUpdate,
+  ): Promise<TeacherAvailability> => {
+    const json = await apiFetch<TeacherAvailability | { data?: TeacherAvailability }>(
+      `/teacher/availabilities/${availabilityId}`,
+      { method: "PATCH", body: JSON.stringify(data) },
+    )
+    const item = (json as { data?: TeacherAvailability }).data ?? (json as TeacherAvailability)
+    return safeValidate(
+      TeacherAvailabilitySchema,
+      item,
+      `PATCH /teacher/availabilities/${availabilityId}`,
+    )
+  },
+
+  deleteMyAvailability: async (availabilityId: number): Promise<void> => {
+    await apiFetch<void>(`/teacher/availabilities/${availabilityId}`, { method: "DELETE" })
   },
 
   deleteAvailability: async (availabilityId: number): Promise<void> => {

--- a/lib/contracts/timetable.ts
+++ b/lib/contracts/timetable.ts
@@ -89,6 +89,39 @@ export const TeacherAvailabilityUpdateSchema = z.object({
   preferred: z.boolean().optional(),
 })
 
+// ---------------------------------------------------------------------------
+// Semaine d'un enseignant
+//
+// Sert a montrer l'empechement AVANT de choisir l'horaire. `has_declarations`
+// porte la regle appliquee par le backend : tant qu'un enseignant n'a rien
+// declare il est disponible partout ; des qu'il a declare une plage, seules
+// celles de `open` restent ouvertes.
+// ---------------------------------------------------------------------------
+
+export const TeacherWeekBusySlotSchema = z.object({
+  day: DayOfWeekSchema,
+  start_time: z.string(),
+  end_time: z.string(),
+  kind: z.enum(["course", "unavailable"]),
+  label: z.string(),
+  class_name: z.string().nullable().optional(),
+})
+
+export const TeacherWeekOpenSlotSchema = z.object({
+  day: DayOfWeekSchema,
+  start_time: z.string(),
+  end_time: z.string(),
+  preferred: z.boolean(),
+})
+
+export const TeacherWeekSchema = z.object({
+  teacher_id: z.number(),
+  teacher_name: z.string(),
+  has_declarations: z.boolean(),
+  busy: z.array(TeacherWeekBusySlotSchema),
+  open: z.array(TeacherWeekOpenSlotSchema),
+})
+
 // Diagnostic pre-generation
 export interface TimetableDiagnostic {
   ready: boolean
@@ -105,3 +138,6 @@ export type DayOfWeek = z.infer<typeof DayOfWeekSchema>
 export type TeacherAvailability = z.infer<typeof TeacherAvailabilitySchema>
 export type TeacherAvailabilityCreate = z.infer<typeof TeacherAvailabilityCreateSchema>
 export type TeacherAvailabilityUpdate = z.infer<typeof TeacherAvailabilityUpdateSchema>
+export type TeacherWeekBusySlot = z.infer<typeof TeacherWeekBusySlotSchema>
+export type TeacherWeekOpenSlot = z.infer<typeof TeacherWeekOpenSlotSchema>
+export type TeacherWeek = z.infer<typeof TeacherWeekSchema>

--- a/lib/hooks/useTimetable.ts
+++ b/lib/hooks/useTimetable.ts
@@ -18,6 +18,9 @@ export const timetableKeys = {
   mine: () => ["timetable", "mine"] as const,
   availabilities: (teacherId: number) =>
     ["timetable", "availabilities", teacherId] as const,
+  myAvailabilities: () => ["timetable", "availabilities", "mine"] as const,
+  teacherWeek: (teacherId: number) => ["timetable", "week", teacherId] as const,
+  myWeek: () => ["timetable", "week", "mine"] as const,
 }
 
 export function useTimetable(classId: number) {
@@ -240,4 +243,74 @@ export function useDeleteAvailability(teacherId: number) {
       toast.error("Erreur", { description: err.message })
     },
   })
+}
+
+// ---------------------------------------------------------------------------
+// Semaine d'un enseignant, et disponibilites vues du portail enseignant
+// ---------------------------------------------------------------------------
+
+/** La semaine occupee de l'enseignant choisi, pour l'afficher avant l'horaire. */
+export function useTeacherWeek(teacherId: number | undefined) {
+  return useQuery({
+    queryKey: timetableKeys.teacherWeek(teacherId ?? 0),
+    queryFn: () => timetableApi.teacherWeek(teacherId as number),
+    enabled: !!teacherId,
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useMyWeek() {
+  return useQuery({
+    queryKey: timetableKeys.myWeek(),
+    queryFn: () => timetableApi.myWeek(),
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useMyAvailabilities() {
+  return useQuery({
+    queryKey: timetableKeys.myAvailabilities(),
+    queryFn: () => timetableApi.myAvailabilities(),
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+/** Les trois ecritures du portail enseignant invalident les memes lectures. */
+function useMyAvailabilityMutation<TVars>(
+  mutationFn: (vars: TVars) => Promise<unknown>,
+  successMessage?: string,
+) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: timetableKeys.myAvailabilities() })
+      queryClient.invalidateQueries({ queryKey: timetableKeys.myWeek() })
+      if (successMessage) toast.success(successMessage)
+    },
+    onError: (err) => {
+      toast.error("Enregistrement impossible", { description: err.message })
+    },
+  })
+}
+
+export function useDeclareMyAvailability() {
+  return useMyAvailabilityMutation(
+    (data: TeacherAvailabilityCreate) => timetableApi.declareMyAvailability(data),
+    "Disponibilité enregistrée",
+  )
+}
+
+export function useUpdateMyAvailability() {
+  return useMyAvailabilityMutation(
+    ({ id, data }: { id: number; data: TeacherAvailabilityUpdate }) =>
+      timetableApi.updateMyAvailability(id, data),
+  )
+}
+
+export function useDeleteMyAvailability() {
+  return useMyAvailabilityMutation(
+    (id: number) => timetableApi.deleteMyAvailability(id),
+    "Disponibilité retirée",
+  )
 }

--- a/lib/timetable/week-overlap.test.ts
+++ b/lib/timetable/week-overlap.test.ts
@@ -1,0 +1,127 @@
+/**
+ * L'avertissement affiché pendant la saisie doit dire la même chose que le
+ * refus du backend — sinon la personne corrige le mauvais champ.
+ */
+
+import { describe, expect, it } from "vitest"
+import type { TeacherWeek } from "@/lib/contracts/timetable"
+import { seChevauchent, trouverEmpechement } from "./week-overlap"
+
+function semaine(partiel: Partial<TeacherWeek> = {}): TeacherWeek {
+  return {
+    teacher_id: 1,
+    teacher_name: "Jean-Baptiste Kouassi",
+    has_declarations: false,
+    busy: [],
+    open: [],
+    ...partiel,
+  }
+}
+
+describe("seChevauchent", () => {
+  it("voit un chevauchement partiel", () => {
+    expect(seChevauchent("09:00", "11:00", "10:00", "12:00")).toBe(true)
+  })
+
+  it("laisse passer deux cours bout à bout", () => {
+    expect(seChevauchent("08:00", "10:00", "10:00", "11:00")).toBe(false)
+  })
+
+  it("ne se prononce pas sur une heure mal formée", () => {
+    expect(seChevauchent("8h", "10:00", "09:00", "11:00")).toBe(false)
+  })
+})
+
+describe("trouverEmpechement", () => {
+  it("ne bloque rien tant que la saisie est incomplète", () => {
+    expect(trouverEmpechement(semaine(), "lundi", "", "")).toBeNull()
+    expect(trouverEmpechement(undefined, "lundi", "08:00", "09:00")).toBeNull()
+  })
+
+  it("nomme le cours, la classe et l'heure qui bloquent", () => {
+    const s = semaine({
+      busy: [
+        {
+          day: "monday",
+          start_time: "08:00",
+          end_time: "10:00",
+          kind: "course",
+          label: "Mathématiques",
+          class_name: "6e B",
+        },
+      ],
+    })
+
+    const e = trouverEmpechement(s, "lundi", "09:00", "11:00")
+
+    expect(e?.kind).toBe("course")
+    expect(e?.message).toContain("Jean-Baptiste Kouassi")
+    expect(e?.message).toContain("Mathématiques")
+    expect(e?.message).toContain("6e B")
+    expect(e?.message).toContain("08:00 à 10:00")
+  })
+
+  it("distingue une plage fermée d'un cours", () => {
+    const s = semaine({
+      busy: [
+        {
+          day: "monday",
+          start_time: "15:00",
+          end_time: "16:00",
+          kind: "unavailable",
+          label: "Indisponible",
+          class_name: null,
+        },
+      ],
+    })
+
+    const e = trouverEmpechement(s, "lundi", "15:30", "17:00")
+
+    expect(e?.kind).toBe("closed")
+    expect(e?.message).toContain("indisponible")
+    expect(e?.message).not.toContain("6e")
+  })
+
+  it("ferme le reste de la semaine dès qu'une plage est déclarée", () => {
+    const s = semaine({
+      has_declarations: true,
+      open: [{ day: "monday", start_time: "08:00", end_time: "12:00", preferred: false }],
+    })
+
+    expect(trouverEmpechement(s, "lundi", "09:00", "10:00")).toBeNull()
+
+    const e = trouverEmpechement(s, "mardi", "09:00", "10:00")
+    expect(e?.kind).toBe("not_open")
+    expect(e?.message).toContain("disponibilités")
+  })
+
+  it("refuse un créneau qui déborde de la plage ouverte", () => {
+    const s = semaine({
+      has_declarations: true,
+      open: [{ day: "monday", start_time: "08:00", end_time: "10:00", preferred: false }],
+    })
+
+    expect(trouverEmpechement(s, "lundi", "09:00", "11:00")?.kind).toBe("not_open")
+  })
+
+  it("ne contraint rien quand l'enseignant n'a rien déclaré", () => {
+    expect(trouverEmpechement(semaine(), "samedi", "17:00", "18:00")).toBeNull()
+  })
+
+  it("accepte le jour déjà en anglais", () => {
+    const s = semaine({
+      busy: [
+        {
+          day: "monday",
+          start_time: "08:00",
+          end_time: "10:00",
+          kind: "course",
+          label: "Français",
+          class_name: "5e A",
+        },
+      ],
+    })
+
+    expect(trouverEmpechement(s, "monday", "09:00", "10:00")?.kind).toBe("course")
+  })
+})

--- a/lib/timetable/week-overlap.ts
+++ b/lib/timetable/week-overlap.ts
@@ -1,0 +1,131 @@
+/**
+ * Ce qui empêche de poser un créneau, dit avant de cliquer.
+ *
+ * Le backend refuse déjà avec une phrase complète, mais un refus arrive après
+ * coup : la personne a choisi son enseignant, son jour, son horaire, et
+ * découvre seulement en validant que c'était impossible. Les mêmes règles
+ * appliquées ici, sur la semaine déjà chargée, permettent de le dire pendant
+ * la saisie.
+ *
+ * La règle est celle du backend et du générateur automatique : tant qu'un
+ * enseignant n'a rien déclaré il est disponible partout ; dès qu'il a déclaré
+ * une plage, seules celles-là restent ouvertes.
+ */
+
+import type { DayOfWeek, TeacherWeek } from "@/lib/contracts/timetable"
+
+/** Le formulaire parle français, le backend anglais. */
+const JOURS_VERS_EN: Record<string, DayOfWeek> = {
+  lundi: "monday",
+  mardi: "tuesday",
+  mercredi: "wednesday",
+  jeudi: "thursday",
+  vendredi: "friday",
+  samedi: "saturday",
+}
+
+export const JOURS_FR: Record<DayOfWeek, string> = {
+  monday: "lundi",
+  tuesday: "mardi",
+  wednesday: "mercredi",
+  thursday: "jeudi",
+  friday: "vendredi",
+  saturday: "samedi",
+}
+
+export function versJourAnglais(jour: string | undefined): DayOfWeek | undefined {
+  if (!jour) return undefined
+  return JOURS_VERS_EN[jour] ?? (JOURS_FR[jour as DayOfWeek] ? (jour as DayOfWeek) : undefined)
+}
+
+/** Minutes depuis minuit, ou `null` si ce n'est pas une heure « HH:MM ». */
+export function enMinutes(heure: string | undefined): number | null {
+  if (!heure) return null
+  const m = /^(\d{1,2}):(\d{2})$/.exec(heure)
+  if (!m) return null
+  return Number(m[1]) * 60 + Number(m[2])
+}
+
+/** Deux plages se chevauchent si l'une commence avant que l'autre finisse. */
+export function seChevauchent(
+  debutA: string,
+  finA: string,
+  debutB: string,
+  finB: string,
+): boolean {
+  const a1 = enMinutes(debutA)
+  const a2 = enMinutes(finA)
+  const b1 = enMinutes(debutB)
+  const b2 = enMinutes(finB)
+  if (a1 === null || a2 === null || b1 === null || b2 === null) return false
+  return a1 < b2 && a2 > b1
+}
+
+export type Empechement = {
+  /** `course` : il enseigne ailleurs. `closed` : plage fermée. `not_open` : hors des plages ouvertes. */
+  kind: "course" | "closed" | "not_open"
+  message: string
+}
+
+/**
+ * L'empêchement qui bloquerait ce créneau, ou `null` s'il passe.
+ *
+ * Renvoie une phrase complète et non un code : c'est elle qui s'affiche, et la
+ * personne qui saisit doit pouvoir agir sans traduire quoi que ce soit.
+ */
+export function trouverEmpechement(
+  semaine: TeacherWeek | undefined,
+  jour: string | undefined,
+  debut: string | undefined,
+  fin: string | undefined,
+): Empechement | null {
+  if (!semaine) return null
+  const jourEn = versJourAnglais(jour)
+  const d = enMinutes(debut)
+  const f = enMinutes(fin)
+  if (!jourEn || d === null || f === null || d >= f) return null
+
+  const jourFr = JOURS_FR[jourEn]
+  const nom = semaine.teacher_name
+
+  const cours = semaine.busy.find(
+    (b) =>
+      b.day === jourEn &&
+      b.kind === "course" &&
+      seChevauchent(debut!, fin!, b.start_time, b.end_time),
+  )
+  if (cours) {
+    const classe = cours.class_name ? ` avec la ${cours.class_name}` : ""
+    return {
+      kind: "course",
+      message: `${nom} a déjà ${cours.label}${classe} le ${jourFr} de ${cours.start_time} à ${cours.end_time}.`,
+    }
+  }
+
+  const fermeture = semaine.busy.find(
+    (b) =>
+      b.day === jourEn &&
+      b.kind === "unavailable" &&
+      seChevauchent(debut!, fin!, b.start_time, b.end_time),
+  )
+  if (fermeture) {
+    return {
+      kind: "closed",
+      message: `${nom} est déclaré indisponible le ${jourFr} de ${fermeture.start_time} à ${fermeture.end_time}.`,
+    }
+  }
+
+  if (!semaine.has_declarations) return null
+
+  const couvert = semaine.open.some((o) => {
+    const o1 = enMinutes(o.start_time)
+    const o2 = enMinutes(o.end_time)
+    return o.day === jourEn && o1 !== null && o2 !== null && o1 <= d && o2 >= f
+  })
+  if (couvert) return null
+
+  return {
+    kind: "not_open",
+    message: `${nom} n'est pas déclaré disponible le ${jourFr} de ${debut} à ${fin}. Ouvrez cette plage dans ses disponibilités si le cours doit y tenir.`,
+  }
+}


### PR DESCRIPTION
Accompagne African-DC/klassci-college-backend#293.

## Ce qui change

**Poser un créneau.** Dès que l'enseignant est choisi, sa semaine s'affiche dans le formulaire : ses cours dans les autres classes, ses plages fermées, ses plages ouvertes, et le créneau en cours de saisie encadré par-dessus. Si l'horaire visé ne passe pas, l'avertissement sort **pendant** la saisie, juste sous les champs d'horaire, avec la même phrase que le refus du backend. Un lien mène aux disponibilités de l'enseignant pour les corriger — l'administration en a le droit.

**Portail enseignant.** `/teacher/availabilities` : il déclare ses propres plages sur la grille de sa fiche côté administration, réutilisée telle quelle. Une surface injectée choisit entre `/teachers/{id}/…` et `/teacher/…` ; le backend résout l'enseignant depuis le jeton.

## Un défaut d'affichage corrigé au passage

La grille peignait toute case vide en rouge « indisponible ». Sur un enseignant qui n'a rien déclaré, elle affichait donc sa semaine entière fermée — en contradiction directe avec le bandeau au-dessus. Une case vide se lit maintenant « non déclaré, aucune contrainte » tant que rien n'est posé, « hors des plages déclarées » ensuite : la règle réellement appliquée.

## Tailles d'écran

| | |
|---|---|
| Bureau (1440) et tablette paysage (1024) | Panneau en grille jour × heure dans le formulaire, avertissement visible sans défiler |
| Téléphone (390) et tablette portrait (820) | Le panneau passe en liste jour par jour. **La pose d'un créneau reste réservée au grand écran** : l'emploi du temps admin bascule en « vue mobile de consultation » sous 1024 px, décision produit antérieure à cette PR |
| Portail enseignant, toutes tailles | Accessible partout. Grille de saisie mesurée à 44 × 44 px au doigt, en-têtes de jour abrégés sous 640 px, six jours sans défilement horizontal sur 390 px |

## Vérification

188 tests passés, `tsc` et `next lint` propres. Nouveau module de règle testé à part (10 cas) : chevauchement, cours bout à bout, liste blanche, heure mal formée. Captures prises sur le tenant local aux trois tailles.

Closes #351
