### PR TITLE
feat(payments): ask for the cancellation reason, and show it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- L'annulation d'un versement demande un motif écrit, affiché ensuite sous le statut dans le journal des paiements *(caissier, comptable, directeur)*
 - L'enseignant déclare ses indisponibilités depuis « Mon emploi du temps », sur la même grille que celle de sa fiche côté administration *(enseignant)*
 - Le formulaire de créneau affiche la semaine de l'enseignant choisi, cours dans les autres classes et plages fermées, et prévient avant d'enregistrer quand l'horaire visé ne passe pas *(directeur des études, secrétariat, admin)*
 - Onglet « Moyens de paiement » dans Paramètres : pour chaque profil qui encaisse, on coche les moyens qu'il a le droit de saisir. Retirer les espèces au comptable prend deux clics, et l'écran prévient qu'autoriser les espèces engage une journée de caisse à ouvrir et à compter *(admin, directeur)*

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -558,11 +558,8 @@ export function PaymentsPageClient() {
                           <span className="text-sm">{statusCfg.label}</span>
                         </div>
                         {payment.cancellation_reason && (
-                          <p
-                            className="mt-0.5 max-w-[22rem] text-xs text-muted-foreground"
-                            title={motifComplet(payment)}
-                          >
-                            {payment.cancellation_reason}
+                          <p className="mt-0.5 max-w-[22rem] text-xs text-muted-foreground">
+                            {motifComplet(payment)}
                           </p>
                         )}
                       </TableCell>
@@ -671,6 +668,11 @@ export function PaymentsPageClient() {
                             {payment.fee_name}
                           </p>
                         )}
+                        {payment.cancellation_reason && (
+                          <p className="mt-1 text-[11px] text-muted-foreground">
+                            {motifComplet(payment)}
+                          </p>
+                        )}
                       </div>
                     </div>
                   </button>
