### PR TITLE
fix(payments): offer the cancel action on a payment already collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+- Annulation d'un versement déjà encaissé, depuis le tableau comme depuis le téléphone : c'est le cas courant, un montant saisi qui n'est pas dans la caisse *(admin)*
+
 ### Added
 - L'annulation d'un versement demande un motif écrit, affiché ensuite sous le statut dans le journal des paiements *(caissier, comptable, directeur)*
 - L'enseignant déclare ses indisponibilités depuis « Mon emploi du temps », sur la même grille que celle de sa fiche côté administration *(enseignant)*

--- a/components/admin/payments/PaymentCardActions.tsx
+++ b/components/admin/payments/PaymentCardActions.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { CheckCircle, XCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { canCancelPayment, canValidatePayment, paymentSubject } from "@/lib/utils/payment-lifecycle"
+import type { Payment } from "@/lib/contracts/payment"
+
+interface PaymentCardActionsProps {
+  payment: Payment
+  onValidate: (payment: Payment) => void
+  onCancel: (payment: Payment) => void
+}
+
+/**
+ * Les gestes sous une carte tactile : boutons pleine largeur, `h-11`.
+ *
+ * C'est au téléphone que la caissière travaille, et la carte n'offrait rien —
+ * livrer la correction comptable sans elle revenait à ne pas la livrer.
+ *
+ * Pas de bouton « reçu » ici : la carte entière l'ouvre déjà, et deux
+ * commandes voisines pour une seule action coûteraient une carte par écran
+ * sur cinq pouces. Le pied de carte, liseré compris, disparaît donc
+ * entièrement quand il ne reste rien à faire — un versement déjà annulé ne
+ * mérite pas une barre vide.
+ *
+ * Le nom de l'élève s'ajoute au libellé visible plutôt que de le remplacer :
+ * la commande vocale doit continuer de répondre au mot affiché.
+ */
+export function PaymentCardActions({ payment, onValidate, onCancel }: PaymentCardActionsProps) {
+  const canValidate = canValidatePayment(payment.status)
+  const canCancel = canCancelPayment(payment.status)
+  if (!canValidate && !canCancel) return null
+
+  const subject = paymentSubject(payment)
+
+  return (
+    <div className="flex gap-2 border-t px-3 py-2">
+      {canValidate && (
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-11 flex-1"
+          onClick={() => onValidate(payment)}
+        >
+          <CheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+          <span>Valider</span>
+          <span className="sr-only"> le versement {subject}</span>
+        </Button>
+      )}
+
+      {canCancel && (
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-11 flex-1 text-destructive hover:text-destructive"
+          onClick={() => onCancel(payment)}
+        >
+          <XCircle className="h-4 w-4" aria-hidden="true" />
+          <span>Annuler</span>
+          <span className="sr-only"> le versement {subject}</span>
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/components/admin/payments/PaymentRowActions.tsx
+++ b/components/admin/payments/PaymentRowActions.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { CheckCircle, Eye, XCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { canCancelPayment, canValidatePayment, paymentSubject } from "@/lib/utils/payment-lifecycle"
+import type { Payment } from "@/lib/contracts/payment"
+
+interface PaymentRowActionsProps {
+  payment: Payment
+  onValidate: (payment: Payment) => void
+  onCancel: (payment: Payment) => void
+  onPreviewReceipt: (payment: Payment) => void
+  /** Le reçu en cours de préparation, pour désactiver le seul bouton concerné. */
+  previewBusy?: boolean
+}
+
+/**
+ * Les gestes sur une ligne du tableau : trois icônes, alignées à droite.
+ *
+ * Icônes seules, donc chaque bouton porte son intitulé en `aria-label` et en
+ * `title` — et nomme l'élève : sans lui, une liste de vingt lignes annonce
+ * vingt fois « Annuler », sur un geste financier irréversible.
+ *
+ * La variante tactile est un composant distinct, `PaymentCardActions` : elle
+ * n'a ni les mêmes gestes ni la même forme, et les réunir sous un drapeau
+ * `stacked` faisait diverger six décisions sur un seul booléen.
+ */
+export function PaymentRowActions({
+  payment,
+  onValidate,
+  onCancel,
+  onPreviewReceipt,
+  previewBusy = false,
+}: PaymentRowActionsProps) {
+  const subject = paymentSubject(payment)
+
+  return (
+    <div className="flex justify-end gap-2">
+      {canValidatePayment(payment.status) && (
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-8 w-8"
+          onClick={() => onValidate(payment)}
+          title={`Valider le versement ${subject}`}
+          aria-label={`Valider le versement ${subject}`}
+        >
+          <CheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+        </Button>
+      )}
+
+      {canCancelPayment(payment.status) && (
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-8 w-8 text-destructive hover:text-destructive"
+          onClick={() => onCancel(payment)}
+          title={`Annuler le versement ${subject}`}
+          aria-label={`Annuler le versement ${subject}`}
+        >
+          <XCircle className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      )}
+
+      <Button
+        type="button"
+        size="icon"
+        variant="ghost"
+        className="h-8 w-8"
+        onClick={() => onPreviewReceipt(payment)}
+        disabled={previewBusy}
+        title={`Voir le reçu ${subject}`}
+        aria-label={`Voir le reçu ${subject}`}
+      >
+        <Eye className="h-4 w-4" aria-hidden="true" />
+      </Button>
+    </div>
+  )
+}

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -2,12 +2,14 @@
 
 import { useState, useMemo, useCallback } from "react"
 import {
-  Plus, CheckCircle, XCircle, Download, Wallet, TrendingUp,
+  Plus, Download, Wallet, TrendingUp,
   AlertCircle, Banknote, CreditCard, Search, X, Eye,
   Receipt, CalendarDays, Coins, Smartphone, Building2, FileText,
   FileSpreadsheet, Loader2, UserCheck,
 } from "lucide-react"
 import { toast } from "sonner"
+import { PaymentRowActions } from "@/components/admin/payments/PaymentRowActions"
+import { PaymentCardActions } from "@/components/admin/payments/PaymentCardActions"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
@@ -572,41 +574,16 @@ export function PaymentsPageClient() {
                       </TableCell>
                       <TableCell className="text-right">
                         <div
-                          className="flex items-center justify-end gap-1 opacity-60 group-hover:opacity-100 transition-opacity"
+                          className="opacity-60 transition-opacity group-hover:opacity-100"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          {payment.status === "pending" && (
-                            <>
-                              <Button
-                                size="icon"
-                                variant="ghost"
-                                className="h-8 w-8"
-                                onClick={() => setConfirmAction({ type: "validate", payment })}
-                                title="Valider"
-                              >
-                                <CheckCircle className="h-4 w-4 text-emerald-600" />
-                              </Button>
-                              <Button
-                                size="icon"
-                                variant="ghost"
-                                className="h-8 w-8"
-                                onClick={() => setConfirmAction({ type: "cancel", payment })}
-                                title="Annuler"
-                              >
-                                <XCircle className="h-4 w-4 text-destructive" />
-                              </Button>
-                            </>
-                          )}
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="h-8 w-8"
-                            onClick={() => handlePreviewReceipt(payment)}
-                            disabled={downloadingId === payment.id}
-                            title="Voir le reçu"
-                          >
-                            <Eye className="h-4 w-4" />
-                          </Button>
+                          <PaymentRowActions
+                            payment={payment}
+                            onValidate={(p) => setConfirmAction({ type: "validate", payment: p })}
+                            onCancel={(p) => setConfirmAction({ type: "cancel", payment: p })}
+                            onPreviewReceipt={handlePreviewReceipt}
+                            previewBusy={downloadingId === payment.id}
+                          />
                         </div>
                       </TableCell>
                     </TableRow>
@@ -625,57 +602,66 @@ export function PaymentsPageClient() {
                   ? payment.student_name.split(" ").map((w) => w[0]).join("").slice(0, 2).toUpperCase()
                   : "?"
                 return (
-                  <button
+                  <div
                     key={payment.id}
-                    type="button"
-                    onClick={() => handlePreviewReceipt(payment)}
-                    className="w-full rounded-lg border bg-card p-3 text-left transition-colors hover:bg-accent/40 active:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    className="overflow-hidden rounded-lg border bg-card"
                   >
-                    <div className="flex items-start gap-3">
-                      <StudentAvatar photoUrl={payment.student_photo_url} initials={initials} />
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-start justify-between gap-2">
-                          <p className="truncate text-sm font-medium leading-tight">
-                            {payment.student_name ?? `Paiement #${payment.id}`}
+                    <button
+                      type="button"
+                      onClick={() => handlePreviewReceipt(payment)}
+                      className="w-full p-3 text-left transition-colors hover:bg-accent/40 active:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                    >
+                      <div className="flex items-start gap-3">
+                        <StudentAvatar photoUrl={payment.student_photo_url} initials={initials} />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-start justify-between gap-2">
+                            <p className="truncate text-sm font-medium leading-tight">
+                              {payment.student_name ?? `Paiement #${payment.id}`}
+                            </p>
+                            <p className="shrink-0 text-base font-semibold tabular-nums leading-tight">
+                              {Number(payment.amount).toLocaleString("fr-FR")}
+                              <span className="ml-0.5 text-[10px] font-normal text-muted-foreground">FCFA</span>
+                            </p>
+                          </div>
+                          <div className="mt-1.5 flex items-center gap-3 text-[11px] text-muted-foreground">
+                            <span className="flex items-center gap-1">
+                              <MethodIcon className="h-3 w-3" aria-hidden="true" />
+                              {paymentMethodLabel(payment.method)}
+                            </span>
+                            <span className="tabular-nums">
+                              {new Date(payment.created_at).toLocaleDateString("fr-FR", {
+                                day: "2-digit",
+                                month: "short",
+                              })}
+                            </span>
+                            <span className="ml-auto inline-flex items-center gap-1">
+                              <span className={`h-1.5 w-1.5 rounded-full ${statusCfg.dot}`} aria-hidden="true" />
+                              <span className="font-medium">{statusCfg.label}</span>
+                            </span>
+                          </div>
+                          <p className="mt-1 flex items-center gap-1 truncate text-[11px] text-muted-foreground">
+                            <UserCheck className="h-3 w-3 shrink-0" aria-hidden="true" />
+                            Encaissé par {payment.received_by_name ?? "—"}
                           </p>
-                          <p className="shrink-0 text-base font-semibold tabular-nums leading-tight">
-                            {Number(payment.amount).toLocaleString("fr-FR")}
-                            <span className="ml-0.5 text-[10px] font-normal text-muted-foreground">FCFA</span>
-                          </p>
+                          {payment.fee_name && (
+                            <p className="mt-1 truncate text-[11px] text-muted-foreground">
+                              {payment.fee_name}
+                            </p>
+                          )}
+                          {payment.cancellation_reason && (
+                            <p className="mt-1 text-[11px] text-muted-foreground">
+                              {motifComplet(payment)}
+                            </p>
+                          )}
                         </div>
-                        <div className="mt-1.5 flex items-center gap-3 text-[11px] text-muted-foreground">
-                          <span className="flex items-center gap-1">
-                            <MethodIcon className="h-3 w-3" aria-hidden="true" />
-                            {paymentMethodLabel(payment.method)}
-                          </span>
-                          <span className="tabular-nums">
-                            {new Date(payment.created_at).toLocaleDateString("fr-FR", {
-                              day: "2-digit",
-                              month: "short",
-                            })}
-                          </span>
-                          <span className="ml-auto inline-flex items-center gap-1">
-                            <span className={`h-1.5 w-1.5 rounded-full ${statusCfg.dot}`} aria-hidden="true" />
-                            <span className="font-medium">{statusCfg.label}</span>
-                          </span>
-                        </div>
-                        <p className="mt-1 flex items-center gap-1 truncate text-[11px] text-muted-foreground">
-                          <UserCheck className="h-3 w-3 shrink-0" aria-hidden="true" />
-                          Encaissé par {payment.received_by_name ?? "—"}
-                        </p>
-                        {payment.fee_name && (
-                          <p className="mt-1 truncate text-[11px] text-muted-foreground">
-                            {payment.fee_name}
-                          </p>
-                        )}
-                        {payment.cancellation_reason && (
-                          <p className="mt-1 text-[11px] text-muted-foreground">
-                            {motifComplet(payment)}
-                          </p>
-                        )}
                       </div>
-                    </div>
-                  </button>
+                    </button>
+                    <PaymentCardActions
+                      payment={payment}
+                      onValidate={(p) => setConfirmAction({ type: "validate", payment: p })}
+                      onCancel={(p) => setConfirmAction({ type: "cancel", payment: p })}
+                    />
+                  </div>
                 )
               })}
             </div>

--- a/components/admin/payments/payment-actions.test.tsx
+++ b/components/admin/payments/payment-actions.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Le bouton d'annulation existe-t-il sur une ligne déjà encaissée ?
+ *
+ * Le défaut qui a vécu en production n'était pas dans une fonction : il était
+ * dans le JSX, un `payment.status === "pending" &&` posé autour du bouton. Un
+ * test du seul prédicat resterait vert si quelqu'un le réintroduisait demain.
+ * Ceux-ci rendent les deux composants et cherchent le bouton — le tableau et
+ * la carte tactile, car c'est au téléphone que la caissière travaille.
+ *
+ * Le versement de test passe par `PaymentSchema.parse` plutôt que par un
+ * `as Payment` : un champ oublié doit faire échouer le test bruyamment, pas
+ * arriver au composant en `undefined`.
+ */
+
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { PaymentCardActions } from "@/components/admin/payments/PaymentCardActions"
+import { PaymentRowActions } from "@/components/admin/payments/PaymentRowActions"
+import { PaymentSchema, type PaymentStatus } from "@/lib/contracts/payment"
+
+function payment(status: PaymentStatus, studentName: string | null = "Aminata Traoré") {
+  return PaymentSchema.parse({
+    id: 42,
+    enrollment_id: 7,
+    amount: 5000,
+    method: "cash",
+    status,
+    reference: null,
+    student_name: studentName,
+    created_at: "2026-08-23T10:00:00",
+    updated_at: "2026-08-23T10:00:00",
+  })
+}
+
+const renderRow = (status: PaymentStatus) =>
+  render(
+    <PaymentRowActions
+      payment={payment(status)}
+      onValidate={vi.fn()}
+      onCancel={vi.fn()}
+      onPreviewReceipt={vi.fn()}
+    />,
+  )
+
+const renderCard = (status: PaymentStatus, studentName?: string | null) =>
+  render(
+    <PaymentCardActions
+      payment={payment(status, studentName)}
+      onValidate={vi.fn()}
+      onCancel={vi.fn()}
+    />,
+  )
+
+const cancelButton = () => screen.queryByRole("button", { name: /Annuler le versement/i })
+const validateButton = () => screen.queryByRole("button", { name: /Valider le versement/i })
+
+describe("les gestes sur une ligne du tableau", () => {
+  it("propose la correction d'un versement déjà encaissé", () => {
+    // L'assertion qui porte tout : c'est ce bouton que l'écran ne montrait pas.
+    renderRow("completed")
+    expect(cancelButton()).toBeInTheDocument()
+  })
+
+  it("propose encore valider et annuler sur un versement en attente", () => {
+    renderRow("pending")
+    expect(validateButton()).toBeInTheDocument()
+    expect(cancelButton()).toBeInTheDocument()
+  })
+
+  it("ne laisse que le reçu sur un versement déjà annulé", () => {
+    renderRow("cancelled")
+    expect(cancelButton()).toBeNull()
+    expect(validateButton()).toBeNull()
+    expect(screen.getByRole("button", { name: /Voir le reçu/i })).toBeInTheDocument()
+  })
+})
+
+describe("les gestes sous une carte tactile", () => {
+  it("propose la correction d'un versement déjà encaissé", () => {
+    renderCard("completed")
+    expect(cancelButton()).toBeInTheDocument()
+  })
+
+  it("n'affiche aucun pied de carte quand il n'y a plus rien à faire", () => {
+    const { container } = renderCard("cancelled")
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("ne répète pas le reçu, que la carte entière ouvre déjà", () => {
+    renderCard("completed")
+    expect(screen.queryByRole("button", { name: /reçu/i })).toBeNull()
+  })
+
+  it("nomme l'élève sans remplacer le libellé visible", () => {
+    renderCard("completed")
+    expect(
+      screen.getByRole("button", { name: "Annuler le versement d'Aminata Traoré" }),
+    ).toBeInTheDocument()
+  })
+
+  it("nomme le versement par son numéro quand l'élève manque", () => {
+    // Sinon le lecteur d'écran disait « le versement de versement nº 42 ».
+    renderCard("completed", null)
+    expect(screen.getByRole("button", { name: "Annuler le versement nº 42" })).toBeInTheDocument()
+  })
+})

--- a/lib/utils/payment-lifecycle.test.ts
+++ b/lib/utils/payment-lifecycle.test.ts
@@ -1,0 +1,55 @@
+/**
+ * La règle d'affichage suit la table de transitions du serveur.
+ *
+ * Le défaut verrouillé ici a vécu en production : l'écran n'offrait le bouton
+ * qu'aux versements `pending`, alors que `completed → cancelled` est
+ * précisément le cas du montant encaissé en trop.
+ */
+
+import { describe, expect, it } from "vitest"
+import { canCancelPayment, canValidatePayment, paymentSubject } from "./payment-lifecycle"
+
+describe("quels versements se contre-passent", () => {
+  it("accepte un versement déjà encaissé", () => {
+    // L'assertion qui porte tout : c'est le cas que l'écran cachait.
+    expect(canCancelPayment("completed")).toBe(true)
+  })
+
+  it("accepte encore le refus d'un versement en attente", () => {
+    expect(canCancelPayment("pending")).toBe(true)
+  })
+
+  it("refuse tout état sur lequel le serveur ne revient plus", () => {
+    for (const status of ["cancelled", "refunded", "failed"] as const) {
+      expect(canCancelPayment(status)).toBe(false)
+    }
+  })
+})
+
+describe("comment on nomme un versement à voix haute", () => {
+  it("élide devant une voyelle, accentuée comprise", () => {
+    expect(paymentSubject({ id: 1, student_name: "Aminata Traoré" })).toBe("d'Aminata Traoré")
+    expect(paymentSubject({ id: 1, student_name: "Émile Kouassi" })).toBe("d'Émile Kouassi")
+  })
+
+  it("garde « de » devant une consonne, Y initial compris", () => {
+    expect(paymentSubject({ id: 1, student_name: "Kouassi N'Dri" })).toBe("de Kouassi N'Dri")
+    // « d'Yao » serait une faute, et Yao est un des noms les plus portés ici.
+    expect(paymentSubject({ id: 1, student_name: "Yao Kouadio" })).toBe("de Yao Kouadio")
+  })
+
+  it("nomme le versement par son numéro quand l'élève manque", () => {
+    // Sans ce cas, le lecteur d'écran disait « le versement de versement nº 42 ».
+    expect(paymentSubject({ id: 42, student_name: null })).toBe("nº 42")
+    expect(paymentSubject({ id: 42 })).toBe("nº 42")
+  })
+})
+
+describe("quels versements se valident", () => {
+  it("n'accepte que ce qui n'est pas encore entré en caisse", () => {
+    expect(canValidatePayment("pending")).toBe(true)
+    for (const status of ["completed", "cancelled", "refunded", "failed"] as const) {
+      expect(canValidatePayment(status)).toBe(false)
+    }
+  })
+})

--- a/lib/utils/payment-lifecycle.ts
+++ b/lib/utils/payment-lifecycle.ts
@@ -1,0 +1,57 @@
+/**
+ * Quels versements se contre-passent, et comment les nommer à voix haute.
+ *
+ * La règle surprend, donc elle est nommée plutôt que recopiée dans un JSX :
+ * un versement **déjà encaissé** s'annule. C'est même le cas courant au
+ * guichet — la caissière a saisi un montant qui n'est pas dans le tiroir, et
+ * il faut le dire avant la clôture. L'écran ne proposait le geste qu'aux
+ * versements « en attente », alors que le serveur acceptait les deux : le seul
+ * cas qui arrive vraiment était donc injoignable.
+ *
+ * C'est le miroir de `VALID_TRANSITIONS` côté serveur, restreint à la
+ * transition qui nous intéresse ici :
+ *
+ *     pending   → completed, cancelled
+ *     completed → refunded,  cancelled     ← la correction comptable
+ *     failed / refunded / cancelled → rien
+ *
+ * Ce que ce module **ne dit pas** : qui a le droit. Le serveur le sait seul —
+ * il connaît la permission et surtout la clôture de la journée de caisse,
+ * qu'aucun navigateur ne peut deviner. Il filtre déjà la liste pour qu'une
+ * caissière ne voie que ses propres saisies. Rejouer ce calcul ici n'éviterait
+ * aucun refus, et en manquerait un vrai.
+ */
+
+import type { Payment, PaymentStatus } from "@/lib/contracts/payment"
+
+/** On ne valide que ce qui n'est pas encore entré en caisse. */
+export function canValidatePayment(status: PaymentStatus): boolean {
+  return status === "pending"
+}
+
+/** Un versement se contre-passe tant qu'il compte encore dans la caisse. */
+export function canCancelPayment(status: PaymentStatus): boolean {
+  return status === "pending" || status === "completed"
+}
+
+/**
+ * Devant une voyelle, « de » s'élide — cette phrase est lue à voix haute.
+ *
+ * Le Y initial fait exception : on dit « de Yao », jamais « d'Yao ». Et Yao,
+ * Yapo, Yeo comptent parmi les noms les plus portés en Côte d'Ivoire.
+ */
+const VOWEL = /^[aeiouâàéèêîïôöûü]/i
+
+/**
+ * Le complément qui suit « le versement » dans le nom accessible d'un bouton.
+ *
+ * Sans lui, une liste de vingt lignes annonce vingt fois « Annuler », sur un
+ * geste financier irréversible. Le nom de l'élève manque parfois : on nomme
+ * alors le versement par son numéro, plutôt que d'accoler « de » à une phrase
+ * qui n'en veut pas — « le versement de versement nº 42 » ne se dit pas.
+ */
+export function paymentSubject(payment: Pick<Payment, "id" | "student_name">): string {
+  const name = payment.student_name?.trim()
+  if (!name) return `nº ${payment.id}`
+  return VOWEL.test(name) ? `d'${name}` : `de ${name}`
+}


### PR DESCRIPTION
Closes #361

## Le défaut

L'écran ne montrait le bouton d'annulation qu'aux versements `pending`. Le backend accepte `completed → cancelled` depuis le début : c'est la contre-passation comptable, et c'est le cas qui arrive vraiment — un montant saisi qui n'est pas dans la caisse. Le geste était donc injoignable.

## Ce que fait cette PR

- **La règle d'état est nommée** dans `lib/utils/payment-lifecycle.ts` (`canValidatePayment`, `canCancelPayment`) au lieu d'être écrite dans le JSX, où vivait le défaut.
- **L'autorisation reste au serveur.** Le navigateur ignore si la journée de caisse est clôturée, et la liste est déjà cloisonnée : rejouer la permission ici n'aurait évité aucun refus et en aurait manqué un vrai.
- **Le geste atteint le téléphone.** La carte était un unique bouton englobant ; elle porte maintenant un pied qui disparaît entièrement, liseré compris, quand il n'y a plus rien à faire. Le reçu n'y est pas répété : toucher la carte l'ouvre déjà.
- **Chaque bouton nomme l'élève**, en s'ajoutant au libellé visible plutôt qu'en le remplaçant. « de » s'élide devant une voyelle mais pas devant un Y initial : « de Yao », jamais « d'Yao ».

## Vérifications

- `tsc --noEmit` propre, 15 tests verts.
- Les tests **rendent les composants** : le défaut vivait dans le JSX, un test du seul prédicat serait resté vert si la garde revenait. Vérifié en réintroduisant la garde d'origine puis le `y` dans l'élision : le test échoue à chaque fois.
- Aucune nouvelle alerte de lint.
- Revue thermo-nucléaire : quatre passes bloquantes avant l'approbation.

## Hors périmètre, signalé

`PaymentsPageClient.tsx` reste à 797 lignes et trois imports y sont inutilisés depuis avant cette PR (`Building2`, `FileText`, `Badge`). Non touchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)