### PR TITLE
refactor(payments): split the payments page into what each part owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Fixed
+- Photo de l'élève correctement recadrée dans le journal des versements, au lieu d'être étirée quand elle n'est pas carrée *(admin)*
 - Annulation d'un versement déjà encaissé, depuis le tableau comme depuis le téléphone : c'est le cas courant, un montant saisi qui n'est pas dans la caisse *(admin)*
 
 ### Added

--- a/components/admin/payments/PaymentConfirmDialog.tsx
+++ b/components/admin/payments/PaymentConfirmDialog.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Textarea } from "@/components/ui/textarea"
+import type { Payment } from "@/lib/contracts/payment"
+
+/** Le serveur exige la même longueur : une phrase, pas un mot. */
+const MOTIF_MINIMUM = 10
+
+export interface PaymentConfirmAction {
+  type: "validate" | "cancel"
+  payment: Payment
+}
+
+interface PaymentConfirmDialogProps {
+  action: PaymentConfirmAction | null
+  onClose: () => void
+  /** `reason` n'est renseigné que pour une annulation. */
+  onConfirm: (reason: string) => void
+  busy: boolean
+}
+
+/**
+ * La confirmation avant de valider ou d'annuler un versement.
+ *
+ * Le motif d'annulation vit ici, et nulle part ailleurs : il ne concerne que
+ * ce dialogue, et le laisser dans la page obligeait celle-ci à le remettre à
+ * zéro à chaque fermeture, à deux endroits différents.
+ *
+ * La longueur minimale reprend celle du serveur pour que le refus arrive avant
+ * l'envoi : mieux vaut que la personne qui annule voie tout de suite qu'elle
+ * signe une phrase, puisque cette phrase ira sur le bordereau de caisse et sur
+ * le reçu réimprimé.
+ */
+export function PaymentConfirmDialog({
+  action,
+  onClose,
+  onConfirm,
+  busy,
+}: PaymentConfirmDialogProps) {
+  const [motif, setMotif] = useState("")
+  const motifTropCourt = motif.trim().length < MOTIF_MINIMUM
+
+  // Un motif saisi puis abandonné ne doit pas réapparaître sur le versement
+  // suivant : ce serait signer l'annulation d'un autre avec la phrase d'avant.
+  useEffect(() => {
+    if (!action) setMotif("")
+  }, [action])
+
+  const annulation = action?.type === "cancel"
+  const montant = action ? Number(action.payment.amount).toLocaleString("fr-FR") : ""
+
+  return (
+    <AlertDialog open={!!action} onOpenChange={(open) => { if (!open) onClose() }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {annulation ? "Annuler ce paiement ?" : "Valider ce paiement ?"}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {annulation
+              ? `Le versement de ${montant} FCFA ne sera pas supprimé : il restera dans le journal, marqué annulé, avec votre nom et votre motif. Le reçu réimprimé le dira aussi.`
+              : `Vous allez valider le paiement de ${montant} FCFA. Cette action est irréversible.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {annulation && (
+          <div className="space-y-1.5">
+            <label htmlFor="motif-annulation" className="text-sm font-medium">
+              Motif de l&apos;annulation *
+            </label>
+            <Textarea
+              id="motif-annulation"
+              value={motif}
+              onChange={(e) => setMotif(e.target.value)}
+              placeholder="Ex : montant saisi en trop, la caisse ne contient pas ces 5 000 F."
+              rows={3}
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              Une phrase, pas un mot : elle figurera sur le bordereau de caisse et sur le
+              reçu.
+            </p>
+            <p className="rounded-md bg-amber-500/10 px-2.5 py-2 text-xs text-amber-900 dark:text-amber-200">
+              À n&apos;utiliser que si <strong>aucun argent n&apos;a bougé</strong> : une
+              saisie en trop, un double. Si l&apos;argent a bien été encaissé, annuler le
+              ferait disparaître alors qu&apos;il est dans le tiroir, et la caisse serait
+              en excédent inexpliqué à la clôture. Passez par la comptabilité.
+            </p>
+          </div>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Retour</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => onConfirm(motif.trim())}
+            disabled={busy || (annulation && motifTropCourt)}
+          >
+            {busy ? "Traitement..." : annulation ? "Annuler le paiement" : "Valider"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/admin/payments/PaymentReceiptDialog.tsx
+++ b/components/admin/payments/PaymentReceiptDialog.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { Download } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface PaymentReceiptDialogProps {
+  /** L'URL objet du PDF déjà téléchargé ; `null` ferme la fenêtre. */
+  url: string | null
+  paymentId: number | null
+  onClose: () => void
+  onDownload: () => void
+}
+
+/**
+ * L'aperçu d'un reçu avant impression.
+ *
+ * On montre le PDF plutôt que de le télécharger d'emblée : au guichet, on
+ * vérifie le montant et le nom à l'écran avant d'engager le papier, qui est
+ * une ressource comptée dans une école.
+ */
+export function PaymentReceiptDialog({
+  url,
+  paymentId,
+  onClose,
+  onDownload,
+}: PaymentReceiptDialogProps) {
+  return (
+    <Dialog open={url !== null} onOpenChange={onClose}>
+      <DialogContent className="max-w-3xl max-h-[90vh]">
+        <DialogHeader>
+          <DialogTitle>Reçu de paiement #{paymentId}</DialogTitle>
+        </DialogHeader>
+        {url && (
+          <iframe src={url} className="h-[65vh] w-full rounded-lg border" title="Aperçu du reçu" />
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Fermer
+          </Button>
+          <Button onClick={onDownload}>
+            <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+            Télécharger le PDF
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin/payments/PaymentsFilters.tsx
+++ b/components/admin/payments/PaymentsFilters.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import { Search, X, CalendarDays } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { ALL_PAYMENT_METHODS, paymentMethodLabel } from "@/lib/payment-methods"
+import type { PaymentFiltersControls } from "@/lib/hooks/usePaymentFilters"
+import type { PaymentMethod, PaymentStatus } from "@/lib/contracts/payment"
+import type { FeeCategory } from "@/lib/contracts/fee"
+
+interface PaymentsFiltersProps extends Pick<PaymentFiltersControls, "filters" | "set" | "reset" | "activeCount"> {
+  feeCategories?: FeeCategory[]
+  cashiers?: { id: number; name: string }[]
+  /** Un guichet unique n'a personne à distinguer : le filtre disparaît. */
+  showCashier: boolean
+}
+
+/**
+ * La barre de filtres du journal des versements.
+ *
+ * Purement présentative : tout l'état vit dans `usePaymentFilters`, ce qui
+ * permet à la page de construire ses paramètres serveur sans connaître la
+ * disposition des champs, et à cette barre de changer de forme sans toucher
+ * à la requête.
+ */
+export function PaymentsFilters({
+  filters,
+  set,
+  reset,
+  activeCount,
+  feeCategories,
+  cashiers,
+  showCashier,
+}: PaymentsFiltersProps) {
+  return (
+      <Card className="border-0 shadow-sm ring-1 ring-border">
+        <CardContent className="p-4">
+          <div className="flex flex-wrap items-center gap-3">
+            {/* Search */}
+            <div className="relative flex-1 min-w-[240px]">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Rechercher par élève, référence..."
+                value={filters.search}
+                onChange={(e) => set("search", e.target.value)}
+                className="h-10 pl-9 pr-9"
+              />
+              {filters.search && (
+                <button
+                  onClick={() => set("search", "")}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+
+            {/* Filtres rapides */}
+            <Select
+              value={filters.status ?? "all"}
+              onValueChange={(v) => set("status", v === "all" ? undefined : (v as PaymentStatus))}
+            >
+              <SelectTrigger className="w-[150px] h-10">
+                <SelectValue placeholder="Statut" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Tous les statuts</SelectItem>
+                <SelectItem value="pending">En attente</SelectItem>
+                <SelectItem value="completed">Validé</SelectItem>
+                <SelectItem value="failed">Échoué</SelectItem>
+                <SelectItem value="refunded">Remboursé</SelectItem>
+                <SelectItem value="cancelled">Annulé</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={filters.method ?? "all"}
+              onValueChange={(v) => set("method", v === "all" ? undefined : (v as PaymentMethod))}
+            >
+              <SelectTrigger className="w-[150px] h-10">
+                <SelectValue placeholder="Méthode" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Toutes méthodes</SelectItem>
+                {/* Le filtre porte sur l'historique, valeur « Mobile Money »
+                    comprise : sans elle, une école ne retrouverait plus les
+                    versements enregistrés avant la distinction des opérateurs. */}
+                {ALL_PAYMENT_METHODS.map((m) => (
+                  <SelectItem key={m} value={m}>
+                    {paymentMethodLabel(m)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Filtre catégorie de frais */}
+            <Select
+              value={filters.category ?? "all"}
+              onValueChange={(v) => set("category", v === "all" ? undefined : v)}
+            >
+              <SelectTrigger className="w-[160px] h-10">
+                <SelectValue placeholder="Catégorie" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Toutes catégories</SelectItem>
+                {feeCategories?.map((cat) => (
+                  <SelectItem key={cat.id} value={cat.id.toString()}>
+                    {cat.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Filtre encaisseur — la question de fond d'une caisse d'école */}
+            {showCashier && (
+              <Select
+                value={filters.cashier ?? "all"}
+                onValueChange={(v) => set("cashier", v === "all" ? undefined : v)}
+              >
+                <SelectTrigger className="w-[170px] h-10" aria-label="Filtrer par encaisseur">
+                  <SelectValue placeholder="Encaissé par" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Toutes les caisses</SelectItem>
+                  {cashiers?.map((cashier) => (
+                    <SelectItem key={cashier.id} value={cashier.id.toString()}>
+                      {cashier.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+
+            {activeCount > 0 && (
+              <Button variant="ghost" size="sm" onClick={reset} className="h-10 text-xs text-muted-foreground">
+                <X className="mr-1 h-3 w-3" />
+                Réinitialiser ({activeCount})
+              </Button>
+            )}
+          </div>
+
+          {/* Date range filter */}
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <CalendarDays className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="text-xs text-muted-foreground shrink-0">Période :</span>
+            <Input
+              type="date"
+              value={filters.dateFrom}
+              onChange={(e) => set("dateFrom", e.target.value)}
+              className="h-8 w-[8.75rem] min-w-0 max-w-full flex-1 text-xs sm:flex-none"
+              placeholder="Du"
+            />
+            <span className="text-xs text-muted-foreground">au</span>
+            <Input
+              type="date"
+              value={filters.dateTo}
+              onChange={(e) => set("dateTo", e.target.value)}
+              className="h-8 w-[8.75rem] min-w-0 max-w-full flex-1 text-xs sm:flex-none"
+              placeholder="Au"
+            />
+            {(filters.dateFrom || filters.dateTo) && (
+              <button
+                onClick={() => { set("dateFrom", ""); set("dateTo", "") }}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+  )
+}

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -3,44 +3,20 @@
 import { useState, useMemo, useCallback } from "react"
 import {
   Plus, Download, Wallet, TrendingUp,
-  AlertCircle, Banknote, CreditCard, Search, X, Eye,
-  Receipt, CalendarDays, Coins, Smartphone, Building2, FileText,
-  FileSpreadsheet, Loader2, UserCheck,
+  AlertCircle, Banknote, CreditCard, Eye,
+  Receipt, FileSpreadsheet, Loader2, UserCheck,
 } from "lucide-react"
 import { toast } from "sonner"
 import { PaymentRowActions } from "@/components/admin/payments/PaymentRowActions"
 import { PaymentCardActions } from "@/components/admin/payments/PaymentCardActions"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
+import { StudentAvatar } from "@/components/admin/payments/StudentAvatar"
+import { PaymentsFilters } from "@/components/admin/payments/PaymentsFilters"
+import { usePaymentFilters } from "@/lib/hooks/usePaymentFilters"
+import { PaymentConfirmDialog, type PaymentConfirmAction } from "@/components/admin/payments/PaymentConfirmDialog"
+import { PaymentReceiptDialog } from "@/components/admin/payments/PaymentReceiptDialog"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Card, CardContent } from "@/components/ui/card"
 import { PageHero, heroAccentBtn, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import {
   Table,
   TableBody,
@@ -59,14 +35,11 @@ import {
 } from "@/lib/hooks/usePayments"
 import { useFeeCategories } from "@/lib/hooks/useFees"
 import { paymentsApi } from "@/lib/api/payments"
-import { ALL_PAYMENT_METHODS, paymentMethodLabel } from "@/lib/payment-methods"
+import { paymentMethodLabel } from "@/lib/payment-methods"
 import { paymentMethodIcon } from "@/components/admin/payments/method-icon"
-import { useDebounce } from "@/lib/hooks/useDebounce"
 import { openPdfPreview } from "@/lib/pdf/preview"
 import { downloadBlob } from "@/lib/utils"
-import type { PaymentListParams, PaymentStatus, PaymentMethod, Payment } from "@/lib/contracts/payment"
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? ""
+import type { PaymentStatus, Payment } from "@/lib/contracts/payment"
 
 /** « Annulé le 23/08/2026 par M. Konan · motif » — la ligne d'un contrôle. */
 function motifComplet(p: Payment): string {
@@ -77,47 +50,23 @@ function motifComplet(p: Payment): string {
   return `Annulé${quand}${qui}${p.cancellation_reason ? ` · ${p.cancellation_reason}` : ""}`
 }
 
-const STATUS_CONFIG: Record<PaymentStatus, { label: string; variant: "default" | "secondary" | "destructive" | "outline"; dot: string }> = {
-  pending: { label: "En attente", variant: "secondary", dot: "bg-amber-500" },
-  completed: { label: "Validé", variant: "default", dot: "bg-emerald-500" },
-  failed: { label: "Échoué", variant: "destructive", dot: "bg-red-500" },
-  refunded: { label: "Remboursé", variant: "outline", dot: "bg-blue-500" },
-  cancelled: { label: "Annulé", variant: "destructive", dot: "bg-rose-500" },
+const STATUS_CONFIG: Record<PaymentStatus, { label: string; dot: string }> = {
+  pending: { label: "En attente", dot: "bg-amber-500" },
+  completed: { label: "Validé", dot: "bg-emerald-500" },
+  failed: { label: "Échoué", dot: "bg-red-500" },
+  refunded: { label: "Remboursé", dot: "bg-blue-500" },
+  cancelled: { label: "Annulé", dot: "bg-rose-500" },
 }
 
 export function PaymentsPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
-  const [search, setSearch] = useState("")
-  const [statusFilter, setStatusFilter] = useState<PaymentStatus | undefined>(undefined)
-  const [methodFilter, setMethodFilter] = useState<PaymentMethod | undefined>(undefined)
-  const [categoryFilter, setCategoryFilter] = useState<string | undefined>(undefined)
-  const [cashierFilter, setCashierFilter] = useState<string | undefined>(undefined)
-  const [dateFrom, setDateFrom] = useState("")
-  const [dateTo, setDateTo] = useState("")
-  const [confirmAction, setConfirmAction] = useState<{ type: "validate" | "cancel"; payment: Payment } | null>(null)
-  // Le motif d'annulation figure sur le bordereau et sur le reçu réimprimé :
-  // il est exigé ici, pas seulement côté serveur, pour que la personne qui
-  // annule sache qu'elle signe une phrase.
-  const [motifAnnulation, setMotifAnnulation] = useState("")
+  const [confirmAction, setConfirmAction] = useState<PaymentConfirmAction | null>(null)
   const [downloadingId, setDownloadingId] = useState<number | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [previewPaymentId, setPreviewPaymentId] = useState<number | null>(null)
   const [exporting, setExporting] = useState<"pdf" | "xlsx" | "preview" | null>(null)
 
-  const debouncedSearch = useDebounce(search)
-
-  // La période part au serveur : la filtrer dans le navigateur ne trierait que
-  // la page affichée, et l'export qui suit ne dirait pas la même chose que
-  // l'écran.
-  const params: PaymentListParams = {
-    ...(statusFilter && { status: statusFilter }),
-    ...(methodFilter && { method: methodFilter }),
-    ...(debouncedSearch && { search: debouncedSearch }),
-    ...(categoryFilter && { fee_category_id: Number(categoryFilter) }),
-    ...(cashierFilter && { received_by: Number(cashierFilter) }),
-    ...(dateFrom && { date_from: `${dateFrom}T00:00:00` }),
-    ...(dateTo && { date_to: `${dateTo}T23:59:59` }),
-  }
+  const { filters, set, reset, params, activeCount } = usePaymentFilters()
 
   const { data, isLoading } = usePayments(params)
   const { data: summary } = useFinancialSummary()
@@ -132,15 +81,6 @@ export function PaymentsPageClient() {
   // distinguer. Un caissier cloisonné ne reçoit que lui-même du serveur : lui
   // proposer une liste d'un seul nom serait un faux choix.
   const showCashierFilter = (cashiers?.length ?? 0) > 1
-
-  const activeFilterCount = [
-    statusFilter,
-    methodFilter,
-    categoryFilter,
-    cashierFilter,
-    dateFrom,
-    dateTo,
-  ].filter(Boolean).length
 
   // Les exports sont produits par le serveur, aux mêmes filtres que l'écran et
   // sous le même cloisonnement : un caissier n'obtient jamais dans un fichier
@@ -201,30 +141,14 @@ export function PaymentsPageClient() {
     }
   }
 
-  const motifTropCourt = motifAnnulation.trim().length < 10
-
-  function handleConfirmAction() {
+  function handleConfirmAction(reason: string) {
     if (!confirmAction) return
-    const onSuccess = () => {
-      setConfirmAction(null)
-      setMotifAnnulation("")
-    }
+    const onSuccess = () => setConfirmAction(null)
     if (confirmAction.type === "validate") {
       validatePayment(confirmAction.payment.id, { onSuccess })
     } else {
-      if (motifTropCourt) return
-      cancelPayment({ id: confirmAction.payment.id, reason: motifAnnulation.trim() }, { onSuccess })
+      cancelPayment({ id: confirmAction.payment.id, reason }, { onSuccess })
     }
-  }
-
-  function clearFilters() {
-    setStatusFilter(undefined)
-    setMethodFilter(undefined)
-    setCategoryFilter(undefined)
-    setCashierFilter(undefined)
-    setDateFrom("")
-    setDateTo("")
-    setSearch("")
   }
 
   // Le serveur ne sert pas le recouvrement a qui ne lit que sa propre caisse.
@@ -324,143 +248,15 @@ export function PaymentsPageClient() {
         kpis={heroKpis}
       />
 
-      {/* Barre de recherche + filtres */}
-      <Card className="border-0 shadow-sm ring-1 ring-border">
-        <CardContent className="p-4">
-          <div className="flex flex-wrap items-center gap-3">
-            {/* Search */}
-            <div className="relative flex-1 min-w-[240px]">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Rechercher par élève, référence..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="h-10 pl-9 pr-9"
-              />
-              {search && (
-                <button
-                  onClick={() => setSearch("")}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              )}
-            </div>
-
-            {/* Filtres rapides */}
-            <Select
-              value={statusFilter ?? "all"}
-              onValueChange={(v) => setStatusFilter(v === "all" ? undefined : (v as PaymentStatus))}
-            >
-              <SelectTrigger className="w-[150px] h-10">
-                <SelectValue placeholder="Statut" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Tous les statuts</SelectItem>
-                <SelectItem value="pending">En attente</SelectItem>
-                <SelectItem value="completed">Validé</SelectItem>
-                <SelectItem value="failed">Échoué</SelectItem>
-                <SelectItem value="refunded">Remboursé</SelectItem>
-                <SelectItem value="cancelled">Annulé</SelectItem>
-              </SelectContent>
-            </Select>
-
-            <Select
-              value={methodFilter ?? "all"}
-              onValueChange={(v) => setMethodFilter(v === "all" ? undefined : (v as PaymentMethod))}
-            >
-              <SelectTrigger className="w-[150px] h-10">
-                <SelectValue placeholder="Méthode" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Toutes méthodes</SelectItem>
-                {/* Le filtre porte sur l'historique, valeur « Mobile Money »
-                    comprise : sans elle, une école ne retrouverait plus les
-                    versements enregistrés avant la distinction des opérateurs. */}
-                {ALL_PAYMENT_METHODS.map((m) => (
-                  <SelectItem key={m} value={m}>
-                    {paymentMethodLabel(m)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            {/* Filtre catégorie de frais */}
-            <Select
-              value={categoryFilter ?? "all"}
-              onValueChange={(v) => setCategoryFilter(v === "all" ? undefined : v)}
-            >
-              <SelectTrigger className="w-[160px] h-10">
-                <SelectValue placeholder="Catégorie" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Toutes catégories</SelectItem>
-                {feeCategories?.map((cat) => (
-                  <SelectItem key={cat.id} value={cat.id.toString()}>
-                    {cat.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            {/* Filtre encaisseur — la question de fond d'une caisse d'école */}
-            {showCashierFilter && (
-              <Select
-                value={cashierFilter ?? "all"}
-                onValueChange={(v) => setCashierFilter(v === "all" ? undefined : v)}
-              >
-                <SelectTrigger className="w-[170px] h-10" aria-label="Filtrer par encaisseur">
-                  <SelectValue placeholder="Encaissé par" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Toutes les caisses</SelectItem>
-                  {cashiers?.map((cashier) => (
-                    <SelectItem key={cashier.id} value={cashier.id.toString()}>
-                      {cashier.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-
-            {activeFilterCount > 0 && (
-              <Button variant="ghost" size="sm" onClick={clearFilters} className="h-10 text-xs text-muted-foreground">
-                <X className="mr-1 h-3 w-3" />
-                Réinitialiser ({activeFilterCount})
-              </Button>
-            )}
-          </div>
-
-          {/* Date range filter */}
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <CalendarDays className="h-4 w-4 text-muted-foreground shrink-0" />
-            <span className="text-xs text-muted-foreground shrink-0">Période :</span>
-            <Input
-              type="date"
-              value={dateFrom}
-              onChange={(e) => setDateFrom(e.target.value)}
-              className="h-8 w-[8.75rem] min-w-0 max-w-full flex-1 text-xs sm:flex-none"
-              placeholder="Du"
-            />
-            <span className="text-xs text-muted-foreground">au</span>
-            <Input
-              type="date"
-              value={dateTo}
-              onChange={(e) => setDateTo(e.target.value)}
-              className="h-8 w-[8.75rem] min-w-0 max-w-full flex-1 text-xs sm:flex-none"
-              placeholder="Au"
-            />
-            {(dateFrom || dateTo) && (
-              <button
-                onClick={() => { setDateFrom(""); setDateTo("") }}
-                className="text-muted-foreground hover:text-foreground"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+      <PaymentsFilters
+        filters={filters}
+        set={set}
+        reset={reset}
+        activeCount={activeCount}
+        feeCategories={feeCategories}
+        cashiers={cashiers}
+        showCashier={showCashierFilter}
+      />
 
       {/* Tableau des paiements premium */}
       <Card className="border-0 shadow-sm ring-1 ring-border overflow-hidden">
@@ -476,7 +272,7 @@ export function PaymentsPageClient() {
               <Receipt className="h-10 w-10 mb-3 opacity-40" />
               <p className="text-sm font-medium">Aucun paiement trouvé</p>
               <p className="text-xs mt-1">
-                {activeFilterCount > 0 || search
+                {activeCount > 0 || filters.search
                   ? "Essayez de modifier vos filtres"
                   : "Créez votre premier paiement"}
               </p>
@@ -679,119 +475,19 @@ export function PaymentsPageClient() {
 
       <PaymentCreateWizard open={createOpen} onClose={() => setCreateOpen(false)} />
 
-      {/* Confirmation dialog */}
-      <AlertDialog
-        open={!!confirmAction}
-        onOpenChange={(open) => {
-          if (!open) {
-            setConfirmAction(null)
-            setMotifAnnulation("")
-          }
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {confirmAction?.type === "validate" ? "Valider ce paiement ?" : "Annuler ce paiement ?"}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {confirmAction?.type === "validate"
-                ? `Vous allez valider le paiement de ${Number(confirmAction.payment.amount).toLocaleString("fr-FR")} FCFA. Cette action est irréversible.`
-                : `Le versement de ${Number(confirmAction?.payment.amount).toLocaleString("fr-FR")} FCFA ne sera pas supprimé : il restera dans le journal, marqué annulé, avec votre nom et votre motif. Le reçu réimprimé le dira aussi.`}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-
-          {confirmAction?.type === "cancel" && (
-            <div className="space-y-1.5">
-              <label htmlFor="motif-annulation" className="text-sm font-medium">
-                Motif de l&apos;annulation *
-              </label>
-              <Textarea
-                id="motif-annulation"
-                value={motifAnnulation}
-                onChange={(e) => setMotifAnnulation(e.target.value)}
-                placeholder="Ex : montant saisi en trop, la caisse ne contient pas ces 5 000 F."
-                rows={3}
-                autoFocus
-              />
-              <p className="text-xs text-muted-foreground">
-                Une phrase, pas un mot : elle figurera sur le bordereau de caisse et sur le
-                reçu.
-              </p>
-              <p className="rounded-md bg-amber-500/10 px-2.5 py-2 text-xs text-amber-900 dark:text-amber-200">
-                À n&apos;utiliser que si <strong>aucun argent n&apos;a bougé</strong> : une
-                saisie en trop, un double. Si l&apos;argent a bien été encaissé, annuler le
-                ferait disparaître alors qu&apos;il est dans le tiroir, et la caisse serait
-                en excédent inexpliqué à la clôture. Passez par la comptabilité.
-              </p>
-            </div>
-          )}
-          <AlertDialogFooter>
-            <AlertDialogCancel>Retour</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmAction}
-              disabled={
-                validating || cancelling || (confirmAction?.type === "cancel" && motifTropCourt)
-              }
-            >
-              {validating || cancelling
-                ? "Traitement..."
-                : confirmAction?.type === "validate" ? "Valider" : "Annuler le paiement"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Receipt Preview Dialog */}
-      <Dialog open={previewUrl !== null} onOpenChange={handleClosePreview}>
-        <DialogContent className="max-w-3xl max-h-[90vh]">
-          <DialogHeader>
-            <DialogTitle>Reçu de paiement #{previewPaymentId}</DialogTitle>
-          </DialogHeader>
-          {previewUrl && (
-            <iframe
-              src={previewUrl}
-              className="w-full h-[65vh] rounded-lg border"
-              title="Aperçu du reçu"
-            />
-          )}
-          <DialogFooter>
-            <Button variant="outline" onClick={handleClosePreview}>
-              Fermer
-            </Button>
-            <Button onClick={handleDownloadFromPreview}>
-              <Download className="mr-2 h-4 w-4" />
-              Télécharger le PDF
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Student Avatar with fallback
-// ---------------------------------------------------------------------------
-
-function StudentAvatar({ photoUrl, initials }: { photoUrl?: string | null; initials: string }) {
-  const [imgError, setImgError] = useState(false)
-  const fullUrl = photoUrl && !imgError ? `${API_URL}${photoUrl}` : null
-
-  if (fullUrl) {
-    return (
-      <img
-        src={fullUrl}
-        alt=""
-        className="h-8 w-8 rounded-full object-cover"
-        onError={() => setImgError(true)}
+      <PaymentConfirmDialog
+        action={confirmAction}
+        onClose={() => setConfirmAction(null)}
+        onConfirm={handleConfirmAction}
+        busy={validating || cancelling}
       />
-    )
-  }
 
-  return (
-    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-      {initials}
+      <PaymentReceiptDialog
+        url={previewUrl}
+        paymentId={previewPaymentId}
+        onClose={handleClosePreview}
+        onDownload={handleDownloadFromPreview}
+      />
     </div>
   )
 }

--- a/components/admin/payments/StudentAvatar.tsx
+++ b/components/admin/payments/StudentAvatar.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { getUploadUrl } from "@/lib/utils"
+
+interface StudentAvatarProps {
+  photoUrl?: string | null
+  /** Les initiales affichées tant qu'il n'y a pas de photo, ou si elle manque. */
+  initials: string
+}
+
+/**
+ * La photo d'un élève dans le journal des versements.
+ *
+ * Trois choses passent par les primitives partagées plutôt que par une copie
+ * locale : `getUploadUrl` qui laisse passer une URL déjà absolue au lieu de la
+ * préfixer une seconde fois, et `Avatar`/`AvatarFallback` qui retombent seuls
+ * sur les initiales quand l'image manque — sans état d'erreur à tenir à la
+ * main, et sans balise `img` nue.
+ */
+export function StudentAvatar({ photoUrl, initials }: StudentAvatarProps) {
+  const src = getUploadUrl(photoUrl ?? undefined)
+  return (
+    <Avatar className="h-8 w-8">
+      {/* `object-cover` recadre : une photo d'identité est en 3:4, et sans lui
+          Radix la rendrait étirée dans un carré de 32 pixels. */}
+      {src ? <AvatarImage src={src} alt="" className="object-cover" /> : null}
+      <AvatarFallback className="bg-primary/10 text-xs font-semibold text-primary">
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/lib/hooks/usePaymentFilters.test.ts
+++ b/lib/hooks/usePaymentFilters.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Les filtres décident de ce que le serveur renvoie : ils se testent.
+ *
+ * Ces sept états vivaient dispersés dans la page, avec la construction des
+ * paramètres à un endroit, le compte des filtres actifs à un autre et la
+ * réinitialisation à un troisième. Réunis, ils deviennent vérifiables — et
+ * c'est la construction des paramètres qui compte, puisqu'une clé oubliée ne
+ * casse rien à l'écran : elle renvoie simplement les mauvais versements.
+ */
+
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { usePaymentFilters } from "./usePaymentFilters"
+
+afterEach(() => { vi.useRealTimers() })
+
+describe("les filtres du journal des versements", () => {
+  it("ne demande rien au serveur tant qu'on n'a rien choisi", () => {
+    const { result } = renderHook(() => usePaymentFilters())
+    expect(result.current.params).toEqual({})
+    expect(result.current.activeCount).toBe(0)
+  })
+
+  it("borne la période sur la journée entière, pas sur minuit", () => {
+    // Sans les heures, « au 21 août » exclurait tout ce qui a été encaissé ce jour-là.
+    const { result } = renderHook(() => usePaymentFilters())
+    act(() => { result.current.set("dateFrom", "2026-08-21") })
+    act(() => { result.current.set("dateTo", "2026-08-21") })
+    expect(result.current.params).toMatchObject({
+      date_from: "2026-08-21T00:00:00",
+      date_to: "2026-08-21T23:59:59",
+    })
+  })
+
+  it("convertit en nombre ce que les listes déroulantes rendent en texte", () => {
+    const { result } = renderHook(() => usePaymentFilters())
+    act(() => { result.current.set("category", "7") })
+    act(() => { result.current.set("cashier", "55") })
+    expect(result.current.params).toMatchObject({ fee_category_id: 7, received_by: 55 })
+  })
+
+  it("envoie la recherche au serveur, une fois la frappe terminée", () => {
+    // La recherche est le seul filtre qui passe par un debounce : son câblage
+    // differe de celui des six autres, donc c'est le seul qu'un test de
+    // « le filtre arrive-t-il dans les paramètres ? » pouvait manquer.
+    vi.useFakeTimers()
+    const { result } = renderHook(() => usePaymentFilters())
+    act(() => { result.current.set("search", "Aminata") })
+    expect(result.current.params).toEqual({})
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(result.current.params).toMatchObject({ search: "Aminata" })
+  })
+
+  it("retire la clé des paramètres quand on revient à « tous »", () => {
+    // « Tous les statuts » passe undefined : il doit effacer la clé, pas
+    // envoyer status=undefined au serveur.
+    const { result } = renderHook(() => usePaymentFilters())
+    act(() => { result.current.set("status", "completed") })
+    expect(result.current.params).toHaveProperty("status")
+    act(() => { result.current.set("status", undefined) })
+    expect(result.current.params).toEqual({})
+  })
+
+  it("ne compte pas la recherche parmi les filtres actifs", () => {
+    // Elle a son propre champ, visible et effaçable : l'ajouter au compteur
+    // ferait clignoter « Réinitialiser (1) » à la première lettre tapée.
+    const { result } = renderHook(() => usePaymentFilters())
+    act(() => { result.current.set("search", "Aminata") })
+    expect(result.current.activeCount).toBe(0)
+    act(() => { result.current.set("status", "cancelled") })
+    expect(result.current.activeCount).toBe(1)
+  })
+
+  it("modifie un filtre sans effacer les autres", () => {
+    const { result } = renderHook(() => usePaymentFilters())
+    act(() => { result.current.set("status", "completed") })
+    act(() => { result.current.set("method", "cash") })
+    expect(result.current.params).toMatchObject({ status: "completed", method: "cash" })
+  })
+
+  it("remet tout à zéro d'un seul geste", () => {
+    const { result } = renderHook(() => usePaymentFilters())
+    act(() => { result.current.set("status", "completed") })
+    act(() => { result.current.set("dateFrom", "2026-08-01") })
+    act(() => { result.current.reset() })
+    expect(result.current.params).toEqual({})
+    expect(result.current.activeCount).toBe(0)
+    expect(result.current.filters.search).toBe("")
+  })
+})

--- a/lib/hooks/usePaymentFilters.ts
+++ b/lib/hooks/usePaymentFilters.ts
@@ -1,0 +1,70 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { useDebounce } from "@/lib/hooks/useDebounce"
+import type { PaymentListParams, PaymentMethod, PaymentStatus } from "@/lib/contracts/payment"
+
+/** L'état des sept filtres du journal des versements, en un seul objet. */
+export interface PaymentFilters {
+  search: string
+  status?: PaymentStatus
+  method?: PaymentMethod
+  category?: string
+  cashier?: string
+  dateFrom: string
+  dateTo: string
+}
+
+const EMPTY: PaymentFilters = { search: "", dateFrom: "", dateTo: "" }
+
+/**
+ * Les filtres du journal, et ce que le serveur doit en recevoir.
+ *
+ * Ils vivaient en sept `useState` dans la page, avec la construction des
+ * paramètres, le compte des filtres actifs et la réinitialisation dispersés
+ * autour. Réunis ici, ils forment un seul état cohérent : ajouter un filtre
+ * demande une clé, pas quatre modifications à quatre endroits.
+ *
+ * La période part au serveur : la filtrer dans le navigateur ne trierait que
+ * la page affichée, et l'export qui suit ne dirait pas la même chose que
+ * l'écran.
+ */
+export function usePaymentFilters() {
+  const [filters, setFilters] = useState<PaymentFilters>(EMPTY)
+  const debouncedSearch = useDebounce(filters.search)
+
+  const params = useMemo<PaymentListParams>(
+    () => ({
+      ...(filters.status && { status: filters.status }),
+      ...(filters.method && { method: filters.method }),
+      ...(debouncedSearch && { search: debouncedSearch }),
+      ...(filters.category && { fee_category_id: Number(filters.category) }),
+      ...(filters.cashier && { received_by: Number(filters.cashier) }),
+      ...(filters.dateFrom && { date_from: `${filters.dateFrom}T00:00:00` }),
+      ...(filters.dateTo && { date_to: `${filters.dateTo}T23:59:59` }),
+    }),
+    [filters, debouncedSearch],
+  )
+
+  // La recherche ne compte pas : elle a son propre champ, visible et effaçable.
+  const activeCount = [
+    filters.status,
+    filters.method,
+    filters.category,
+    filters.cashier,
+    filters.dateFrom,
+    filters.dateTo,
+  ].filter(Boolean).length
+
+  return {
+    filters,
+    /** Modifie un filtre sans toucher aux autres. */
+    set: <K extends keyof PaymentFilters>(key: K, value: PaymentFilters[K]) =>
+      setFilters((f) => ({ ...f, [key]: value })),
+    reset: () => setFilters(EMPTY),
+    params,
+    activeCount,
+  }
+}
+
+export type PaymentFiltersControls = ReturnType<typeof usePaymentFilters>


### PR DESCRIPTION
Closes #363

## Ce que fait cette PR

Un découpage **à comportement identique**, sauf sur un point signalé plus bas.

| Nouveau fichier | Ce qu'il possède | Lignes |
|---|---|---|
| `lib/hooks/usePaymentFilters.ts` | les sept filtres, les paramètres serveur, le compte actif, la remise à zéro | 70 |
| `PaymentsFilters.tsx` | la barre, purement présentative | 181 |
| `PaymentConfirmDialog.tsx` | le motif d'annulation et sa longueur minimale | 115 |
| `PaymentReceiptDialog.tsx` | l'aperçu du reçu | 55 |
| `StudentAvatar.tsx` | la photo de l'élève | 33 |

**797 → 493 lignes**, six alertes de lint → zéro.

## Le seul changement de comportement, et pourquoi

L'avatar recopiait ce qui existait déjà : il fabriquait son URL par concaténation, ce qui préfixe deux fois une adresse déjà absolue, et dessinait une balise `img` nue avec un drapeau d'erreur tenu à la main. Il passe par `getUploadUrl` et l'`Avatar` partagé — en gardant `object-cover`, sans quoi une photo d'identité en 3:4 serait étirée dans un carré de 32 pixels au lieu d'être recadrée.

## Vérifications

- `tsc --noEmit` propre, `next lint` sans alerte, **231 tests verts** sur 30 fichiers.
- Les filtres sont désormais testés : bornes de journée (`T00:00:00`/`T23:59:59`, sans quoi « au 21 août » exclurait la recette du jour), conversion des identifiants en nombre, recherche débounce, retour à « tous » qui efface la clé au lieu d'envoyer `undefined`.
- Chaque test a été vérifié en réintroduisant le défaut qu'il verrouille.
- Revue thermo-nucléaire : une passe bloquante, puis approbation. Elle a trouvé la photo étirée et une docstring de moi qui affirmait le faux.

## Hors périmètre, signalé

Le tableau et la liste de cartes (~180 lignes) recopient les mêmes trois dérivations. C'est la prochaine jointure, mais elle touche la surface de rendu la plus risquée : elle mérite sa propre PR, pas d'être mêlée à un découpage déjà large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)