### PR TITLE
chore(ci): laisser passer les branches Dependabot a la validation de nom

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -21,8 +21,16 @@ jobs:
           # test/42-description
           # chore/42-description (no issue number required for chore)
           # hotfix/42-description
+          # dependabot/... : nom impose par Dependabot, que nous ne choisissons pas.
+          #
+          # Sans cette ligne, chaque montee de dependance echoue sur ce seul
+          # controle, et la seule facon de la fusionner est `--admin`, qui passe
+          # outre TOUS les controles, tests compris. Une regle cosmetique rendait
+          # donc muettes les verifications qui comptent, sur les PR que personne
+          # ne relit ligne a ligne.
           if [[ "$BRANCH" =~ ^(feature|fix|refactor|test|hotfix)/[0-9]+-[a-z0-9-]+$ ]] || \
              [[ "$BRANCH" =~ ^chore/[a-z0-9-]+$ ]] || \
+             [[ "$BRANCH" == dependabot/* ]] || \
              [[ "$BRANCH" == "develop" ]] || \
              [[ "$BRANCH" == "staging" ]]; then
             echo "✅ Branch name valid: $BRANCH"
@@ -36,6 +44,7 @@ jobs:
             echo "  refactor/42-description-courte"
             echo "  test/42-description-courte"
             echo "  chore/description-courte"
+            echo "  dependabot/... (cree par Dependabot)"
             echo ""
             echo "Exemples valides :"
             echo "  feature/2-nextauth-v5-setup"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ le projet adhère à [Semantic Versioning](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Fixed
+- Les montées de dépendances passent la validation de nom de branche, au lieu de forcer une fusion qui contourne tous les contrôles *(technique)*
 - Les boutons Valider, Annuler, Restaurer et Supprimer s'annoncent à nouveau avec une espace : un lecteur d'écran disait « Annulerle versement » *(admin)*
 - Valider ou annuler un versement met à jour la ligne immédiatement, y compris au-delà de la première page chargée *(admin)*
 - La carte « Collecté » ne prétend plus suivre le filtre quand elle parle de l'année entière *(admin)*


### PR DESCRIPTION
Pendant frontend. Voir la PR backend jumelle pour le raisonnement complet : une regle cosmetique forcait `--admin`, qui ne saute pas le controle de nom mais **tous** les controles, sur les PR que personne ne relit ligne a ligne.