@@ -729,6 +731,12 @@ export function PaymentsPageClient() {
               <p className="text-xs text-muted-foreground">
                 Une phrase, pas un mot : elle figurera sur le bordereau de caisse et sur le
                 reçu.
+              </p>
+              <p className="rounded-md bg-amber-500/10 px-2.5 py-2 text-xs text-amber-900 dark:text-amber-200">
+                À n&apos;utiliser que si <strong>aucun argent n&apos;a bougé</strong> : une
+                saisie en trop, un double. Si l&apos;argent a bien été encaissé, annuler le
+                ferait disparaître alors qu&apos;il est dans le tiroir, et la caisse serait
+                en excédent inexpliqué à la clôture. Passez par la comptabilité.
               </p>
             </div>
           )}

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Card, CardContent } from "@/components/ui/card"
 import { PageHero, heroAccentBtn, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
@@ -65,6 +66,15 @@ import type { PaymentListParams, PaymentStatus, PaymentMethod, Payment } from "@
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? ""
 
+/** « Annulé le 23/08/2026 par M. Konan · motif » — la ligne d'un contrôle. */
+function motifComplet(p: Payment): string {
+  const quand = p.cancelled_at
+    ? ` le ${new Date(p.cancelled_at).toLocaleDateString("fr-FR")}`
+    : ""
+  const qui = p.cancelled_by_name ? ` par ${p.cancelled_by_name}` : ""
+  return `Annulé${quand}${qui}${p.cancellation_reason ? ` · ${p.cancellation_reason}` : ""}`
+}
+
 const STATUS_CONFIG: Record<PaymentStatus, { label: string; variant: "default" | "secondary" | "destructive" | "outline"; dot: string }> = {
   pending: { label: "En attente", variant: "secondary", dot: "bg-amber-500" },
   completed: { label: "Validé", variant: "default", dot: "bg-emerald-500" },
@@ -83,6 +93,10 @@ export function PaymentsPageClient() {
   const [dateFrom, setDateFrom] = useState("")
   const [dateTo, setDateTo] = useState("")
   const [confirmAction, setConfirmAction] = useState<{ type: "validate" | "cancel"; payment: Payment } | null>(null)
+  // Le motif d'annulation figure sur le bordereau et sur le reçu réimprimé :
+  // il est exigé ici, pas seulement côté serveur, pour que la personne qui
+  // annule sache qu'elle signe une phrase.
+  const [motifAnnulation, setMotifAnnulation] = useState("")
   const [downloadingId, setDownloadingId] = useState<number | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [previewPaymentId, setPreviewPaymentId] = useState<number | null>(null)
@@ -185,13 +199,19 @@ export function PaymentsPageClient() {
     }
   }
 
+  const motifTropCourt = motifAnnulation.trim().length < 10
+
   function handleConfirmAction() {
     if (!confirmAction) return
-    const onSuccess = () => setConfirmAction(null)
+    const onSuccess = () => {
+      setConfirmAction(null)
+      setMotifAnnulation("")
+    }
     if (confirmAction.type === "validate") {
       validatePayment(confirmAction.payment.id, { onSuccess })
     } else {
-      cancelPayment(confirmAction.payment.id, { onSuccess })
+      if (motifTropCourt) return
+      cancelPayment({ id: confirmAction.payment.id, reason: motifAnnulation.trim() }, { onSuccess })
     }
   }
 
@@ -537,6 +557,14 @@ export function PaymentsPageClient() {
                           <div className={`h-2 w-2 rounded-full ${statusCfg.dot}`} />
                           <span className="text-sm">{statusCfg.label}</span>
                         </div>
+                        {payment.cancellation_reason && (
+                          <p
+                            className="mt-0.5 max-w-[22rem] text-xs text-muted-foreground"
+                            title={motifComplet(payment)}
+                          >
+                            {payment.cancellation_reason}
+                          </p>
+                        )}
                       </TableCell>
                       <TableCell className="text-sm text-muted-foreground tabular-nums">
                         {new Date(payment.created_at).toLocaleDateString("fr-FR", {
@@ -664,7 +692,15 @@ export function PaymentsPageClient() {
       <PaymentCreateWizard open={createOpen} onClose={() => setCreateOpen(false)} />
 
       {/* Confirmation dialog */}
-      <AlertDialog open={!!confirmAction} onOpenChange={(open) => { if (!open) setConfirmAction(null) }}>
+      <AlertDialog
+        open={!!confirmAction}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmAction(null)
+            setMotifAnnulation("")
+          }
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
@@ -673,12 +709,37 @@ export function PaymentsPageClient() {
             <AlertDialogDescription>
               {confirmAction?.type === "validate"
                 ? `Vous allez valider le paiement de ${Number(confirmAction.payment.amount).toLocaleString("fr-FR")} FCFA. Cette action est irréversible.`
-                : `Vous allez annuler le paiement de ${Number(confirmAction?.payment.amount).toLocaleString("fr-FR")} FCFA. Cette action est irréversible.`}
+                : `Le versement de ${Number(confirmAction?.payment.amount).toLocaleString("fr-FR")} FCFA ne sera pas supprimé : il restera dans le journal, marqué annulé, avec votre nom et votre motif. Le reçu réimprimé le dira aussi.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
+
+          {confirmAction?.type === "cancel" && (
+            <div className="space-y-1.5">
+              <label htmlFor="motif-annulation" className="text-sm font-medium">
+                Motif de l&apos;annulation *
+              </label>
+              <Textarea
+                id="motif-annulation"
+                value={motifAnnulation}
+                onChange={(e) => setMotifAnnulation(e.target.value)}
+                placeholder="Ex : montant saisi en trop, la caisse ne contient pas ces 5 000 F."
+                rows={3}
+                autoFocus
+              />
+              <p className="text-xs text-muted-foreground">
+                Une phrase, pas un mot : elle figurera sur le bordereau de caisse et sur le
+                reçu.
+              </p>
+            </div>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>Retour</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmAction} disabled={validating || cancelling}>
+            <AlertDialogAction
+              onClick={handleConfirmAction}
+              disabled={
+                validating || cancelling || (confirmAction?.type === "cancel" && motifTropCourt)
+              }
+            >
               {validating || cancelling
                 ? "Traitement..."
                 : confirmAction?.type === "validate" ? "Valider" : "Annuler le paiement"}

--- a/lib/api/payments.ts
+++ b/lib/api/payments.ts
@@ -153,8 +153,11 @@ export const paymentsApi = {
   },
 
   // Annuler un paiement (cascade DELETE allocations + recompute fees)
-  cancel: async (id: number): Promise<Payment> => {
-    const json = await apiFetch<unknown>(`/payments/${id}/cancel`, { method: "POST" })
+  cancel: async (id: number, reason: string): Promise<Payment> => {
+    const json = await apiFetch<unknown>(`/payments/${id}/cancel`, {
+      method: "POST",
+      body: JSON.stringify({ reason }),
+    })
     return safeValidate(
       PaymentSchema,
       unwrapPayment(json),

--- a/lib/contracts/payment.ts
+++ b/lib/contracts/payment.ts
@@ -51,6 +51,12 @@ export const PaymentSchema = z.object({
   // Qui a encaissé, en clair. Sans lui, la colonne « Encaissé par » afficherait
   // un identifiant, ce qui ne répond pas à la question qu'on lui pose.
   received_by_name: z.string().nullable().optional(),
+  // Renseignés seulement sur un versement annulé : le bordereau et le reçu
+  // réimprimé les portent, l'écran doit pouvoir les dire aussi.
+  cancelled_at: z.string().nullable().optional(),
+  cancelled_by: z.number().nullable().optional(),
+  cancelled_by_name: z.string().nullable().optional(),
+  cancellation_reason: z.string().nullable().optional(),
   created_at: z.string(),
   updated_at: z.string(),
   student_name: z.string().nullable().optional(),

--- a/lib/hooks/usePayments.ts
+++ b/lib/hooks/usePayments.ts
@@ -174,8 +174,9 @@ export function useValidatePayment() {
 export function useCancelPayment() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (id: number) => paymentsApi.cancel(id),
-    onMutate: async (id) => {
+    mutationFn: ({ id, reason }: { id: number; reason: string }) =>
+      paymentsApi.cancel(id, reason),
+    onMutate: async ({ id }) => {
       await queryClient.cancelQueries({ queryKey: paymentKeys.all })
       const snapshots = queryClient.getQueriesData<PaginatedResponse<Payment>>({
         queryKey: paymentKeys.all,


### PR DESCRIPTION
Accompagne African-DC/klassci-college-backend#304.

Le bouton d'annulation ouvrait une confirmation qui parlait d'action irréversible et n'attendait qu'un clic. Elle demande maintenant une phrase, la refuse en dessous de dix caractères, et dit ce qui se passe vraiment : le versement n'est pas supprimé, il reste dans le journal marqué annulé, avec le nom de qui annule et son motif.

Une mise en garde dit à quoi l'annulation **ne** sert pas : si l'argent a bien été encaissé, l'annuler le ferait disparaître alors qu'il est dans le tiroir, et la caisse serait en excédent inexpliqué à la clôture. Sans cette phrase, le champ libre acceptait volontiers « remboursement au parent ».

Le motif se lit ensuite sous le statut, avec la date et le signataire — dans le DOM et non en infobulle, qui n'existe pas au doigt sur l'écran du terrain.

204 tests verts.