### PR TITLE
feat(notifications): mark what was shown, and lead where the work is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Annulation d'un versement déjà encaissé, depuis le tableau comme depuis le téléphone : c'est le cas courant, un montant saisi qui n'est pas dans la caisse *(admin)*
 
 ### Added
+- Ouvrir la cloche marque comme lues les notifications affichées, et cliquer dessus mène à l'écran où l'on fait l'action attendue *(tous)*
 - L'annulation d'un versement demande un motif écrit, affiché ensuite sous le statut dans le journal des paiements *(caissier, comptable, directeur)*
 - L'enseignant déclare ses indisponibilités depuis « Mon emploi du temps », sur la même grille que celle de sa fiche côté administration *(enseignant)*
 - Le formulaire de créneau affiche la semaine de l'enseignant choisi, cours dans les autres classes et plages fermées, et prévient avant d'enregistrer quand l'horaire visé ne passe pas *(directeur des études, secrétariat, admin)*

--- a/components/admin/notifications/NotificationsPageClient.tsx
+++ b/components/admin/notifications/NotificationsPageClient.tsx
@@ -3,12 +3,6 @@
 import { useState } from "react"
 import {
   Bell,
-  CreditCard,
-  ClipboardList,
-  FileText,
-  AlertCircle,
-  Settings,
-  UserCheck,
   Check,
   CheckCheck,
   Filter,
@@ -40,39 +34,7 @@ import {
 } from "@/lib/hooks/useNotifications"
 import type { Notification, NotificationType } from "@/lib/contracts/notification"
 import { cn } from "@/lib/utils"
-
-/** Icône par type de notification */
-const TYPE_ICONS: Record<NotificationType, React.ComponentType<{ className?: string }>> = {
-  payment_due: CreditCard,
-  payment_received: CreditCard,
-  grade_available: ClipboardList,
-  bulletin_published: FileText,
-  absence_recorded: AlertCircle,
-  enrollment_status: UserCheck,
-  system: Settings,
-}
-
-/** Couleur de fond par type */
-const TYPE_COLORS: Record<NotificationType, string> = {
-  payment_due: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-  payment_received: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
-  grade_available: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
-  bulletin_published: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400",
-  absence_recorded: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400",
-  enrollment_status: "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400",
-  system: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
-}
-
-/** Labels pour les types */
-const TYPE_LABELS: Record<NotificationType, string> = {
-  payment_due: "Paiement dû",
-  payment_received: "Paiement reçu",
-  grade_available: "Note disponible",
-  bulletin_published: "Bulletin publié",
-  absence_recorded: "Absence enregistrée",
-  enrollment_status: "Inscription",
-  system: "Système",
-}
+import { notificationTypeView } from "@/lib/notifications/type-view"
 
 /** Formater une date relative */
 function timeAgo(dateStr: string): string {
@@ -183,7 +145,7 @@ export function NotificationsPageClient() {
             <SelectItem value="all">Tous les types</SelectItem>
             {NOTIFICATION_TYPES.map((type) => (
               <SelectItem key={type} value={type}>
-                {TYPE_LABELS[type]}
+                {notificationTypeView(type).label}
               </SelectItem>
             ))}
           </SelectContent>
@@ -241,7 +203,7 @@ function NotificationRow({
   notification: Notification
   onMarkAsRead: () => void
 }) {
-  const Icon = TYPE_ICONS[notification.type]
+  const { Icon, tone } = notificationTypeView(notification.type)
 
   return (
     <Card
@@ -254,7 +216,7 @@ function NotificationRow({
         <div
           className={cn(
             "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg",
-            TYPE_COLORS[notification.type],
+            tone,
           )}
         >
           <Icon className="h-5 w-5" />
@@ -266,7 +228,7 @@ function NotificationRow({
               {notification.title}
             </p>
             <Badge variant="secondary" className="text-[10px]">
-              {TYPE_LABELS[notification.type]}
+              {notificationTypeView(notification.type).label}
             </Badge>
           </div>
           <p className="text-sm text-muted-foreground mt-0.5">{notification.body}</p>

--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -3,12 +3,6 @@
 import Link from "next/link"
 import {
   Bell,
-  CreditCard,
-  ClipboardList,
-  FileText,
-  AlertCircle,
-  Settings,
-  UserCheck,
   Check,
   CheckCheck,
 } from "lucide-react"
@@ -21,31 +15,17 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { useNotificationCount, useNotifications, useMarkAsRead, useMarkAllAsRead } from "@/lib/hooks/useNotifications"
-import type { Notification, NotificationType } from "@/lib/contracts/notification"
+import {
+  useMarkAllAsRead,
+  useMarkAsRead,
+  useMarkSeen,
+  useNotificationCount,
+  useNotifications,
+} from "@/lib/hooks/useNotifications"
+import type { Route } from "next"
+import type { Notification } from "@/lib/contracts/notification"
 import { cn } from "@/lib/utils"
-
-/** Icône par type de notification */
-const TYPE_ICONS: Record<NotificationType, React.ComponentType<{ className?: string }>> = {
-  payment_due: CreditCard,
-  payment_received: CreditCard,
-  grade_available: ClipboardList,
-  bulletin_published: FileText,
-  absence_recorded: AlertCircle,
-  enrollment_status: UserCheck,
-  system: Settings,
-}
-
-/** Couleur de fond par type */
-const TYPE_COLORS: Record<NotificationType, string> = {
-  payment_due: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-  payment_received: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
-  grade_available: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
-  bulletin_published: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400",
-  absence_recorded: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400",
-  enrollment_status: "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400",
-  system: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
-}
+import { idsAMarquerCommeVues, notificationTypeView } from "@/lib/notifications/type-view"
 
 /** Formater une date relative simple */
 function timeAgo(dateStr: string): string {
@@ -65,11 +45,25 @@ export function NotificationBell() {
   const { data: recent } = useNotifications({ size: 5 })
   const markAsRead = useMarkAsRead()
   const markAllAsRead = useMarkAllAsRead()
+  const markSeen = useMarkSeen()
 
   const unreadCount = countData?.count ?? 0
 
+  /**
+   * A l'ouverture, ce qui est affiche passe en lu.
+   *
+   * Ce qui est affiche, et rien de plus : les alertes plus bas dans le
+   * stock, et celles qui arriveront ensuite, restent a voir. Les effacer
+   * ferait disparaitre des taches que personne n'a lues.
+   */
+  function handleOpenChange(ouvert: boolean) {
+    if (!ouvert || !recent) return
+    const aMarquer = idsAMarquerCommeVues(recent)
+    if (aMarquer.length > 0) markSeen.mutate(aMarquer)
+  }
+
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="icon" className="relative">
           <Bell className="h-5 w-5 text-muted-foreground" />
@@ -136,19 +130,22 @@ function NotificationItem({
   notification: Notification
   onMarkAsRead: () => void
 }) {
-  const Icon = TYPE_ICONS[notification.type]
+  const { Icon, tone } = notificationTypeView(notification.type)
+  // Le serveur pose la destination : lui seul sait quelle action il attend.
+  const lien = notification.action_url
 
-  return (
+  const contenu = (
     <div
       className={cn(
-        "flex items-start gap-3 px-3 py-2.5 hover:bg-muted/50 transition-colors",
+        "flex items-start gap-3 px-3 py-2.5 transition-colors",
+        lien ? "hover:bg-muted" : "hover:bg-muted/50",
         !notification.read && "bg-primary/5",
       )}
     >
       <div
         className={cn(
           "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
-          TYPE_COLORS[notification.type],
+          tone,
         )}
       >
         <Icon className="h-4 w-4" />
@@ -178,5 +175,15 @@ function NotificationItem({
         </Button>
       )}
     </div>
+  )
+
+  // Sans destination, la notification reste une information : on ne
+  // fabrique pas un lien vers une page ou il n'y a rien a faire.
+  if (!lien) return contenu
+
+  return (
+    <Link href={lien as Route} className="block">
+      {contenu}
+    </Link>
   )
 }

--- a/lib/api/notifications.ts
+++ b/lib/api/notifications.ts
@@ -53,4 +53,21 @@ export const notificationsApi = {
     const res = await apiFetch<unknown>("/notifications/read-all", { method: "POST" })
     return safeValidate(MarkAllReadSchema, res, "POST /notifications/read-all")
   },
+
+  /**
+   * Marquer comme lues les notifications que le panneau vient d'afficher.
+   *
+   * Distinct de `markAllAsRead` : ouvrir la cloche ne veut pas dire avoir
+   * tout lu. Le stock contient des alertes plus bas dans la liste, et
+   * d'autres arrivent pendant que le panneau est ouvert — les effacer
+   * toutes ferait disparaitre des taches que personne n'a vues.
+   */
+  markSeen: async (ids: number[]): Promise<{ updated: number }> => {
+    if (ids.length === 0) return { updated: 0 }
+    const res = await apiFetch<unknown>("/notifications/mark-seen", {
+      method: "POST",
+      body: JSON.stringify({ notification_ids: ids }),
+    })
+    return safeValidate(MarkAllReadSchema, res, "POST /notifications/mark-seen")
+  },
 }

--- a/lib/contracts/notification.ts
+++ b/lib/contracts/notification.ts
@@ -15,7 +15,17 @@ export const NotificationChannelSchema = z.enum(["in_app", "sms", "whatsapp", "e
 export const NotificationSchema = z.object({
   id: z.number(),
   user_id: z.number(),
-  type: NotificationTypeSchema,
+  // Volontairement large, et non le `z.enum` strict.
+  //
+  // `safeValidate` leve quand la validation echoue : une seule notification
+  // d'un type que le client ne connait pas encore faisait donc tomber la
+  // liste entiere, et le panneau devenait noir. Une ligne sans style vaut
+  // mieux que toutes les autres invisibles.
+  //
+  // C'est `notificationTypeView` qui decide de l'apparence et retombe sur un
+  // rendu neutre. Le serveur prend de l'avance sur le client a chaque
+  // deploiement, puisque les deux ne partent pas ensemble.
+  type: z.string(),
   channel: NotificationChannelSchema,
   title: z.string(),
   body: z.string(),

--- a/lib/contracts/notification.ts
+++ b/lib/contracts/notification.ts
@@ -5,6 +5,9 @@ import { z } from "zod"
 export const NotificationTypeSchema = z.enum([
   "payment_due", "payment_received", "grade_available",
   "bulletin_published", "absence_recorded", "enrollment_status", "system",
+  // Les deux temps de la chaine d'inscription : quelqu'un doit encaisser,
+  // puis quelqu'un doit valider.
+  "enrollment_awaiting_payment", "enrollment_awaiting_validation",
 ])
 
 export const NotificationChannelSchema = z.enum(["in_app", "sms", "whatsapp", "email"])
@@ -19,6 +22,9 @@ export const NotificationSchema = z.object({
   read: z.boolean(),
   sent_at: z.string().nullable(),
   read_at: z.string().nullable(),
+  // Ou la notification mene. Le serveur le decide : lui seul sait quelle
+  // action il attend, puisque c'est lui qui a decide de prevenir.
+  action_url: z.string().nullish(),
   entity_type: z.string().nullable(),
   entity_id: z.number().nullable(),
   created_at: z.string(),

--- a/lib/hooks/useNotifications.ts
+++ b/lib/hooks/useNotifications.ts
@@ -114,3 +114,62 @@ export function useMarkAllAsRead() {
     },
   })
 }
+
+/**
+ * Marquer comme lues les notifications que le panneau vient d'afficher.
+ *
+ * Distinct de `useMarkAllAsRead` : ouvrir la cloche ne veut pas dire avoir
+ * tout lu. Le stock contient des alertes plus bas dans la liste, et d'autres
+ * arrivent pendant que le panneau est ouvert — les effacer toutes ferait
+ * disparaître des tâches que personne n'a vues.
+ *
+ * La mise à jour optimiste ne touche que les identifiants concernés, et le
+ * compteur ne descend que du nombre de non-lues réellement affichées : le
+ * mettre à zéro mentirait sur ce qui reste.
+ */
+export function useMarkSeen() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (ids: number[]) => notificationsApi.markSeen(ids),
+    onMutate: async (ids: number[]) => {
+      await queryClient.cancelQueries({ queryKey: notificationKeys.all })
+      const vus = new Set(ids)
+
+      const queries = queryClient.getQueriesData<Notification[]>({
+        queryKey: ["notifications", "list"],
+      })
+      let baisse = 0
+      for (const [key, data] of queries) {
+        if (!Array.isArray(data)) continue
+        queryClient.setQueryData(
+          key,
+          data.map((n) => {
+            if (!vus.has(n.id) || n.read) return n
+            baisse += 1
+            return { ...n, read: true }
+          }),
+        )
+      }
+
+      const prevCount = queryClient.getQueryData<{ count: number }>(notificationKeys.count())
+      if (prevCount) {
+        queryClient.setQueryData(notificationKeys.count(), {
+          count: Math.max(0, prevCount.count - baisse),
+        })
+      }
+      return { queries, prevCount }
+    },
+    onError: (_e, _ids, context) => {
+      // Rendre le compteur : une alerte effacée à tort est une tâche perdue.
+      for (const [key, data] of context?.queries ?? []) {
+        queryClient.setQueryData(key, data)
+      }
+      if (context?.prevCount) {
+        queryClient.setQueryData(notificationKeys.count(), context.prevCount)
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: notificationKeys.all })
+    },
+  })
+}

--- a/lib/notifications/type-view.test.ts
+++ b/lib/notifications/type-view.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Une notification d'un type inconnu ne doit pas disparaître.
+ *
+ * Ces tables existaient en cinq exemplaires, sur deux fichiers. Ajouter un
+ * type obligeait à modifier six endroits, et rien n'obligeait à les modifier
+ * tous : le compilateur voyait les tables typées, pas les divergences de
+ * couleur entre deux copies.
+ */
+
+import { describe, expect, it } from "vitest"
+import { idsAMarquerCommeVues, notificationTypeView } from "./type-view"
+
+describe("l'apparence d'un type de notification", () => {
+  it("nomme les deux temps de la chaîne d'inscription", () => {
+    expect(notificationTypeView("enrollment_awaiting_payment").label).toBe("Versement attendu")
+    expect(notificationTypeView("enrollment_awaiting_validation").label).toBe(
+      "Inscription à valider",
+    )
+  })
+
+  it("donne la même teinte aux deux, parce que ce sont des tâches à faire", () => {
+    const versement = notificationTypeView("enrollment_awaiting_payment")
+    const validation = notificationTypeView("enrollment_awaiting_validation")
+    expect(versement.tone).toBe(validation.tone)
+    // L'ambre est ce que le reste du produit emploie pour « il reste
+    // quelque chose à poser », par opposition au vert d'un fait acquis.
+    expect(versement.tone).toContain("amber")
+    expect(notificationTypeView("payment_received").tone).toContain("emerald")
+  })
+
+  it("ne fait pas disparaître une notification d'un type qu'il ne connaît pas", () => {
+    // Le serveur peut prendre de l'avance sur le client : mieux vaut une
+    // apparence neutre qu'une alerte invisible.
+    const inconnu = notificationTypeView("type_ajoute_demain")
+    expect(inconnu.label).toBeTruthy()
+    expect(inconnu.Icon).toBeDefined()
+  })
+
+  it("donne à chaque type connu une icône et un libellé", () => {
+    for (const t of [
+      "payment_due", "payment_received", "grade_available", "bulletin_published",
+      "absence_recorded", "enrollment_status", "system",
+      "enrollment_awaiting_payment", "enrollment_awaiting_validation",
+    ]) {
+      const vue = notificationTypeView(t)
+      expect(vue.label.length).toBeGreaterThan(0)
+      expect(vue.tone).toMatch(/^bg-/)
+    }
+  })
+})
+
+describe("ce que la cloche marque en s'ouvrant", () => {
+  const n = (id: number, read: boolean) => ({ id, read })
+
+  it("ne retient que les non-lues effectivement affichées", () => {
+    // La quatrième est plus bas dans le stock : elle n'est pas affichée,
+    // donc elle reste à voir. C'est tout l'objet de ce marquage ciblé.
+    expect(idsAMarquerCommeVues([n(1, false), n(2, false), n(3, true)])).toEqual([1, 2])
+  })
+
+  it("ne demande rien quand tout ce qui est affiché est déjà lu", () => {
+    // Une liste vide évite un aller-retour serveur inutile à chaque
+    // ouverture de la cloche.
+    expect(idsAMarquerCommeVues([n(1, true), n(2, true)])).toEqual([])
+  })
+
+  it("tolère l'absence de données", () => {
+    expect(idsAMarquerCommeVues(undefined)).toEqual([])
+  })
+})

--- a/lib/notifications/type-view.test.ts
+++ b/lib/notifications/type-view.test.ts
@@ -7,7 +7,9 @@
  * couleur entre deux copies.
  */
 
+import { z } from "zod"
 import { describe, expect, it } from "vitest"
+import { NotificationSchema } from "@/lib/contracts/notification"
 import { idsAMarquerCommeVues, notificationTypeView } from "./type-view"
 
 describe("l'apparence d'un type de notification", () => {
@@ -29,11 +31,37 @@ describe("l'apparence d'un type de notification", () => {
   })
 
   it("ne fait pas disparaître une notification d'un type qu'il ne connaît pas", () => {
-    // Le serveur peut prendre de l'avance sur le client : mieux vaut une
-    // apparence neutre qu'une alerte invisible.
-    const inconnu = notificationTypeView("type_ajoute_demain")
-    expect(inconnu.label).toBeTruthy()
-    expect(inconnu.Icon).toBeDefined()
+    // Ce test passait déjà avant, en appelant la fonction directement — et il
+    // affirmait donc une propriété que le produit n'avait pas : le schéma
+    // était un enum strict, `safeValidate` levait, et une seule notification
+    // inconnue faisait disparaître toute la liste. Il traverse maintenant la
+    // couche qui cassait.
+    const brut = {
+      id: 1, user_id: 1, type: "type_ajoute_demain", channel: "in_app",
+      title: "Nouveau", body: "…", read: false, sent_at: null, read_at: null,
+      entity_type: null, entity_id: null, action_url: null,
+      created_at: new Date().toISOString(),
+    }
+    const valide = NotificationSchema.parse(brut)
+    const vue = notificationTypeView(valide.type)
+    expect(vue.label).toBeTruthy()
+    expect(vue.Icon).toBeDefined()
+  })
+
+  it("laisse passer une liste où une seule notification est d'un type inconnu", () => {
+    // Le cas qui comptait vraiment : une inconnue ne doit pas emporter les
+    // autres.
+    const ligne = (type: string, id: number) => ({
+      id, user_id: 1, type, channel: "in_app", title: `T${id}`, body: "…",
+      read: false, sent_at: null, read_at: null, entity_type: null,
+      entity_id: null, action_url: null, created_at: new Date().toISOString(),
+    })
+    const liste = z.array(NotificationSchema).parse([
+      ligne("payment_due", 1),
+      ligne("type_ajoute_demain", 2),
+      ligne("system", 3),
+    ])
+    expect(liste).toHaveLength(3)
   })
 
   it("donne à chaque type connu une icône et un libellé", () => {

--- a/lib/notifications/type-view.ts
+++ b/lib/notifications/type-view.ts
@@ -1,0 +1,89 @@
+import {
+  AlertCircle,
+  ClipboardList,
+  CreditCard,
+  FileText,
+  Settings,
+  UserCheck,
+} from "lucide-react"
+import type { ComponentType } from "react"
+import type { NotificationType } from "@/lib/contracts/notification"
+
+/** Ce qu'un type de notification donne à voir. */
+export interface NotificationTypeView {
+  Icon: ComponentType<{ className?: string }>
+  /** Les classes de la pastille, fond et texte, clair et sombre. */
+  tone: string
+  label: string
+}
+
+const AMBRE = "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+
+const TYPES: Record<NotificationType, NotificationTypeView> = {
+  payment_due: { Icon: CreditCard, tone: AMBRE, label: "Paiement dû" },
+  payment_received: {
+    Icon: CreditCard,
+    tone: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+    label: "Paiement reçu",
+  },
+  grade_available: {
+    Icon: ClipboardList,
+    tone: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+    label: "Note disponible",
+  },
+  bulletin_published: {
+    Icon: FileText,
+    tone: "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400",
+    label: "Bulletin publié",
+  },
+  absence_recorded: {
+    Icon: AlertCircle,
+    tone: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400",
+    label: "Absence enregistrée",
+  },
+  enrollment_status: {
+    Icon: UserCheck,
+    tone: "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400",
+    label: "Inscription",
+  },
+  // Les deux temps de la chaîne d'inscription. Ambre pour les deux, parce que
+  // ce sont des tâches à faire et non des événements passés : c'est la teinte
+  // que le reste du produit emploie déjà pour « il reste quelque chose à poser ».
+  enrollment_awaiting_payment: { Icon: CreditCard, tone: AMBRE, label: "Versement attendu" },
+  enrollment_awaiting_validation: { Icon: UserCheck, tone: AMBRE, label: "Inscription à valider" },
+  system: {
+    Icon: Settings,
+    tone: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400",
+    label: "Système",
+  },
+}
+
+/**
+ * L'icône, la teinte et le libellé d'un type de notification.
+ *
+ * Ces trois tables existaient en double, dans la cloche et dans la page des
+ * notifications. Ajouter un type obligeait à modifier six endroits, et rien
+ * n'obligeait à les modifier tous — le compilateur signalait les tables
+ * typées, pas les divergences de couleur entre deux copies.
+ *
+ * Un type inconnu ne fait pas disparaître la ligne : il s'affiche avec
+ * l'apparence neutre du système, ce qui vaut mieux qu'une notification
+ * invisible parce que le serveur a pris de l'avance sur le client.
+ */
+export function notificationTypeView(type: string): NotificationTypeView {
+  return TYPES[type as NotificationType] ?? TYPES.system
+}
+
+/**
+ * Les notifications affichées qui restent à marquer comme lues.
+ *
+ * Extrait de la cloche pour être vérifiable : c'est cette sélection qui
+ * décide de ce qui disparaît du compteur, et une erreur ici efface des tâches
+ * que personne n'a vues. Le composant ne fait plus que la déclencher.
+ */
+export function idsAMarquerCommeVues(
+  affichees: ReadonlyArray<{ id: number; read: boolean }> | undefined,
+): number[] {
+  if (!affichees) return []
+  return affichees.filter((n) => !n.read).map((n) => n.id)
+}


### PR DESCRIPTION
Closes #380 · dépend de [BE #315](https://github.com/African-DC/klassci-college-backend/pull/315) pour que le lien sorte du serveur

## Marquer ce qui a été montré

Ouvrir la cloche marque les notifications **affichées**, et rien d'autre. Celles plus bas dans le stock, et celles qui arrivent pendant que le panneau est ouvert, restent à voir.

Le compteur baisse du nombre de non-lues réellement montrées, **pas à zéro** : zéro mentirait sur ce qui reste. En cas d'échec il est rendu, parce qu'une alerte effacée à tort est une tâche perdue.

## Mener là où l'on agit

Chaque notification pointe vers son `action_url`. Sans destination, elle reste une information : on ne fabrique pas un lien vers une page où il n'y a rien à faire.

## Cinq tables devenues une

Icônes, teintes et libellés vivaient en double. Un type inconnu s'affiche désormais avec une apparence neutre au lieu de disparaître : le serveur peut prendre de l'avance sur le client, et une alerte invisible est pire qu'une alerte sans style.

## Sur les tests

La sélection de ce qu'il faut marquer est extraite en fonction simple pour être vérifiable. **C'est nécessaire, pas commode** : Radix n'ouvre pas son menu sous jsdom, donc un test qui pilote le vrai geste passerait quoi qu'il arrive, y compris avec le défaut.

**Vérifié en retirant le filtre sur les non-lues** : deux tests tombent.

278 tests verts sur 37 fichiers, `tsc` et lint propres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)