### PR TITLE
fix(timetable): a lone absence no longer greys out the whole grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page Frais : copie des montants d'une catégorie vers une autre en un clic (choix des niveaux à copier), pour ne plus ressaisir la même grille à chaque trimestre *(admin)*.
 
 ### Fixed
+- La grille de disponibilités peignait toute la semaine en « hors des plages déclarées » dès qu'une seule absence était notée *(admin, directeur des études, enseignant)*
 - Les bulletins et les statistiques DREN s'ouvraient sur une année sans données au lieu de l'année en cours *(admin)*
 - La grille de disponibilités d'un enseignant affichait toute sa semaine en rouge « indisponible » alors qu'il n'avait rien déclaré : une semaine vierge ne ferme plus rien *(admin, directeur des études, enseignant)*
 - Le bandeau de la page des versements annonce à la caissière ce qu'elle a encaissé, et non plus les chiffres de toute l'école *(caissier)*

--- a/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
+++ b/components/admin/teachers/tabs/TeacherAvailabilityTab.tsx
@@ -175,7 +175,12 @@ export function TeacherAvailabilityTab({ teacherId, intro }: TeacherAvailability
   const maxSlots = DAYS.length * HOURS.length
   // Rien de declare : la semaine ne contraint rien, et la grille ne doit pas
   // afficher le contraire (cf. UNDECLARED_STYLE).
-  const hasDeclarations = savedMap.size > 0
+  // Ce qui bascule la grille en liste blanche, c'est une plage OUVERTE.
+  // Compter toutes les lignes ferait qu'une seule absence notée peindrait la
+  // semaine entière en « hors des plages déclarées ».
+  const hasDeclarations = [...savedMap.values()].some(
+    (c) => c.state === "available" || c.state === "preferred",
+  )
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
Pendant du correctif backend African-DC/klassci-college-backend#299.

La grille de la fiche enseignant bascule en liste blanche dès qu'une plage est déclarée — mais elle comptait **toutes** les lignes :

```ts
const hasDeclarations = savedMap.size > 0
```

`savedMap` contient aussi les fermetures. Une seule absence notée peignait donc les six jours en « hors des plages déclarées », alors que rien n'était ouvert ni fermé ailleurs.

Elle compte désormais les ouvertures, comme le serveur.

`tsc --noEmit` vert, les 10 tests de `week-overlap` passent. Le fichier `week-overlap.ts` n'avait pas besoin d'être touché : il lit `has_declarations` du serveur, donc il est corrigé par la PR backend.
