### PR TITLE
fix(e2e): the tests asked for a school that CI never created

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -18,7 +18,12 @@ export async function loginAs(
   password: string,
 ): Promise<void> {
   await page.goto('/login')
-  await page.getByPlaceholder('ROSTAN').fill('local')
+  // Le code de l’établissement decide de la base que le backend ouvre.
+  // La CI provisionne `klasscie2e` (voir e2e.yml : MYSQL_DATABASE et
+  // TENANT_ID) ; taper `local` faisait chercher une base qui n’existe pas,
+  // et le backend répondait 500 sur chaque connexion : les douze tests
+  // échouaient sur la meme cause, en restant sur /login.
+  await page.getByPlaceholder('ROSTAN').fill(process.env.E2E_SCHOOL_CODE ?? 'klasscie2e')
   await page.getByPlaceholder('nom@etablissement.ci').fill(email)
   await page.getByPlaceholder('Entrez votre mot de passe').fill(password)
   await page.getByRole('button', { name: /Se connecter/i }).click()


### PR DESCRIPTION
Closes #373

Une ligne. Le helper tapait `local`, la CI provisionne `klasscie2e`.

Le code vient désormais de `E2E_SCHOOL_CODE` quand la variable est posée, pour que la suite puisse viser un autre tenant sans éditer le helper.

C'est la CI qui prouvera le correctif : si les douze tests passent, la cause était bien celle-là.

🤖 Generated with [Claude Code](https://claude.com/claude-code)