### PR TITLE
fix(security): a teacher's password was readable in their own address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Page « Mes notes » du portail enseignant qui était inaccessible (lien sidebar vers une page absente) *(enseignant)* (#111).
 
 ### Security
+- Le mot de passe d'un enseignant créé depuis l'emploi du temps n'est plus déductible de son adresse, et s'affiche une fois pour être transmis *(admin)*
 - Un identifiant saisi puis validé avant que la page ne soit prête ne peut plus se retrouver dans l'adresse du navigateur *(tous)*
 
 - Endpoint d'exposition des permissions effectives sécurisé par JWT et tenant scope, consommé par le portail pour le gating UI *(tous)* (#108).

--- a/components/forms/timetable-slot/credentials.test.ts
+++ b/components/forms/timetable-slot/credentials.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Le mot de passe d'un enseignant ne doit pas se lire dans son adresse.
+ *
+ * La version précédente tirait un suffixe à trois chiffres avec `Math.random`
+ * et le posait des deux côtés : l'adresse `aissatou.diallo.437@klassci.local`
+ * annonçait le mot de passe `Klassci437!A`. Connaître l'un donnait l'autre,
+ * sans une seule tentative, et l'adresse d'un enseignant n'est pas un secret.
+ *
+ * Ces tests appellent la vraie fonction. Le premier est celui qui compte :
+ * il échoue dès qu'un fragment de l'adresse reparaît dans le mot de passe.
+ */
+
+import { describe, expect, it } from "vitest"
+import { generateAutoCredentials } from "./inline-create-dialogs"
+
+/** Les morceaux de l'adresse qu'un curieux peut lire. */
+function fragmentsDeLAdresse(email: string): string[] {
+  const local = email.split("@")[0]
+  return local.split(".").filter((f) => f.length >= 2)
+}
+
+describe("les identifiants d'un enseignant créé au vol", () => {
+  it("ne laisse aucun fragment de l'adresse reparaître dans le mot de passe", () => {
+    for (let i = 0; i < 200; i++) {
+      const { email, password } = generateAutoCredentials("Aïssatou", "Diallo")
+      for (const fragment of fragmentsDeLAdresse(email)) {
+        expect(password.toLowerCase()).not.toContain(fragment.toLowerCase())
+      }
+    }
+  })
+
+  it("donne deux mots de passe différents pour le même enseignant", () => {
+    const vus = new Set<string>()
+    for (let i = 0; i < 100; i++) vus.add(generateAutoCredentials("Kouadio", "Yao").password)
+    expect(vus.size).toBe(100)
+  })
+
+  it("tire assez de hasard pour qu'on ne l'épuise pas", () => {
+    // L'ancienne version avait 900 possibilités : une liste, pas un secret.
+    const { password } = generateAutoCredentials("Mariam", "Koné")
+    expect(password.length).toBeGreaterThanOrEqual(20)
+  })
+
+  it("satisfait les règles usuelles de composition", () => {
+    const { password } = generateAutoCredentials("Sophie", "Yao")
+    expect(password).toMatch(/[a-z]/)
+    expect(password).toMatch(/[A-Z]/)
+    expect(password).toMatch(/[0-9]/)
+    expect(password).toMatch(/[^a-zA-Z0-9]/)
+  })
+
+  it("garde une adresse lisible, accents retirés", () => {
+    const { email } = generateAutoCredentials("Aïssatou", "Diallo")
+    expect(email).toMatch(/^aissatou\.diallo\.[a-z0-9]+@klassci\.local$/)
+  })
+})

--- a/components/forms/timetable-slot/inline-create-dialogs.tsx
+++ b/components/forms/timetable-slot/inline-create-dialogs.tsx
@@ -88,12 +88,33 @@ export function InlineCreateSubjectDialog({
   )
 }
 
-function generateAutoCredentials(first: string, last: string) {
+/** Des octets tires du generateur cryptographique du navigateur. */
+function alea(octets: number): string {
+  const buf = new Uint8Array(octets)
+  crypto.getRandomValues(buf)
+  return Array.from(buf, (o) => o.toString(36).padStart(2, "0")).join("")
+}
+
+/**
+ * L'adresse et le mot de passe d'un enseignant cree au vol.
+ *
+ * Les deux sont tires separement, et c'est tout le point. La version
+ * precedente derivait le mot de passe du meme suffixe a trois chiffres que
+ * l'adresse : lire `aissatou.diallo.437@klassci.local` donnait
+ * `Klassci437!A` sans une seule tentative. Le hasard venait de plus de
+ * `Math.random`, qui ne promet rien contre la prediction.
+ *
+ * Le mot de passe est rendu a l'appelant pour etre montre une fois. Sans
+ * cela le compte ne serait pas sur, il serait inutilisable : son
+ * proprietaire legitime serait le seul a ne pas pouvoir s'y connecter.
+ */
+export function generateAutoCredentials(first: string, last: string) {
   const slug = `${first}.${last}`.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/\s+/g, ".")
-  const suffix = String(Math.floor(Math.random() * 900) + 100)
   return {
-    email: `${slug}.${suffix}@klassci.local`,
-    password: `Klassci${suffix}!${first[0]?.toUpperCase() ?? "X"}`,
+    email: `${slug}.${alea(3)}@klassci.local`,
+    // Majuscule, minuscule, chiffre et signe : les regles usuelles sont
+    // satisfaites sans rien retirer aux douze octets tires au sort.
+    password: `Kl${alea(12)}!A9`,
   }
 }
 
