### PR TITLE
fix(security): credentials can no longer end up in the address bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page « Mes notes » du portail enseignant qui était inaccessible (lien sidebar vers une page absente) *(enseignant)* (#111).
 
 ### Security
+- Un identifiant saisi puis validé avant que la page ne soit prête ne peut plus se retrouver dans l'adresse du navigateur *(tous)*
 
 - Endpoint d'exposition des permissions effectives sécurisé par JWT et tenant scope, consommé par le portail pour le gating UI *(tous)* (#108).
 

--- a/components/admin/parents/ParentCreateModal.tsx
+++ b/components/admin/parents/ParentCreateModal.tsx
@@ -62,7 +62,7 @@ export function ParentCreateModal({ open, onClose }: ParentCreateModalProps) {
           <DialogTitle>Nouveau parent</DialogTitle>
         </DialogHeader>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+          <form method="post" onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
             <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}

--- a/components/admin/settings/MailPulseSection.tsx
+++ b/components/admin/settings/MailPulseSection.tsx
@@ -88,7 +88,7 @@ function MailPulseForm({
       <Card className="border-0 shadow-sm ring-1 ring-border">
         <CardContent className="p-4 sm:p-5">
           <Form {...form}>
-            <form onSubmit={form.handleSubmit((d) => save(d))} className="space-y-5">
+            <form method="post" onSubmit={form.handleSubmit((d) => save(d))} className="space-y-5">
               {/* Interrupteur maître */}
               <FormField
                 control={form.control}

--- a/components/admin/students/parents/ParentCreateModal.tsx
+++ b/components/admin/students/parents/ParentCreateModal.tsx
@@ -94,7 +94,7 @@ export function ParentCreateModal({ studentId, open, onClose }: ParentCreateModa
         </DialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <form method="post" onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <FormField
                 control={form.control}

--- a/components/forms/ChangePasswordForm.tsx
+++ b/components/forms/ChangePasswordForm.tsx
@@ -50,7 +50,10 @@ export function ChangePasswordForm() {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+      {/* Voir LoginForm : sans `method="post"`, une soumission avant l'hydratation
+          partirait en GET. Ce formulaire porte le mot de passe actuel en plus du
+          nouveau. */}
+      <form method="post" onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
         <FormField
           control={form.control}
           name="current_password"

--- a/components/forms/LoginForm.tsx
+++ b/components/forms/LoginForm.tsx
@@ -102,7 +102,15 @@ export function LoginForm() {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+      {/* `method="post"` n'est jamais emprunté une fois que React écoute, mais il
+          décide de ce qui arrive avant. Entre l'affichage du HTML et l'exécution du
+          bundle, le bouton existe déjà et personne n'intercepte : un clic déclenche
+          la soumission native du navigateur, qui sans `method` est un GET. Le mot de
+          passe part alors dans l'URL, donc dans l'historique, dans les journaux du
+          serveur et, pour une requête de même origine, dans l'en-tête Referer de la
+          page suivante. La fenêtre est étroite, et elle s'allonge exactement là où la
+          connexion est lente. */}
+      <form method="post" onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
         {sessionExpired && !error && (
           <div
             role="alert"

--- a/components/forms/StaffForm.tsx
+++ b/components/forms/StaffForm.tsx
@@ -58,7 +58,7 @@ export function StaffForm({ onSuccess }: StaffFormProps) {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+      <form method="post" onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
         <div className="grid grid-cols-2 gap-4">
           <FormField
             control={form.control}

--- a/components/forms/StudentForm.tsx
+++ b/components/forms/StudentForm.tsx
@@ -63,7 +63,7 @@ export function StudentForm({ onSuccess }: StudentFormProps) {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+      <form method="post" onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
         <StudentPhotoField value={photo} onChange={setPhoto} disabled={isPending || attachPhoto.isPending} />
 
         <div className="grid grid-cols-2 gap-4">

--- a/components/forms/TeacherForm.tsx
+++ b/components/forms/TeacherForm.tsx
@@ -59,7 +59,7 @@ export function TeacherForm({ onSuccess }: TeacherFormProps) {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+      <form method="post" onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
         <div className="grid grid-cols-2 gap-4">
           <FormField
             control={form.control}

--- a/components/forms/credentials-never-in-url.test.tsx
+++ b/components/forms/credentials-never-in-url.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Un identifiant ne doit jamais pouvoir partir dans une URL.
+ *
+ * Ces formulaires sont soumis par React. Mais entre l'affichage du HTML et
+ * l'hydratation, le bouton existe déjà et React n'écoute pas encore : un clic
+ * dans cet intervalle déclenche la soumission native du navigateur. Sans
+ * `method`, celle-ci est un GET, et les champs partent en paramètres d'URL,
+ * donc dans l'historique, dans les journaux du serveur et dans l'en-tête
+ * Referer de la page suivante.
+ *
+ * L'intervalle est court, et il s'allonge exactement là où la connexion est
+ * lente : une école au bout d'une 3G est le cas le plus exposé, pas le moins.
+ *
+ * Ces tests rendent les formulaires et interrogent le DOM produit. Ils ne
+ * lisent pas le source : ce qui compte est ce que le navigateur recevrait.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { ChangePasswordForm } from "@/components/forms/ChangePasswordForm"
+import { LoginForm } from "@/components/forms/LoginForm"
+import { StaffForm } from "@/components/forms/StaffForm"
+import { WizardShell } from "@/components/super-admin/tenants-new/WizardShell"
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  useSession: () => ({ data: null, status: "unauthenticated" }),
+}))
+
+/** Le wizard interroge le serveur pour vérifier le slug : il lui faut un client. */
+function rendreAvecQuery(noeud: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{noeud}</QueryClientProvider>)
+}
+
+const FORMULAIRES = [
+  { nom: "la page de connexion", rendre: () => render(<LoginForm />) },
+  { nom: "le changement de mot de passe", rendre: () => render(<ChangePasswordForm />) },
+  // Le mot de passe du premier administrateur d'une école : le champ est déclaré
+  // dans StepAdmin, mais le formulaire qui l'entoure est ici.
+  { nom: "la création d'un établissement", rendre: () => rendreAvecQuery(<WizardShell />), sansMotDePasseAuDepart: true },
+  // Son champ bascule entre `text` et `password` selon l'œil affiché : une
+  // recherche de `type="password"` littéral ne le voit pas. C'est comme ça
+  // qu'il avait été oublié.
+  { nom: "la création d'un membre du personnel", rendre: () => rendreAvecQuery(<StaffForm onSuccess={() => {}} />) },
+]
+
+describe.each(FORMULAIRES)("$nom", ({ rendre, sansMotDePasseAuDepart }) => {
+  it("ne peut pas se soumettre en GET, même avant que React n'écoute", () => {
+    const { container } = rendre()
+    const form = container.querySelector("form")
+    expect(form).not.toBeNull()
+    // `method` vaut « get » par défaut : c'est ce défaut qui fuit.
+    expect(form!.method).toBe("post")
+  })
+
+  it("porte bien un champ de mot de passe, sinon le test précédent ne garde rien", ({ skip }) => {
+    // Le wizard n'affiche son étape « administrateur » qu'au second écran :
+    // le champ n'est pas encore monté, mais le formulaire qui l'accueillera l'est.
+    if (sansMotDePasseAuDepart) return skip()
+    const { container } = rendre()
+    expect(container.querySelector('input[type="password"]')).not.toBeNull()
+  })
+})

--- a/components/super-admin/pats/PatsPanel.tsx
+++ b/components/super-admin/pats/PatsPanel.tsx
@@ -75,7 +75,7 @@ export function PatsPanel() {
           <CardTitle className="text-base">Créer un token</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <form method="post" onSubmit={form.handleSubmit(onSubmit)} className="grid grid-cols-1 gap-4 md:grid-cols-3">
             <div className="space-y-1.5">
               <Label htmlFor="name">Nom</Label>
               <Input id="name" placeholder="dev-laptop" {...form.register("name")} />

--- a/components/super-admin/tenants-new/WizardShell.tsx
+++ b/components/super-admin/tenants-new/WizardShell.tsx
@@ -93,7 +93,7 @@ export function WizardShell() {
           <p className="text-sm text-muted-foreground">{STEPS[step].description}</p>
         </div>
 
-        <form onSubmit={methods.handleSubmit(onSubmit)} className="rounded-lg border bg-card p-4 shadow-sm sm:p-6">
+        <form method="post" onSubmit={methods.handleSubmit(onSubmit)} className="rounded-lg border bg-card p-4 shadow-sm sm:p-6">
           {step === 0 && <StepSchool />}
           {step === 1 && <StepAdmin />}
           {step === 2 && <StepOptional />}


### PR DESCRIPTION
Closes #367

## Le défaut

Un clic tombé entre l'arrivée du HTML et l'exécution du bundle déclenche la soumission **native** du navigateur, que React n'intercepte pas encore. Sans `method`, cette soumission est un GET :

```
/login?school_code=LOCAL&email=admin%40klassci.com&password=Admin%402026
```

Le mot de passe part alors dans l'historique, dans les journaux d'accès, et dans l'en-tête `Referer` de la requête suivante de même origine.

## Le correctif

`method="post"` sur les **dix** formulaires qui portent un identifiant ou un secret. Le repli natif se produit toujours, mais les champs voyagent dans le corps. Next rend la page à nouveau et l'ignore : rien ne casse, rien ne fuit.

| Réellement exposés (formulaires de page) | Défensifs (modales, inatteignables avant hydratation) |
|---|---|
| `LoginForm`, `ChangePasswordForm`, `WizardShell`, `PatsPanel` | `StaffForm`, `StudentForm`, `TeacherForm`, les deux `ParentCreateModal`, `MailPulseSection` |

## Ce que la revue a rattrapé, et que je n'avais pas vu

**Deux formulaires manquaient, chacun pour une raison différente.**

Le premier : j'avais écrit que le wizard super-admin « contient un champ mot de passe mais pas de `<form>` ». C'était faux. Le champ est déclaré dans `StepAdmin`, mais le formulaire qui l'entoure vit dans `WizardShell`. Un formulaire portant un mot de passe avait donc été exclu sur une affirmation fausse.

Le second : ma recherche cherchait `type="password"` littéral. Le champ de `StaffForm` bascule entre `text` et `password` selon l'œil affiché, donc le motif ne le voyait pas. Le commentaire du test le dit, pour que la prochaine recherche ne refasse pas l'erreur.

La revue a aussi corrigé deux imprécisions dans mes commentaires : la fenêtre est **avant** l'exécution du bundle, pas « pendant l'hydratation » ; et la fuite par `Referer` ne vaut qu'en même origine, l'application posant `Referrer-Policy: strict-origin-when-cross-origin`.

## Vérifications

- `tsc --noEmit` propre, `next lint` sans alerte, **257 tests verts** sur 33 fichiers.
- Un test de rendu interroge le `<form>` produit et assertit `method === "post"`. Il ne lit pas le source : ce qui compte est ce que le navigateur recevrait.
- **Chaque cas vérifié en le cassant** : retirer l'attribut d'un seul formulaire fait tomber exactement son cas, avec `expected 'get' to be 'post'` — ce qui prouve au passage que le défaut par défaut est bien GET.

## Hors périmètre, signalé

Je me suis arrêté aux formulaires portant un identifiant ou un secret. Les ~40 autres sont surtout des modales ; les rares de page portent des noms de classe et des montants. `GradeEntryForm` soumet des notes d'élèves, mais il n'est référencé nulle part — c'est du code mort, à traiter séparément.

Le correctif durable pour toute la classe serait une règle de lint exigeant `method` sur tout `<form>` contenant un champ de mot de passe, plutôt qu'une liste qu'il faut penser à étendre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)