### PR TITLE
feat(enrolments): select several and validate them at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Annulation d'un versement déjà encaissé, depuis le tableau comme depuis le téléphone : c'est le cas courant, un montant saisi qui n'est pas dans la caisse *(admin)*
 
 ### Added
+- Sélection de plusieurs inscriptions et validation en une fois, chaque refus étant signalé avec son motif *(admin)*
 - L'annulation d'un versement demande un motif écrit, affiché ensuite sous le statut dans le journal des paiements *(caissier, comptable, directeur)*
 - L'enseignant déclare ses indisponibilités depuis « Mon emploi du temps », sur la même grille que celle de sa fiche côté administration *(enseignant)*
 - Le formulaire de créneau affiche la semaine de l'enseignant choisi, cours dans les autres classes et plages fermées, et prévient avant d'enregistrer quand l'horaire visé ne passe pas *(directeur des études, secrétariat, admin)*

--- a/components/admin/enrollments/BulkValidateBar.tsx
+++ b/components/admin/enrollments/BulkValidateBar.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+
+interface BulkValidateBarProps {
+  /** Combien de dossiers partiront réellement, affichés et cochés. */
+  nombre: number
+  enCours: boolean
+  onValider: () => void
+  onAnnuler: () => void
+}
+
+/**
+ * La barre qui valide une sélection d'inscriptions.
+ *
+ * Elle ne s'affiche qu'une fois quelque chose de sélectionné : permanente,
+ * elle occuperait la hauteur d'une ligne pour ne rien dire, sur un écran où
+ * la liste est déjà longue.
+ *
+ * Le nombre vient de ce qui partira vraiment, pas du nombre de cases cochées.
+ * Une ligne cochée puis passée à la page suivante, ou validée entre-temps par
+ * un collègue, ne compte plus : annoncer trente et en valider vingt-huit
+ * serait pire que de n'avoir rien annoncé.
+ */
+export function BulkValidateBar({ nombre, enCours, onValider, onAnnuler }: BulkValidateBarProps) {
+  if (nombre === 0) return null
+
+  return (
+    <div className="hidden items-center justify-between gap-3 rounded-lg border bg-muted/40 px-4 py-2.5 md:flex">
+      <p className="text-sm">
+        <span className="font-semibold">{nombre}</span>{" "}
+        {nombre === 1 ? "inscription sélectionnée" : "inscriptions sélectionnées"}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onAnnuler}>
+          Annuler
+        </Button>
+        <Button size="sm" disabled={enCours} onClick={onValider}>
+          {enCours ? "Validation…" : "Valider la sélection"}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/enrollments/EnrollmentsTable.tsx
+++ b/components/admin/enrollments/EnrollmentsTable.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
 import type { Route } from "next"
-import type { ColumnDef } from "@tanstack/react-table"
 import { Check } from "lucide-react"
 import {
   useBulkValidateEnrollments,
@@ -11,8 +10,10 @@ import {
   useEnrollments,
   useValidateEnrollment,
 } from "@/lib/hooks/useEnrollments"
-import { Checkbox } from "@/components/ui/checkbox"
 import { enrollmentStatusView } from "@/lib/enrollment/status"
+import { STATUTS_VALIDABLES, selectionVisible } from "@/lib/enrollment/selection"
+import { BulkValidateBar } from "@/components/admin/enrollments/BulkValidateBar"
+import { StudentInitialsAvatar, colonnesInscriptions } from "@/components/admin/enrollments/enrollment-columns"
 import type { Enrollment } from "@/lib/contracts/enrollment"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -34,35 +35,14 @@ import { cn } from "@/lib/utils"
 
 // Cohorte « À valider » = prospect + en_validation. La sémantique queue : c'est
 // ce que l'admin doit traiter activement à la rentrée.
-const TO_VALIDATE_STATUSES = new Set<Enrollment["status"]>(["prospect", "en_validation"])
+/** Reexporte pour les filtres locaux ; la source est `lib/enrollment/selection`. */
+const TO_VALIDATE_STATUSES = STATUTS_VALIDABLES
 
 
 const PAGE_SIZE = 20
 
 // Avatar inline avec initiales — pas de photo (les enrollments n'en exposent
 // pas, l'admin verra la photo dans la fiche élève).
-function StudentInitialsAvatar({
-  firstName,
-  lastName,
-  size = "md",
-}: {
-  firstName: string | null | undefined
-  lastName: string | null | undefined
-  size?: "sm" | "md"
-}) {
-  const initials = `${firstName?.[0] ?? ""}${lastName?.[0] ?? ""}`.toUpperCase() || "?"
-  const sizeClass = size === "sm" ? "h-9 w-9" : "h-8 w-8"
-  return (
-    <div
-      className={cn(
-        sizeClass,
-        "flex shrink-0 items-center justify-center rounded-lg border border-border bg-primary/10",
-      )}
-    >
-      <span className="text-xs font-semibold text-primary">{initials}</span>
-    </div>
-  )
-}
 
 // Chip de filtre cohorte — duplication locale du pattern StudentsTable. À
 // extraire dans `components/shared/FilterChip.tsx` au 3e consommateur (rule
@@ -151,9 +131,8 @@ export function EnrollmentsTable() {
   const deleteMutation = useDeleteEnrollment()
   const validateMutation = useValidateEnrollment()
   const bulkValidate = useBulkValidateEnrollments()
-  // La selection ne survit pas a un changement de page : on ne valide que
-  // ce qu'on a sous les yeux, sinon on signe pour des dossiers qu'on n'a
-  // pas relus.
+  // Les cases cochees. Ce qui part au serveur est `selectionVisible`, son
+  // intersection avec la page affichee : voir plus bas.
   const [selection, setSelection] = useState<Set<number>>(new Set())
 
   const allItems = data?.items ?? []
@@ -235,7 +214,13 @@ export function EnrollmentsTable() {
     () => paginatedItems.filter((e) => TO_VALIDATE_STATUSES.has(e.status)),
     [paginatedItems],
   )
-  const toutSelectionne = validables.length > 0 && validables.every((e) => selection.has(e.id))
+  // Ce qui partira au serveur : voir `lib/enrollment/selection.ts`, ou le
+  // calcul est teste.
+  const aEnvoyer = useMemo(
+    () => selectionVisible(paginatedItems, selection),
+    [paginatedItems, selection],
+  )
+  const toutSelectionne = validables.length > 0 && validables.length === aEnvoyer.length
 
   const basculer = useCallback((id: number) => {
     setSelection((prec) => {
@@ -246,105 +231,19 @@ export function EnrollmentsTable() {
     })
   }, [])
 
-  const columns: ColumnDef<Enrollment>[] = useMemo(
-    () => [
-      {
-        id: "selection",
-        header: () => (
-          <Checkbox
-            checked={toutSelectionne}
-            onCheckedChange={(v: boolean | "indeterminate") =>
-              setSelection(v ? new Set(validables.map((e) => e.id)) : new Set())
-            }
-            aria-label="Tout sélectionner"
-            disabled={validables.length === 0}
-          />
-        ),
-        cell: ({ row }) => {
-          // Une inscription deja validee n'a rien a offrir au lot : la case
-          // absente dit pourquoi mieux qu'une case grisee.
-          if (!TO_VALIDATE_STATUSES.has(row.original.status)) return null
-          return (
-            <Checkbox
-              checked={selection.has(row.original.id)}
-              onCheckedChange={() => basculer(row.original.id)}
-              onClick={(ev: React.MouseEvent) => ev.stopPropagation()}
-              aria-label={`Sélectionner ${row.original.student_last_name ?? ""}`}
-            />
-          )
-        },
-      },
-      {
-        accessorKey: "student_id",
-        header: "Élève",
-        cell: ({ row }) => {
-          const e = row.original
-          return (
-            <div className="flex items-center gap-3">
-              <StudentInitialsAvatar
-                firstName={e.student_first_name}
-                lastName={e.student_last_name}
-              />
-              <div className="min-w-0">
-                <p className="truncate font-medium">
-                  {e.student_first_name} {e.student_last_name}
-                </p>
-                <p className="truncate text-[11px] text-muted-foreground">
-                  #{e.id} · {e.academic_year_name}
-                </p>
-              </div>
-            </div>
-          )
-        },
-      },
-      {
-        accessorKey: "class_id",
-        header: "Classe",
-        cell: ({ row }) => (
-          <Badge variant="outline" className="text-xs font-medium">
-            {row.original.class_name ?? `#${row.original.class_id}`}
-          </Badge>
-        ),
-      },
-      {
-        accessorKey: "assignment_status",
-        header: "Affectation",
-        cell: ({ row }) => <AssignmentStatusBadge status={row.original.assignment_status} />,
-      },
-      {
-        accessorKey: "status",
-        header: "Statut",
-        cell: ({ row }) => (
-          <Badge variant="secondary" className="text-xs">
-            {enrollmentStatusView(row.original.status).label}
-          </Badge>
-        ),
-      },
-      {
-        id: "validate-action",
-        header: "",
-        cell: ({ row }) => {
-          const e = row.original
-          if (!isToValidate(e)) return null
-          return (
-            <Button
-              type="button"
-              size="sm"
-              className="h-9 bg-emerald-600 text-white hover:bg-emerald-700"
-              onClick={(ev) => {
-                ev.stopPropagation()
-                setValidateTarget(e)
-              }}
-            >
-              <Check className="mr-1 h-4 w-4" />
-              Valider
-            </Button>
-          )
-        },
-      },
-    ],
+  const columns = useMemo(
+    () =>
+      colonnesInscriptions({
+        selection,
+        basculer,
+        toutSelectionne,
+        validables,
+        onValider: setValidateTarget,
+        onToutSelectionner: (tout: boolean) =>
+          setSelection(tout ? new Set(validables.map((e) => e.id)) : new Set()),
+      }),
     // Sans ces dependances, cocher une case ne redessine pas les cellules :
-    // l etat change, l ecran ne bouge pas.
+    // l'etat change, l'ecran ne bouge pas.
     [basculer, selection, toutSelectionne, validables],
   )
 
@@ -403,32 +302,18 @@ export function EnrollmentsTable() {
       {/* La barre n'apparait qu'une fois quelque chose de selectionne : une
           barre vide en permanence occupe la hauteur d'une ligne pour ne rien
           dire, sur un ecran ou la liste est deja longue. */}
-      {selection.size > 0 && (
-        <div className="hidden items-center justify-between gap-3 rounded-lg border bg-muted/40 px-4 py-2.5 md:flex">
-          <p className="text-sm">
-            <span className="font-semibold">{selection.size}</span>{" "}
-            {selection.size === 1 ? "inscription sélectionnée" : "inscriptions sélectionnées"}
-          </p>
-          <div className="flex items-center gap-2">
-            <Button variant="ghost" size="sm" onClick={() => setSelection(new Set())}>
-              Annuler
-            </Button>
-            <Button
-              size="sm"
-              disabled={bulkValidate.isPending}
-              onClick={() =>
-                bulkValidate.mutate([...selection], {
-                  // On vide apres coup : les statuts ont change, garder la
-                  // selection proposerait de valider ce qui vient de l'etre.
-                  onSuccess: () => setSelection(new Set()),
-                })
-              }
-            >
-              {bulkValidate.isPending ? "Validation…" : "Valider la sélection"}
-            </Button>
-          </div>
-        </div>
-      )}
+      <BulkValidateBar
+        nombre={aEnvoyer.length}
+        enCours={bulkValidate.isPending}
+        onAnnuler={() => setSelection(new Set())}
+        onValider={() =>
+          bulkValidate.mutate(aEnvoyer.map((e) => e.id), {
+            // On vide apres coup : les statuts ont change, garder la
+            // selection proposerait de valider ce qui vient de l'etre.
+            onSuccess: () => setSelection(new Set()),
+          })
+        }
+      />
 
       {/* Desktop : table dense via CrudTable. Mobile : liste minimaliste +
           bouton Valider distinct (Wave-style — la zone tap-to-drill n'avale

--- a/components/admin/enrollments/EnrollmentsTable.tsx
+++ b/components/admin/enrollments/EnrollmentsTable.tsx
@@ -5,7 +5,14 @@ import { useRouter } from "next/navigation"
 import type { Route } from "next"
 import type { ColumnDef } from "@tanstack/react-table"
 import { Check } from "lucide-react"
-import { useDeleteEnrollment, useEnrollments, useValidateEnrollment } from "@/lib/hooks/useEnrollments"
+import {
+  useBulkValidateEnrollments,
+  useDeleteEnrollment,
+  useEnrollments,
+  useValidateEnrollment,
+} from "@/lib/hooks/useEnrollments"
+import { Checkbox } from "@/components/ui/checkbox"
+import { enrollmentStatusView } from "@/lib/enrollment/status"
 import type { Enrollment } from "@/lib/contracts/enrollment"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -29,13 +36,6 @@ import { cn } from "@/lib/utils"
 // ce que l'admin doit traiter activement à la rentrée.
 const TO_VALIDATE_STATUSES = new Set<Enrollment["status"]>(["prospect", "en_validation"])
 
-const statusLabels: Record<Enrollment["status"], string> = {
-  prospect: "Prospect",
-  en_validation: "En validation",
-  valide: "Validé",
-  rejete: "Rejeté",
-  annule: "Annulé",
-}
 
 const PAGE_SIZE = 20
 
@@ -150,6 +150,11 @@ export function EnrollmentsTable() {
   const { data, isLoading, isError, error, refetch } = useEnrollments(params)
   const deleteMutation = useDeleteEnrollment()
   const validateMutation = useValidateEnrollment()
+  const bulkValidate = useBulkValidateEnrollments()
+  // La selection ne survit pas a un changement de page : on ne valide que
+  // ce qu'on a sous les yeux, sinon on signe pour des dossiers qu'on n'a
+  // pas relus.
+  const [selection, setSelection] = useState<Set<number>>(new Set())
 
   const allItems = data?.items ?? []
 
@@ -225,8 +230,50 @@ export function EnrollmentsTable() {
       ? "Aucune inscription trouvée"
       : "Aucune inscription ne correspond à cette affectation"
 
+  /** Les lignes affichees qu'on a le droit de valider. */
+  const validables = useMemo(
+    () => paginatedItems.filter((e) => TO_VALIDATE_STATUSES.has(e.status)),
+    [paginatedItems],
+  )
+  const toutSelectionne = validables.length > 0 && validables.every((e) => selection.has(e.id))
+
+  const basculer = useCallback((id: number) => {
+    setSelection((prec) => {
+      const suivant = new Set(prec)
+      if (suivant.has(id)) suivant.delete(id)
+      else suivant.add(id)
+      return suivant
+    })
+  }, [])
+
   const columns: ColumnDef<Enrollment>[] = useMemo(
     () => [
+      {
+        id: "selection",
+        header: () => (
+          <Checkbox
+            checked={toutSelectionne}
+            onCheckedChange={(v: boolean | "indeterminate") =>
+              setSelection(v ? new Set(validables.map((e) => e.id)) : new Set())
+            }
+            aria-label="Tout sélectionner"
+            disabled={validables.length === 0}
+          />
+        ),
+        cell: ({ row }) => {
+          // Une inscription deja validee n'a rien a offrir au lot : la case
+          // absente dit pourquoi mieux qu'une case grisee.
+          if (!TO_VALIDATE_STATUSES.has(row.original.status)) return null
+          return (
+            <Checkbox
+              checked={selection.has(row.original.id)}
+              onCheckedChange={() => basculer(row.original.id)}
+              onClick={(ev: React.MouseEvent) => ev.stopPropagation()}
+              aria-label={`Sélectionner ${row.original.student_last_name ?? ""}`}
+            />
+          )
+        },
+      },
       {
         accessorKey: "student_id",
         header: "Élève",
@@ -269,7 +316,7 @@ export function EnrollmentsTable() {
         header: "Statut",
         cell: ({ row }) => (
           <Badge variant="secondary" className="text-xs">
-            {statusLabels[row.original.status] ?? row.original.status}
+            {enrollmentStatusView(row.original.status).label}
           </Badge>
         ),
       },
@@ -296,7 +343,9 @@ export function EnrollmentsTable() {
         },
       },
     ],
-    [],
+    // Sans ces dependances, cocher une case ne redessine pas les cellules :
+    // l etat change, l ecran ne bouge pas.
+    [basculer, selection, toutSelectionne, validables],
   )
 
   return (
@@ -350,6 +399,36 @@ export function EnrollmentsTable() {
           onClick={() => handleAssignmentChipClick("non_renseigne")}
         />
       </div>
+
+      {/* La barre n'apparait qu'une fois quelque chose de selectionne : une
+          barre vide en permanence occupe la hauteur d'une ligne pour ne rien
+          dire, sur un ecran ou la liste est deja longue. */}
+      {selection.size > 0 && (
+        <div className="hidden items-center justify-between gap-3 rounded-lg border bg-muted/40 px-4 py-2.5 md:flex">
+          <p className="text-sm">
+            <span className="font-semibold">{selection.size}</span>{" "}
+            {selection.size === 1 ? "inscription sélectionnée" : "inscriptions sélectionnées"}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={() => setSelection(new Set())}>
+              Annuler
+            </Button>
+            <Button
+              size="sm"
+              disabled={bulkValidate.isPending}
+              onClick={() =>
+                bulkValidate.mutate([...selection], {
+                  // On vide apres coup : les statuts ont change, garder la
+                  // selection proposerait de valider ce qui vient de l'etre.
+                  onSuccess: () => setSelection(new Set()),
+                })
+              }
+            >
+              {bulkValidate.isPending ? "Validation…" : "Valider la sélection"}
+            </Button>
+          </div>
+        </div>
+      )}
 
       {/* Desktop : table dense via CrudTable. Mobile : liste minimaliste +
           bouton Valider distinct (Wave-style — la zone tap-to-drill n'avale
@@ -415,7 +494,7 @@ export function EnrollmentsTable() {
               status={
                 <div className="flex flex-col items-end gap-1">
                   <Badge variant="secondary" className="text-[10px]">
-                    {statusLabels[e.status] ?? e.status}
+                    {enrollmentStatusView(e.status).label}
                   </Badge>
                   <AssignmentStatusBadge status={e.assignment_status} className="text-[10px]" />
                 </div>

--- a/components/admin/enrollments/enrollment-columns.tsx
+++ b/components/admin/enrollments/enrollment-columns.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import { Check } from "lucide-react"
+import type { ColumnDef } from "@tanstack/react-table"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { AssignmentStatusBadge } from "@/components/shared/AssignmentStatusBadge"
+import { cn } from "@/lib/utils"
+import { STATUTS_VALIDABLES } from "@/lib/enrollment/selection"
+import { enrollmentStatusView } from "@/lib/enrollment/status"
+import type { Enrollment } from "@/lib/contracts/enrollment"
+
+const TO_VALIDATE_STATUSES = STATUTS_VALIDABLES
+
+function StudentInitialsAvatar({
+  firstName,
+  lastName,
+  size = "md",
+}: {
+  firstName: string | null | undefined
+  lastName: string | null | undefined
+  size?: "sm" | "md"
+}) {
+  const initials = `${firstName?.[0] ?? ""}${lastName?.[0] ?? ""}`.toUpperCase() || "?"
+  const sizeClass = size === "sm" ? "h-9 w-9" : "h-8 w-8"
+  return (
+    <div
+      className={cn(
+        sizeClass,
+        "flex shrink-0 items-center justify-center rounded-lg border border-border bg-primary/10",
+      )}
+    >
+      <span className="text-xs font-semibold text-primary">{initials}</span>
+    </div>
+  )
+}
+
+interface ColonnesOptions {
+  selection: ReadonlySet<number>
+  basculer: (id: number) => void
+  toutSelectionne: boolean
+  validables: Enrollment[]
+  onToutSelectionner: (tout: boolean) => void
+  /** Ouvre la confirmation de validation pour une ligne. */
+  onValider: (enrollment: Enrollment) => void
+}
+
+/**
+ * Les colonnes du journal des inscriptions.
+ *
+ * Sorties de la page, qui dépassait la limite de taille du projet avant même
+ * d'accueillir la sélection multiple. Elles forment un bloc cohérent : ce
+ * qu'une ligne montre, et rien de la pagination ni des filtres qui décident
+ * quelles lignes s'affichent.
+ */
+export { StudentInitialsAvatar }
+
+export function colonnesInscriptions({
+  selection,
+  basculer,
+  toutSelectionne,
+  validables,
+  onToutSelectionner,
+  onValider,
+}: ColonnesOptions): ColumnDef<Enrollment>[] {
+  return [
+      {
+        id: "selection",
+        header: () => (
+          <Checkbox
+            checked={toutSelectionne}
+            onCheckedChange={(v: boolean | "indeterminate") =>
+              onToutSelectionner(v === true)
+            }
+            aria-label="Tout sélectionner"
+            disabled={validables.length === 0}
+          />
+        ),
+        cell: ({ row }) => {
+          // Une inscription deja validee n'a rien a offrir au lot : la case
+          // absente dit pourquoi mieux qu'une case grisee.
+          if (!TO_VALIDATE_STATUSES.has(row.original.status)) return null
+          return (
+            <Checkbox
+              checked={selection.has(row.original.id)}
+              onCheckedChange={() => basculer(row.original.id)}
+              onClick={(ev: React.MouseEvent) => ev.stopPropagation()}
+              aria-label={`Sélectionner ${row.original.student_last_name ?? ""}`}
+            />
+          )
+        },
+      },
+      {
+        accessorKey: "student_id",
+        header: "Élève",
+        cell: ({ row }) => {
+          const e = row.original
+          return (
+            <div className="flex items-center gap-3">
+              <StudentInitialsAvatar
+                firstName={e.student_first_name}
+                lastName={e.student_last_name}
+              />
+              <div className="min-w-0">
+                <p className="truncate font-medium">
+                  {e.student_first_name} {e.student_last_name}
+                </p>
+                <p className="truncate text-[11px] text-muted-foreground">
+                  #{e.id} · {e.academic_year_name}
+                </p>
+              </div>
+            </div>
+          )
+        },
+      },
+      {
+        accessorKey: "class_id",
+        header: "Classe",
+        cell: ({ row }) => (
+          <Badge variant="outline" className="text-xs font-medium">
+            {row.original.class_name ?? `#${row.original.class_id}`}
+          </Badge>
+        ),
+      },
+      {
+        accessorKey: "assignment_status",
+        header: "Affectation",
+        cell: ({ row }) => <AssignmentStatusBadge status={row.original.assignment_status} />,
+      },
+      {
+        accessorKey: "status",
+        header: "Statut",
+        cell: ({ row }) => (
+          <Badge variant="secondary" className="text-xs">
+            {enrollmentStatusView(row.original.status).label}
+          </Badge>
+        ),
+      },
+      {
+        id: "validate-action",
+        header: "",
+        cell: ({ row }) => {
+          const e = row.original
+          if (!TO_VALIDATE_STATUSES.has(e.status)) return null
+          return (
+            <Button
+              type="button"
+              size="sm"
+              className="h-9 bg-emerald-600 text-white hover:bg-emerald-700"
+              onClick={(ev) => {
+                ev.stopPropagation()
+                onValider(e)
+              }}
+            >
+              <Check className="mr-1 h-4 w-4" />
+              Valider
+            </Button>
+          )
+        },
+      },
+  ]
+}

--- a/lib/api/enrollments.ts
+++ b/lib/api/enrollments.ts
@@ -1,5 +1,5 @@
-import { EnrollmentSchema } from "@/lib/contracts/enrollment"
-import type { Enrollment, EnrollmentCreate, EnrollmentUpdate, NewEnrollment, ReEnrollment, FeeVariantOption } from "@/lib/contracts/enrollment"
+import { BulkValidateResultSchema, EnrollmentSchema } from "@/lib/contracts/enrollment"
+import type { BulkValidateResult, Enrollment, EnrollmentCreate, EnrollmentUpdate, NewEnrollment, ReEnrollment, FeeVariantOption } from "@/lib/contracts/enrollment"
 import { createCrudApi } from "./createCrudApi"
 import { apiFetch, safeValidate } from "./client"
 
@@ -32,5 +32,14 @@ export const enrollmentsApi = {
 
   validate: async (id: number) => {
     return apiFetch<Enrollment>(`/enrollments/${id}/validate`, { method: "POST" })
+  },
+
+  /** Valide une liste d'inscriptions ; un refus n'arrete pas les autres. */
+  bulkValidate: async (ids: number[]): Promise<BulkValidateResult> => {
+    const res = await apiFetch<unknown>("/enrollments/bulk-validate", {
+      method: "POST",
+      body: JSON.stringify({ enrollment_ids: ids }),
+    })
+    return safeValidate(BulkValidateResultSchema, res, "POST /enrollments/bulk-validate")
   },
 }

--- a/lib/contracts/enrollment.ts
+++ b/lib/contracts/enrollment.ts
@@ -135,3 +135,13 @@ export type ParentInput = z.infer<typeof ParentInputSchema>
 export type NewEnrollment = z.infer<typeof NewEnrollmentSchema>
 export type ReEnrollment = z.infer<typeof ReEnrollmentSchema>
 export type FeeVariantOption = z.infer<typeof FeeVariantOptionSchema>
+
+/** Ce que rend une validation en lot. */
+export const BulkValidateResultSchema = z.object({
+  validated: z.array(z.number()),
+  // Chaque refus avec son motif : sans lui, l'ecran ne peut que dire
+  // « certaines ont echoue », ce qui oblige a rouvrir chaque dossier.
+  failed: z.array(z.object({ enrollment_id: z.number(), reason: z.string() })),
+})
+
+export type BulkValidateResult = z.infer<typeof BulkValidateResultSchema>

--- a/lib/enrollment/selection.test.ts
+++ b/lib/enrollment/selection.test.ts
@@ -1,0 +1,48 @@
+/**
+ * On ne valide que ce qu'on a sous les yeux.
+ *
+ * La sélection était un `Set` d'identifiants que rien ne remettait à zéro :
+ * cocher trois lignes page 1, passer page 2 et cliquer « Valider » envoyait
+ * trois dossiers que la personne ne voyait plus. Le commentaire du code
+ * affirmait pourtant que la sélection ne survivait pas au changement de page.
+ */
+
+import { describe, expect, it } from "vitest"
+import { selectionVisible } from "./selection"
+
+const page1 = [
+  { id: 1, status: "prospect" },
+  { id: 2, status: "en_validation" },
+  { id: 3, status: "valide" },
+]
+const page2 = [
+  { id: 10, status: "prospect" },
+  { id: 11, status: "prospect" },
+]
+
+describe("ce qui part au serveur quand on valide une sélection", () => {
+  it("ne retient que les lignes cochées et affichées", () => {
+    expect(selectionVisible(page1, new Set([1, 2])).map((l) => l.id)).toEqual([1, 2])
+  })
+
+  it("oublie ce qui a changé de page", () => {
+    // Coché page 1, puis on tourne la page : plus rien à valider ici.
+    expect(selectionVisible(page2, new Set([1, 2]))).toEqual([])
+  })
+
+  it("oublie ce qu'un collègue vient de valider", () => {
+    // La liste se recharge, la ligne 1 est passée « valide » : l'envoyer
+    // reviendrait à demander une action déjà faite, et à récolter un refus
+    // qui inquiéterait pour rien.
+    const rechargee = [{ id: 1, status: "valide" }, { id: 2, status: "prospect" }]
+    expect(selectionVisible(rechargee, new Set([1, 2])).map((l) => l.id)).toEqual([2])
+  })
+
+  it("ne propose jamais une ligne déjà validée", () => {
+    expect(selectionVisible(page1, new Set([3]))).toEqual([])
+  })
+
+  it("ne renvoie rien quand rien n'est coché", () => {
+    expect(selectionVisible(page1, new Set())).toEqual([])
+  })
+})

--- a/lib/enrollment/selection.ts
+++ b/lib/enrollment/selection.ts
@@ -1,0 +1,24 @@
+/** Une ligne du journal des inscriptions, réduite à ce que la sélection regarde. */
+export interface LigneSelectionnable {
+  id: number
+  status: string
+}
+
+/** Les statuts qu'on a le droit de valider. */
+export const STATUTS_VALIDABLES: ReadonlySet<string> = new Set(["prospect", "en_validation"])
+
+/**
+ * Ce qu'on validera vraiment : les lignes cochées **et** affichées.
+ *
+ * Retenir les cases cochées telles quelles suffirait à valider des dossiers
+ * passés à la page suivante, filtrés hors de la vue, ou validés entre-temps
+ * par un collègue au guichet. On signe pour ce qu'on a sous les yeux, et
+ * c'est le calcul qui doit le garantir : un commentaire ne le garantissait
+ * pas, il l'affirmait seulement.
+ */
+export function selectionVisible(
+  affichees: ReadonlyArray<LigneSelectionnable>,
+  cochees: ReadonlySet<number>,
+): LigneSelectionnable[] {
+  return affichees.filter((l) => STATUTS_VALIDABLES.has(l.status) && cochees.has(l.id))
+}

--- a/lib/hooks/useEnrollments.ts
+++ b/lib/hooks/useEnrollments.ts
@@ -77,3 +77,39 @@ export function useValidateEnrollment() {
     },
   })
 }
+
+/**
+ * Valide plusieurs inscriptions d'un coup.
+ *
+ * Le retour distingue ce qui est passé de ce qui a refusé, avec le motif :
+ * un lot de trente dossiers dont deux échouent doit dire lesquels, sinon le
+ * secrétariat rouvre les trente pour comprendre.
+ */
+export function useBulkValidateEnrollments() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (ids: number[]) => enrollmentsApi.bulkValidate(ids),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: enrollmentKeys.all })
+      const n = res.validated.length
+      if (n > 0) {
+        toast.success(
+          n === 1 ? "1 inscription validée" : `${n} inscriptions validées`,
+        )
+      }
+      if (res.failed.length > 0) {
+        toast.error(
+          res.failed.length === 1
+            ? "1 inscription n'a pas pu être validée"
+            : `${res.failed.length} inscriptions n'ont pas pu être validées`,
+          // Le premier motif suffit à orienter : les autres sont dans la liste,
+          // qui se recharge avec les statuts à jour.
+          { description: res.failed[0].reason },
+        )
+      }
+    },
+    onError: (error: Error) => {
+      toast.error("Validation impossible", { description: error.message })
+    },
+  })
+}


