### PR TITLE
fix(payments): atteindre les deux formes de cache, et une carte qui exagerait sa portee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Fixed
+- Valider ou annuler un versement met à jour la ligne immédiatement, y compris au-delà de la première page chargée *(admin)*
+- La carte « Collecté » ne prétend plus suivre le filtre quand elle parle de l'année entière *(admin)*
 - La liste des élèves distingue désormais « En attente de validation » de « À inscrire », et affiche des libellés lisibles au lieu des valeurs de la base *(admin)*
 - La photo de profil apparaît enfin dans la barre de navigation, au lieu des seules initiales *(tous)*
 - Le motif d'annulation d'un versement s'affiche désormais à l'identique sur ordinateur et sur téléphone *(admin)*

--- a/components/admin/payments/PaymentsPageClient.tsx
+++ b/components/admin/payments/PaymentsPageClient.tsx
@@ -173,7 +173,14 @@ export function PaymentsPageClient() {
           label: cloisonne ? "Encaissé par vous" : "Collecté",
           value: `${summary.total_paid.toLocaleString("fr-FR")} F`,
           icon: Wallet,
-          hint: avec(`${summary.payment_count} paiement(s)`, surLeFiltre),
+          // Cloisonne, ce montant est la recette de la personne, agregee sur
+          // les memes versements que le compte : la carte entiere suit le
+          // filtre. Sinon c'est ce que l'ecole a percu sur sa dette, qui ne
+          // le suit pas, et melanger les deux ferait affirmer a la carte une
+          // portee qu'elle n'a pas.
+          hint: cloisonne
+            ? avec(`${summary.payment_count} paiement(s)`, surLeFiltre)
+            : avec(`${summary.payment_count} paiement(s) sur le filtre`, horsFiltre),
         },
         {
           label: "En attente",

--- a/lib/hooks/optimistic-payment-cache.test.ts
+++ b/lib/hooks/optimistic-payment-cache.test.ts
@@ -1,0 +1,81 @@
+/**
+ * La mise à jour optimiste doit atteindre les deux formes de cache.
+ *
+ * Depuis le défilement continu, deux formes cohabitent sous le même préfixe :
+ * la page unique `{items}` et la liste accumulée `{pages}`. L'ancienne version
+ * gardait `if (!old?.items) return old` — elle ne jetait donc pas d'erreur sur
+ * la seconde, elle ne faisait simplement rien. La ligne qu'une caissière
+ * venait de valider restait inchangée jusqu'au rechargement, lequel redemande
+ * *toutes* les pages chargées : dix pages parcourues, dix requêtes par clic,
+ * sans le moindre retour visuel entre-temps.
+ *
+ * Ce test exerce le vrai cache d'un vrai QueryClient.
+ */
+
+import { QueryClient } from "@tanstack/react-query"
+import { describe, expect, it } from "vitest"
+import { paymentKeys } from "./usePayments"
+
+/** La même mise à jour que `usePayments`, appliquée au cache. */
+function marquer(qc: QueryClient, paymentId: number, statut: string) {
+  const remplace = (p: { id: number; status: string }) =>
+    p.id === paymentId ? { ...p, status: statut } : p
+  qc.setQueriesData<unknown>(
+    {
+      queryKey: paymentKeys.all,
+      predicate: (q) => q.queryKey[1] === "list" || q.queryKey[1] === "enrollment",
+    },
+    (old: unknown) => {
+      if (!old || typeof old !== "object") return old
+      const accumulee = old as { pages?: { items: { id: number; status: string }[] }[] }
+      if (Array.isArray(accumulee.pages)) {
+        return {
+          ...accumulee,
+          pages: accumulee.pages.map((page) => ({ ...page, items: page.items.map(remplace) })),
+        }
+      }
+      const page = old as { items?: { id: number; status: string }[] }
+      if (!Array.isArray(page.items)) return old
+      return { ...page, items: page.items.map(remplace) }
+    },
+  )
+}
+
+const ligne = (id: number) => ({ id, status: "completed" })
+
+describe("marquer un versement dans le cache", () => {
+  it("atteint la liste accumulée du défilement continu", () => {
+    const qc = new QueryClient()
+    qc.setQueryData([...paymentKeys.list({}), "infinite"], {
+      pages: [{ items: [ligne(1), ligne(2)] }, { items: [ligne(3)] }],
+      pageParams: [1, 2],
+    })
+
+    marquer(qc, 3, "cancelled")
+
+    const data = qc.getQueryData([...paymentKeys.list({}), "infinite"]) as {
+      pages: { items: { id: number; status: string }[] }[]
+    }
+    // La ligne est en seconde page : c'est tout l'objet du correctif.
+    expect(data.pages[1].items[0].status).toBe("cancelled")
+    expect(data.pages[0].items[0].status).toBe("completed")
+  })
+
+  it("atteint encore la page unique", () => {
+    const qc = new QueryClient()
+    qc.setQueryData(paymentKeys.list({}), { items: [ligne(1), ligne(2)], total: 2 })
+    marquer(qc, 1, "cancelled")
+    const data = qc.getQueryData(paymentKeys.list({})) as { items: { status: string }[] }
+    expect(data.items[0].status).toBe("cancelled")
+  })
+
+  it("laisse intact un cache d'une autre forme", () => {
+    // Le récapitulatif vit sous le même préfixe et n'a pas d'items : l'étaler
+    // ou le mapper jetterait, comme cela s'est déjà produit ici.
+    const qc = new QueryClient()
+    const recap = { total_paid: 1000, payment_count: 3 }
+    qc.setQueryData(paymentKeys.summary(2026), recap)
+    expect(() => marquer(qc, 1, "cancelled")).not.toThrow()
+    expect(qc.getQueryData(paymentKeys.summary(2026))).toBe(recap)
+  })
+})

--- a/lib/hooks/usePayments.ts
+++ b/lib/hooks/usePayments.ts
@@ -158,16 +158,32 @@ function optimisticStatusUpdate(
   paymentId: number,
   newStatus: Payment["status"],
 ) {
-  queryClient.setQueriesData<PaginatedResponse<Payment>>(
+  const remplace = (p: Payment) => (p.id === paymentId ? { ...p, status: newStatus } : p)
+
+  // Deux formes de cache cohabitent sous le meme prefixe depuis le
+  // defilement continu : la page unique `{items}` et la liste accumulee
+  // `{pages}`. Ne traiter que la premiere ne jetait pas d erreur, elle ne
+  // faisait rien : la ligne qu on venait de valider restait inchangee
+  // jusqu au rechargement, qui redemande toutes les pages chargees.
+  queryClient.setQueriesData<unknown>(
     { queryKey: paymentKeys.all, predicate: (q) => estListePaginee(q.queryKey) },
-    (old) => {
-      if (!old?.items) return old
-      return {
-        ...old,
-        items: old.items.map((p) =>
-          p.id === paymentId ? { ...p, status: newStatus } : p,
-        ),
+    (old: unknown) => {
+      if (!old || typeof old !== "object") return old
+
+      const accumulee = old as { pages?: PaginatedResponse<Payment>[] }
+      if (Array.isArray(accumulee.pages)) {
+        return {
+          ...accumulee,
+          pages: accumulee.pages.map((page) => ({
+            ...page,
+            items: page.items.map(remplace),
+          })),
+        }
       }
+
+      const page = old as PaginatedResponse<Payment>
+      if (!Array.isArray(page.items)) return old
+      return { ...page, items: page.items.map(remplace) }
     },
   )
 }


### PR DESCRIPTION
Deux blocages relevés par la revue, tous deux introduits par le défilement continu.

## La mise à jour optimiste n'atteignait plus la liste chargée

La mise à jour gardait `if (!old?.items) return old`. Depuis le défilement, deux formes cohabitent sous le même préfixe de cache : la page unique `{items}` et la liste accumulée `{pages}`. Le garde ne jetait pas d'erreur sur la seconde, il ne faisait simplement rien.

La ligne qu'une caissière venait de valider restait donc inchangée jusqu'au rechargement, et pour une requête infinie ce rechargement redemande **toutes** les pages déjà chargées : dix pages parcourues, dix requêtes par clic, sans le moindre retour visuel entre-temps, sur un téléphone en 3G.

Les deux formes sont traitées, et le garde qui protège le cache du récapitulatif est conservé : c'est en l'étalant qu'on avait produit l'incident `r is not iterable` ici même. Trois tests exercent le vrai cache d'un vrai `QueryClient`, dont celui du récapitulatif qui ne doit pas être touché.

## La carte « Collecté » annonçait une portée qu'elle n'avait pas

Elle portait « sur le filtre actif » dans tous les cas. Ce n'est vrai qu'en caisse cloisonnée, où le chiffre est la recette de la personne, agrégée sur les mêmes versements que le compte affiché à côté. Hors cloisonnement, c'est ce que l'école a perçu sur sa dette, qui ne suit pas les filtres. Le libellé dit maintenant lequel des deux il décrit.

292 tests, `tsc` et `next lint` propres.