### PR TITLE
refactor(payments): one row view for the table and the cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Fixed
+- Le motif d'annulation d'un versement s'affiche désormais à l'identique sur ordinateur et sur téléphone *(admin)*
 - Photo de l'élève correctement recadrée dans le journal des versements, au lieu d'être étirée quand elle n'est pas carrée *(admin)*
 - Annulation d'un versement déjà encaissé, depuis le tableau comme depuis le téléphone : c'est le cas courant, un montant saisi qui n'est pas dans la caisse *(admin)*
 

--- a/components/admin/payments/PaymentsCardList.tsx
+++ b/components/admin/payments/PaymentsCardList.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { UserCheck } from "lucide-react"
+import { PaymentCardActions } from "@/components/admin/payments/PaymentCardActions"
+import { StudentAvatar } from "@/components/admin/payments/StudentAvatar"
+import { paymentRowView } from "@/components/admin/payments/paymentRowView"
+import type { Payment } from "@/lib/contracts/payment"
+
+interface PaymentsCardListProps {
+  payments: Payment[]
+  onPreviewReceipt: (payment: Payment) => void
+  onValidate: (payment: Payment) => void
+  onCancel: (payment: Payment) => void
+}
+
+/**
+ * Le journal des versements en cartes, pour un téléphone.
+ *
+ * Ce n'est pas le tableau rétréci : le montant passe en premier, comme sur
+ * les applications d'argent mobile que la caissière utilise déjà, parce
+ * qu'au guichet c'est le chiffre qu'on cherche d'abord. Les valeurs
+ * affichées viennent du même `paymentRowView` que le tableau.
+ */
+export function PaymentsCardList({
+  payments,
+  onPreviewReceipt,
+  onValidate,
+  onCancel,
+}: PaymentsCardListProps) {
+  return (
+    <div className="space-y-2 p-3 md:hidden">
+      {payments.map((payment) => {
+        const vue = paymentRowView(payment)
+        return (
+          <div
+            key={payment.id}
+            className="overflow-hidden rounded-lg border bg-card"
+          >
+            <button
+              type="button"
+              onClick={() => onPreviewReceipt(payment)}
+              className="w-full p-3 text-left transition-colors hover:bg-accent/40 active:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            >
+              <div className="flex items-start gap-3">
+                <StudentAvatar photoUrl={payment.student_photo_url} initials={vue.initials} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="truncate text-sm font-medium leading-tight">
+                      {payment.student_name ?? `Paiement #${payment.id}`}
+                    </p>
+                    <p className="shrink-0 text-base font-semibold tabular-nums leading-tight">
+                      {Number(payment.amount).toLocaleString("fr-FR")}
+                      <span className="ml-0.5 text-[10px] font-normal text-muted-foreground">FCFA</span>
+                    </p>
+                  </div>
+                  <div className="mt-1.5 flex items-center gap-3 text-[11px] text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <vue.MethodIcon className="h-3 w-3" aria-hidden="true" />
+                      {vue.methodLabel}
+                    </span>
+                    <span className="tabular-nums">
+                      {new Date(payment.created_at).toLocaleDateString("fr-FR", {
+                        day: "2-digit",
+                        month: "short",
+                      })}
+                    </span>
+                    <span className="ml-auto inline-flex items-center gap-1">
+                      <span className={`h-1.5 w-1.5 rounded-full ${vue.statusDot}`} aria-hidden="true" />
+                      <span className="font-medium">{vue.statusLabel}</span>
+                    </span>
+                  </div>
+                  <p className="mt-1 flex items-center gap-1 truncate text-[11px] text-muted-foreground">
+                    <UserCheck className="h-3 w-3 shrink-0" aria-hidden="true" />
+                    Encaissé par {payment.received_by_name ?? "—"}
+                  </p>
+                  {payment.fee_name && (
+                    <p className="mt-1 truncate text-[11px] text-muted-foreground">
+                      {payment.fee_name}
+                    </p>
+                  )}
+                  {vue.cancellation && (
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      {vue.cancellation}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </button>
+            <PaymentCardActions
+              payment={payment}
+              onValidate={onValidate}
+              onCancel={onCancel}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -4,27 +4,18 @@ import { useState, useMemo, useCallback } from "react"
 import {
   Plus, Download, Wallet, TrendingUp,
   AlertCircle, Banknote, CreditCard, Eye,
-  Receipt, FileSpreadsheet, Loader2, UserCheck,
+  Receipt, FileSpreadsheet, Loader2,
 } from "lucide-react"
 import { toast } from "sonner"
-import { PaymentRowActions } from "@/components/admin/payments/PaymentRowActions"
-import { PaymentCardActions } from "@/components/admin/payments/PaymentCardActions"
-import { StudentAvatar } from "@/components/admin/payments/StudentAvatar"
 import { PaymentsFilters } from "@/components/admin/payments/PaymentsFilters"
 import { usePaymentFilters } from "@/lib/hooks/usePaymentFilters"
 import { PaymentConfirmDialog, type PaymentConfirmAction } from "@/components/admin/payments/PaymentConfirmDialog"
 import { PaymentReceiptDialog } from "@/components/admin/payments/PaymentReceiptDialog"
+import { PaymentsTable } from "@/components/admin/payments/PaymentsTable"
+import { PaymentsCardList } from "@/components/admin/payments/PaymentsCardList"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Card, CardContent } from "@/components/ui/card"
 import { PageHero, heroAccentBtn, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 import { PaymentCreateWizard } from "./PaymentCreateWizard"
 import {
   usePayments,
@@ -35,28 +26,9 @@ import {
 } from "@/lib/hooks/usePayments"
 import { useFeeCategories } from "@/lib/hooks/useFees"
 import { paymentsApi } from "@/lib/api/payments"
-import { paymentMethodLabel } from "@/lib/payment-methods"
-import { paymentMethodIcon } from "@/components/admin/payments/method-icon"
 import { openPdfPreview } from "@/lib/pdf/preview"
 import { downloadBlob } from "@/lib/utils"
-import type { PaymentStatus, Payment } from "@/lib/contracts/payment"
-
-/** « Annulé le 23/08/2026 par M. Konan · motif » — la ligne d'un contrôle. */
-function motifComplet(p: Payment): string {
-  const quand = p.cancelled_at
-    ? ` le ${new Date(p.cancelled_at).toLocaleDateString("fr-FR")}`
-    : ""
-  const qui = p.cancelled_by_name ? ` par ${p.cancelled_by_name}` : ""
-  return `Annulé${quand}${qui}${p.cancellation_reason ? ` · ${p.cancellation_reason}` : ""}`
-}
-
-const STATUS_CONFIG: Record<PaymentStatus, { label: string; dot: string }> = {
-  pending: { label: "En attente", dot: "bg-amber-500" },
-  completed: { label: "Validé", dot: "bg-emerald-500" },
-  failed: { label: "Échoué", dot: "bg-red-500" },
-  refunded: { label: "Remboursé", dot: "bg-blue-500" },
-  cancelled: { label: "Annulé", dot: "bg-rose-500" },
-}
+import type { Payment } from "@/lib/contracts/payment"
 
 export function PaymentsPageClient() {
   const [createOpen, setCreateOpen] = useState(false)
@@ -279,188 +251,19 @@ export function PaymentsPageClient() {
             </div>
           ) : (
             <>
-            {/* Desktop : table dense. Mobile : cards persona-first */}
-            <div className="hidden md:block">
-            <Table>
-              <TableHeader>
-                <TableRow className="bg-muted/30 hover:bg-muted/30">
-                  <TableHead>Élève</TableHead>
-                  <TableHead>Frais</TableHead>
-                  <TableHead className="text-right">Montant</TableHead>
-                  <TableHead>Méthode</TableHead>
-                  <TableHead>Encaissé par</TableHead>
-                  <TableHead>Statut</TableHead>
-                  <TableHead>Date</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {payments.map((payment: Payment) => {
-                  const statusCfg = STATUS_CONFIG[payment.status]
-                  const MethodIcon = paymentMethodIcon(payment.method)
-                  const initials = payment.student_name
-                    ? payment.student_name.split(" ").map((w) => w[0]).join("").slice(0, 2).toUpperCase()
-                    : "?"
-                  return (
-                    <TableRow
-                      key={payment.id}
-                      className="group cursor-pointer"
-                      onClick={() => {
-                        // Navigate to student detail if we have student info
-                        // For now, open receipt preview
-                        handlePreviewReceipt(payment)
-                      }}
-                    >
-                      <TableCell>
-                        <div className="flex items-center gap-2.5">
-                          <StudentAvatar
-                            photoUrl={payment.student_photo_url}
-                            initials={initials}
-                          />
-                          <div>
-                            <p className="text-sm font-medium leading-tight">
-                              {payment.student_name ?? `Paiement #${payment.id}`}
-                            </p>
-                            <p className="text-[11px] text-muted-foreground">#{payment.id}</p>
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <span className="text-sm text-muted-foreground">
-                          {payment.fee_name ?? "—"}
-                        </span>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <span className="font-semibold tabular-nums">
-                          {Number(payment.amount).toLocaleString("fr-FR")}
-                        </span>
-                        <span className="ml-1 text-xs text-muted-foreground">FCFA</span>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <MethodIcon className="h-3.5 w-3.5 text-muted-foreground" />
-                          <span className="text-sm">{paymentMethodLabel(payment.method)}</span>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <UserCheck className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
-                          <span className="text-sm">
-                            {payment.received_by_name ?? "—"}
-                          </span>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <div className={`h-2 w-2 rounded-full ${statusCfg.dot}`} />
-                          <span className="text-sm">{statusCfg.label}</span>
-                        </div>
-                        {payment.cancellation_reason && (
-                          <p className="mt-0.5 max-w-[22rem] text-xs text-muted-foreground">
-                            {motifComplet(payment)}
-                          </p>
-                        )}
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground tabular-nums">
-                        {new Date(payment.created_at).toLocaleDateString("fr-FR", {
-                          day: "2-digit",
-                          month: "short",
-                          year: "numeric",
-                        })}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <div
-                          className="opacity-60 transition-opacity group-hover:opacity-100"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <PaymentRowActions
-                            payment={payment}
-                            onValidate={(p) => setConfirmAction({ type: "validate", payment: p })}
-                            onCancel={(p) => setConfirmAction({ type: "cancel", payment: p })}
-                            onPreviewReceipt={handlePreviewReceipt}
-                            previewBusy={downloadingId === payment.id}
-                          />
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
-            </div>
-
-            {/* Mobile : cards verticales, Wave-style amount-first + status colored */}
-            <div className="space-y-2 p-3 md:hidden">
-              {payments.map((payment: Payment) => {
-                const statusCfg = STATUS_CONFIG[payment.status]
-                const MethodIcon = paymentMethodIcon(payment.method)
-                const initials = payment.student_name
-                  ? payment.student_name.split(" ").map((w) => w[0]).join("").slice(0, 2).toUpperCase()
-                  : "?"
-                return (
-                  <div
-                    key={payment.id}
-                    className="overflow-hidden rounded-lg border bg-card"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => handlePreviewReceipt(payment)}
-                      className="w-full p-3 text-left transition-colors hover:bg-accent/40 active:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-                    >
-                      <div className="flex items-start gap-3">
-                        <StudentAvatar photoUrl={payment.student_photo_url} initials={initials} />
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-start justify-between gap-2">
-                            <p className="truncate text-sm font-medium leading-tight">
-                              {payment.student_name ?? `Paiement #${payment.id}`}
-                            </p>
-                            <p className="shrink-0 text-base font-semibold tabular-nums leading-tight">
-                              {Number(payment.amount).toLocaleString("fr-FR")}
-                              <span className="ml-0.5 text-[10px] font-normal text-muted-foreground">FCFA</span>
-                            </p>
-                          </div>
-                          <div className="mt-1.5 flex items-center gap-3 text-[11px] text-muted-foreground">
-                            <span className="flex items-center gap-1">
-                              <MethodIcon className="h-3 w-3" aria-hidden="true" />
-                              {paymentMethodLabel(payment.method)}
-                            </span>
-                            <span className="tabular-nums">
-                              {new Date(payment.created_at).toLocaleDateString("fr-FR", {
-                                day: "2-digit",
-                                month: "short",
-                              })}
-                            </span>
-                            <span className="ml-auto inline-flex items-center gap-1">
-                              <span className={`h-1.5 w-1.5 rounded-full ${statusCfg.dot}`} aria-hidden="true" />
-                              <span className="font-medium">{statusCfg.label}</span>
-                            </span>
-                          </div>
-                          <p className="mt-1 flex items-center gap-1 truncate text-[11px] text-muted-foreground">
-                            <UserCheck className="h-3 w-3 shrink-0" aria-hidden="true" />
-                            Encaissé par {payment.received_by_name ?? "—"}
-                          </p>
-                          {payment.fee_name && (
-                            <p className="mt-1 truncate text-[11px] text-muted-foreground">
-                              {payment.fee_name}
-                            </p>
-                          )}
-                          {payment.cancellation_reason && (
-                            <p className="mt-1 text-[11px] text-muted-foreground">
-                              {motifComplet(payment)}
-                            </p>
-                          )}
-                        </div>
-                      </div>
-                    </button>
-                    <PaymentCardActions
-                      payment={payment}
-                      onValidate={(p) => setConfirmAction({ type: "validate", payment: p })}
-                      onCancel={(p) => setConfirmAction({ type: "cancel", payment: p })}
-                    />
-                  </div>
-                )
-              })}
-            </div>
+            <PaymentsTable
+              payments={payments}
+              downloadingId={downloadingId}
+              onPreviewReceipt={handlePreviewReceipt}
+              onValidate={(p) => setConfirmAction({ type: "validate", payment: p })}
+              onCancel={(p) => setConfirmAction({ type: "cancel", payment: p })}
+            />
+            <PaymentsCardList
+              payments={payments}
+              onPreviewReceipt={handlePreviewReceipt}
+              onValidate={(p) => setConfirmAction({ type: "validate", payment: p })}
+              onCancel={(p) => setConfirmAction({ type: "cancel", payment: p })}
+            />
             </>
           )}
         </CardContent>

--- a/components/admin/payments/PaymentsTable.tsx
+++ b/components/admin/payments/PaymentsTable.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { UserCheck } from "lucide-react"
+import { PaymentRowActions } from "@/components/admin/payments/PaymentRowActions"
+import { StudentAvatar } from "@/components/admin/payments/StudentAvatar"
+import { paymentRowView } from "@/components/admin/payments/paymentRowView"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { Payment } from "@/lib/contracts/payment"
+
+interface PaymentsTableProps {
+  payments: Payment[]
+  /** Le reçu en cours de téléchargement, pour n'immobiliser que sa ligne. */
+  downloadingId: number | null
+  onPreviewReceipt: (payment: Payment) => void
+  onValidate: (payment: Payment) => void
+  onCancel: (payment: Payment) => void
+}
+
+/**
+ * Le journal des versements au format tableau, pour un écran large.
+ *
+ * Sa contrepartie `PaymentsCardList` montre les mêmes versements sur un
+ * téléphone. Les deux dérivent ce qu'elles affichent du même
+ * `paymentRowView`, faute de quoi elles finiraient par diverger.
+ */
+export function PaymentsTable({
+  payments,
+  downloadingId,
+  onPreviewReceipt,
+  onValidate,
+  onCancel,
+}: PaymentsTableProps) {
+  return (
+    <div className="hidden md:block">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/30 hover:bg-muted/30">
+            <TableHead>Élève</TableHead>
+            <TableHead>Frais</TableHead>
+            <TableHead className="text-right">Montant</TableHead>
+            <TableHead>Méthode</TableHead>
+            <TableHead>Encaissé par</TableHead>
+            <TableHead>Statut</TableHead>
+            <TableHead>Date</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {payments.map((payment) => {
+            const vue = paymentRowView(payment)
+            return (
+              <TableRow
+                key={payment.id}
+                className="group cursor-pointer"
+                onClick={() => {
+                  // Navigate to student detail if we have student info
+                  // For now, open receipt preview
+                  onPreviewReceipt(payment)
+                }}
+              >
+                <TableCell>
+                  <div className="flex items-center gap-2.5">
+                    <StudentAvatar
+                      photoUrl={payment.student_photo_url}
+                      initials={vue.initials}
+                    />
+                    <div>
+                      <p className="text-sm font-medium leading-tight">
+                        {payment.student_name ?? `Paiement #${payment.id}`}
+                      </p>
+                      <p className="text-[11px] text-muted-foreground">#{payment.id}</p>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <span className="text-sm text-muted-foreground">
+                    {payment.fee_name ?? "—"}
+                  </span>
+                </TableCell>
+                <TableCell className="text-right">
+                  <span className="font-semibold tabular-nums">
+                    {Number(payment.amount).toLocaleString("fr-FR")}
+                  </span>
+                  <span className="ml-1 text-xs text-muted-foreground">FCFA</span>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <vue.MethodIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="text-sm">{vue.methodLabel}</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <UserCheck className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <span className="text-sm">
+                      {payment.received_by_name ?? "—"}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <div className={`h-2 w-2 rounded-full ${vue.statusDot}`} />
+                    <span className="text-sm">{vue.statusLabel}</span>
+                  </div>
+                  {vue.cancellation && (
+                    <p className="mt-0.5 max-w-[22rem] text-xs text-muted-foreground">
+                      {vue.cancellation}
+                    </p>
+                  )}
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground tabular-nums">
+                  {new Date(payment.created_at).toLocaleDateString("fr-FR", {
+                    day: "2-digit",
+                    month: "short",
+                    year: "numeric",
+                  })}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div
+                    className="opacity-60 transition-opacity group-hover:opacity-100"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <PaymentRowActions
+                      payment={payment}
+                      onValidate={onValidate}
+                      onCancel={onCancel}
+                      onPreviewReceipt={onPreviewReceipt}
+                      previewBusy={downloadingId === payment.id}
+                    />
+                  </div>
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/components/admin/payments/paymentRowView.test.ts
+++ b/components/admin/payments/paymentRowView.test.ts
@@ -1,0 +1,89 @@
+/**
+ * La vue de ligne est lue par le tableau et par les cartes.
+ *
+ * Elle décide de ce que la caissière voit, sur les deux appareils à la fois :
+ * une erreur ici s'affiche deux fois, et une divergence entre les deux
+ * lectures ne se verrait qu'en comparant un téléphone et un écran côte à côte.
+ */
+
+import { describe, expect, it } from "vitest"
+import { paymentRowView } from "./paymentRowView"
+import type { Payment } from "@/lib/contracts/payment"
+
+function versement(champs: Partial<Payment> = {}): Payment {
+  return {
+    id: 1,
+    amount: 3000,
+    method: "cash",
+    status: "completed",
+    student_name: "Traoré Aminata",
+    ...champs,
+  } as Payment
+}
+
+describe("ce qu'une ligne du journal affiche", () => {
+  it("tire les initiales du nom, prénom compris", () => {
+    expect(paymentRowView(versement()).initials).toBe("TA")
+  })
+
+  it("s'en tient à deux lettres quand le nom en compte plus", () => {
+    expect(paymentRowView(versement({ student_name: "Kouadio Yao N'Guessan" })).initials).toBe("KY")
+  })
+
+  it("affiche un point d'interrogation plutôt qu'un vide quand le nom manque", () => {
+    expect(paymentRowView(versement({ student_name: null })).initials).toBe("?")
+  })
+
+  it("ne dit rien de plus sur un versement valide", () => {
+    expect(paymentRowView(versement()).cancellation).toBeNull()
+  })
+
+  it("dit quand, par qui et pourquoi sur un versement annulé", () => {
+    const vue = paymentRowView(versement({
+      status: "cancelled",
+      cancelled_at: "2026-08-23T17:15:27",
+      cancelled_by_name: "Admin KLASSCI",
+      cancellation_reason: "Double saisie du COGES",
+    }))
+    expect(vue.cancellation).toBe("Annulé le 23/08/2026 par Admin KLASSCI · Double saisie du COGES")
+    expect(vue.statusLabel).toBe("Annulé")
+  })
+
+  it("se tait sur une annulation antérieure au motif obligatoire", () => {
+    // Le badge dit déjà « Annulé » : sans motif, la ligne se contenterait de
+    // le répéter. C'est le comportement d'avant l'extraction, pas un choix neuf.
+    const vue = paymentRowView(versement({ status: "cancelled", cancelled_at: "2026-01-04T09:00:00" }))
+    expect(vue.cancellation).toBeNull()
+    expect(vue.statusLabel).toBe("Annulé")
+  })
+
+  it("tolère un motif sans auteur ni date", () => {
+    const vue = paymentRowView(versement({ status: "cancelled", cancellation_reason: "Saisie en trop" }))
+    expect(vue.cancellation).toBe("Annulé · Saisie en trop")
+  })
+
+  it("nomme la méthode de paiement et lui donne son icône", () => {
+    const mobile = paymentRowView(versement({ method: "mobile_money" }))
+    const especes = paymentRowView(versement({ method: "cash" }))
+    expect(mobile.methodLabel).toMatch(/Mobile Money/i)
+    expect(especes.methodLabel).toMatch(/esp/i)
+    // Deux méthodes se distinguent au premier coup d'œil par leur icône :
+    // c'est la colonne qu'on parcourt pour retrouver un versement en espèces.
+    expect(mobile.MethodIcon).toBeDefined()
+    expect(mobile.MethodIcon).not.toBe(especes.MethodIcon)
+  })
+
+  it("donne à chaque statut sa pastille et son libellé", () => {
+    for (const [statut, libelle] of [
+      ["pending", "En attente"],
+      ["completed", "Validé"],
+      ["failed", "Échoué"],
+      ["refunded", "Remboursé"],
+      ["cancelled", "Annulé"],
+    ] as const) {
+      const vue = paymentRowView(versement({ status: statut }))
+      expect(vue.statusLabel).toBe(libelle)
+      expect(vue.statusDot).toMatch(/^bg-/)
+    }
+  })
+})

--- a/components/admin/payments/paymentRowView.ts
+++ b/components/admin/payments/paymentRowView.ts
@@ -1,0 +1,62 @@
+import { paymentMethodIcon } from "@/components/admin/payments/method-icon"
+import { paymentMethodLabel } from "@/lib/payment-methods"
+import type { Payment, PaymentStatus } from "@/lib/contracts/payment"
+
+const STATUS_CONFIG: Record<PaymentStatus, { label: string; dot: string }> = {
+  pending: { label: "En attente", dot: "bg-amber-500" },
+  completed: { label: "Validé", dot: "bg-emerald-500" },
+  failed: { label: "Échoué", dot: "bg-red-500" },
+  refunded: { label: "Remboursé", dot: "bg-blue-500" },
+  cancelled: { label: "Annulé", dot: "bg-rose-500" },
+}
+
+/** Ce qu'une ligne du journal affiche, quelle que soit sa forme. */
+export interface PaymentRowView {
+  statusLabel: string
+  /** La classe de la pastille de couleur du statut. */
+  statusDot: string
+  methodLabel: string
+  MethodIcon: ReturnType<typeof paymentMethodIcon>
+  /** Deux lettres, ou « ? » quand le nom manque. */
+  initials: string
+  /**
+   * La phrase d'annulation — quand, par qui, pourquoi — ou `null`.
+   *
+   * Elle est conditionnée au motif, pas au statut : un versement annulé
+   * avant que le motif ne devienne obligatoire n'a rien à dire de plus que
+   * son badge « Annulé », et la ligne se réduirait à le répéter.
+   */
+  cancellation: string | null
+}
+
+/**
+ * Ce qu'il faut dériver d'un versement pour l'afficher.
+ *
+ * Le même journal se lit sous deux formes : un tableau dense au bureau, des
+ * cartes sur un téléphone. Les deux dérivaient ces cinq valeurs chacune de
+ * leur côté, à l'identique — et la seule chose qu'une telle copie garantit,
+ * c'est qu'un jour l'une des deux changera sans l'autre, et que la caissière
+ * lira deux vérités selon l'appareil qu'elle a en main.
+ */
+export function paymentRowView(payment: Payment): PaymentRowView {
+  const status = STATUS_CONFIG[payment.status]
+  return {
+    statusLabel: status.label,
+    statusDot: status.dot,
+    methodLabel: paymentMethodLabel(payment.method),
+    MethodIcon: paymentMethodIcon(payment.method),
+    initials: payment.student_name
+      ? payment.student_name.split(" ").map((w) => w[0]).join("").slice(0, 2).toUpperCase()
+      : "?",
+    cancellation: payment.cancellation_reason ? phraseAnnulation(payment) : null,
+  }
+}
+
+function phraseAnnulation(p: Payment): string {
+  const quand = p.cancelled_at
+    ? ` le ${new Date(p.cancelled_at).toLocaleDateString("fr-FR")}`
+    : ""
+  const qui = p.cancelled_by_name ? ` par ${p.cancelled_by_name}` : ""
+  const pourquoi = p.cancellation_reason ? ` · ${p.cancellation_reason}` : ""
+  return `Annulé${quand}${qui}${pourquoi}`
+}

--- a/components/admin/payments/payments-list-views.test.tsx
+++ b/components/admin/payments/payments-list-views.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Le tableau et les cartes montrent-ils vraiment la même chose ?
+ *
+ * C'est toute la raison d'être de `paymentRowView` : la caissière consulte le
+ * même journal sur l'ordinateur du secrétariat et sur son téléphone, et les
+ * deux doivent dire la même chose du même versement. La fonction partagée est
+ * testée à part ; ces tests-ci vérifient que les deux vues la lisent, ce qu'une
+ * substitution manquée dans l'une des deux casserait sans bruit.
+ */
+
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { PaymentsCardList } from "./PaymentsCardList"
+import { PaymentsTable } from "./PaymentsTable"
+import type { Payment } from "@/lib/contracts/payment"
+
+const ANNULE = {
+  id: 1820,
+  amount: 3000,
+  method: "mobile_money",
+  status: "cancelled",
+  student_name: "dago désiré",
+  fee_category_name: "COGES",
+  cancelled_at: "2026-08-23T17:15:27",
+  cancelled_by_name: "Admin KLASSCI",
+  cancellation_reason: "Double saisie du COGES",
+} as unknown as Payment
+
+const rien = () => {}
+
+const VUES = [
+  {
+    nom: "le tableau",
+    rendre: (p: Payment[]) => render(
+      <PaymentsTable
+        payments={p}
+        downloadingId={null}
+        onPreviewReceipt={rien}
+        onValidate={rien}
+        onCancel={rien}
+      />,
+    ),
+  },
+  {
+    nom: "les cartes",
+    rendre: (p: Payment[]) => render(
+      <PaymentsCardList payments={p} onPreviewReceipt={rien} onValidate={rien} onCancel={rien} />,
+    ),
+  },
+]
+
+describe.each(VUES)("$nom", ({ rendre }) => {
+  it("porte le statut du versement", () => {
+    rendre([ANNULE])
+    expect(screen.getAllByText("Annulé").length).toBeGreaterThan(0)
+  })
+
+  it("dit quand, par qui et pourquoi le versement a été annulé", () => {
+    rendre([ANNULE])
+    expect(
+      screen.getByText("Annulé le 23/08/2026 par Admin KLASSCI · Double saisie du COGES"),
+    ).toBeTruthy()
+  })
+
+  it("nomme la méthode de paiement", () => {
+    rendre([ANNULE])
+    expect(screen.getAllByText(/Mobile Money/i).length).toBeGreaterThan(0)
+  })
+
+  it("se tait sur une annulation sans motif, que le badge dit déjà", () => {
+    const sansMotif = { ...ANNULE, cancellation_reason: null } as unknown as Payment
+    rendre([sansMotif])
+    expect(screen.queryByText(/^Annulé le /)).toBeNull()
+  })
+
+  it("affiche les initiales de l'élève", () => {
+    rendre([ANNULE])
+    expect(screen.getAllByText("DD").length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Closes #365

Suite de la [#364](https://github.com/African-DC/klassci-college-frontend/pull/364), qui avait laissé cette jointure en la signalant.

## Ce que fait cette PR

| Fichier | Rôle | Lignes |
|---|---|---|
| `paymentRowView.ts` | la dérivation, une seule fois | 62 |
| `PaymentsTable.tsx` | le tableau, écran large | 146 |
| `PaymentsCardList.tsx` | les cartes, téléphone | 99 |

**493 → 296 lignes** pour la page.

## La décision que porte `paymentRowView`

Ce n'est pas un simple sac de cinq champs. La ligne d'annulation est conditionnée au **motif**, pas au statut : un versement annulé avant que le motif ne devienne obligatoire n'a rien à ajouter à son badge « Annulé », et la ligne se réduirait à le répéter.

**J'ai écrit la version « statut » en premier.** Elle aurait fait apparaître une ligne vide de sens sur un versement ancien de la démo. C'est en comparant au code d'origine que je l'ai vu, et le test qui garde ce comportement échoue quand on rebascule la condition.

## Vérifications

- `tsc --noEmit` propre, `next lint` sans alerte, **250 tests verts** sur 32 fichiers.
- 9 tests sur la dérivation, **10 tests de rendu sur les deux vues** (`describe.each`) : ils échouent quand une substitution est manquée **dans une seule des deux**, c'est-à-dire exactement la divergence que la fonction partagée existe pour empêcher. Vérifié en cassant `{vue.cancellation}` dans les cartes seulement.
- Revue thermo-nucléaire : équivalence ligne à ligne des deux blocs contre l'origine confirmée, puis approbation. Elle a trouvé une docstring orpheline recollée au composant de page, et une indentation restée à la profondeur de l'ancien emplacement.

## Reste, signalé

`STATUS_CONFIG` est la seconde table de libellés de statut du projet — `PaymentHistoryList` a la sienne. La duplication est antérieure à cette PR ; sa place est `lib/`, à côté de `payment-methods.ts`. Séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)