### PR DESCRIPTION
Closes #382 · dépend de [BE #317](https://github.com/African-DC/klassci-college-backend/pull/317)

## Quatre décisions, et leurs raisons

**La sélection porte sur la page affichée**, pas sur tout l'ensemble filtré. On signe pour ce qu'on a lu, et une sélection qui survivrait au changement de page reviendrait à valider des dossiers que personne n'a regardés.

**Une ligne déjà validée n'a pas de case du tout**, plutôt qu'une case grisée : l'absence dit pourquoi mieux qu'un contrôle désactivé.

**La barre n'apparaît qu'une fois quelque chose de sélectionné.** Permanente, elle occuperait la hauteur d'une ligne pour ne rien dire, sur un écran où la liste est déjà longue. Elle se vide après un lot réussi, parce que les statuts ont changé et que garder la sélection proposerait de valider ce qui vient de l'être.

**Les échecs reviennent avec leur motif**, et le message porte le premier.

## Ce que le lint a trouvé

Le tableau de dépendances de mes colonnes était vide : cocher une case n'aurait rien redessiné. Corrigé. Les deux avertissements restants sont antérieurs — le fichier d'origine en produit exactement deux.

## Au passage

**Quatrième copie** du dictionnaire des statuts d'inscription retirée. Celle-ci avait dérivé aussi : elle rendait « prospect » en texte brut là où les autres utilisaient un badge.

271 tests verts, `tsc` propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)