### PR TITLE
fix(students): say which enrolment is open, not just which is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Fixed
+- La liste des élèves distingue désormais « En attente de validation » de « À inscrire », et affiche des libellés lisibles au lieu des valeurs de la base *(admin)*
 - Le motif d'annulation d'un versement s'affiche désormais à l'identique sur ordinateur et sur téléphone *(admin)*
 - Photo de l'élève correctement recadrée dans le journal des versements, au lieu d'être étirée quand elle n'est pas carrée *(admin)*
 - Annulation d'un versement déjà encaissé, depuis le tableau comme depuis le téléphone : c'est le cas courant, un montant saisi qui n'est pas dans la caisse *(admin)*

--- a/components/admin/enrollments/EnrollmentDetailClient.tsx
+++ b/components/admin/enrollments/EnrollmentDetailClient.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { enrollmentStatusView } from "@/lib/enrollment/status"
 import { useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -43,14 +44,6 @@ import { EnrollmentOverviewTab } from "./tabs/EnrollmentOverviewTab"
 import { EnrollmentPaymentsTab } from "./tabs/EnrollmentPaymentsTab"
 import { useEnrollment, useDeleteEnrollment } from "@/lib/hooks/useEnrollments"
 
-const statusConfig: Record<string, string> = {
-  prospect: "Prospect",
-  en_validation: "En validation",
-  valide: "Validé",
-  rejete: "Rejeté",
-  annule: "Annulé",
-}
-
 interface EnrollmentDetailClientProps {
   enrollmentId: number
 }
@@ -86,7 +79,7 @@ export function EnrollmentDetailClient({ enrollmentId }: EnrollmentDetailClientP
     .join(" ") || `Élève #${enrollment.student_id}`
   const className = enrollment.class_name ?? `Classe #${enrollment.class_id}`
   const academicYear = enrollment.academic_year_name ?? ""
-  const statusLabel = statusConfig[enrollment.status] ?? enrollment.status
+  const statusLabel = enrollmentStatusView(enrollment.status).label
 
   const initials = `${enrollment.student_first_name?.[0] ?? ""}${enrollment.student_last_name?.[0] ?? ""}`.toUpperCase()
 

--- a/components/admin/enrollments/EnrollmentViewModal.tsx
+++ b/components/admin/enrollments/EnrollmentViewModal.tsx
@@ -1,18 +1,12 @@
 "use client"
 
 import { useEnrollment } from "@/lib/hooks/useEnrollments"
+import { enrollmentStatusView } from "@/lib/enrollment/status"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Badge } from "@/components/ui/badge"
 import { AssignmentStatusBadge } from "@/components/shared/AssignmentStatusBadge"
 
-const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  prospect: { label: "Prospect", variant: "secondary" },
-  en_validation: { label: "En validation", variant: "secondary" },
-  valide: { label: "Validé", variant: "default" },
-  rejete: { label: "Rejeté", variant: "destructive" },
-  annule: { label: "Annulé", variant: "destructive" },
-}
 
 function formatDate(dateStr: string | null | undefined): string {
   if (!dateStr) return "—"
@@ -51,7 +45,7 @@ function ViewContent({ enrollmentId }: { enrollmentId: number }) {
     .filter(Boolean)
     .join(" ") || "—"
 
-  const status = statusConfig[enrollment.status]
+  const status = enrollmentStatusView(enrollment.status)
 
   return (
     <div className="grid grid-cols-2 gap-5">

--- a/components/admin/enrollments/tabs/EnrollmentOverviewTab.tsx
+++ b/components/admin/enrollments/tabs/EnrollmentOverviewTab.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { enrollmentStatusView } from "@/lib/enrollment/status"
 import {
   GraduationCap,
   CalendarDays,
@@ -13,20 +14,12 @@ import { Card, CardContent } from "@/components/ui/card"
 import { AssignmentStatusBadge } from "@/components/shared/AssignmentStatusBadge"
 import type { Enrollment } from "@/lib/contracts/enrollment"
 
-const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  prospect: { label: "Prospect", variant: "outline" },
-  en_validation: { label: "En validation", variant: "secondary" },
-  valide: { label: "Validé", variant: "default" },
-  rejete: { label: "Rejeté", variant: "destructive" },
-  annule: { label: "Annulé", variant: "destructive" },
-}
-
 interface EnrollmentOverviewTabProps {
   enrollment: Enrollment
 }
 
 export function EnrollmentOverviewTab({ enrollment }: EnrollmentOverviewTabProps) {
-  const status = statusConfig[enrollment.status] ?? { label: enrollment.status, variant: "outline" as const }
+  const status = enrollmentStatusView(enrollment.status)
 
   const studentName = [enrollment.student_first_name, enrollment.student_last_name]
     .filter(Boolean)

--- a/components/admin/students/StudentsTable.tsx
+++ b/components/admin/students/StudentsTable.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
+import { enrollmentStatusView } from "@/lib/enrollment/status"
 import Link from "next/link"
 import type { Route } from "next"
 import type { ColumnDef } from "@tanstack/react-table"
@@ -212,7 +213,7 @@ export function StudentsTable({
           if (ce) {
             return (
               <Badge variant="outline" className="text-xs font-medium">
-                {ce.class_name}
+                {ce.class_name || "Classe à affecter"}
               </Badge>
             )
           }
@@ -227,9 +228,10 @@ export function StudentsTable({
           if (!ce) {
             return <span className="text-xs text-muted-foreground">—</span>
           }
+          const vue = enrollmentStatusView(ce.status)
           return (
-            <Badge variant="secondary" className="text-xs capitalize">
-              {ce.status}
+            <Badge variant={vue.variant} className="text-xs">
+              {vue.label}
             </Badge>
           )
         },
@@ -333,15 +335,15 @@ export function StudentsTable({
             }
             secondary={
               s.current_enrollment ? (
-                s.current_enrollment.class_name
+                s.current_enrollment.class_name || enrollmentStatusView(s.current_enrollment.status).label
               ) : (
                 <span className="text-amber-700">À inscrire</span>
               )
             }
             status={
               s.current_enrollment ? (
-                <Badge variant="secondary" className="text-[10px] capitalize">
-                  {s.current_enrollment.status}
+                <Badge variant={enrollmentStatusView(s.current_enrollment.status).variant} className="text-[10px]">
+                  {enrollmentStatusView(s.current_enrollment.status).label}
                 </Badge>
               ) : null
             }

--- a/lib/enrollment/status.test.ts
+++ b/lib/enrollment/status.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Un dossier ouvert n'est pas un dossier inexistant.
+ *
+ * La liste des élèves affichait « À inscrire » à tout élève sans inscription
+ * *validée*. Un élève dont le dossier était en attente depuis des semaines
+ * apparaissait donc comme n'ayant rien entamé, et le badge invitait à rouvrir
+ * une inscription déjà ouverte.
+ */
+
+import { describe, expect, it } from "vitest"
+import { enrollmentStatusView } from "./status"
+
+describe("ce qu'un statut d'inscription dit à l'écran", () => {
+  it("distingue un dossier en cours d'une inscription acquise", () => {
+    expect(enrollmentStatusView("en_validation").enCours).toBe(true)
+    expect(enrollmentStatusView("prospect").enCours).toBe(true)
+    expect(enrollmentStatusView("valide").enCours).toBe(false)
+  })
+
+  it("ne dit jamais « à inscrire » d'un dossier déjà ouvert", () => {
+    for (const statut of ["prospect", "en_validation", "valide", "rejete", "annule"]) {
+      expect(enrollmentStatusView(statut).label.toLowerCase()).not.toContain("à inscrire")
+    }
+  })
+
+  it("donne un libellé lisible, pas la valeur de la base", () => {
+    expect(enrollmentStatusView("en_validation").label).toBe("En attente de validation")
+    expect(enrollmentStatusView("valide").label).toBe("Inscrit")
+  })
+
+  it("ne fait pas disparaître une ligne au statut inconnu", () => {
+    // Un statut ajouté côté serveur et pas encore ici doit rester visible.
+    expect(enrollmentStatusView("nouveau_statut").label).toBe("nouveau_statut")
+  })
+
+  it("tolère l'absence de statut", () => {
+    expect(enrollmentStatusView(null).label).toBe("—")
+    expect(enrollmentStatusView(undefined).enCours).toBe(false)
+  })
+})

--- a/lib/enrollment/status.ts
+++ b/lib/enrollment/status.ts
@@ -1,0 +1,32 @@
+/**
+ * Ce qu'un statut d'inscription dit à l'écran.
+ *
+ * Deux écrans en gardaient chacun leur copie, et la liste des élèves n'en
+ * avait aucune : elle affichait le statut brut de la base, `en_validation`,
+ * et surtout elle traitait toute inscription non validée comme inexistante.
+ * Un élève dont le dossier était ouvert depuis des semaines s'affichait donc
+ * « À inscrire », invitant à rouvrir un dossier déjà ouvert.
+ */
+
+export type EnrollmentStatus = "prospect" | "en_validation" | "valide" | "rejete" | "annule"
+
+export interface EnrollmentStatusView {
+  label: string
+  variant: "default" | "secondary" | "destructive" | "outline"
+  /** Vrai tant que l'inscription n'est ni acquise ni abandonnée. */
+  enCours: boolean
+}
+
+const STATUTS: Record<EnrollmentStatus, EnrollmentStatusView> = {
+  prospect: { label: "Dossier ouvert", variant: "secondary", enCours: true },
+  en_validation: { label: "En attente de validation", variant: "secondary", enCours: true },
+  valide: { label: "Inscrit", variant: "default", enCours: false },
+  rejete: { label: "Rejeté", variant: "destructive", enCours: false },
+  annule: { label: "Annulé", variant: "destructive", enCours: false },
+}
+
+/** Un statut inconnu s'affiche tel quel plutôt que de faire disparaître la ligne. */
+export function enrollmentStatusView(statut: string | null | undefined): EnrollmentStatusView {
+  if (!statut) return { label: "—", variant: "outline", enCours: false }
+  return STATUTS[statut as EnrollmentStatus] ?? { label: statut, variant: "outline", enCours: false }
+}


### PR DESCRIPTION
Va avec la [BE #307](https://github.com/African-DC/klassci-college-backend/pull/307) : un élève dont l'inscription est ouverte mais pas validée atteint désormais la liste, et la liste doit le dire au lieu de retomber sur « À inscrire ».

## Ce qui change à l'écran

| Situation | Avant | Après |
|---|---|---|
| Aucune inscription | « À inscrire » | « À inscrire » (inchangé) |
| Dossier ouvert | **« À inscrire »** | « En attente de validation » |
| Validée | La classe | La classe |

Le statut venait de la base : un badge affichait **`en_validation`** à une secrétaire.

## Trois copies devenues une

Le dictionnaire qui traduit ces valeurs en français existait en **trois exemplaires**, dans trois fichiers, et divergeait déjà : l'un rendait `prospect` en badge `secondary`, l'autre en `outline`. Un seul module maintenant — et la liste des élèves le lit, ce qu'elle ne faisait pas du tout.

« Dossier ouvert » et « En attente de validation » remplacent « Prospect » et « En validation » : ce que la secrétaire cherche sur cet écran, c'est s'il y a quelque chose à faire, et pour qui.

## Vérification

5 tests sur le module partagé, dont celui qui verrouille le défaut : aucun statut ne doit jamais produire le libellé « à inscrire ». Un statut inconnu reste affiché tel quel plutôt que de faire disparaître la ligne.

`tsc` propre, **257 tests verts** sur 33 fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)