### PR TITLE
fix(navbar): show the profile photo, which it never tried to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Fixed
+- La photo de profil apparaît enfin dans la barre de navigation, au lieu des seules initiales *(tous)*
 - Le motif d'annulation d'un versement s'affiche désormais à l'identique sur ordinateur et sur téléphone *(admin)*
 - Photo de l'élève correctement recadrée dans le journal des versements, au lieu d'être étirée quand elle n'est pas carrée *(admin)*
 - Annulation d'un versement déjà encaissé, depuis le tableau comme depuis le téléphone : c'est le cas courant, un montant saisi qui n'est pas dans la caisse *(admin)*

--- a/components/shared/Navbar.tsx
+++ b/components/shared/Navbar.tsx
@@ -6,7 +6,9 @@ import { useSession } from "next-auth/react"
 import { useTheme } from "next-themes"
 import { Menu, LogOut, User, ChevronDown, Sun, Moon } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { useMyProfile } from "@/lib/hooks/useProfile"
+import { getUploadUrl } from "@/lib/utils"
 import { Separator } from "@/components/ui/separator"
 import {
   DropdownMenu,
@@ -30,6 +32,12 @@ export function Navbar({ onMenuClick }: NavbarProps) {
   const { theme, setTheme } = useTheme()
   const nom = displayName(session?.user)
   const initials = nom.slice(0, 2).toUpperCase()
+  // La photo vient du profil, pas de la session : NextAuth ne porte que
+  // l'identité, et la barre affichait donc les initiales même quand une
+  // photo existait. Le cache de la requête est partagé avec la page
+  // profil, donc changer sa photo met la barre à jour sans rechargement.
+  const { data: profile } = useMyProfile()
+  const photoSrc = getUploadUrl(profile?.photo_url)
 
   const role = session?.user?.role
   const profilePortal =
@@ -76,6 +84,9 @@ export function Navbar({ onMenuClick }: NavbarProps) {
           <DropdownMenuTrigger asChild>
             <button className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-muted transition-colors outline-none">
               <Avatar className="h-8 w-8">
+                {photoSrc ? (
+                  <AvatarImage src={photoSrc} alt="" className="object-cover" />
+                ) : null}
                 <AvatarFallback className="bg-primary/10 text-primary text-xs font-semibold">
                   {initials}
                 </AvatarFallback>

--- a/components/shared/navbar-avatar.test.tsx
+++ b/components/shared/navbar-avatar.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * La barre de navigation passe-t-elle la photo à l'avatar ?
+ *
+ * Elle ne l'a jamais fait : le composant n'importait même pas `AvatarImage`,
+ * si bien qu'un utilisateur voyait ses initiales sur toutes les pages alors
+ * que sa photo s'affichait sur son profil. Ce n'était pas une URL cassée,
+ * c'était un câblage absent — le genre de défaut qu'aucune vérification de
+ * type ne trouve, puisque le code est parfaitement valide.
+ *
+ * Les primitives d'avatar sont remplacées ici par des doublures qui exposent
+ * ce qu'on leur donne. C'est nécessaire, pas commode : le vrai `AvatarImage`
+ * de Radix n'apparaît qu'une fois l'image chargée, et jsdom ne charge jamais
+ * d'image. Un test écrit contre le rendu réel serait donc vert quoi qu'il
+ * arrive, y compris avec le défaut d'origine.
+ */
+
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { Navbar } from "@/components/shared/Navbar"
+
+const profil = vi.fn()
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { firstName: "KLASSCI", lastName: "Admin", role: "admin" } } }),
+}))
+vi.mock("next-themes", () => ({ useTheme: () => ({ theme: "light", setTheme: vi.fn() }) }))
+vi.mock("@/lib/hooks/useProfile", () => ({ useMyProfile: () => profil() }))
+vi.mock("@/components/shared/NotificationBell", () => ({ NotificationBell: () => null }))
+vi.mock("@/lib/hooks/useAcademicYears", () => ({ useCurrentAcademicYear: () => ({ data: null }) }))
+
+vi.mock("@/components/ui/avatar", () => ({
+  Avatar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AvatarImage: ({ src }: { src?: string }) => <div data-testid="photo" data-src={src} />,
+  AvatarFallback: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="initiales">{children}</div>
+  ),
+}))
+
+describe("l'avatar de la barre de navigation", () => {
+  beforeEach(() => profil.mockReset())
+
+  it("passe la photo du profil quand elle existe", () => {
+    profil.mockReturnValue({ data: { photo_url: "/uploads/photos/admin_1_ab.jpg" } })
+    render(<Navbar onMenuClick={() => {}} />)
+    expect(screen.getByTestId("photo").getAttribute("data-src")).toContain(
+      "/uploads/photos/admin_1_ab.jpg",
+    )
+  })
+
+  it("ne passe aucune photo quand le profil n'en a pas", () => {
+    profil.mockReturnValue({ data: { photo_url: null } })
+    render(<Navbar onMenuClick={() => {}} />)
+    expect(screen.queryByTestId("photo")).toBeNull()
+  })
+
+  it("garde toujours les initiales en repli", () => {
+    profil.mockReturnValue({ data: { photo_url: "/uploads/photos/x.jpg" } })
+    render(<Navbar onMenuClick={() => {}} />)
+    expect(screen.getByTestId("initiales").textContent).toBe("KL")
+  })
+
+  it("ne casse pas tant que le profil n'est pas chargé", () => {
+    profil.mockReturnValue({ data: undefined })
+    render(<Navbar onMenuClick={() => {}} />)
+    expect(screen.queryByTestId("photo")).toBeNull()
+    expect(screen.getByTestId("initiales")).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Closes #376

La photo vient de la requête profil, pas de la session : NextAuth porte l'identité, pas l'image. Réutiliser cette requête fait aussi que le cache partagé met la barre à jour dès qu'on change sa photo, sans rechargement.

## Sur les tests

Ils remplacent les primitives d'avatar par des doublures qui exposent ce qu'on leur donne. C'est **nécessaire, pas commode** : le vrai `AvatarImage` de Radix n'apparaît qu'une fois l'image chargée, et jsdom ne charge jamais d'image. Un test écrit contre le rendu réel serait vert quoi qu'il arrive — y compris avec le défaut d'origine.

**Vérifié en retirant l'`AvatarImage`** : le test « passe la photo du profil » tombe, seul.

261 tests verts sur 34 fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)