### PR TITLE
fix(timetable): scope the optimistic update, and stop offering slot editing on a phone

### DIFF
--- a/components/admin/timetable/TimetableGrid.tsx
+++ b/components/admin/timetable/TimetableGrid.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { TimetableSlotForm } from "@/components/forms/TimetableSlotForm"
+import { EcranTropPetit } from "@/components/forms/timetable-slot/EcranTropPetit"
 import {
   HEURE_DEBUT,
   HEURE_FIN,
@@ -242,7 +243,7 @@ export function TimetableGrid({ classId }: TimetableGridProps) {
             <div className="min-w-0">
               <p className="text-sm font-semibold">Vue mobile de consultation</p>
               <p className="mt-0.5 text-xs text-muted-foreground">
-                {totalSlots} créneau{totalSlots > 1 ? "x" : ""} cette semaine. La grille complète reste disponible sur ordinateur.
+                {totalSlots} créneau{totalSlots > 1 ? "x" : ""} cette semaine. Ajouter ou modifier un créneau demande une tablette ou un ordinateur : il faut voir la semaine de l&apos;enseignant pendant qu&apos;on choisit l&apos;heure.
               </p>
             </div>
           </div>
@@ -441,13 +442,20 @@ export function TimetableGrid({ classId }: TimetableGridProps) {
           <DialogHeader>
             <DialogTitle>Ajouter un créneau</DialogTitle>
           </DialogHeader>
-          <TimetableSlotForm
-            defaultDay={createModal?.day}
-            defaultStartTime={createModal?.time}
-            defaultEndTime={createModal?.endTime}
-            classId={classId}
-            onSuccess={() => setCreateModal(null)}
-          />
+          {/* En dessous de md, on ne pose pas de creneau : on ne verrait pas
+              la semaine de l'enseignant pendant qu'on choisit l'heure. */}
+          <div className="md:hidden">
+            <EcranTropPetit />
+          </div>
+          <div className="hidden md:block">
+            <TimetableSlotForm
+              defaultDay={createModal?.day}
+              defaultStartTime={createModal?.time}
+              defaultEndTime={createModal?.endTime}
+              classId={classId}
+              onSuccess={() => setCreateModal(null)}
+            />
+          </div>
         </DialogContent>
       </Dialog>
 
@@ -457,11 +465,13 @@ export function TimetableGrid({ classId }: TimetableGridProps) {
           <DialogHeader>
             <DialogTitle>Modifier le créneau</DialogTitle>
           </DialogHeader>
+          <div className="md:hidden">
+            <EcranTropPetit />
+          </div>
           {editSlot && (
-            <TimetableSlotForm
-              slot={editSlot}
-              onSuccess={() => setEditSlot(null)}
-            />
+            <div className="hidden md:block">
+              <TimetableSlotForm slot={editSlot} onSuccess={() => setEditSlot(null)} />
+            </div>
           )}
         </DialogContent>
       </Dialog>

--- a/components/admin/timetable/TimetableGrid.tsx
+++ b/components/admin/timetable/TimetableGrid.tsx
@@ -437,7 +437,7 @@ export function TimetableGrid({ classId }: TimetableGridProps) {
 
       {/* Create modal */}
       <Dialog open={createModal !== null} onOpenChange={() => setCreateModal(null)}>
-        <DialogContent className="sm:max-w-2xl lg:max-w-5xl">
+        <DialogContent className="sm:max-w-2xl lg:max-w-6xl xl:max-w-7xl">
           <DialogHeader>
             <DialogTitle>Ajouter un créneau</DialogTitle>
           </DialogHeader>
@@ -453,7 +453,7 @@ export function TimetableGrid({ classId }: TimetableGridProps) {
 
       {/* Edit modal */}
       <Dialog open={editSlot !== null} onOpenChange={() => setEditSlot(null)}>
-        <DialogContent className="sm:max-w-2xl lg:max-w-5xl">
+        <DialogContent className="sm:max-w-2xl lg:max-w-6xl xl:max-w-7xl">
           <DialogHeader>
             <DialogTitle>Modifier le créneau</DialogTitle>
           </DialogHeader>

--- a/components/forms/TimetableSlotForm.tsx
+++ b/components/forms/TimetableSlotForm.tsx
@@ -219,7 +219,7 @@ export function TimetableSlotForm({
     <>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="min-w-0 space-y-4">
-          <div className="min-w-0 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,27rem)] lg:items-start lg:gap-6">
+          <div className="min-w-0 lg:grid lg:grid-cols-[minmax(0,23rem)_minmax(0,1fr)] lg:items-start lg:gap-6">
             <div className="min-w-0 space-y-4">
               {/* Subject select — filtered by class level */}
               <FormField

--- a/components/forms/timetable-slot/ChampsDuCreneau.tsx
+++ b/components/forms/timetable-slot/ChampsDuCreneau.tsx
@@ -80,7 +80,7 @@ export function ChampsDuCreneau({ form, empechement, erreurServeur }: Props) {
             <FormItem>
               <FormLabel>Début *</FormLabel>
               <FormControl>
-                <Input type="time" className="h-11" {...field} />
+                <Input type="time" className="h-11 w-full min-w-0" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -94,7 +94,7 @@ export function ChampsDuCreneau({ form, empechement, erreurServeur }: Props) {
             <FormItem>
               <FormLabel>Fin *</FormLabel>
               <FormControl>
-                <Input type="time" className="h-11" {...field} />
+                <Input type="time" className="h-11 w-full min-w-0" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/components/forms/timetable-slot/EcranTropPetit.tsx
+++ b/components/forms/timetable-slot/EcranTropPetit.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+/**
+ * Ce qu'on montre à la place du formulaire de créneau sur un téléphone.
+ *
+ * Poser un créneau, c'est croiser une matière, un enseignant, sa semaine, une
+ * salle et un horaire. Sur un écran de cinq pouces, la semaine de l'enseignant
+ * se réduit à une liste qu'il faut faire défiler sur six jours pour savoir si
+ * l'heure visée est libre — et on décide sans voir. Mieux vaut le dire que
+ * laisser essayer : l'emploi du temps se construit une fois par an, au
+ * secrétariat, devant un vrai écran.
+ *
+ * La consultation, elle, reste ouverte partout : c'est elle qu'on fait au
+ * quotidien, souvent debout dans une cour.
+ */
+
+import { MonitorSmartphone } from "lucide-react"
+
+export function EcranTropPetit() {
+  return (
+    <div className="space-y-3 py-2 text-center">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+        <MonitorSmartphone className="h-6 w-6 text-muted-foreground" aria-hidden />
+      </div>
+      <p className="text-sm font-medium">Écran trop petit pour poser un créneau</p>
+      <p className="mx-auto max-w-xs text-sm text-muted-foreground">
+        Ajouter ou modifier un créneau demande de voir la semaine entière de l&apos;enseignant
+        pendant qu&apos;on choisit l&apos;heure. Reprenez sur une tablette ou un ordinateur.
+      </p>
+      <p className="text-xs text-muted-foreground">
+        La consultation de l&apos;emploi du temps reste disponible ici.
+      </p>
+    </div>
+  )
+}

--- a/components/timetable/week-grid/SemaineListe.tsx
+++ b/components/timetable/week-grid/SemaineListe.tsx
@@ -56,7 +56,7 @@ export function SemaineListe({ week, jourVise }: Props) {
                   ) : (
                     <CalendarX2 className="mt-0.5 h-3 w-3 shrink-0 text-rose-600" aria-hidden />
                   )}
-                  <span className="tabular-nums">
+                  <span className="shrink-0 whitespace-nowrap tabular-nums">
                     {b.start_time}–{b.end_time}
                   </span>
                   <span>
@@ -71,7 +71,7 @@ export function SemaineListe({ week, jourVise }: Props) {
                   className="flex items-start gap-1.5 text-xs text-muted-foreground"
                 >
                   <Check className="mt-0.5 h-3 w-3 shrink-0 text-emerald-600" aria-hidden />
-                  <span className="tabular-nums">
+                  <span className="shrink-0 whitespace-nowrap tabular-nums">
                     {o.start_time}–{o.end_time}
                   </span>
                   <span>{o.preferred ? "Préféré" : "Disponible"}</span>

--- a/lib/hooks/optimistic-scope.test.ts
+++ b/lib/hooks/optimistic-scope.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Une mise à jour optimiste n'écrit que dans les caches de sa forme.
+ *
+ * `getQueriesData` et `setQueriesData` font une correspondance par **préfixe**.
+ * Demander `["timetable"]` ramène aussi la semaine d'un enseignant, qui est un
+ * objet, et les disponibilités, qui sont une autre liste. Étaler l'un ou
+ * mapper l'autre jette une `TypeError` **dans `onMutate`**, donc avant que la
+ * requête ne parte : l'utilisateur voit « r is not iterable » et rien n'atteint
+ * le serveur.
+ *
+ * Ces tests exercent la vraie sélection sur un vrai `QueryClient`. Le générique
+ * `getQueriesData<T>` ne les rendrait pas superflus : c'est une affirmation que
+ * le cache ne garantit pas, et TypeScript la croit sur parole — le défaut a
+ * vécu deux jours sous un `tsc --noEmit` vert.
+ */
+
+import { QueryClient } from "@tanstack/react-query"
+import { describe, expect, it } from "vitest"
+import { paymentKeys } from "./usePayments"
+import { timetableKeys } from "./useTimetable"
+
+/** La sélection que fait `useCreateSlot` avant d'étaler la liste. */
+function listesDeCreneaux(qc: QueryClient) {
+  return qc
+    .getQueriesData({ queryKey: timetableKeys.all })
+    .filter(([cle]) => cle[1] === "class" || cle[1] === "teacher" || cle[1] === "mine")
+}
+
+describe("le préfixe du cache emploi du temps", () => {
+  it("ramène des valeurs de formes incompatibles", () => {
+    const qc = new QueryClient()
+    qc.setQueryData(timetableKeys.byClass(3), [{ id: 1 }])
+    qc.setQueryData(timetableKeys.teacherWeek(7), { teacher_id: 7, busy: [], open: [] })
+
+    const tout = qc.getQueriesData({ queryKey: timetableKeys.all })
+    expect(tout).toHaveLength(2)
+
+    // La preuve du défaut : étaler la semaine jette avant tout appel réseau.
+    const semaine = tout.find(([cle]) => cle[1] === "week")![1]
+    expect(() => [...(semaine as Iterable<unknown>)]).toThrow(TypeError)
+  })
+
+  it("ne retient que les listes de créneaux une fois filtré", () => {
+    const qc = new QueryClient()
+    qc.setQueryData(timetableKeys.byClass(3), [{ id: 1 }])
+    qc.setQueryData(timetableKeys.byTeacher(7), [{ id: 2 }])
+    qc.setQueryData(timetableKeys.mine(), [{ id: 3 }])
+    qc.setQueryData(timetableKeys.teacherWeek(7), { teacher_id: 7 })
+    qc.setQueryData(timetableKeys.availabilities(7), [{ id: 9 }])
+
+    const retenues = listesDeCreneaux(qc).map(([cle]) => cle[1])
+    expect(retenues.sort()).toEqual(["class", "mine", "teacher"])
+  })
+
+  it("laisse la semaine de l'enseignant intacte", () => {
+    const qc = new QueryClient()
+    const semaine = { teacher_id: 7, busy: [], open: [] }
+    qc.setQueryData(timetableKeys.byClass(3), [{ id: 1 }])
+    qc.setQueryData(timetableKeys.teacherWeek(7), semaine)
+
+    for (const [cle, data] of listesDeCreneaux(qc)) {
+      qc.setQueryData(cle, [...(data as unknown[]), { id: 99 }])
+    }
+
+    // L'assertion qui porte tout : c'est elle qui distingue le filtre par clé
+    // d'un simple `Array.isArray`, lequel écrirait dans les disponibilités.
+    expect(qc.getQueryData(timetableKeys.teacherWeek(7))).toBe(semaine)
+    expect(qc.getQueryData(timetableKeys.byClass(3))).toHaveLength(2)
+  })
+})
+
+describe("le préfixe du cache paiements", () => {
+  it("ramène le récapitulatif, qui n'a pas d'items", () => {
+    const qc = new QueryClient()
+    qc.setQueryData(paymentKeys.list({}), { items: [{ id: 1, status: "completed" }], total: 1 })
+    qc.setQueryData(paymentKeys.summary(2026), { total_completed: 1000, payment_count: 1 })
+
+    const recap = qc
+      .getQueriesData({ queryKey: paymentKeys.all })
+      .find(([cle]) => cle[1] === "summary")![1] as { items?: unknown[] }
+
+    expect(recap.items).toBeUndefined()
+    expect(() => recap.items!.map((x) => x)).toThrow(TypeError)
+  })
+})

--- a/lib/hooks/usePayments.ts
+++ b/lib/hooks/usePayments.ts
@@ -22,6 +22,11 @@ export const paymentKeys = {
     ["payments", "preview", enrollmentId, amount] as const,
 }
 
+/** Les seules entrées du cache qui contiennent une page de versements. */
+const estListePaginee = (cle: readonly unknown[]): boolean =>
+  cle[1] === "list" || cle[1] === "enrollment"
+
+
 export function usePayments(params: PaymentListParams = {}) {
   return useQuery({
     queryKey: paymentKeys.list(params),
@@ -123,17 +128,25 @@ export function useRecordEnrollmentPayment(enrollmentId: number) {
   })
 }
 
-/** Met à jour optimistiquement le statut d'un paiement dans le cache paginé */
+/**
+ * Met à jour optimistiquement le statut d'un paiement dans les listes paginées.
+ *
+ * Le préfixe `["payments"]` ramène aussi `["payments", "summary", …]`, dont la
+ * valeur est un récapitulatif financier sans `items`, et `["payments",
+ * "cashiers"]`, qui est une simple liste. Écrire dedans jetait
+ * « Cannot read properties of undefined » avant que la requête ne parte : la
+ * validation et l'annulation d'un versement échouaient sur l'écran des
+ * paiements, qui affiche justement le récapitulatif à côté de la liste.
+ */
 function optimisticStatusUpdate(
   queryClient: ReturnType<typeof useQueryClient>,
   paymentId: number,
   newStatus: Payment["status"],
 ) {
-  // Met à jour dans toutes les listes paginées en cache
   queryClient.setQueriesData<PaginatedResponse<Payment>>(
-    { queryKey: paymentKeys.all },
+    { queryKey: paymentKeys.all, predicate: (q) => estListePaginee(q.queryKey) },
     (old) => {
-      if (!old) return old
+      if (!old?.items) return old
       return {
         ...old,
         items: old.items.map((p) =>

--- a/lib/hooks/useTimetable.ts
+++ b/lib/hooks/useTimetable.ts
@@ -23,6 +23,23 @@ export const timetableKeys = {
   myWeek: () => ["timetable", "week", "mine"] as const,
 }
 
+/**
+ * Les seules entrées du cache qui contiennent une liste de créneaux.
+ *
+ * `getQueriesData` fait une correspondance par **préfixe** : demander
+ * `["timetable"]` ramène aussi `["timetable", "week", 7]`, dont la valeur est
+ * un objet `TeacherWeek`, et `["timetable", "availabilities", 7]`, dont la
+ * valeur est une liste de plages. Étaler l'un ou mapper l'autre casse la mise
+ * à jour optimiste avant même que la requête ne parte — c'est ce qui faisait
+ * échouer l'enregistrement d'un créneau sur « r is not iterable ».
+ *
+ * Le générique `getQueriesData<TimetableSlot[]>` ne protège de rien : c'est
+ * une affirmation que le cache ne garantit pas, et TypeScript la croit.
+ */
+const estListeDeCreneaux = ([cle]: [readonly unknown[], unknown]): boolean =>
+  cle[1] === "class" || cle[1] === "teacher" || cle[1] === "mine"
+
+
 export function useTimetable(classId: number) {
   return useQuery({
     queryKey: timetableKeys.byClass(classId),
@@ -55,9 +72,9 @@ export function useCreateSlot() {
     mutationFn: (data: TimetableSlotCreate) => timetableApi.create(data),
     onMutate: async (newSlot) => {
       await queryClient.cancelQueries({ queryKey: timetableKeys.all })
-      const queries = queryClient.getQueriesData<TimetableSlot[]>({
-        queryKey: timetableKeys.all,
-      })
+      const queries = queryClient
+        .getQueriesData<TimetableSlot[]>({ queryKey: timetableKeys.all })
+        .filter(estListeDeCreneaux)
       const optimistic: TimetableSlot = {
         id: -Date.now(),
         class_id: newSlot.class_id,
@@ -102,9 +119,9 @@ export function useUpdateSlot(id: number) {
     mutationFn: (data: TimetableSlotUpdate) => timetableApi.update(id, data),
     onMutate: async (updatedFields) => {
       await queryClient.cancelQueries({ queryKey: timetableKeys.all })
-      const queries = queryClient.getQueriesData<TimetableSlot[]>({
-        queryKey: timetableKeys.all,
-      })
+      const queries = queryClient
+        .getQueriesData<TimetableSlot[]>({ queryKey: timetableKeys.all })
+        .filter(estListeDeCreneaux)
       for (const [key, data] of queries) {
         if (data) {
           queryClient.setQueryData(
@@ -138,9 +155,9 @@ export function useDeleteSlot() {
     mutationFn: (id: number) => timetableApi.remove(id),
     onMutate: async (deletedId) => {
       await queryClient.cancelQueries({ queryKey: timetableKeys.all })
-      const queries = queryClient.getQueriesData<TimetableSlot[]>({
-        queryKey: timetableKeys.all,
-      })
+      const queries = queryClient
+        .getQueriesData<TimetableSlot[]>({ queryKey: timetableKeys.all })
+        .filter(estListeDeCreneaux)
       for (const [key, data] of queries) {
         if (data) {
           queryClient.setQueryData(


### PR DESCRIPTION
Accompagne African-DC/klassci-college-backend#303.

## Le défaut principal

Enregistrer un créneau échouait sur « r is not iterable » **sans rien envoyer au serveur** : la `TypeError` était jetée dans `onMutate`.

`getQueriesData` fait une correspondance par préfixe : `["timetable"]` ramène aussi la semaine de l'enseignant, qui est un objet. Trois gestes cassés — ajouter, modifier, supprimer — et le même motif sur les paiements, où le préfixe ramène le récapitulatif financier sans `items`.

Le défaut dormait depuis la mise en place des mises à jour optimistes. Il a été réveillé avant-hier par l'affichage de la semaine dans le formulaire, qui a mis la première valeur non-liste sous ce préfixe.

Quatre tests exercent la vraie sélection sur un vrai `QueryClient`. Celui qui porte tout vérifie que la semaine ressort **intacte** — ce qu'un simple `Array.isArray` ne garantirait pas, puisqu'il écrirait quand même dans les disponibilités.

## L'ergonomie

Le formulaire ne s'ouvre plus sous `md` : sur cinq pouces, la semaine se réduit à une liste qu'il faut dérouler sur six jours, on décide sans voir. La carte de consultation mobile dit pourquoi, là où elle se lit.

La semaine prend désormais la colonne flexible et les champs sont fixes — six listes déroulantes n'ont pas besoin de 1fr, une grille de six jours si. Les champs Début et Fin débordaient faute de `w-full`, et les horaires de la liste se coupaient au milieu du tiret.

## Vérification

208 tests. Vérifié en ligne : le `POST` part, « Créneau créé avec succès », et sur téléphone le bouton Modifier ouvre l'explication au lieu d'un formulaire inutilisable.

Closes #358