@@ -109,6 +130,8 @@ export function InlineCreateTeacherDialog({
   const [firstName, setFirstName] = useState("")
   const [lastName, setLastName] = useState("")
   const [speciality, setSpeciality] = useState("")
+  // Montres une fois, apres creation : personne d autre ne les connaitra.
+  const [identifiants, setIdentifiants] = useState<{ email: string; password: string } | null>(null)
   const { mutate, isPending } = useCreateTeacher()
 
   function handleSubmit(e: React.FormEvent) {
@@ -128,6 +151,7 @@ export function InlineCreateTeacherDialog({
           setFirstName("")
           setLastName("")
           setSpeciality("")
+          setIdentifiants({ email, password })
           onCreated(created.id)
         },
       },
@@ -140,6 +164,33 @@ export function InlineCreateTeacherDialog({
         <DialogHeader>
           <DialogTitle>Créer un enseignant</DialogTitle>
         </DialogHeader>
+        {identifiants ? (
+          <div className="space-y-3">
+            <p className="text-sm">
+              Compte créé. Ces identifiants ne seront <strong>plus jamais affichés</strong> :
+              transmettez-les à l&apos;enseignant maintenant.
+            </p>
+            <dl className="space-y-2 rounded-lg border bg-muted/40 p-3 text-sm">
+              <div>
+                <dt className="text-xs text-muted-foreground">Adresse</dt>
+                <dd className="font-mono break-all">{identifiants.email}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Mot de passe</dt>
+                <dd className="font-mono break-all">{identifiants.password}</dd>
+              </div>
+            </dl>
+            <DialogFooter>
+              <Button
+                type="button"
+                className="h-11"
+                onClick={() => { setIdentifiants(null); onClose() }}
+              >
+                J&apos;ai noté, fermer
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : (
         <form onSubmit={handleSubmit} className="space-y-3">
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
@@ -175,7 +226,7 @@ export function InlineCreateTeacherDialog({
             />
           </div>
           <p className="text-xs text-muted-foreground">
-            Un compte sera créé automatiquement. Pour configurer les identifiants, rendez-vous sur la page de l'enseignant.
+            Un compte sera créé, et ses identifiants affichés une seule fois : notez-les avant de fermer.
           </p>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={onClose}>
@@ -189,6 +240,7 @@ export function InlineCreateTeacherDialog({
             </Button>
           </DialogFooter>
         </form>
+        )}
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
Closes #370

## Le correctif

Les deux valeurs sont désormais tirées **séparément** de `crypto.getRandomValues`, et les identifiants s'affichent **une fois** après création pour être transmis.

Corriger le hasard sans corriger l'affichage n'aurait rien réglé : un mot de passe imprévisible que personne ne voit ne rend pas le compte sûr, il le rend seulement inutilisable. La phrase qui promettait une page de configuration inexistante part avec.

## Vérification

5 tests appellent la vraie fonction. Le premier est celui qui porte tout : sur 200 tirages, aucun fragment de l'adresse ne doit reparaître dans le mot de passe.

**Vérifié en remettant l'ancienne version** : 3 tests sur 5 tombent, dont celui-là.

`tsc` propre, `next lint` sans alerte, **262 tests verts** sur 34 fichiers.

## Contexte

Trouvé en vérifiant les alertes CodeQL des PR de release. C'est le seul défaut réellement exploitable du lot : les deux « injections SQL » du backend sont contrôlées (MySQL ne peut pas lier un nom de base, garde `[a-z0-9-]` strict ; l'exécuteur SQL est un outil de diagnostic derrière `super-admin:db:execute`), et les trois « injections de chemin » ne sont pas exploitables — le nom de fichier commence par `teacher_{id}_{uuid}`, la traversée échouerait sur un dossier inexistant. Cette dernière tient toutefois par accident et mérite une validation d'extension explicite, séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)