### PR TITLE
feat(payments): load as you scroll, and say what the figures count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 - Écran « Point journalier » pour le comptable : chaque caisse de la journée avec son total, son écart et son état de clôture, sur n'importe quelle date. Une caisse restée ouverte est signalée *(comptable)*.
 
 ### Changed
+- Le journal des paiements se charge au fil du défilement : la pagination affichait « Page 1/92 » sans permettre d'atteindre la seconde *(admin)*
+- Les chiffres du bandeau suivent les filtres, et chaque carte dit si elle les suit ou parle de l'année entière *(admin)*
 - Le créneau se trace directement sur la semaine de l'enseignant : on clique, on descend, l'heure de début et de fin suivent *(admin, directeur des études)*
 - La fenêtre d'ajout de créneau occupe la largeur disponible et montre la semaine à côté des champs, au lieu de la reléguer sous un ascenseur *(admin, directeur des études)*
 - Les états de la semaine se distinguent par leur matière et non par leur seule couleur : un cours est plein, une indisponibilité hachurée, une heure non déclarée tramée *(tous)*

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -9,6 +9,7 @@ import {
 import { toast } from "sonner"
 import { PaymentsFilters } from "@/components/admin/payments/PaymentsFilters"
 import { usePaymentFilters } from "@/lib/hooks/usePaymentFilters"
+import { useScrollSentinel } from "@/lib/hooks/useScrollSentinel"
 import { PaymentConfirmDialog, type PaymentConfirmAction } from "@/components/admin/payments/PaymentConfirmDialog"
 import { PaymentReceiptDialog } from "@/components/admin/payments/PaymentReceiptDialog"
 import { PaymentsTable } from "@/components/admin/payments/PaymentsTable"
@@ -18,7 +19,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { PageHero, heroAccentBtn, heroGlassBtn, type HeroKpi } from "@/components/shared/PageHero"
 import { PaymentCreateWizard } from "./PaymentCreateWizard"
 import {
-  usePayments,
+  useInfinitePayments,
   useFinancialSummary,
   useValidatePayment,
   useCancelPayment,
@@ -40,14 +41,32 @@ export function PaymentsPageClient() {
 
   const { filters, set, reset, params, activeCount } = usePaymentFilters()
 
-  const { data, isLoading } = usePayments(params)
-  const { data: summary } = useFinancialSummary()
+  const {
+    data,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfinitePayments(params)
+  // Le bandeau recoit les memes criteres que la liste : sinon il annonce
+  // l'annee entiere au-dessus de trois lignes filtrees.
+  const { data: summary } = useFinancialSummary(undefined, params)
   const { mutate: validatePayment, isPending: validating } = useValidatePayment()
   const { mutate: cancelPayment, isPending: cancelling } = useCancelPayment()
   const { data: feeCategories } = useFeeCategories()
   const { data: cashiers } = useCashiers()
 
-  const payments = useMemo(() => data?.items ?? [], [data])
+  // Les pages chargees, mises bout a bout.
+  const payments = useMemo(
+    () => data?.pages.flatMap((page) => page.items) ?? [],
+    [data],
+  )
+  const total = data?.pages[0]?.total ?? 0
+
+  const sentinelle = useScrollSentinel({
+    actif: Boolean(hasNextPage) && !isFetchingNextPage,
+    onApproche: () => void fetchNextPage(),
+  })
 
   // Le filtre « Encaissé par » n'a de sens qu'avec plusieurs guichets à
   // distinguer. Un caissier cloisonné ne reçoit que lui-même du serveur : lui
@@ -127,6 +146,15 @@ export function PaymentsPageClient() {
   // Son absence est donc le signal, et il n'y en a pas d'autre a inventer.
   const cloisonne = summary?.total_expected === null
 
+  // Un filtre actif change le sens de la moitie des chiffres. Le dire sur
+  // chaque carte evite de lire « 3 versements » en ayant oublie un filtre
+  // pose dix minutes plus tot, et de croire que la caisse est vide.
+  const filtre = activeCount > 0 || Boolean(filters.search)
+  const surLeFiltre = filtre ? "sur le filtre actif" : undefined
+  const horsFiltre = filtre ? "toute l'année, hors filtre" : undefined
+  const avec = (base: string | undefined, mention: string | undefined) =>
+    [base, mention].filter(Boolean).join(" · ") || undefined
+
   const heroKpis: HeroKpi[] | undefined = summary
     ? [
         {
@@ -136,26 +164,33 @@ export function PaymentsPageClient() {
           // n'est du ».
           value: cloisonne ? "—" : `${summary.total_expected!.toLocaleString("fr-FR")} F`,
           icon: Banknote,
+          // Le recouvrement parle de la dette de l'ecole, pas des lignes
+          // affichees : filtrer une dette sur un moyen de paiement ne veut
+          // rien dire. On le signale plutot que de laisser croire le contraire.
+          hint: horsFiltre,
         },
         {
           label: cloisonne ? "Encaissé par vous" : "Collecté",
           value: `${summary.total_paid.toLocaleString("fr-FR")} F`,
           icon: Wallet,
-          hint: `${summary.payment_count} paiement(s)`,
+          hint: avec(`${summary.payment_count} paiement(s)`, surLeFiltre),
         },
         {
           label: "En attente",
           value: `${summary.total_pending.toLocaleString("fr-FR")} F`,
           icon: AlertCircle,
+          hint: surLeFiltre,
         },
         {
           label: "Taux de recouvrement",
           value: cloisonne ? "—" : `${summary.completion_rate!.toFixed(1)}%`,
           icon: TrendingUp,
-          hint:
+          hint: avec(
             summary.total_cancelled > 0
               ? `${summary.total_cancelled.toLocaleString("fr-FR")} FCFA annulés`
               : undefined,
+            horsFiltre,
+          ),
         },
       ]
     : undefined
@@ -269,10 +304,17 @@ export function PaymentsPageClient() {
         </CardContent>
       </Card>
 
-      {/* Pagination info */}
-      {data && payments.length > 0 && (
-        <div className="text-xs text-muted-foreground text-right">
-          {data.total} paiement(s) — Page {data.page}/{data.size > 0 ? Math.ceil(data.total / data.size) : 1}
+      {/* La sentinelle : charger la suite en approchant du bas, plutot que
+          d'obliger a viser un numero de page. */}
+      <div ref={sentinelle} aria-hidden="true" className="h-px" />
+
+      {payments.length > 0 && (
+        <div className="pb-2 text-center text-xs text-muted-foreground">
+          {isFetchingNextPage
+            ? "Chargement…"
+            : hasNextPage
+              ? `${payments.length} sur ${total} versements`
+              : `${payments.length} versement(s), tout est affiché`}
         </div>
       )}
 

--- a/lib/api/payments.ts
+++ b/lib/api/payments.ts
@@ -166,8 +166,23 @@ export const paymentsApi = {
   },
 
   // Résumé financier (KPIs dashboard)
-  getSummary: async (academicYearId?: number): Promise<FinancialSummary> => {
-    const query = academicYearId ? `?academic_year_id=${academicYearId}` : ""
+  /**
+   * Les chiffres du bandeau, sur le perimetre de l'ecran.
+   *
+   * Les memes criteres que la liste : sans eux, filtrer sur « Annule »
+   * laissait le bandeau annoncer tout l'argent de l'annee au-dessus d'un
+   * tableau qui en montrait trois.
+   */
+  getSummary: async (
+    academicYearId?: number,
+    filtres?: PaymentListParams,
+  ): Promise<FinancialSummary> => {
+    const p = new URLSearchParams()
+    if (academicYearId) p.set("academic_year_id", String(academicYearId))
+    for (const [cle, valeur] of Object.entries(filtres ?? {})) {
+      if (valeur !== undefined && valeur !== null && valeur !== "") p.set(cle, String(valeur))
+    }
+    const query = p.toString() ? `?${p.toString()}` : ""
     const json = await apiFetch<unknown>(`/payments/summary${query}`)
     return safeValidate(
       FinancialSummarySchema,

--- a/lib/hooks/pagination.test.ts
+++ b/lib/hooks/pagination.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Quand s'arrêter de charger.
+ *
+ * La page des paiements affichait « Page 1/92 » sans aucun moyen d'atteindre
+ * la seconde : la pagination était affichée, pas navigable. Le défilement
+ * continu la remplace, et la seule décision qu'il porte est celle-ci.
+ */
+
+import { describe, expect, it } from "vitest"
+import { pageSuivante } from "./pagination"
+
+const pleine = (n: number) => ({ items: Array.from({ length: n }), size: n })
+
+describe("le chargement au fil du défilement", () => {
+  it("demande la suite tant que les pages arrivent pleines", () => {
+    expect(pageSuivante(pleine(20), 1)).toBe(2)
+    expect(pageSuivante(pleine(20), 5)).toBe(6)
+  })
+
+  it("s'arrête sur une page incomplète", () => {
+    expect(pageSuivante({ items: Array.from({ length: 7 }), size: 20 }, 3)).toBeUndefined()
+  })
+
+  it("s'arrête sur une page vide", () => {
+    expect(pageSuivante({ items: [], size: 20 }, 4)).toBeUndefined()
+  })
+
+  it("ne se fie pas au total annoncé", () => {
+    // Une page pleine suffit à continuer, même si le total dit le contraire :
+    // entre deux requêtes, une caissière encaisse et un collègue annule.
+    expect(pageSuivante(pleine(20), 92)).toBe(93)
+  })
+
+  it("tolère une taille de page absente", () => {
+    expect(pageSuivante({ items: Array.from({ length: 20 }), size: 0 }, 1)).toBe(2)
+  })
+})

--- a/lib/hooks/pagination.ts
+++ b/lib/hooks/pagination.ts
@@ -1,0 +1,19 @@
+/** Une page rendue par l'API, réduite à ce qui décide de la suite. */
+export interface PageRendue {
+  items: unknown[]
+  size: number
+}
+
+/**
+ * Le numéro de la page suivante, ou `undefined` quand tout est chargé.
+ *
+ * On s'arrête dès que la page rendue est plus courte que demandée, plutôt
+ * que de comparer au total annoncé. Le total est vrai au moment où il est
+ * calculé : entre deux requêtes, une caissière enregistre un versement et un
+ * collègue en annule un autre. Se fier au compte fait alors soit boucler sur
+ * une page vide, soit s'arrêter avant la fin.
+ */
+export function pageSuivante(derniere: PageRendue, pagesChargees: number): number | undefined {
+  const taille = derniere.size || 20
+  return derniere.items.length < taille ? undefined : pagesChargees + 1
+}

--- a/lib/hooks/usePayments.ts
+++ b/lib/hooks/usePayments.ts
@@ -1,8 +1,15 @@
 "use client"
 
-import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query"
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { toast } from "sonner"
 import { paymentsApi } from "@/lib/api/payments"
+import { pageSuivante } from "./pagination"
 import type {
   EnrollmentPaymentCreate,
   Payment,
@@ -14,7 +21,8 @@ import type { PaginatedResponse } from "@/lib/contracts"
 export const paymentKeys = {
   all: ["payments"] as const,
   list: (params: PaymentListParams) => ["payments", "list", params] as const,
-  summary: (academicYearId?: number) => ["payments", "summary", academicYearId] as const,
+  summary: (academicYearId?: number, filtres?: PaymentListParams) =>
+    ["payments", "summary", academicYearId, filtres] as const,
   cashiers: ["payments", "cashiers"] as const,
   byEnrollment: (enrollmentId: number) =>
     ["payments", "enrollment", enrollmentId] as const,
@@ -35,10 +43,17 @@ export function usePayments(params: PaymentListParams = {}) {
   })
 }
 
-export function useFinancialSummary(academicYearId?: number) {
+/**
+ * Les chiffres du bandeau, calcules sur le perimetre de l'ecran.
+ *
+ * Les filtres partent au serveur : agreger ce qui est charge donnerait des
+ * totaux faux des la deuxieme page, et un bandeau qui ignore les filtres
+ * annonce l'annee entiere au-dessus d'une liste qui montre trois lignes.
+ */
+export function useFinancialSummary(academicYearId?: number, filtres?: PaymentListParams) {
   return useQuery({
-    queryKey: paymentKeys.summary(academicYearId),
-    queryFn: () => paymentsApi.getSummary(academicYearId),
+    queryKey: paymentKeys.summary(academicYearId, filtres),
+    queryFn: () => paymentsApi.getSummary(academicYearId, filtres),
     staleTime: 1000 * 60 * 5,
   })
 }
@@ -208,5 +223,24 @@ export function useCancelPayment() {
       queryClient.invalidateQueries({ queryKey: paymentKeys.all })
       queryClient.invalidateQueries({ queryKey: paymentKeys.summary() })
     },
+  })
+}
+
+
+/**
+ * Le journal des versements, charge au fil du defilement.
+ *
+ * La pagination existait a l'ecran sans etre navigable : le pied de page
+ * annoncait « Page 1/92 » et rien ne permettait d'atteindre la seconde.
+ */
+export function useInfinitePayments(params: PaymentListParams = {}) {
+  return useInfiniteQuery({
+    queryKey: [...paymentKeys.list(params), "infinite"] as const,
+    queryFn: ({ pageParam }: { pageParam: number }) => paymentsApi.list({ ...params, page: pageParam }),
+    initialPageParam: 1,
+    // La condition d arret vit dans `./pagination`, ou elle est testee.
+    getNextPageParam: (derniere: PaginatedResponse<Payment>, pages: unknown[]) =>
+      pageSuivante(derniere, pages.length),
+    staleTime: 1000 * 60 * 5,
   })
 }

--- a/lib/hooks/useScrollSentinel.ts
+++ b/lib/hooks/useScrollSentinel.ts
@@ -1,0 +1,48 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+interface Options {
+  /** Faux quand il n'y a plus rien à charger, ou qu'un chargement court déjà. */
+  actif: boolean
+  onApproche: () => void
+  /** Distance avant le bas à laquelle on déclenche. */
+  marge?: string
+}
+
+/**
+ * Déclenche un chargement quand la sentinelle approche du bas de l'écran.
+ *
+ * La marge par défaut est volontairement courte. Sur une connexion lente, une
+ * marge généreuse charge des pages que personne n'a demandées et que personne
+ * ne lira : on paie des données pour du contenu dépassé au moment où il
+ * arrive. Deux cents pixels laissent le temps de charger sans devancer
+ * l'intention de la personne.
+ *
+ * `actif` doit passer à faux pendant un chargement, sinon l'observateur
+ * redéclenche à chaque frame tant que la sentinelle reste visible, et on
+ * demande la même page cinq fois.
+ */
+export function useScrollSentinel({ actif, onApproche, marge = "200px" }: Options) {
+  const sentinelle = useRef<HTMLDivElement | null>(null)
+  // Gardée dans une ref pour que changer de rappel ne recree pas l'observateur
+  // a chaque rendu, ce qui le ferait declencher a nouveau.
+  const rappel = useRef(onApproche)
+  rappel.current = onApproche
+
+  useEffect(() => {
+    const cible = sentinelle.current
+    if (!cible || !actif) return
+
+    const observateur = new IntersectionObserver(
+      (entrees) => {
+        if (entrees[0]?.isIntersecting) rappel.current()
+      },
+      { rootMargin: marge },
+    )
+    observateur.observe(cible)
+    return () => observateur.disconnect()
+  }, [actif, marge])
+
+  return sentinelle
+}


### PR DESCRIPTION
Closes #384 · dépend de [BE #318](https://github.com/African-DC/klassci-college-backend/pull/318)

**Référence pour les onze autres listes.** Les pièces partagées sont écrites une fois : `useScrollSentinel` et `pagination.ts`.

## Trois décisions

**La marge de déclenchement est courte** (200 px). Généreuse, elle charge des pages que personne n'a demandées — sur une connexion lente, ce sont les données de quelqu'un dépensées pour des lignes qu'il ne lira pas.

**On s'arrête sur une page courte, pas sur le total annoncé.** Un total est vrai au moment où il est calculé ; entre deux requêtes une caissière encaisse et un collègue annule. S'y fier fait soit boucler sur une page vide, soit s'arrêter avant la fin.

**Chaque carte du bandeau dit ce qu'elle compte.** La moitié caisse suit les filtres. Le recouvrement ne les suit pas, délibérément : il parle de la dette de l'école, et filtrer une dette sur un moyen de paiement ne veut rien dire. Sans la mention, « 3 versements » lu avec un filtre oublié ressemble à une caisse vide.

## Vérification

5 tests sur la condition d'arrêt, extraite pour être vérifiable. 276 tests verts, `tsc` et lint propres.

## Reste à faire

Onze listes : élèves, inscriptions, enseignants, parents, classes, niveaux, années, archives, présences, journal d'audit, bulletins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)